### PR TITLE
[EventDispatcher] Split events across requests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -28,6 +28,7 @@
         <service id="data_collector.events" class="Symfony\Component\HttpKernel\DataCollector\EventDataCollector">
             <tag name="data_collector" template="@WebProfiler/Collector/events.html.twig" id="events" priority="290" />
             <argument type="service" id="debug.event_dispatcher" on-invalid="ignore" />
+            <argument type="service" id="request_stack" on-invalid="ignore" />
         </service>
 
         <service id="data_collector.logger" class="Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="debug.event_dispatcher.inner" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="request_stack" on-invalid="null" />
         </service>
 
         <service id="debug.controller_resolver" decorates="controller_resolver" class="Symfony\Component\HttpKernel\Controller\TraceableControllerResolver">

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\EventDispatcher\Debug;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -24,14 +25,18 @@ interface TraceableEventDispatcherInterface extends EventDispatcherInterface, Re
     /**
      * Gets the called listeners.
      *
+     * @param Request|null $request The request to get listeners for
+     *
      * @return array An array of called listeners
      */
-    public function getCalledListeners();
+    public function getCalledListeners(/* Request $request = null */);
 
     /**
      * Gets the not called listeners.
      *
+     * @param Request|null $request The request to get listeners for
+     *
      * @return array An array of not called listeners
      */
-    public function getNotCalledListeners();
+    public function getNotCalledListeners(/* Request $request = null */);
 }

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -23,6 +23,7 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/config": "~3.4|~4.0",
+        "symfony/http-foundation": "^3.4|^4.0",
         "symfony/stopwatch": "~3.4|~4.0",
         "psr/log": "~1.0"
     },

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\DataCollector;
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -26,10 +27,13 @@ use Symfony\Contracts\Service\ResetInterface;
 class EventDataCollector extends DataCollector implements LateDataCollectorInterface
 {
     protected $dispatcher;
+    private $requestStack;
+    private $currentRequest;
 
-    public function __construct(EventDispatcherInterface $dispatcher = null)
+    public function __construct(EventDispatcherInterface $dispatcher = null, RequestStack $requestStack = null)
     {
         $this->dispatcher = $dispatcher;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -37,6 +41,7 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
+        $this->currentRequest = $this->requestStack && $this->requestStack->getMasterRequest() !== $request ? $request : null;
         $this->data = [
             'called_listeners' => [],
             'not_called_listeners' => [],
@@ -56,12 +61,12 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     public function lateCollect()
     {
         if ($this->dispatcher instanceof TraceableEventDispatcherInterface) {
-            $this->setCalledListeners($this->dispatcher->getCalledListeners());
-            $this->setNotCalledListeners($this->dispatcher->getNotCalledListeners());
+            $this->setCalledListeners($this->dispatcher->getCalledListeners($this->currentRequest));
+            $this->setNotCalledListeners($this->dispatcher->getNotCalledListeners($this->currentRequest));
         }
 
         if ($this->dispatcher instanceof TraceableEventDispatcher) {
-            $this->setOrphanedEvents($this->dispatcher->getOrphanedEvents());
+            $this->setOrphanedEvents($this->dispatcher->getOrphanedEvents($this->currentRequest));
         }
 
         $this->data = $this->cloneVar($this->data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #24275
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Split events per request, as currently a profiled sub-request includes all events. Follows same approach how logs are split in #23659.