### PR TITLE
[VarDumper] Fix ClassStub ellipsis

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ClassStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ClassStub.php
@@ -74,8 +74,8 @@ class ClassStub extends ConstStub
         } catch (\ReflectionException $e) {
             return;
         } finally {
-            if (0 < $i = strrpos($identifier, '\\')) {
-                $this->attr['ellipsis'] = \strlen($identifier) - $i;
+            if (0 < $i = strrpos($this->value, '\\')) {
+                $this->attr['ellipsis'] = \strlen($this->value) - $i;
                 $this->attr['ellipsis-type'] = 'class';
                 $this->attr['ellipsis-tail'] = 1;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29311
| License       | MIT
| Doc PR        | -

Confirmed by @nicolas-grekas this is the right fix.

Before:

![image](https://user-images.githubusercontent.com/1047696/48979309-56c27280-f0b9-11e8-85f8-5ce6837b58fc.png)


After:

![image](https://user-images.githubusercontent.com/1047696/48979310-617d0780-f0b9-11e8-8c43-b12febc1c859.png)
