### PR TITLE
[HttpKernel] Add a method to report an exception without throwing it

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,9 +6,10 @@ CHANGELOG
 
  * deprecated `KernelInterface::getRootDir()` and the `kernel.root_dir` parameter
  * deprecated `KernelInterface::getName()` and the `kernel.name` parameter
- * deprecated the first and second constructor argument of `ConfigDataCollector` 
- * deprecated `ConfigDataCollector::getApplicationName()` 
+ * deprecated the first and second constructor argument of `ConfigDataCollector`
+ * deprecated `ConfigDataCollector::getApplicationName()`
  * deprecated `ConfigDataCollector::getApplicationVersion()`
+ * added the `HttpKernel::reportException()` method
 
 4.1.0
 -----

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -222,6 +222,22 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     }
 
     /**
+     * Reports an exception to the exception listeners.
+     *
+     * @param \Exception $e An \Exception instance
+     */
+    public function reportException(\Exception $e)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $type = $this->requestStack->getParentRequest()
+            ? HttpKernelInterface::SUB_REQUEST
+            : HttpKernelInterface::MASTER_REQUEST;
+
+        $event = new GetResponseForExceptionEvent($this, $request, $type, $e);
+        $this->dispatcher->dispatch(KernelEvents::EXCEPTION, $event);
+    }
+
+    /**
      * Handles an exception by trying to convert it to a Response.
      *
      * @param \Exception $e       An \Exception instance

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -139,6 +139,26 @@ class HttpKernelTest extends TestCase
         $this->assertEquals($expectedStatusCode, $response->getStatusCode());
     }
 
+    public function testReportException()
+    {
+        $exceptionHasBeenReported = false;
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::EXCEPTION, function ($event) use (&$exceptionHasBeenReported) {
+            $exceptionHasBeenReported = true;
+            $event->setResponse(new Response());
+        });
+
+        $kernel = $this->getHttpKernel($dispatcher, function () use (&$kernel) {
+            $kernel->reportException(new \Exception());
+            return new Response();
+        });
+
+        $kernel->handle(new Request());
+
+        $this->assertTrue($exceptionHasBeenReported);
+    }
+
     public function getSpecificStatusCodes()
     {
         return array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | _to do_

Sometimes you may need to report an exception but continue handling the current request. The `reportException` method allows you to dispatch an exception to all the listeners without throwing it:

```php
class DefaultController extends AbstractController
{
    public function index(HttpKernelInterface $httpKernel) {
        // Make some work...

        try {
            // Here you run an instruction which you know can fail
        } catch (\Exception $e) {
            // The instruction failed, this is not normal but you don't need it to
            // finish the request, so you only report the exception:
            $httpKernel->reportException($e);
        }

        // Finish your work and return a response in all cases
    }
}
```

That way, all the listeners will handle the exception: the logger, the profiler, some services like Sentry or Bugsnag, etc…

**Note:** Before writing the documentation, I would like some feedback on this feature.