### PR TITLE
[Validator] Allow `ConstraintViolation::__toString()` to expose codes that are not null or emtpy strings

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -79,13 +79,13 @@ class ConstraintViolation implements ConstraintViolationInterface
         }
 
         $propertyPath = (string) $this->propertyPath;
-        $code = $this->code;
+        $code = (string) $this->code;
 
         if ('' !== $propertyPath && '[' !== $propertyPath[0] && '' !== $class) {
             $class .= '.';
         }
 
-        if (!empty($code)) {
+        if ('' !== $code) {
             $code = ' (code '.$code.')';
         }
 

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -53,4 +53,59 @@ EOF;
 
         $this->assertSame($expected, (string) $violation);
     }
+
+    public function testToStringHandlesCodes()
+    {
+        $violation = new ConstraintViolation(
+            '42 cannot be used here',
+            'this is the message template',
+            array(),
+            array('some_value' => 42),
+            'some_value',
+            null,
+            null,
+            0
+        );
+
+        $expected = <<<'EOF'
+Array.some_value:
+    42 cannot be used here (code 0)
+EOF;
+
+        $this->assertSame($expected, (string) $violation);
+    }
+
+    public function testToStringOmitsEmptyCodes()
+    {
+        $expected = <<<'EOF'
+Array.some_value:
+    42 cannot be used here
+EOF;
+
+        $violation = new ConstraintViolation(
+            '42 cannot be used here',
+            'this is the message template',
+            array(),
+            array('some_value' => 42),
+            'some_value',
+            null,
+            null,
+            null
+        );
+
+        $this->assertSame($expected, (string) $violation);
+
+        $violation = new ConstraintViolation(
+            '42 cannot be used here',
+            'this is the message template',
+            array(),
+            array('some_value' => 42),
+            'some_value',
+            null,
+            null,
+            ''
+        );
+
+        $this->assertSame($expected, (string) $violation);
+    }
 }


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Branch       |2.8|
|Bug fix?     |yes|
|New feature? |no |
|BC breaks?   |no |
|Deprecations?|no |
|Tests pass?  |yes|
|Fixed tickets|n/a|
|License      |MIT|
|Doc PR       |n/a|
                   

Allow to expose `0` or `"0"` validation codes.