### PR TITLE
[Validator] Dump `ConstraintViolation::$invalidValue` at `ConstraintViolation::__toString()`

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -174,7 +174,7 @@ HttpKernel
  * The `Kernel::getRootDir()` and the `kernel.root_dir` parameter have been removed
  * The `KernelInterface::getName()` and the `kernel.name` parameter have been removed
  * Removed the first and second constructor argument of `ConfigDataCollector`
- * Removed `ConfigDataCollector::getApplicationName()` 
+ * Removed `ConfigDataCollector::getApplicationName()`
  * Removed `ConfigDataCollector::getApplicationVersion()`
 
 Monolog
@@ -265,6 +265,7 @@ Validator
  * The `symfony/intl` component is now required for using the `Bic`, `Country`, `Currency`, `Language` and `Locale` constraints
  * The `egulias/email-validator` component is now required for using the `Email` constraint in strict mode
  * The `symfony/expression-language` component is now required for using the `Expression` constraint
+ * `ConstraintViolation::__toString()` now includes a string representation for the invalid value
 
 Workflow
 --------

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -85,11 +85,25 @@ class ConstraintViolation implements ConstraintViolationInterface
             $class .= '.';
         }
 
+        $context = '';
         if ('' !== $code) {
-            $code = ' (code '.$code.')';
+            $context .= 'code '.$this->code.', ';
+        }
+        $context .= 'invalid value ';
+        if (\is_object($this->invalidValue)) {
+            $invalidObjectClass = \get_class($this->invalidValue);
+            $context .= 'c' === $invalidObjectClass[0] && 0 === strpos($invalidObjectClass, "class@anonymous\0") ? get_parent_class($invalidObjectClass).'@anonymous' : $invalidObjectClass;
+        } elseif (\is_array($this->invalidValue)) {
+            $context .= 'array';
+        } elseif (\is_resource($this->invalidValue)) {
+            $context .= \get_resource_type($this->invalidValue);
+        } elseif (null === $this->invalidValue || \is_bool($this->invalidValue)) {
+            $context .= var_export($this->invalidValue, true);
+        } else {
+            $context .= (string) $this->invalidValue;
         }
 
-        return $class.$propertyPath.":\n    ".$this->getMessage().$code;
+        return $class.$propertyPath.":\n    ".$this->getMessage().' ('.$context.')';
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -113,15 +113,15 @@ class ConstraintViolationListTest extends TestCase
 
         $expected = <<<'EOF'
 Root:
-    Error 1
+    Error 1 (invalid value NULL)
 Root.foo.bar:
-    Error 2
+    Error 2 (invalid value NULL)
 Root[baz]:
-    Error 3
+    Error 3 (invalid value NULL)
 foo.bar:
-    Error 4
+    Error 4 (invalid value NULL)
 [baz]:
-    Error 5
+    Error 5 (invalid value NULL)
 
 EOF;
 

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -29,7 +29,7 @@ class ConstraintViolationTest extends TestCase
 
         $expected = <<<'EOF'
 Root.property.path:
-    Array
+    Array (invalid value NULL)
 EOF;
 
         $this->assertSame($expected, (string) $violation);
@@ -48,7 +48,7 @@ EOF;
 
         $expected = <<<'EOF'
 Array.some_value:
-    42 cannot be used here
+    42 cannot be used here (invalid value NULL)
 EOF;
 
         $this->assertSame($expected, (string) $violation);
@@ -69,7 +69,7 @@ EOF;
 
         $expected = <<<'EOF'
 Array.some_value:
-    42 cannot be used here (code 0)
+    42 cannot be used here (code 0, invalid value NULL)
 EOF;
 
         $this->assertSame($expected, (string) $violation);
@@ -79,7 +79,7 @@ EOF;
     {
         $expected = <<<'EOF'
 Array.some_value:
-    42 cannot be used here
+    42 cannot be used here (invalid value NULL)
 EOF;
 
         $violation = new ConstraintViolation(
@@ -107,5 +107,46 @@ EOF;
         );
 
         $this->assertSame($expected, (string) $violation);
+    }
+
+    /**
+     * @dataProvider getInvalidValues
+     */
+    public function testInvalidValuesToString($invalidValue, $invalidValueAsString)
+    {
+        $violation = new ConstraintViolation(
+            '42 cannot be used here',
+            'this is the message template',
+            array(),
+            array('some_value' => 42),
+            'some_value',
+            $invalidValue
+        );
+
+        $expected = <<<'EOF'
+Array.some_value:
+    42 cannot be used here (invalid value %s)
+EOF;
+        $expected = sprintf($expected, $invalidValueAsString);
+
+        $this->assertSame($expected, (string) $violation);
+    }
+
+    public function getInvalidValues(): iterable
+    {
+        return array(
+            array(null, 'NULL'),
+            array(true, 'true'),
+            array(false, 'false'),
+            array('', ''),
+            array(' ', ' '),
+            array(0, '0'),
+            array('0', '0'),
+            array(array(), 'array'),
+            array(new \stdClass(), 'stdClass'),
+            array(new class() {
+            }, '@anonymous'),
+            array(tmpfile(), 'stream'),
+        );
     }
 }


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |yes    |
|BC breaks?   |no   |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |