### PR TITLE
[MonologBridge] Return empty list for unknown requests

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -60,8 +60,8 @@ class DebugProcessor implements DebugLoggerInterface
      */
     public function getLogs(/* Request $request = null */)
     {
-        if (1 <= \func_num_args() && null !== ($request = \func_get_arg(0)) && isset($this->records[$hash = spl_object_hash($request)])) {
-            return $this->records[$hash];
+        if (1 <= \func_num_args() && null !== $request = \func_get_arg(0)) {
+            return $this->records[spl_object_hash($request)] ?? array();
         }
 
         if (0 === \count($this->records)) {
@@ -76,8 +76,8 @@ class DebugProcessor implements DebugLoggerInterface
      */
     public function countErrors(/* Request $request = null */)
     {
-        if (1 <= \func_num_args() && null !== ($request = \func_get_arg(0)) && isset($this->errorCount[$hash = spl_object_hash($request)])) {
-            return $this->errorCount[$hash];
+        if (1 <= \func_num_args() && null !== $request = \func_get_arg(0)) {
+            return $this->errorCount[spl_object_hash($request)] ?? 0;
         }
 
         return array_sum($this->errorCount);

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
@@ -58,6 +58,9 @@ class DebugProcessorTest extends TestCase
 
         $this->assertCount(2, $processor->getLogs($request));
         $this->assertSame(1, $processor->countErrors($request));
+
+        $this->assertCount(0, $processor->getLogs(new Request()));
+        $this->assertSame(0, $processor->countErrors(new Request()));
     }
 
     private function getRecord($level = Logger::WARNING, $message = 'test')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Small continuation of #23659. Currently if the specified request is unknown, you'll get all available requests merged. This fixes it.