### PR TITLE
Speed up ObjectNormalizer by introducing ObjectPropertyAccessorInterface

### DIFF
--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added `ObjectPropertyAccessorInterface` to read and write object properties.
+ * `PropertyAccessor` now implements the `ObjectPropertyAccessorInterface` interface.
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/PropertyAccess/ObjectPropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/ObjectPropertyAccessorInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess;
+
+/**
+ * Writes and reads values to/from an object.
+ *
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ */
+interface ObjectPropertyAccessorInterface
+{
+    /**
+     * Returns the object property value.
+     *
+     * @param object $object   The object to get the value from
+     * @param string $property The property to get the value from
+     *
+     * @return mixed The object property value
+     *
+     * @throws Exception\AccessException If the property does not exist
+     */
+    public function getPropertyValue($object, string $property);
+
+    /**
+     * Sets the object property value.
+     *
+     * @param object $object   The object to modify
+     * @param string $property The property to modify
+     * @param mixed  $value    The value to set in the object property
+     *
+     * @throws Exception\InvalidArgumentException If the value is incompatible with property type
+     * @throws Exception\AccessException          If the property does not exist
+     */
+    public function setPropertyValue($object, string $property, $value);
+}

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -31,7 +31,7 @@ use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class PropertyAccessor implements PropertyAccessorInterface
+class PropertyAccessor implements PropertyAccessorInterface, ObjectPropertyAccessorInterface
 {
     private const VALUE = 0;
     private const REF = 1;
@@ -815,5 +815,36 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         return $apcu;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPropertyValue($object, string $property)
+    {
+        $zval = array(
+            self::VALUE => $object,
+        );
+
+        return $this->readProperty($zval, $property)[self::VALUE];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPropertyValue($object, string $property, $value)
+    {
+        $zval = array(
+            self::VALUE => $object,
+        );
+
+        try {
+            $this->writeProperty($zval, $property, $value);
+        } catch (\TypeError $e) {
+            self::throwInvalidArgumentException($e->getMessage(), $e->getTrace(), 0, $property);
+
+            // It wasn't thrown in this class so rethrow it
+            throw $e;
+        }
     }
 }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -822,9 +822,9 @@ class PropertyAccessor implements PropertyAccessorInterface, ObjectPropertyAcces
      */
     public function getPropertyValue($object, string $property)
     {
-        $zval = array(
+        $zval = [
             self::VALUE => $object,
-        );
+        ];
 
         return $this->readProperty($zval, $property)[self::VALUE];
     }
@@ -834,9 +834,9 @@ class PropertyAccessor implements PropertyAccessorInterface, ObjectPropertyAcces
      */
     public function setPropertyValue($object, string $property, $value)
     {
-        $zval = array(
+        $zval = [
             self::VALUE => $object,
-        );
+        ];
 
         try {
             $this->writeProperty($zval, $property, $value);

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -85,6 +85,7 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getValidPropertyPaths
+     * @dataProvider getValidObjectProperty
      */
     public function testGetValue($objectOrArray, $path, $value)
     {
@@ -204,6 +205,7 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getValidPropertyPaths
+     * @dataProvider getValidObjectProperty
      */
     public function testSetValue($objectOrArray, $path)
     {
@@ -310,6 +312,7 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getValidPropertyPaths
+     * @dataProvider getValidObjectProperty
      */
     public function testIsReadable($objectOrArray, $path)
     {
@@ -371,6 +374,7 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getValidPropertyPaths
+     * @dataProvider getValidObjectProperty
      */
     public function testIsWritable($objectOrArray, $path)
     {
@@ -430,6 +434,42 @@ class PropertyAccessorTest extends TestCase
         $this->assertFalse($this->propertyAccessor->isWritable($objectOrArray, $path));
     }
 
+    /**
+     * @dataProvider getValidObjectProperty
+     */
+    public function testGetPropertyValue($object, $property, $value)
+    {
+        $this->assertSame($value, $this->propertyAccessor->getPropertyValue($object, $property));
+    }
+
+    /**
+     * @dataProvider getPathsWithMissingProperty
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     */
+    public function testGetPropertyValueThrowsExceptionIfPropertyNotFound($object, $property)
+    {
+        $this->propertyAccessor->getPropertyValue($object, $property);
+    }
+
+    /**
+     * @dataProvider getValidObjectProperty
+     */
+    public function testSetPropertyValue($object, $property)
+    {
+        $this->propertyAccessor->setPropertyValue($object, $property, 'Updated');
+
+        $this->assertSame('Updated', $this->propertyAccessor->getPropertyValue($object, $property));
+    }
+
+    /**
+     * @dataProvider getPathsWithMissingProperty
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     */
+    public function testSetPropertyValueThrowsExceptionIfPropertyNotFound($object, $property)
+    {
+        $this->propertyAccessor->setPropertyValue($object, $property, 'Updated');
+    }
+
     public function getValidPropertyPaths()
     {
         return [
@@ -441,19 +481,6 @@ class PropertyAccessorTest extends TestCase
             [(object) ['property' => ['firstName' => 'Bernhard']], 'property[firstName]', 'Bernhard'],
             [['index' => (object) ['firstName' => 'Bernhard']], '[index].firstName', 'Bernhard'],
             [(object) ['property' => (object) ['firstName' => 'Bernhard']], 'property.firstName', 'Bernhard'],
-
-            // Accessor methods
-            [new TestClass('Bernhard'), 'publicProperty', 'Bernhard'],
-            [new TestClass('Bernhard'), 'publicAccessor', 'Bernhard'],
-            [new TestClass('Bernhard'), 'publicAccessorWithDefaultValue', 'Bernhard'],
-            [new TestClass('Bernhard'), 'publicAccessorWithRequiredAndDefaultValue', 'Bernhard'],
-            [new TestClass('Bernhard'), 'publicIsAccessor', 'Bernhard'],
-            [new TestClass('Bernhard'), 'publicHasAccessor', 'Bernhard'],
-            [new TestClass('Bernhard'), 'publicGetSetter', 'Bernhard'],
-
-            // Methods are camelized
-            [new TestClass('Bernhard'), 'public_accessor', 'Bernhard'],
-            [new TestClass('Bernhard'), '_public_accessor', 'Bernhard'],
 
             // Missing indices
             [['index' => []], '[index][firstName]', null],
@@ -472,6 +499,24 @@ class PropertyAccessorTest extends TestCase
             [new TestClass(['foo' => new TestClass('bar')]), 'publicGetter[foo].publicGetSetter', 'bar'],
             [new TestClass(new TestClass(new TestClass('bar'))), 'publicGetter.publicGetter.publicGetSetter', 'bar'],
             [new TestClass(['foo' => ['baz' => new TestClass('bar')]]), 'publicGetter[foo][baz].publicGetSetter', 'bar'],
+        ];
+    }
+
+    public function getValidObjectProperty()
+    {
+        return [
+            // Accessor methods
+            [new TestClass('Bernhard'), 'publicProperty', 'Bernhard'],
+            [new TestClass('Bernhard'), 'publicAccessor', 'Bernhard'],
+            [new TestClass('Bernhard'), 'publicAccessorWithDefaultValue', 'Bernhard'],
+            [new TestClass('Bernhard'), 'publicAccessorWithRequiredAndDefaultValue', 'Bernhard'],
+            [new TestClass('Bernhard'), 'publicIsAccessor', 'Bernhard'],
+            [new TestClass('Bernhard'), 'publicHasAccessor', 'Bernhard'],
+            [new TestClass('Bernhard'), 'publicGetSetter', 'Bernhard'],
+
+            // Methods are camelized
+            [new TestClass('Bernhard'), 'public_accessor', 'Bernhard'],
+            [new TestClass('Bernhard'), '_public_accessor', 'Bernhard'],
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -43,11 +43,11 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         parent::__construct($classMetadataFactory, $nameConverter, $propertyTypeExtractor, $classDiscriminatorResolver, $objectClassResolver, $defaultContext);
 
         if (null !== $propertyAccessor && !$propertyAccessor instanceof ObjectPropertyAccessorInterface && !$propertyAccessor instanceof PropertyAccessorInterface) {
-            throw new InvalidArgumentException(sprintf('Argument 3 passed to %s() must be an instance of %s or an instance of %s or null, %s given.', __METHOD__, ObjectPropertyAccessorInterface::class, PropertyAccessorInterface::class, \gettype($propertyAccessor)));
+            throw new InvalidArgumentException(sprintf('Argument 3 passed to "%s()" must be an instance of "%s" or an instance of "%s" or null, "%s" given.', __METHOD__, ObjectPropertyAccessorInterface::class, PropertyAccessorInterface::class, \gettype($propertyAccessor)));
         }
 
         if (null !== $propertyAccessor && !$propertyAccessor instanceof ObjectPropertyAccessorInterface) {
-            @trigger_error(sprintf('Passing an instance of %s as the 3rd argument to "%s()" is deprecated since Symfony 4.3. Pass a %s instance instead.', PropertyAccessorInterface::class, __METHOD__, ObjectPropertyAccessorInterface::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Passing an instance of "%s" as the 3rd argument to "%s()" is deprecated since Symfony 4.3. Pass a "%s" instance instead.', PropertyAccessorInterface::class, __METHOD__, ObjectPropertyAccessorInterface::class), E_USER_DEPRECATED);
         }
 
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #28926
| License       | MIT
| Doc PR        | To do

The main goal of this PR is to speed up the `ObjectNormalizer`. It's a simpler implementation of #28926 which does not change any `PropertyAccessor` internals.

The performance boost depends on the size of the graph. The larger the graph is, bigger the performance boost is.

Here is some bench created using https://github.com/php-serializers/ivory-serializer-benchmark. The numbers in parenthesis are the horizontal and vertical complexity used when profiling.
- [Small graph (1,1)](https://blackfire.io/profiles/compare/06a2e9df-51aa-4aa4-869e-d6cc0c9942a0/graph)
- [Larger graph (24,24)](https://blackfire.io/profiles/compare/a6f3e8da-5793-432e-ba45-bbd57a178cc9/graph)

# To do
- [x] `PropertyAccessor::getPropertyValue` tests.
- [x] `PropertyAccessor::setPropertyValue` tests.
- [ ] `UPGRADE-4.3.md`.
- [ ] `UPGRADE-5.0.md`.
- [x] `src/Component/PropertyAccess/CHANGELOG.md`.
- [ ] `src/Component/Serializer/CHANGELOG.md`.
- [ ] Documentation.
