### PR TITLE
[Console] Fix synopsis when an error occurs

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -592,7 +592,8 @@ class Command
         $key = $short ? 'short' : 'long';
 
         if (!isset($this->synopsis[$key])) {
-            $this->synopsis[$key] = trim(sprintf('%s %s', $this->name, $this->definition->getSynopsis($short)));
+            $partialSynopsis = $this->definition->getPartialSynopsis(array('command'), array(), $short);
+            $this->synopsis[$key] = trim(sprintf('%s %s', $this->name, $partialSynopsis));
         }
 
         return $this->synopsis[$key];

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -349,13 +349,15 @@ class InputDefinition
     }
 
     /**
-     * Gets the synopsis.
+     * Gets the synopsis without displaying given arguments and options.
      *
-     * @param bool $short Whether to return the short version (with options folded) or not
+     * @param array $exceptArguments arguments that won't be displayed
+     * @param array $exceptOptions   options that won't be displayed
+     * @param bool  $short           Whether to return the short version (with options folded) or not
      *
      * @return string The synopsis
      */
-    public function getSynopsis($short = false)
+    public function getPartialSynopsis(array $exceptArguments, array $exceptOptions = array(), $short = false)
     {
         $elements = array();
 
@@ -363,12 +365,17 @@ class InputDefinition
             $elements[] = '[options]';
         } elseif (!$short) {
             foreach ($this->getOptions() as $option) {
+                $name = $option->getName();
+                if (\in_array($name, $exceptOptions)) {
+                    continue;
+                }
+
                 $value = '';
                 if ($option->acceptValue()) {
                     $value = sprintf(
                         ' %s%s%s',
                         $option->isValueOptional() ? '[' : '',
-                        strtoupper($option->getName()),
+                        strtoupper($name),
                         $option->isValueOptional() ? ']' : ''
                     );
                 }
@@ -383,7 +390,12 @@ class InputDefinition
         }
 
         foreach ($this->getArguments() as $argument) {
-            $element = '<'.$argument->getName().'>';
+            $name = $argument->getName();
+            if (\in_array($name, $exceptArguments)) {
+                continue;
+            }
+
+            $element = '<'.$name.'>';
             if (!$argument->isRequired()) {
                 $element = '['.$element.']';
             } elseif ($argument->isArray()) {
@@ -398,5 +410,17 @@ class InputDefinition
         }
 
         return implode(' ', $elements);
+    }
+
+    /**
+     * Gets the synopsis.
+     *
+     * @param bool $short Whether to return the short version (with options folded) or not
+     *
+     * @return string The synopsis
+     */
+    public function getSynopsis($short = false)
+    {
+        return $this->getPartialSynopsis(array(), array(), $short);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -192,6 +192,23 @@ class CommandTest extends TestCase
         $this->assertEquals('namespace:name [--foo] [--] [<bar>]', $command->getSynopsis(), '->getSynopsis() returns the synopsis');
     }
 
+    public function testGetSypnosisWithApplication()
+    {
+        $appDef = $this->getMockBuilder('Symfony\Component\Console\Input\InputDefinition')->getMock();
+        $appDef->method('getArguments')->willReturn(array(new InputArgument('command'), new InputArgument('appbar')));
+        $appDef->method('getOptions')->willReturn(array(new InputOption('appfoo')));
+        $helperSet = $this->getMockBuilder('Symfony\Component\Console\Helper\HelperSet')->getMock();
+        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
+        $application->method('getDefinition')->willReturn($appDef);
+        $application->method('getHelperSet')->willReturn($helperSet);
+        $command = new \TestCommand();
+        $command->setApplication($application);
+        $command->mergeApplicationDefinition();
+        $command->addOption('foo');
+        $command->addArgument('bar');
+        $this->assertEquals('namespace:name [--appfoo] [--foo] [--] [<appbar>] [<bar>]', $command->getSynopsis());
+    }
+
     public function testAddGetUsages()
     {
         $command = new \TestCommand();

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -387,6 +387,27 @@ class InputDefinitionTest extends TestCase
         $this->assertEquals('[options] [--] [<cat>]', $definition->getSynopsis(true), '->getSynopsis(true) groups options in [options]');
     }
 
+    public function getGetPartialSynopsisData()
+    {
+        return array(
+            array(array(), array(), '[--foobar] [--] [<foo>] [<bar>]'),
+            array(array('foo'), array(), '[--foobar] [--] [<bar>]'),
+            array(array('bar'), array('foobar'), '[<foo>]'),
+            array(array('foo', 'bar'), array('foobar'), ''),
+        );
+    }
+
+    /**
+     * @dataProvider getGetPartialSynopsisData
+     */
+    public function testGetPartialSynopsis($exceptArguments, $exceptOptions, $expectedSynopsis)
+    {
+        $definition = new InputDefinition(
+            array(new InputArgument('foo'), new InputArgument('bar'), new InputOption('foobar'))
+        );
+        $this->assertEquals($expectedSynopsis, $definition->getPartialSynopsis($exceptArguments, $exceptOptions));
+    }
+
     protected function initializeArguments()
     {
         $this->foo = new InputArgument('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no->
| Tests pass?   | yes
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The short help displayed when an error occurs (synopsis) displays the real command name but also a placeholder for this command name (`debug:container` and `<command>` are the same thing):

<img width="1350" alt="capture d ecran 2018-11-25 a 17 53 04" src="https://user-images.githubusercontent.com/15314293/48981857-ff34fe80-f0da-11e8-8bb6-40ca169eb1a8.png">

This PR fixes this behavior.
