### PR TITLE
[FrameworkBundle][Controller] Use interface from Contracts to remove deprecation arnings

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -15,7 +15,6 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
-use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -27,6 +26,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Templating\EngineInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Twig\Environment;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2?
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | I don't think so     <!-- see https://symfony.com/bc -->
| Deprecations? | no - removing some :) <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a

When we installed 4.2, we hit issues in our qa tools with [vimeo/psalm](https://github.com/vimeo/psalm) reporting that all of our controllers were implementing a deprecated interface (by extending the AbstractController).

This pr simply updates the AbstractController to use the interface provided in `symfony/contracts`

I'm not sure if there was any other reason for not including this in the 4.2 release (bc?), so apologies if I've overstepped this.