### PR TITLE
[WebProfiler] Detect non-file paths in file viewer

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -134,7 +134,7 @@ class CodeExtension extends AbstractExtension
      */
     public function fileExcerpt($file, $line, $srcContext = 3)
     {
-        if (is_readable($file)) {
+        if (is_file($file) && is_readable($file)) {
             // highlight_file could throw warnings
             // see https://bugs.php.net/bug.php?id=25725
             $code = @highlight_file($file, true);
@@ -157,6 +157,8 @@ class CodeExtension extends AbstractExtension
 
             return '<ol start="'.max($line - $srcContext, 1).'">'.implode("\n", $lines).'</ol>';
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
@@ -54,6 +54,11 @@ a.doc:hover {
     text-decoration: underline;
 }
 
+.empty {
+    padding: 10px;
+    color: #555;
+}
+
 .source {
     margin-top: 41px;
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
@@ -7,11 +7,16 @@
 {% endblock %}
 
 {% block body %}
-<div class="header">
-    <h1>{{ file }}{% if 0 < line %} <small>line {{ line }}</small>{% endif %}</h1>
-    <a class="doc" href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION') }}/reference/configuration/framework.html#ide" rel="help">Open in your IDE?</a>
-</div>
-<div class="source">
-    {{ filename|file_excerpt(line, -1) }}
-</div>
+    {% set source = filename|file_excerpt(line, -1) %}
+    <div class="header">
+        <h1>{{ file }}{% if 0 < line %} <small>line {{ line }}</small>{% endif %}</h1>
+        <a class="doc" href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION') }}/reference/configuration/framework.html#ide" rel="help">Open in your IDE?</a>
+    </div>
+    <div class="source">
+        {% if source is null %}
+            <p class="empty">The file is not readable.</p>
+        {% else %}
+            {{ source|raw }}
+        {% endif %}
+    </div>
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

We actually link directories sometimes :) now looks like:

![image](https://user-images.githubusercontent.com/1047696/48981263-7b2b4880-f0d3-11e8-9334-9e2f45d62c09.png)
