### PR TITLE
[Form] Handle all case variants of "nan" when parsing a number

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -146,7 +146,7 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
             return;
         }
 
-        if ('NaN' === $value) {
+        if (\in_array($value, array('NaN', 'NAN', 'nan'), true)) {
             throw new TransformationFailedException('"NaN" is not a valid number');
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -514,24 +514,24 @@ class NumberToLocalizedStringTransformerTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     * @dataProvider nanRepresentationProvider
      *
      * @see https://github.com/symfony/symfony/issues/3161
      */
-    public function testReverseTransformDisallowsNaN()
+    public function testReverseTransformDisallowsNaN($nan)
     {
         $transformer = new NumberToLocalizedStringTransformer();
 
-        $transformer->reverseTransform('NaN');
+        $transformer->reverseTransform($nan);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
-    public function testReverseTransformDisallowsNaN2()
+    public function nanRepresentationProvider()
     {
-        $transformer = new NumberToLocalizedStringTransformer();
-
-        $transformer->reverseTransform('nan');
+        return array(
+            array('nan'),
+            array('NaN'), // see https://github.com/symfony/symfony/issues/3161
+            array('NAN'),
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #29321 
| License       | MIT
| Doc PR        | n/a

NumberToLocalizedStringTransformer::reverseTransform now special cases all case variants of "NaN", not just "NaN" specifically to insulate itself from changing behaviour in ICU.