### PR TITLE
[Security] getTargetPath of TargetPathTrait must return string or null

### DIFF
--- a/src/Symfony/Component/Security/Http/Util/TargetPathTrait.php
+++ b/src/Symfony/Component/Security/Http/Util/TargetPathTrait.php
@@ -38,7 +38,7 @@ trait TargetPathTrait
      * @param SessionInterface $session
      * @param string           $providerKey The name of your firewall
      *
-     * @return string
+     * @return string|null
      */
     private function getTargetPath(SessionInterface $session, $providerKey)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes (possible bug)
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes 
| License       | MIT

Since the return type is string the default return value must be also string.
