### PR TITLE
Optimize perf by replacing call_user_func with dynamic variables

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -212,7 +212,7 @@ abstract class DoctrineType extends AbstractType
         // for equal query builders
         $queryBuilderNormalizer = function (Options $options, $queryBuilder) {
             if (\is_callable($queryBuilder)) {
-                $queryBuilder = \call_user_func($queryBuilder, $options['em']->getRepository($options['class']));
+                $queryBuilder = $queryBuilder($options['em']->getRepository($options['class']));
             }
 
             return $queryBuilder;

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -29,7 +29,7 @@ class EntityType extends DoctrineType
         // for equal query builders
         $queryBuilderNormalizer = function (Options $options, $queryBuilder) {
             if (\is_callable($queryBuilder)) {
-                $queryBuilder = \call_user_func($queryBuilder, $options['em']->getRepository($options['class']));
+                $queryBuilder = $queryBuilder($options['em']->getRepository($options['class']));
 
                 if (null !== $queryBuilder && !$queryBuilder instanceof QueryBuilder) {
                     throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder');

--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -102,7 +102,7 @@ class ServerLogHandler extends AbstractHandler
     {
         if ($this->processors) {
             foreach ($this->processors as $processor) {
-                $record = \call_user_func($processor, $record);
+                $record = $processor($record);
             }
         }
 

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
@@ -51,7 +51,7 @@ class RuntimeInstantiator implements InstantiatorInterface
         return $this->factory->createProxy(
             $definition->getClass(),
             function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($realInstantiator) {
-                $wrappedInstance = \call_user_func($realInstantiator);
+                $wrappedInstance = $realInstantiator();
 
                 $proxy->setProxyInitializer(null);
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -122,11 +122,11 @@ class PhpArrayAdapterWrapper extends PhpArrayAdapter
 {
     public function save(CacheItemInterface $item)
     {
-        \call_user_func(\Closure::bind(function () use ($item) {
+        (\Closure::bind(function () use ($item) {
             $this->values[$item->getKey()] = $item->get();
             $this->warmUp($this->values);
             $this->values = eval(substr(file_get_contents($this->file), 6));
-        }, $this, PhpArrayAdapter::class));
+        }, $this, PhpArrayAdapter::class))();
 
         return true;
     }

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -59,9 +59,9 @@ class CacheItemTest extends TestCase
         $this->assertSame($item, $item->tag('foo'));
         $this->assertSame($item, $item->tag(array('bar', 'baz')));
 
-        \call_user_func(\Closure::bind(function () use ($item) {
+        (\Closure::bind(function () use ($item) {
             $this->assertSame(array('foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'), $item->tags);
-        }, $this, CacheItem::class));
+        }, $this, CacheItem::class))();
     }
 
     /**

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
@@ -116,11 +116,11 @@ class PhpArrayCacheWrapper extends PhpArrayCache
 {
     public function set($key, $value, $ttl = null)
     {
-        \call_user_func(\Closure::bind(function () use ($key, $value) {
+        (\Closure::bind(function () use ($key, $value) {
             $this->values[$key] = $value;
             $this->warmUp($this->values);
             $this->values = eval(substr(file_get_contents($this->file), 6));
-        }, $this, PhpArrayCache::class));
+        }, $this, PhpArrayCache::class))();
 
         return true;
     }
@@ -130,13 +130,13 @@ class PhpArrayCacheWrapper extends PhpArrayCache
         if (!\is_array($values) && !$values instanceof \Traversable) {
             return parent::setMultiple($values, $ttl);
         }
-        \call_user_func(\Closure::bind(function () use ($values) {
+        (\Closure::bind(function () use ($values) {
             foreach ($values as $key => $value) {
                 $this->values[$key] = $value;
             }
             $this->warmUp($this->values);
             $this->values = eval(substr(file_get_contents($this->file), 6));
-        }, $this, PhpArrayCache::class));
+        }, $this, PhpArrayCache::class))();
 
         return true;
     }

--- a/src/Symfony/Component/Config/ConfigCacheFactory.php
+++ b/src/Symfony/Component/Config/ConfigCacheFactory.php
@@ -43,7 +43,7 @@ class ConfigCacheFactory implements ConfigCacheFactoryInterface
 
         $cache = new ConfigCache($file, $this->debug);
         if (!$cache->isFresh()) {
-            \call_user_func($callback, $cache);
+            $callback($cache);
         }
 
         return $cache;

--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -154,12 +154,12 @@ class ReflectionClassResource implements SelfCheckingResourceInterface, \Seriali
 
         if (interface_exists(EventSubscriberInterface::class, false) && $class->isSubclassOf(EventSubscriberInterface::class)) {
             yield EventSubscriberInterface::class;
-            yield print_r(\call_user_func(array($class->name, 'getSubscribedEvents')), true);
+            yield print_r($class->name::getSubscribedEvents(), true);
         }
 
         if (interface_exists(ServiceSubscriberInterface::class, false) && $class->isSubclassOf(ServiceSubscriberInterface::class)) {
             yield ServiceSubscriberInterface::class;
-            yield print_r(\call_user_func(array($class->name, 'getSubscribedServices')), true);
+            yield print_r($class->name::getSubscribedServices(), true);
         }
     }
 }

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCacheFactory.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCacheFactory.php
@@ -40,7 +40,7 @@ class ResourceCheckerConfigCacheFactory implements ConfigCacheFactoryInterface
 
         $cache = new ResourceCheckerConfigCache($file, $this->resourceCheckers);
         if (!$cache->isFresh()) {
-            \call_user_func($callback, $cache);
+            $callback($cache);
         }
 
         return $cache;

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -80,7 +80,7 @@ class XmlUtils
             $e = null;
             if (\is_callable($schemaOrCallable)) {
                 try {
-                    $valid = \call_user_func($schemaOrCallable, $dom, $internalErrors);
+                    $valid = $schemaOrCallable($dom, $internalErrors);
                 } catch (\Exception $e) {
                     $valid = false;
                 }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -250,7 +250,7 @@ class Command
         $input->validate();
 
         if ($this->code) {
-            $statusCode = \call_user_func($this->code, $input, $output);
+            $statusCode = ($this->code)($input, $output);
         } else {
             $statusCode = $this->execute($input, $output);
         }

--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -121,7 +121,7 @@ class ProcessHelper extends Helper
             $output->write($formatter->progress(spl_object_hash($process), $this->escapeString($buffer), Process::ERR === $type));
 
             if (null !== $callback) {
-                \call_user_func($callback, $type, $buffer);
+                $callback($type, $buffer);
             }
         };
     }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -496,7 +496,7 @@ final class ProgressBar
         $regex = "{%([a-z\-_]+)(?:\:([^%]+))?%}i";
         $callback = function ($matches) {
             if ($formatter = $this::getPlaceholderFormatterDefinition($matches[1])) {
-                $text = \call_user_func($formatter, $this, $this->output);
+                $text = $formatter($this, $this->output);
             } elseif (isset($this->messages[$matches[1]])) {
                 $text = $this->messages[$matches[1]];
             } else {

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -196,7 +196,7 @@ class ProgressIndicator
 
         $this->overwrite(preg_replace_callback("{%([a-z\-_]+)(?:\:([^%]+))?%}i", function ($matches) use ($self) {
             if ($formatter = $self::getPlaceholderFormatterDefinition($matches[1])) {
-                return \call_user_func($formatter, $self);
+                return $formatter($self);
             }
 
             return $matches[0];

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -381,7 +381,7 @@ class QuestionHelper extends Helper
             }
 
             try {
-                return \call_user_func($question->getValidator(), $interviewer());
+                return $question->getValidator()($interviewer());
             } catch (RuntimeException $e) {
                 throw $e;
             } catch (\Exception $error) {

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -155,7 +155,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Node "%s" not supported.', $node->getNodeName()));
         }
 
-        return \call_user_func($this->nodeTranslators[$node->getNodeName()], $node, $this);
+        return $this->nodeTranslators[$node->getNodeName()]($node, $this);
     }
 
     /**
@@ -167,7 +167,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Combiner "%s" not supported.', $combiner));
         }
 
-        return \call_user_func($this->combinationTranslators[$combiner], $this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
+        return $this->combinationTranslators[$combiner]($this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
     }
 
     /**
@@ -179,7 +179,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Function "%s" not supported.', $function->getName()));
         }
 
-        return \call_user_func($this->functionTranslators[$function->getName()], $xpath, $function);
+        return $this->functionTranslators[$function->getName()]($xpath, $function);
     }
 
     /**
@@ -191,7 +191,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Pseudo-class "%s" not supported.', $pseudoClass));
         }
 
-        return \call_user_func($this->pseudoClassTranslators[$pseudoClass], $xpath);
+        return $this->pseudoClassTranslators[$pseudoClass]($xpath);
     }
 
     /**
@@ -203,7 +203,7 @@ class Translator implements TranslatorInterface
             throw new ExpressionErrorException(sprintf('Attribute matcher operator "%s" not supported.', $operator));
         }
 
-        return \call_user_func($this->attributeMatchingTranslators[$operator], $xpath, $attribute, $value);
+        return $this->attributeMatchingTranslators[$operator]($xpath, $attribute, $value);
     }
 
     /**

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -147,7 +147,7 @@ class DebugClassLoader
                     require $file;
                 }
             } else {
-                \call_user_func($this->classLoader, $class);
+                ($this->classLoader)($class);
                 $file = false;
             }
         } finally {

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -553,7 +553,7 @@ class ErrorHandler
         $this->exceptionHandler = null;
         try {
             if (null !== $exceptionHandler) {
-                return \call_user_func($exceptionHandler, $exception);
+                return $exceptionHandler($exception);
             }
             $handlerException = $handlerException ?: $exception;
         } catch (\Throwable $handlerException) {

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -142,7 +142,7 @@ class ExceptionHandler
         $this->caughtBuffer = null;
 
         try {
-            \call_user_func($this->handler, $exception);
+            ($this->handler)($exception);
             $this->caughtLength = $caughtLength;
         } catch (\Exception $e) {
             if (!$caughtLength) {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1160,7 +1160,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 throw new InvalidArgumentException(sprintf('The configure callable for class "%s" is not a callable.', \get_class($service)));
             }
 
-            \call_user_func($callable, $service);
+            $callable($service);
         }
 
         return $service;

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
@@ -28,6 +28,6 @@ class RealServiceInstantiator implements InstantiatorInterface
      */
     public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
     {
-        return \call_user_func($realInstantiator);
+        return $realInstantiator();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
@@ -35,7 +35,7 @@ class ClosureLoader extends Loader
      */
     public function load($resource, $type = null)
     {
-        \call_user_func($resource, $this->container);
+        $resource($this->container);
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -108,7 +108,7 @@ class WrappedListener
 
         $e = $this->stopwatch->start($this->name, 'event_listener');
 
-        \call_user_func($this->listener, $event, $eventName, $this->dispatcher ?: $dispatcher);
+        ($this->listener)($event, $eventName, $this->dispatcher ?: $dispatcher);
 
         if ($e->isStarted()) {
             $e->stop();

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -209,7 +209,7 @@ class EventDispatcher implements EventDispatcherInterface
             if ($event->isPropagationStopped()) {
                 break;
             }
-            \call_user_func($listener, $event, $eventName, $this);
+            $listener($event, $eventName, $this);
         }
     }
 

--- a/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
@@ -51,7 +51,7 @@ class CustomFilterIterator extends \FilterIterator
         $fileinfo = $this->current();
 
         foreach ($this->filters as $filter) {
-            if (false === \call_user_func($filter, $fileinfo)) {
+            if (false === $filter($fileinfo)) {
                 return false;
             }
         }

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -41,7 +41,7 @@ class CallbackTransformer implements DataTransformerInterface
      */
     public function transform($data)
     {
-        return \call_user_func($this->transform, $data);
+        return ($this->transform)($data);
     }
 
     /**
@@ -57,6 +57,6 @@ class CallbackTransformer implements DataTransformerInterface
      */
     public function reverseTransform($data)
     {
-        return \call_user_func($this->reverseTransform, $data);
+        return ($this->reverseTransform)($data);
     }
 }

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -155,7 +155,7 @@ class ArrayChoiceList implements ChoiceListInterface
             $givenValues = array();
 
             foreach ($choices as $i => $givenChoice) {
-                $givenValues[$i] = (string) \call_user_func($this->valueCallback, $givenChoice);
+                $givenValues[$i] = (string) ($this->valueCallback)($givenChoice);
             }
 
             return array_intersect($givenValues, array_keys($this->choices));
@@ -202,7 +202,7 @@ class ArrayChoiceList implements ChoiceListInterface
                 continue;
             }
 
-            $choiceValue = (string) \call_user_func($value, $choice);
+            $choiceValue = (string) $value($choice);
             $choicesByValues[$choiceValue] = $choice;
             $keysByValues[$choiceValue] = $key;
             $structuredValues[$key] = $choiceValue;

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -118,7 +118,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         // $value may be an integer or a string, since it's stored in the array
         // keys. We want to guarantee it's a string though.
         $key = $keys[$value];
-        $nextIndex = \is_int($index) ? $index++ : \call_user_func($index, $choice, $key, $value);
+        $nextIndex = \is_int($index) ? $index++ : $index($choice, $key, $value);
 
         // BC normalize label to accept a false value
         if (null === $label) {
@@ -127,7 +127,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         } elseif (false !== $label) {
             // If "choice_label" is set to false and "expanded" is true, the value false
             // should be passed on to the "label" option of the checkboxes/radio buttons
-            $dynamicLabel = \call_user_func($label, $choice, $key, $value);
+            $dynamicLabel = $label($choice, $key, $value);
             $label = false === $dynamicLabel ? false : (string) $dynamicLabel;
         }
 
@@ -137,11 +137,11 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             $label,
             // The attributes may be a callable or a mapping from choice indices
             // to nested arrays
-            \is_callable($attr) ? \call_user_func($attr, $choice, $key, $value) : (isset($attr[$key]) ? $attr[$key] : array())
+            \is_callable($attr) ? $attr($choice, $key, $value) : (isset($attr[$key]) ? $attr[$key] : array())
         );
 
         // $isPreferred may be null if no choices are preferred
-        if ($isPreferred && \call_user_func($isPreferred, $choice, $key, $value)) {
+        if ($isPreferred && $isPreferred($choice, $key, $value)) {
             $preferredViews[$nextIndex] = $view;
         } else {
             $otherViews[$nextIndex] = $view;
@@ -200,7 +200,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
 
     private static function addChoiceViewGroupedBy($groupBy, $choice, $value, $label, $keys, &$index, $attr, $isPreferred, &$preferredViews, &$otherViews)
     {
-        $groupLabel = \call_user_func($groupBy, $choice, $keys[$value], $value);
+        $groupLabel = $groupBy($choice, $keys[$value], $value);
 
         if (null === $groupLabel) {
             // If the callable returns null, don't group the choice

--- a/src/Symfony/Component/Form/ChoiceList/Loader/CallbackChoiceLoader.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/CallbackChoiceLoader.php
@@ -46,7 +46,7 @@ class CallbackChoiceLoader implements ChoiceLoaderInterface
             return $this->choiceList;
         }
 
-        return $this->choiceList = new ArrayChoiceList(\call_user_func($this->callback), $value);
+        return $this->choiceList = new ArrayChoiceList(($this->callback)(), $value);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -135,7 +135,7 @@ class ResizeFormListener implements EventSubscriberInterface
             /** @var FormInterface $child */
             foreach ($form as $name => $child) {
                 $isNew = !isset($previousData[$name]);
-                $isEmpty = \is_callable($this->deleteEmpty) ? \call_user_func($this->deleteEmpty, $child->getData()) : $child->isEmpty();
+                $isEmpty = \is_callable($this->deleteEmpty) ? ($this->deleteEmpty)($child->getData()) : $child->isEmpty();
 
                 // $isNew can only be true if allowAdd is true, so we don't
                 // need to check allowAdd again

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -73,7 +73,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
                 $form->submit(null, false);
 
                 $form->addError(new FormError(
-                    \call_user_func($form->getConfig()->getOption('upload_max_size_message')),
+                    $form->getConfig()->getOption('upload_max_size_message')(),
                     null,
                     array('{{ max }}' => $this->serverParams->getNormalizedIniPostMaxSize())
                 ));

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -180,7 +180,7 @@ class FormValidator extends ConstraintValidator
     private static function resolveValidationGroups($groups, FormInterface $form)
     {
         if (!\is_string($groups) && \is_callable($groups)) {
-            $groups = \call_user_func($groups, $form);
+            $groups = $groups($form);
         }
 
         if ($groups instanceof GroupSequence) {

--- a/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php
@@ -40,7 +40,7 @@ class UploadValidatorExtension extends AbstractTypeExtension
         $translationDomain = $this->translationDomain;
         $resolver->setNormalizer('upload_max_size_message', function (Options $options, $message) use ($translator, $translationDomain) {
             return function () use ($translator, $translationDomain, $message) {
-                return $translator->trans(\call_user_func($message), array(), $translationDomain);
+                return $translator->trans($message(), array(), $translationDomain);
             };
         });
     }

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -78,7 +78,7 @@ class NativeRequestHandler implements RequestHandlerInterface
                 $form->submit(null, false);
 
                 $form->addError(new FormError(
-                    \call_user_func($form->getConfig()->getOption('upload_max_size_message')),
+                    $form->getConfig()->getOption('upload_max_size_message')(),
                     null,
                     array('{{ max }}' => $this->serverParams->getNormalizedIniPostMaxSize())
                 ));

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
@@ -40,6 +40,6 @@ class UploadValidatorExtensionTest extends TypeTestCase
         $extension->configureOptions($resolver);
         $options = $resolver->resolve();
 
-        $this->assertEquals('translated max {{ max }}!', \call_user_func($options['upload_max_size_message']));
+        $this->assertEquals('translated max {{ max }}!', $options['upload_max_size_message']());
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1905,7 +1905,7 @@ class Request
     private static function createRequestFromFactory(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null)
     {
         if (self::$requestFactory) {
-            $request = \call_user_func(self::$requestFactory, $query, $request, $attributes, $cookies, $files, $server, $content);
+            $request = (self::$requestFactory)($query, $request, $attributes, $cookies, $files, $server, $content);
 
             if (!$request instanceof self) {
                 throw new \LogicException('The Request factory must return an instance of Symfony\Component\HttpFoundation\Request.');

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -111,7 +111,7 @@ class StreamedResponse extends Response
             throw new \LogicException('The Response callback must not be null.');
         }
 
-        \call_user_func($this->callback);
+        ($this->callback)();
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -390,7 +390,7 @@ class MockPdo extends \PDO
     public function prepare($statement, $driverOptions = array())
     {
         return \is_callable($this->prepareResult)
-            ? \call_user_func($this->prepareResult, $statement, $driverOptions)
+            ? ($this->prepareResult)($statement, $driverOptions)
             : $this->prepareResult;
     }
 

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -91,7 +91,7 @@ class FileLinkFormatter implements \Serializable
         if ($this->requestStack && $this->baseDir && $this->urlFormat) {
             $request = $this->requestStack->getMasterRequest();
             if ($request instanceof Request) {
-                if ($this->urlFormat instanceof \Closure && !$this->urlFormat = \call_user_func($this->urlFormat)) {
+                if ($this->urlFormat instanceof \Closure && !$this->urlFormat = ($this->urlFormat)()) {
                     return;
                 }
 

--- a/src/Symfony/Component/OptionsResolver/Debug/OptionsResolverIntrospector.php
+++ b/src/Symfony/Component/OptionsResolver/Debug/OptionsResolverIntrospector.php
@@ -47,7 +47,7 @@ class OptionsResolverIntrospector
      */
     public function getDefault(string $option)
     {
-        return \call_user_func($this->get, 'defaults', $option, sprintf('No default value was set for the "%s" option.', $option));
+        return ($this->get)('defaults', $option, sprintf('No default value was set for the "%s" option.', $option));
     }
 
     /**
@@ -57,7 +57,7 @@ class OptionsResolverIntrospector
      */
     public function getLazyClosures(string $option): array
     {
-        return \call_user_func($this->get, 'lazy', $option, sprintf('No lazy closures were set for the "%s" option.', $option));
+        return ($this->get)('lazy', $option, sprintf('No lazy closures were set for the "%s" option.', $option));
     }
 
     /**
@@ -67,7 +67,7 @@ class OptionsResolverIntrospector
      */
     public function getAllowedTypes(string $option): array
     {
-        return \call_user_func($this->get, 'allowedTypes', $option, sprintf('No allowed types were set for the "%s" option.', $option));
+        return ($this->get)('allowedTypes', $option, sprintf('No allowed types were set for the "%s" option.', $option));
     }
 
     /**
@@ -77,7 +77,7 @@ class OptionsResolverIntrospector
      */
     public function getAllowedValues(string $option): array
     {
-        return \call_user_func($this->get, 'allowedValues', $option, sprintf('No allowed values were set for the "%s" option.', $option));
+        return ($this->get)('allowedValues', $option, sprintf('No allowed values were set for the "%s" option.', $option));
     }
 
     /**
@@ -85,6 +85,6 @@ class OptionsResolverIntrospector
      */
     public function getNormalizer(string $option): \Closure
     {
-        return \call_user_func($this->get, 'normalizers', $option, sprintf('No normalizer was set for the "%s" option.', $option));
+        return ($this->get)('normalizers', $option, sprintf('No normalizer was set for the "%s" option.', $option));
     }
 }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1227,7 +1227,7 @@ class Process implements \IteratorAggregate
         if ($this->outputDisabled) {
             return function ($type, $data) use ($callback) {
                 if (null !== $callback) {
-                    \call_user_func($callback, $type, $data);
+                    $callback($type, $data);
                 }
             };
         }
@@ -1242,7 +1242,7 @@ class Process implements \IteratorAggregate
             }
 
             if (null !== $callback) {
-                \call_user_func($callback, $type, $data);
+                $callback($type, $data);
             }
         };
     }

--- a/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
@@ -67,7 +67,7 @@ abstract class ObjectRouteLoader extends Loader
             throw new \BadMethodCallException(sprintf('Method "%s" not found on "%s" when importing routing resource "%s"', $method, \get_class($loaderObject), $resource));
         }
 
-        $routeCollection = \call_user_func(array($loaderObject, $method), $this);
+        $routeCollection = $loaderObject->$method($this);
 
         if (!$routeCollection instanceof RouteCollection) {
             $type = \is_object($routeCollection) ? \get_class($routeCollection) : \gettype($routeCollection);

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -96,7 +96,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             $attributeValue = $this->getAttributeValue($object, $attribute, $format, $context);
             if ($maxDepthReached) {
-                $attributeValue = \call_user_func($this->maxDepthHandler, $attributeValue, $object, $attribute, $format, $context);
+                $attributeValue = ($this->maxDepthHandler)($attributeValue, $object, $attribute, $format, $context);
             }
 
             if (isset($this->callbacks[$attribute])) {
@@ -345,7 +345,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 return (float) $data;
             }
 
-            if (\call_user_func('is_'.$builtinType, $data)) {
+            if (('is_'.$builtinType)($data)) {
                 return $data;
             }
         }

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -53,7 +53,7 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
 
         $builtinType = isset($context['key_type']) ? $context['key_type']->getBuiltinType() : null;
         foreach ($data as $key => $value) {
-            if (null !== $builtinType && !\call_user_func('is_'.$builtinType, $key)) {
+            if (null !== $builtinType && !('is_'.$builtinType)($key)) {
                 throw new NotNormalizableValueException(sprintf('The type of the key "%s" must be "%s" ("%s" given).', $key, $builtinType, \gettype($key)));
             }
 

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -313,13 +313,13 @@ class PhpEngine implements EngineInterface, \ArrayAccess
         // the performance when the same value is escaped multiple times (e.g. loops)
         if (is_scalar($value)) {
             if (!isset(self::$escaperCache[$context][$value])) {
-                self::$escaperCache[$context][$value] = \call_user_func($this->getEscaper($context), $value);
+                self::$escaperCache[$context][$value] = $this->getEscaper($context)($value);
             }
 
             return self::$escaperCache[$context][$value];
         }
 
-        return \call_user_func($this->getEscaper($context), $value);
+        return $this->getEscaper($context)($value);
     }
 
     /**

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -238,7 +238,7 @@ EOF
         };
 
         if (null !== $this->directoryIteratorProvider) {
-            return \call_user_func($this->directoryIteratorProvider, $directory, $default);
+            return ($this->directoryIteratorProvider)($directory, $default);
         }
 
         return $default($directory);
@@ -251,7 +251,7 @@ EOF
         };
 
         if (null !== $this->isReadableProvider) {
-            return \call_user_func($this->isReadableProvider, $fileOrDirectory, $default);
+            return ($this->isReadableProvider)($fileOrDirectory, $default);
         }
 
         return $default($fileOrDirectory);

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -40,7 +40,7 @@ class PluralizationRules
         }
 
         if (isset(self::$rules[$locale])) {
-            $return = \call_user_func(self::$rules[$locale], $number);
+            $return = self::$rules[$locale]($number);
 
             if (!\is_int($return) || $return < 0) {
                 return 0;

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -43,7 +43,7 @@ class CallbackValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException(sprintf('%s targeted by Callback constraint is not a valid callable', json_encode($method)));
             }
 
-            \call_user_func($method, $object, $this->context, $constraint->payload);
+            $method($object, $this->context, $constraint->payload);
         } elseif (null !== $object) {
             if (!method_exists($object, $method)) {
                 throw new ConstraintDefinitionException(sprintf('Method "%s" targeted by Callback constraint does not exist in class %s', $method, \get_class($object)));

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -53,7 +53,7 @@ class ChoiceValidator extends ConstraintValidator
             ) {
                 throw new ConstraintDefinitionException('The Choice constraint expects a valid callback');
             }
-            $choices = \call_user_func($choices);
+            $choices = $choices();
         } else {
             $choices = $constraint->choices;
         }

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -218,7 +218,7 @@ abstract class AbstractCloner implements ClonerInterface
             }
 
             if ($this->prevErrorHandler) {
-                return \call_user_func($this->prevErrorHandler, $type, $msg, $file, $line, $context);
+                return ($this->prevErrorHandler)($type, $msg, $file, $line, $context);
             }
 
             return false;

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -164,7 +164,7 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
      */
     protected function dumpLine($depth)
     {
-        \call_user_func($this->lineDumper, $this->line, $depth, $this->indentPad);
+        ($this->lineDumper)($this->line, $depth, $this->indentPad);
         $this->line = '';
     }
 

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -35,7 +35,7 @@ class VarDumper
             };
         }
 
-        return \call_user_func(self::$handler, $var);
+        return (self::$handler)($var);
     }
 
     public static function setHandler(callable $callable = null)

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -229,7 +229,7 @@ EOF
         };
 
         if (null !== $this->directoryIteratorProvider) {
-            return \call_user_func($this->directoryIteratorProvider, $directory, $default);
+            return ($this->directoryIteratorProvider)($directory, $default);
         }
 
         return $default($directory);
@@ -242,7 +242,7 @@ EOF
         };
 
         if (null !== $this->isReadableProvider) {
-            return \call_user_func($this->isReadableProvider, $fileOrDirectory, $default);
+            return ($this->isReadableProvider)($fileOrDirectory, $default);
         }
 
         return $default($fileOrDirectory);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This provides similar boost as in https://github.com/symfony/symfony/pull/29245, but on more places and without complexity increase. Check eg. https://github.com/fab2s/call_user_func for proof 

Fabpot failure unrelated