### PR TITLE
[EventDispatcher] Fix eventListener wrapper loop in TraceableEventDispatcher

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -132,18 +132,23 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         }
 
         $this->preProcess($eventName);
-        $this->preDispatch($eventName, $event);
-
-        $e = $this->stopwatch->start($eventName, 'section');
-
-        $this->dispatcher->dispatch($eventName, $event);
-
-        if ($e->isStarted()) {
-            $e->stop();
+        try {
+            $this->preDispatch($eventName, $event);
+            try {
+                $e = $this->stopwatch->start($eventName, 'section');
+                try {
+                    $this->dispatcher->dispatch($eventName, $event);
+                } finally {
+                    if ($e->isStarted()) {
+                        $e->stop();
+                    }
+                }
+            } finally {
+                $this->postDispatch($eventName, $event);
+            }
+        } finally {
+            $this->postProcess($eventName);
         }
-
-        $this->postDispatch($eventName, $event);
-        $this->postProcess($eventName);
 
         return $event;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | na

The `TracableEventDispatcher` wrap decorate (in the method `preProcess`) each listeners in a `WrappedListener` before delegating the dispatch to the real dispatcher, then remove the wrapper (in the method `postProcess`.

But, if a listener triggers an exception, the `postProcess` method is not called, and the wrapper in not removed.
If the same event is triggered a second time, the listeners will be decorated twice, etc, etc..
This is an issue with php-pm where the same event is triggered hundred of times within the same process.

This PR moves the `postProcess` in a finally block in order to be called even if an exception in thrown.