### PR TITLE
Changes for upcoming Travis' infra migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 dist: trusty
-sudo: false
 
 git:
     depth: 2


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Travis is deprecating the `sudo` keyword and moves everything to the same infrastructure (`sudo` really selects between two infrastructures).

See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration