### PR TITLE
[FrameworkBundle][Cache] Do not process cache aliases that are not present in the container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1635,7 +1635,10 @@ class FrameworkExtension extends Extension
         }
         foreach (array('doctrine', 'psr6', 'redis', 'memcached', 'pdo') as $name) {
             if (isset($config[$name = 'default_'.$name.'_provider'])) {
-                $container->setAlias('cache.'.$name, new Alias(CachePoolPass::getServiceProvider($container, $config[$name]), false));
+                if (!$container->hasDefinition($alias = CachePoolPass::getServiceProvider($container, $config[$name]))) {
+                    continue;
+                }
+                $container->setAlias('cache.'.$name, new Alias($alias, false));
             }
         }
         foreach (array('app', 'system') as $name) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

https://github.com/symfony/symfony/commit/148411743085b808af9582f64d83565b38760bbf

Introduced a major problem when framework-bundle is used WITHOUT doctrine.
On kernel compilation this results in ServiceNotFoundException: You have requested a non-existent service "doctrine.dbal.default_connection".
This is due to the fact there is no check whether such definition is present in the container
Since there is no clear view as how to handle such a situation (remove default value from configuration or ignore those that are not present) I chose the latter.
