### PR TITLE
undeprecate the single-colon notation for controllers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -95,7 +95,7 @@ class DelegatingLoader extends BaseDelegatingLoader
 
             if (1 === substr_count($controller, ':')) {
                 $nonDeprecatedNotation = str_replace(':', '::', $controller);
-                @trigger_error(sprintf('Referencing controllers with a single colon is deprecated since Symfony 4.1, use "%s" instead.', $nonDeprecatedNotation), E_USER_DEPRECATED);
+                // TODO deprecate this in 5.1
             }
 
             $route->setDefault('_controller', $controller);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/DelegatingLoaderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/DelegatingLoaderTest.php
@@ -25,7 +25,6 @@ class DelegatingLoaderTest extends TestCase
     /**
      * @group legacy
      * @expectedDeprecation Referencing controllers with foo:bar:baz is deprecated since Symfony 4.1, use "some_parsed::controller" instead.
-     * @expectedDeprecation Referencing controllers with a single colon is deprecated since Symfony 4.1, use "foo::baz" instead.
      */
     public function testLoad()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This is the same as https://github.com/symfony/symfony/pull/29218 but for `Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader`.
