### PR TITLE
[FrameworkBundle][Messenger] Restore check for messenger serializer default id

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1059,7 +1059,7 @@ class Configuration implements ConfigurationInterface
                                 })
                             ->end()
                             ->children()
-                                ->scalarNode('id')->defaultValue('messenger.transport.symfony_serializer')->end()
+                                ->scalarNode('id')->defaultValue(!class_exists(FullStack::class) && class_exists(Serializer::class) ? 'messenger.transport.symfony_serializer' : null)->end()
                                 ->scalarNode('format')->defaultValue('json')->end()
                                 ->arrayNode('context')
                                     ->normalizeKeys(false)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Serializer\Serializer;
 
 class ConfigurationTest extends TestCase
 {
@@ -293,7 +294,7 @@ class ConfigurationTest extends TestCase
                 'routing' => array(),
                 'transports' => array(),
                 'serializer' => array(
-                    'id' => 'messenger.transport.symfony_serializer',
+                    'id' => !class_exists(FullStack::class) && class_exists(Serializer::class) ? 'messenger.transport.symfony_serializer' : null,
                     'format' => 'json',
                     'context' => array(),
                 ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
@@ -3,6 +3,7 @@
 $container->loadFromExtension('framework', array(
     'serializer' => true,
     'messenger' => array(
+        'serializer' => 'messenger.transport.symfony_serializer',
         'routing' => array(
             'Symfony\Component\Messenger\Tests\Fixtures\DummyMessage' => array('amqp', 'audit'),
             'Symfony\Component\Messenger\Tests\Fixtures\SecondMessage' => array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport.php
@@ -4,6 +4,7 @@ $container->loadFromExtension('framework', array(
     'serializer' => true,
     'messenger' => array(
         'serializer' => array(
+            'id' => 'messenger.transport.symfony_serializer',
             'format' => 'csv',
             'context' => array('enable_max_depth' => true),
         ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport_no_serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport_no_serializer.php
@@ -5,6 +5,7 @@ $container->loadFromExtension('framework', array(
         'enabled' => false,
     ),
     'messenger' => array(
+        'serializer' => 'messenger.transport.symfony_serializer',
         'transports' => array(
             'default' => 'amqp://localhost/%2f/messages',
         ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
@@ -3,6 +3,7 @@
 $container->loadFromExtension('framework', array(
     'serializer' => true,
     'messenger' => array(
+        'serializer' => 'serializer: messenger.transport.symfony_serializer',
         'transports' => array(
             'default' => 'amqp://localhost/%2f/messages',
             'customised' => array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
@@ -8,6 +8,7 @@
     <framework:config>
         <framework:serializer enabled="true" />
         <framework:messenger>
+            <framework:serializer id="messenger.transport.symfony_serializer" />
             <framework:routing message-class="Symfony\Component\Messenger\Tests\Fixtures\DummyMessage">
                 <framework:sender service="amqp" />
                 <framework:sender service="audit" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport.xml
@@ -8,7 +8,7 @@
     <framework:config>
         <framework:serializer enabled="true" />
         <framework:messenger>
-            <framework:serializer format="csv">
+            <framework:serializer id="messenger.transport.symfony_serializer" format="csv">
                 <framework:context>
                     <framework:enable_max_depth>true</framework:enable_max_depth>
                 </framework:context>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport_no_serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport_no_serializer.xml
@@ -8,6 +8,7 @@
     <framework:config>
         <framework:serializer enabled="false" />
         <framework:messenger>
+            <framework:serializer id="messenger.transport.symfony_serializer" />
             <framework:transport name="default" dsn="amqp://localhost/%2f/messages" />
         </framework:messenger>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
@@ -8,6 +8,7 @@
     <framework:config>
         <framework:serializer enabled="true" />
         <framework:messenger>
+            <framework:serializer id="messenger.transport.symfony_serializer" />
             <framework:transport name="default" dsn="amqp://localhost/%2f/messages" />
             <framework:transport name="customised" dsn="amqp://localhost/%2f/messages?exchange_name=exchange_name">
                 <framework:options>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
@@ -1,6 +1,7 @@
 framework:
     serializer: true
     messenger:
+        serializer: messenger.transport.symfony_serializer
         routing:
             'Symfony\Component\Messenger\Tests\Fixtures\DummyMessage': [amqp, audit]
             'Symfony\Component\Messenger\Tests\Fixtures\SecondMessage':

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport.yml
@@ -2,6 +2,7 @@ framework:
     serializer: true
     messenger:
         serializer:
+            id: messenger.transport.symfony_serializer
             format: csv
             context:
                 enable_max_depth: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport_no_serializer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport_no_serializer.yml
@@ -2,5 +2,6 @@ framework:
     serializer:
         enabled: false
     messenger:
+        serializer: messenger.transport.symfony_serializer
         transports:
             default: 'amqp://localhost/%2f/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
@@ -1,6 +1,7 @@
 framework:
     serializer: true
     messenger:
+        serializer: messenger.transport.symfony_serializer
         transports:
             default: 'amqp://localhost/%2f/messages'
             customised:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |  https://symfony-devs.slack.com/archives/C9PQ75TV3/p1543590611003500  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

From Slack:

> @adamquaile [4:10 PM]
> So, I just updated to 4.2 today, and got this message:
> > The default Messenger serializer cannot be enabled as the Serializer support is not available. Try enabling it or running "composer require symfony/serializer-pack"
> 
> In the docs it's stated:
> > In order to use Symfony's built-in AMQP transport, you will need the Serializer Component. Ensure that it is installed with:
>
>But I haven't yet configured AMQP - I'm using my own transport. Should I be getting this exception?

---
This check was removed in https://github.com/symfony/symfony/pull/28405, but is actually still necessary to not fail as soon as you can install the Messenger component without the Serializer one installed.