### PR TITLE
[Serializer] fixed DateTimeNormalizer to maintain microseconds when a different timezone required

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -59,7 +59,8 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         $timezone = $this->getTimezone($context);
 
         if (null !== $timezone) {
-            $object = (new \DateTimeImmutable('@'.$object->getTimestamp()))->setTimezone($timezone);
+            $object = clone $object;
+            $object = $object->setTimezone($timezone);
         }
 
         return $object->format($format);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -79,6 +79,82 @@ class DateTimeNormalizerTest extends TestCase
     }
 
     /**
+     * @dataProvider normalizeUsingTimeZonePassedInContextAndExpectedFormatWithMicrosecondsProvider
+     */
+    public function testNormalizeUsingTimeZonePassedInContextAndFormattedWithMicroseconds($expected, $expectedFormat, $input, $timezone)
+    {
+        $this->assertSame(
+            $expected,
+            $this->normalizer->normalize(
+                $input,
+                null,
+                array(
+                    DateTimeNormalizer::TIMEZONE_KEY => $timezone,
+                    DateTimeNormalizer::FORMAT_KEY => $expectedFormat,
+                )
+            )
+        );
+    }
+
+    public function normalizeUsingTimeZonePassedInContextAndExpectedFormatWithMicrosecondsProvider()
+    {
+        yield array(
+            '2018-12-01T18:03:06.067634',
+            'Y-m-d\TH:i:s.u',
+            \DateTime::createFromFormat(
+                'Y-m-d\TH:i:s.u',
+                '2018-12-01T18:03:06.067634',
+                new \DateTimeZone('UTC')
+            ),
+            null,
+        );
+
+        yield array(
+            '2018-12-01T18:03:06.067634',
+            'Y-m-d\TH:i:s.u',
+            \DateTime::createFromFormat(
+                'Y-m-d\TH:i:s.u',
+                '2018-12-01T18:03:06.067634',
+                new \DateTimeZone('UTC')
+            ),
+            new \DateTimeZone('UTC'),
+        );
+
+        yield array(
+            '2018-12-01T19:03:06.067634+01:00',
+            'Y-m-d\TH:i:s.uP',
+            \DateTimeImmutable::createFromFormat(
+                'Y-m-d\TH:i:s.u',
+                '2018-12-01T18:03:06.067634',
+                new \DateTimeZone('UTC')
+            ),
+            new \DateTimeZone('Europe/Rome'),
+        );
+
+        yield array(
+            '2018-12-01T20:03:06.067634+02:00',
+            'Y-m-d\TH:i:s.uP',
+            \DateTime::createFromFormat(
+                'Y-m-d\TH:i:s.u',
+                '2018-12-01T18:03:06.067634',
+                new \DateTimeZone('UTC')
+            ),
+            new \DateTimeZone('Europe/Kiev'),
+        );
+
+        yield array(
+            '2018-12-01T21:03:06.067634',
+            'Y-m-d\TH:i:s.u',
+            \DateTime::createFromFormat(
+                'Y-m-d\TH:i:s.u',
+                '2018-12-01T18:03:06.067634',
+                new \DateTimeZone('UTC')
+            ),
+            new \DateTimeZone('Europe/Moscow'),
+        );
+    }
+
+    /**
      * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
      * @expectedExceptionMessage The object must implement the "\DateTimeInterface".
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 up to 4.2 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #
| License       | MIT
| Doc PR        | none

fixed `DateTimeNormalizer::normalizer()` when `$object` is mutated internally to change timezone we lost microseconds of origina `$object`