### PR TITLE
[WebProfilerBundle] Display messenger exception count instead of total count

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -33,10 +33,11 @@
 <span class="label{{ collector.exceptionsCount ? ' label-status-error' }}{{ collector.messages is empty ? ' disabled' }}">
     <span class="icon">{{ include('@WebProfiler/Icon/messenger.svg') }}</span>
     <strong>Messages</strong>
-
-    <span class="count">
-        <span>{{ collector.messages|length }}</span>
-    </span>
+    {% if collector.exceptionsCount > 0 %}
+        <span class="count">
+            <span>{{ collector.exceptionsCount }}</span>
+        </span>
+    {% endif %}
 </span>
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Each panel hides the count if zero, except messenger:

![image](https://user-images.githubusercontent.com/1047696/48981495-7ae07c80-f0d6-11e8-9dda-f40ce61844d6.png)

Now fixed.