### PR TITLE
[PropertyAccess] Extract AccessInfoGuesser from PropertyAccessor

### DIFF
--- a/src/Symfony/Component/PropertyAccess/AccessInfoGuesser.php
+++ b/src/Symfony/Component/PropertyAccess/AccessInfoGuesser.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Inflector\Inflector;
+
+final class AccessInfoGuesser
+{
+    public const ACCESS_HAS_PROPERTY = 0;
+    public const ACCESS_TYPE = 1;
+    public const ACCESS_NAME = 2;
+    public const ACCESS_REF = 3;
+    public const ACCESS_ADDER = 4;
+    public const ACCESS_REMOVER = 5;
+    public const ACCESS_TYPE_METHOD = 0;
+    public const ACCESS_TYPE_PROPERTY = 1;
+    public const ACCESS_TYPE_MAGIC = 2;
+    public const ACCESS_TYPE_ADDER_AND_REMOVER = 3;
+    public const ACCESS_TYPE_NOT_FOUND = 4;
+    public const CACHE_PREFIX_READ = 'r';
+    public const CACHE_PREFIX_WRITE = 'w';
+
+    /**
+     * @var bool
+     */
+    private $magicCall;
+
+    private $readPropertyCache = array();
+    private $writePropertyCache = array();
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cacheItemPool;
+
+    public function __construct(bool $magicCall, CacheItemPoolInterface $cacheItemPool = null)
+    {
+        $this->magicCall = $magicCall;
+        $this->cacheItemPool = $cacheItemPool instanceof NullAdapter ? null : $cacheItemPool; // Replace the NullAdapter by the null value
+    }
+
+    /**
+     * Guesses how to write the property value.
+     *
+     * @param mixed $value
+     */
+    public function getWriteAccessInfo(string $class, string $property, $value): array
+    {
+        $key = str_replace('\\', '.', $class).'..'.$property;
+
+        if (isset($this->writePropertyCache[$key])) {
+            return $this->writePropertyCache[$key];
+        }
+
+        if ($this->cacheItemPool) {
+            $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_WRITE.rawurlencode($key));
+            if ($item->isHit()) {
+                return $this->writePropertyCache[$key] = $item->get();
+            }
+        }
+
+        $access = array();
+
+        $reflClass = new \ReflectionClass($class);
+        $access[self::ACCESS_HAS_PROPERTY] = $reflClass->hasProperty($property);
+        $camelized = $this->camelize($property);
+        $singulars = (array) Inflector::singularize($camelized);
+
+        if (!isset($access[self::ACCESS_TYPE])) {
+            $setter = 'set'.$camelized;
+            $getsetter = lcfirst($camelized); // jQuery style, e.g. read: last(), write: last($item)
+
+            if ($this->isMethodAccessible($reflClass, $setter, 1)) {
+                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
+                $access[self::ACCESS_NAME] = $setter;
+            } elseif ($this->isMethodAccessible($reflClass, $getsetter, 1)) {
+                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
+                $access[self::ACCESS_NAME] = $getsetter;
+            } elseif ($this->isMethodAccessible($reflClass, '__set', 2)) {
+                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
+                $access[self::ACCESS_NAME] = $property;
+            } elseif ($access[self::ACCESS_HAS_PROPERTY] && $reflClass->getProperty($property)->isPublic()) {
+                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
+                $access[self::ACCESS_NAME] = $property;
+            } elseif ($this->magicCall && $this->isMethodAccessible($reflClass, '__call', 2)) {
+                // we call the getter and hope the __call do the job
+                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
+                $access[self::ACCESS_NAME] = $setter;
+            } elseif (null !== $methods = $this->findAdderAndRemover($reflClass, $singulars)) {
+                if (\is_array($value) || $value instanceof \Traversable) {
+                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_ADDER_AND_REMOVER;
+                    $access[self::ACCESS_ADDER] = $methods[0];
+                    $access[self::ACCESS_REMOVER] = $methods[1];
+                } else {
+                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
+                    $access[self::ACCESS_NAME] = sprintf(
+                        'The property "%s" in class "%s" can be defined with the methods "%s()" but '.
+                        'the new value must be an array or an instance of \Traversable, '.
+                        '"%s" given.',
+                        $property,
+                        $reflClass->name,
+                        implode('()", "', $methods),
+                        \is_object($value) ? \get_class($value) : \gettype($value)
+                    );
+                }
+            } else {
+                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
+                $access[self::ACCESS_NAME] = sprintf(
+                    'Neither the property "%s" nor one of the methods %s"%s()", "%s()", '.
+                    '"__set()" or "__call()" exist and have public access in class "%s".',
+                    $property,
+                    implode('', array_map(function ($singular) {
+                        return '"add'.$singular.'()"/"remove'.$singular.'()", ';
+                    }, $singulars)),
+                    $setter,
+                    $getsetter,
+                    $reflClass->name
+                );
+            }
+        }
+
+        if (isset($item)) {
+            $this->cacheItemPool->save($item->set($access));
+        }
+
+        return $this->writePropertyCache[$key] = $access;
+    }
+
+    /**
+     * Guesses how to read the property value.
+     *
+     * @param string $class
+     * @param string $property
+     *
+     * @return array
+     */
+    public function getReadAccessInfo($class, $property)
+    {
+        $key = str_replace('\\', '.', $class).'..'.$property;
+
+        if (isset($this->readPropertyCache[$key])) {
+            return $this->readPropertyCache[$key];
+        }
+
+        if ($this->cacheItemPool) {
+            $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_READ.rawurlencode($key));
+            if ($item->isHit()) {
+                return $this->readPropertyCache[$key] = $item->get();
+            }
+        }
+
+        $access = array();
+
+        $reflClass = new \ReflectionClass($class);
+        $access[self::ACCESS_HAS_PROPERTY] = $reflClass->hasProperty($property);
+        $camelProp = $this->camelize($property);
+        $getter = 'get'.$camelProp;
+        $getsetter = lcfirst($camelProp); // jQuery style, e.g. read: last(), write: last($item)
+        $isser = 'is'.$camelProp;
+        $hasser = 'has'.$camelProp;
+
+        if ($reflClass->hasMethod($getter) && $reflClass->getMethod($getter)->isPublic()) {
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
+            $access[self::ACCESS_NAME] = $getter;
+        } elseif ($reflClass->hasMethod($getsetter) && $reflClass->getMethod($getsetter)->isPublic()) {
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
+            $access[self::ACCESS_NAME] = $getsetter;
+        } elseif ($reflClass->hasMethod($isser) && $reflClass->getMethod($isser)->isPublic()) {
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
+            $access[self::ACCESS_NAME] = $isser;
+        } elseif ($reflClass->hasMethod($hasser) && $reflClass->getMethod($hasser)->isPublic()) {
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
+            $access[self::ACCESS_NAME] = $hasser;
+        } elseif ($reflClass->hasMethod('__get') && $reflClass->getMethod('__get')->isPublic()) {
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
+            $access[self::ACCESS_NAME] = $property;
+            $access[self::ACCESS_REF] = false;
+        } elseif ($access[self::ACCESS_HAS_PROPERTY] && $reflClass->getProperty($property)->isPublic()) {
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
+            $access[self::ACCESS_NAME] = $property;
+            $access[self::ACCESS_REF] = true;
+        } elseif ($this->magicCall && $reflClass->hasMethod('__call') && $reflClass->getMethod('__call')->isPublic()) {
+            // we call the getter and hope the __call do the job
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
+            $access[self::ACCESS_NAME] = $getter;
+        } else {
+            $methods = array($getter, $getsetter, $isser, $hasser, '__get');
+            if ($this->magicCall) {
+                $methods[] = '__call';
+            }
+
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
+            $access[self::ACCESS_NAME] = sprintf(
+                'Neither the property "%s" nor one of the methods "%s()" '.
+                'exist and have public access in class "%s".',
+                $property,
+                implode('()", "', $methods),
+                $reflClass->name
+            );
+        }
+
+        if (isset($item)) {
+            $this->cacheItemPool->save($item->set($access));
+        }
+
+        return $this->readPropertyCache[$key] = $access;
+    }
+
+    /**
+     * Searches for add and remove methods.
+     *
+     * @param \ReflectionClass $reflClass The reflection class for the given object
+     * @param array            $singulars The singular form of the property name or null
+     *
+     * @return array|null An array containing the adder and remover when found, null otherwise
+     */
+    private function findAdderAndRemover(\ReflectionClass $reflClass, array $singulars)
+    {
+        foreach ($singulars as $singular) {
+            $addMethod = 'add'.$singular;
+            $removeMethod = 'remove'.$singular;
+
+            $addMethodFound = $this->isMethodAccessible($reflClass, $addMethod, 1);
+            $removeMethodFound = $this->isMethodAccessible($reflClass, $removeMethod, 1);
+
+            if ($addMethodFound && $removeMethodFound) {
+                return array($addMethod, $removeMethod);
+            }
+        }
+    }
+
+    /**
+     * Returns whether a method is public and has the number of required parameters.
+     */
+    private function isMethodAccessible(\ReflectionClass $class, string $methodName, int $parameters): bool
+    {
+        if ($class->hasMethod($methodName)) {
+            $method = $class->getMethod($methodName);
+
+            if ($method->isPublic()
+                && $method->getNumberOfRequiredParameters() <= $parameters
+                && $method->getNumberOfParameters() >= $parameters) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Camelizes a given string.
+     */
+    private function camelize(string $string): string
+    {
+        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -36,25 +36,8 @@ class PropertyAccessor implements PropertyAccessorInterface
     private const VALUE = 0;
     private const REF = 1;
     private const IS_REF_CHAINED = 2;
-    private const ACCESS_HAS_PROPERTY = 0;
-    private const ACCESS_TYPE = 1;
-    private const ACCESS_NAME = 2;
-    private const ACCESS_REF = 3;
-    private const ACCESS_ADDER = 4;
-    private const ACCESS_REMOVER = 5;
-    private const ACCESS_TYPE_METHOD = 0;
-    private const ACCESS_TYPE_PROPERTY = 1;
-    private const ACCESS_TYPE_MAGIC = 2;
-    private const ACCESS_TYPE_ADDER_AND_REMOVER = 3;
-    private const ACCESS_TYPE_NOT_FOUND = 4;
-    private const CACHE_PREFIX_READ = 'r';
-    private const CACHE_PREFIX_WRITE = 'w';
     private const CACHE_PREFIX_PROPERTY_PATH = 'p';
 
-    /**
-     * @var bool
-     */
-    private $magicCall;
     private $ignoreInvalidIndices;
 
     /**
@@ -62,19 +45,22 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private $cacheItemPool;
 
-    private $readPropertyCache = array();
-    private $writePropertyCache = array();
+    /**
+     * @var AccessInfoGuesser
+     */
+    private $accessInfoGuesser;
+
     private static $resultProto = array(self::VALUE => null);
 
     /**
      * Should not be used by application code. Use
      * {@link PropertyAccess::createPropertyAccessor()} instead.
      */
-    public function __construct(bool $magicCall = false, bool $throwExceptionOnInvalidIndex = false, CacheItemPoolInterface $cacheItemPool = null)
+    public function __construct(bool $magicCall = false, bool $throwExceptionOnInvalidIndex = false, CacheItemPoolInterface $cacheItemPool = null, AccessInfoGuesser $accessInfoGuesser = null)
     {
-        $this->magicCall = $magicCall;
         $this->ignoreInvalidIndices = !$throwExceptionOnInvalidIndex;
         $this->cacheItemPool = $cacheItemPool instanceof NullAdapter ? null : $cacheItemPool; // Replace the NullAdapter by the null value
+        $this->accessInfoGuesser = $accessInfoGuesser ?? new AccessInfoGuesser($magicCall, $cacheItemPool);
     }
 
     /**
@@ -366,19 +352,19 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         $result = self::$resultProto;
         $object = $zval[self::VALUE];
-        $access = $this->getReadAccessInfo(\get_class($object), $property);
+        $access = $this->accessInfoGuesser->getReadAccessInfo(\get_class($object), $property);
 
-        if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
-            $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]}();
-        } elseif (self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]) {
-            $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]};
+        if (AccessInfoGuesser::ACCESS_TYPE_METHOD === $access[AccessInfoGuesser::ACCESS_TYPE]) {
+            $result[self::VALUE] = $object->{$access[AccessInfoGuesser::ACCESS_NAME]}();
+        } elseif (AccessInfoGuesser::ACCESS_TYPE_PROPERTY === $access[AccessInfoGuesser::ACCESS_TYPE]) {
+            $result[self::VALUE] = $object->{$access[AccessInfoGuesser::ACCESS_NAME]};
 
-            if ($access[self::ACCESS_REF] && isset($zval[self::REF])) {
-                $result[self::REF] = &$object->{$access[self::ACCESS_NAME]};
+            if ($access[AccessInfoGuesser::ACCESS_REF] && isset($zval[self::REF])) {
+                $result[self::REF] = &$object->{$access[AccessInfoGuesser::ACCESS_NAME]};
             }
-        } elseif (!$access[self::ACCESS_HAS_PROPERTY] && property_exists($object, $property)) {
+        } elseif (!$access[AccessInfoGuesser::ACCESS_HAS_PROPERTY] && property_exists($object, $property)) {
             // Needed to support \stdClass instances. We need to explicitly
-            // exclude $access[self::ACCESS_HAS_PROPERTY], otherwise if
+            // exclude $access[AccessInfoGuesser::ACCESS_HAS_PROPERTY], otherwise if
             // a *protected* property was found on the class, property_exists()
             // returns true, consequently the following line will result in a
             // fatal error.
@@ -387,11 +373,11 @@ class PropertyAccessor implements PropertyAccessorInterface
             if (isset($zval[self::REF])) {
                 $result[self::REF] = &$object->$property;
             }
-        } elseif (self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE]) {
+        } elseif (AccessInfoGuesser::ACCESS_TYPE_MAGIC === $access[AccessInfoGuesser::ACCESS_TYPE]) {
             // we call the getter and hope the __call do the job
-            $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]}();
+            $result[self::VALUE] = $object->{$access[AccessInfoGuesser::ACCESS_NAME]}();
         } else {
-            throw new NoSuchPropertyException($access[self::ACCESS_NAME]);
+            throw new NoSuchPropertyException($access[AccessInfoGuesser::ACCESS_NAME]);
         }
 
         // Objects are always passed around by reference
@@ -400,86 +386,6 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         return $result;
-    }
-
-    /**
-     * Guesses how to read the property value.
-     *
-     * @param string $class
-     * @param string $property
-     *
-     * @return array
-     */
-    private function getReadAccessInfo($class, $property)
-    {
-        $key = str_replace('\\', '.', $class).'..'.$property;
-
-        if (isset($this->readPropertyCache[$key])) {
-            return $this->readPropertyCache[$key];
-        }
-
-        if ($this->cacheItemPool) {
-            $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_READ.rawurlencode($key));
-            if ($item->isHit()) {
-                return $this->readPropertyCache[$key] = $item->get();
-            }
-        }
-
-        $access = array();
-
-        $reflClass = new \ReflectionClass($class);
-        $access[self::ACCESS_HAS_PROPERTY] = $reflClass->hasProperty($property);
-        $camelProp = $this->camelize($property);
-        $getter = 'get'.$camelProp;
-        $getsetter = lcfirst($camelProp); // jQuery style, e.g. read: last(), write: last($item)
-        $isser = 'is'.$camelProp;
-        $hasser = 'has'.$camelProp;
-
-        if ($reflClass->hasMethod($getter) && $reflClass->getMethod($getter)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $getter;
-        } elseif ($reflClass->hasMethod($getsetter) && $reflClass->getMethod($getsetter)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $getsetter;
-        } elseif ($reflClass->hasMethod($isser) && $reflClass->getMethod($isser)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $isser;
-        } elseif ($reflClass->hasMethod($hasser) && $reflClass->getMethod($hasser)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $hasser;
-        } elseif ($reflClass->hasMethod('__get') && $reflClass->getMethod('__get')->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
-            $access[self::ACCESS_NAME] = $property;
-            $access[self::ACCESS_REF] = false;
-        } elseif ($access[self::ACCESS_HAS_PROPERTY] && $reflClass->getProperty($property)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
-            $access[self::ACCESS_NAME] = $property;
-            $access[self::ACCESS_REF] = true;
-        } elseif ($this->magicCall && $reflClass->hasMethod('__call') && $reflClass->getMethod('__call')->isPublic()) {
-            // we call the getter and hope the __call do the job
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
-            $access[self::ACCESS_NAME] = $getter;
-        } else {
-            $methods = array($getter, $getsetter, $isser, $hasser, '__get');
-            if ($this->magicCall) {
-                $methods[] = '__call';
-            }
-
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
-            $access[self::ACCESS_NAME] = sprintf(
-                'Neither the property "%s" nor one of the methods "%s()" '.
-                'exist and have public access in class "%s".',
-                $property,
-                implode('()", "', $methods),
-                $reflClass->name
-            );
-        }
-
-        if (isset($item)) {
-            $this->cacheItemPool->save($item->set($access));
-        }
-
-        return $this->readPropertyCache[$key] = $access;
     }
 
     /**
@@ -516,28 +422,28 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         $object = $zval[self::VALUE];
-        $access = $this->getWriteAccessInfo(\get_class($object), $property, $value);
+        $access = $this->accessInfoGuesser->getWriteAccessInfo(\get_class($object), $property, $value);
 
-        if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
-            $object->{$access[self::ACCESS_NAME]}($value);
-        } elseif (self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]) {
-            $object->{$access[self::ACCESS_NAME]} = $value;
-        } elseif (self::ACCESS_TYPE_ADDER_AND_REMOVER === $access[self::ACCESS_TYPE]) {
-            $this->writeCollection($zval, $property, $value, $access[self::ACCESS_ADDER], $access[self::ACCESS_REMOVER]);
-        } elseif (!$access[self::ACCESS_HAS_PROPERTY] && property_exists($object, $property)) {
+        if (AccessInfoGuesser::ACCESS_TYPE_METHOD === $access[AccessInfoGuesser::ACCESS_TYPE]) {
+            $object->{$access[AccessInfoGuesser::ACCESS_NAME]}($value);
+        } elseif (AccessInfoGuesser::ACCESS_TYPE_PROPERTY === $access[AccessInfoGuesser::ACCESS_TYPE]) {
+            $object->{$access[AccessInfoGuesser::ACCESS_NAME]} = $value;
+        } elseif (AccessInfoGuesser::ACCESS_TYPE_ADDER_AND_REMOVER === $access[AccessInfoGuesser::ACCESS_TYPE]) {
+            $this->writeCollection($zval, $property, $value, $access[AccessInfoGuesser::ACCESS_ADDER], $access[AccessInfoGuesser::ACCESS_REMOVER]);
+        } elseif (!$access[AccessInfoGuesser::ACCESS_HAS_PROPERTY] && property_exists($object, $property)) {
             // Needed to support \stdClass instances. We need to explicitly
-            // exclude $access[self::ACCESS_HAS_PROPERTY], otherwise if
+            // exclude $access[AccessInfoGuesser::ACCESS_HAS_PROPERTY], otherwise if
             // a *protected* property was found on the class, property_exists()
             // returns true, consequently the following line will result in a
             // fatal error.
 
             $object->$property = $value;
-        } elseif (self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE]) {
-            $object->{$access[self::ACCESS_NAME]}($value);
-        } elseif (self::ACCESS_TYPE_NOT_FOUND === $access[self::ACCESS_TYPE]) {
-            throw new NoSuchPropertyException(sprintf('Could not determine access type for property "%s" in class "%s"%s.', $property, \get_class($object), isset($access[self::ACCESS_NAME]) ? ': '.$access[self::ACCESS_NAME] : ''));
+        } elseif (AccessInfoGuesser::ACCESS_TYPE_MAGIC === $access[AccessInfoGuesser::ACCESS_TYPE]) {
+            $object->{$access[AccessInfoGuesser::ACCESS_NAME]}($value);
+        } elseif (AccessInfoGuesser::ACCESS_TYPE_NOT_FOUND === $access[AccessInfoGuesser::ACCESS_TYPE]) {
+            throw new NoSuchPropertyException(sprintf('Could not determine access type for property "%s" in class "%s"%s.', $property, \get_class($object), isset($access[AccessInfoGuesser::ACCESS_NAME]) ? ': '.$access[AccessInfoGuesser::ACCESS_NAME] : ''));
         } else {
-            throw new NoSuchPropertyException($access[self::ACCESS_NAME]);
+            throw new NoSuchPropertyException($access[AccessInfoGuesser::ACCESS_NAME]);
         }
     }
 
@@ -581,93 +487,6 @@ class PropertyAccessor implements PropertyAccessorInterface
     }
 
     /**
-     * Guesses how to write the property value.
-     *
-     * @param mixed $value
-     */
-    private function getWriteAccessInfo(string $class, string $property, $value): array
-    {
-        $key = str_replace('\\', '.', $class).'..'.$property;
-
-        if (isset($this->writePropertyCache[$key])) {
-            return $this->writePropertyCache[$key];
-        }
-
-        if ($this->cacheItemPool) {
-            $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_WRITE.rawurlencode($key));
-            if ($item->isHit()) {
-                return $this->writePropertyCache[$key] = $item->get();
-            }
-        }
-
-        $access = array();
-
-        $reflClass = new \ReflectionClass($class);
-        $access[self::ACCESS_HAS_PROPERTY] = $reflClass->hasProperty($property);
-        $camelized = $this->camelize($property);
-        $singulars = (array) Inflector::singularize($camelized);
-
-        if (!isset($access[self::ACCESS_TYPE])) {
-            $setter = 'set'.$camelized;
-            $getsetter = lcfirst($camelized); // jQuery style, e.g. read: last(), write: last($item)
-
-            if ($this->isMethodAccessible($reflClass, $setter, 1)) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-                $access[self::ACCESS_NAME] = $setter;
-            } elseif ($this->isMethodAccessible($reflClass, $getsetter, 1)) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-                $access[self::ACCESS_NAME] = $getsetter;
-            } elseif ($this->isMethodAccessible($reflClass, '__set', 2)) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
-                $access[self::ACCESS_NAME] = $property;
-            } elseif ($access[self::ACCESS_HAS_PROPERTY] && $reflClass->getProperty($property)->isPublic()) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
-                $access[self::ACCESS_NAME] = $property;
-            } elseif ($this->magicCall && $this->isMethodAccessible($reflClass, '__call', 2)) {
-                // we call the getter and hope the __call do the job
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
-                $access[self::ACCESS_NAME] = $setter;
-            } elseif (null !== $methods = $this->findAdderAndRemover($reflClass, $singulars)) {
-                if (\is_array($value) || $value instanceof \Traversable) {
-                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_ADDER_AND_REMOVER;
-                    $access[self::ACCESS_ADDER] = $methods[0];
-                    $access[self::ACCESS_REMOVER] = $methods[1];
-                } else {
-                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
-                    $access[self::ACCESS_NAME] = sprintf(
-                        'The property "%s" in class "%s" can be defined with the methods "%s()" but '.
-                        'the new value must be an array or an instance of \Traversable, '.
-                        '"%s" given.',
-                        $property,
-                        $reflClass->name,
-                        implode('()", "', $methods),
-                        \is_object($value) ? \get_class($value) : \gettype($value)
-                    );
-                }
-            } else {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
-                $access[self::ACCESS_NAME] = sprintf(
-                    'Neither the property "%s" nor one of the methods %s"%s()", "%s()", '.
-                    '"__set()" or "__call()" exist and have public access in class "%s".',
-                    $property,
-                    implode('', array_map(function ($singular) {
-                        return '"add'.$singular.'()"/"remove'.$singular.'()", ';
-                    }, $singulars)),
-                    $setter,
-                    $getsetter,
-                    $reflClass->name
-                );
-            }
-        }
-
-        if (isset($item)) {
-            $this->cacheItemPool->save($item->set($access));
-        }
-
-        return $this->writePropertyCache[$key] = $access;
-    }
-
-    /**
      * Returns whether a property is writable in the given object.
      *
      * @param object $object The object to write to
@@ -678,62 +497,13 @@ class PropertyAccessor implements PropertyAccessorInterface
             return false;
         }
 
-        $access = $this->getWriteAccessInfo(\get_class($object), $property, array());
+        $access = $this->accessInfoGuesser->getWriteAccessInfo(\get_class($object), $property, array());
 
-        return self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]
-            || self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]
-            || self::ACCESS_TYPE_ADDER_AND_REMOVER === $access[self::ACCESS_TYPE]
-            || (!$access[self::ACCESS_HAS_PROPERTY] && property_exists($object, $property))
-            || self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE];
-    }
-
-    /**
-     * Camelizes a given string.
-     */
-    private function camelize(string $string): string
-    {
-        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
-    }
-
-    /**
-     * Searches for add and remove methods.
-     *
-     * @param \ReflectionClass $reflClass The reflection class for the given object
-     * @param array            $singulars The singular form of the property name or null
-     *
-     * @return array|null An array containing the adder and remover when found, null otherwise
-     */
-    private function findAdderAndRemover(\ReflectionClass $reflClass, array $singulars)
-    {
-        foreach ($singulars as $singular) {
-            $addMethod = 'add'.$singular;
-            $removeMethod = 'remove'.$singular;
-
-            $addMethodFound = $this->isMethodAccessible($reflClass, $addMethod, 1);
-            $removeMethodFound = $this->isMethodAccessible($reflClass, $removeMethod, 1);
-
-            if ($addMethodFound && $removeMethodFound) {
-                return array($addMethod, $removeMethod);
-            }
-        }
-    }
-
-    /**
-     * Returns whether a method is public and has the number of required parameters.
-     */
-    private function isMethodAccessible(\ReflectionClass $class, string $methodName, int $parameters): bool
-    {
-        if ($class->hasMethod($methodName)) {
-            $method = $class->getMethod($methodName);
-
-            if ($method->isPublic()
-                && $method->getNumberOfRequiredParameters() <= $parameters
-                && $method->getNumberOfParameters() >= $parameters) {
-                return true;
-            }
-        }
-
-        return false;
+        return AccessInfoGuesser::ACCESS_TYPE_METHOD === $access[AccessInfoGuesser::ACCESS_TYPE]
+            || AccessInfoGuesser::ACCESS_TYPE_PROPERTY === $access[AccessInfoGuesser::ACCESS_TYPE]
+            || AccessInfoGuesser::ACCESS_TYPE_ADDER_AND_REMOVER === $access[AccessInfoGuesser::ACCESS_TYPE]
+            || (!$access[AccessInfoGuesser::ACCESS_HAS_PROPERTY] && property_exists($object, $property))
+            || AccessInfoGuesser::ACCESS_TYPE_MAGIC === $access[AccessInfoGuesser::ACCESS_TYPE];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ?
| License       | MIT
| Doc PR        | todo

This is an attempt to extract `PropertyAccessor::getReadAccessInfo` and `PropertyAccessor::getWriteAccessInfo` in a dedicated class.

This would allow:
- Leverage the PHP7 static array cache for a faster `PropertyAccessor` which will be faster than PSR-6 caching.
- Allow to configure how to read/write properties using metadata. This would solve issues like https://github.com/symfony/symfony/issues/9336.

WDYT?
