### PR TITLE
[WebProfilerBundle] Split form field heading

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -177,6 +177,12 @@
             color: inherit;
             text-decoration: inherit;
         }
+        h2 + h3.form-data-type {
+            margin-top: 0;
+        }
+        h3.form-data-type + h3 {
+            margin-top: 1em;
+        }
     </style>
 {% endblock %}
 
@@ -455,9 +461,10 @@
 {% macro form_tree_details(name, data, forms_by_hash, show) %}
     {% import _self as tree %}
     <div class="tree-details{% if not show|default(false) %} hidden{% endif %}" {% if data.id is defined %}id="{{ data.id }}-details"{% endif %}>
-        <h2 class="dump-inline">
-            {{ name|default('(no name)') }} {% if data.type_class is defined %}({{ profiler_dump(data.type_class) }}){% endif %}
-        </h2>
+        <h2>{{ name|default('(no name)') }}</h2>
+        {% if data.type_class is defined %}
+            <h3 class="dump-inline form-data-type">{{ profiler_dump(data.type_class) }}</h3>
+        {% endif %}
 
         {% if data.errors is defined and data.errors|length > 0 %}
         <div class="errors">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

By default the data class 9/10 breaks inline, making it harder to read. This fixes it.

Before

![image](https://user-images.githubusercontent.com/1047696/49332204-02cbf800-f5a9-11e8-8565-f0f084fa76dd.png)


After

![image](https://user-images.githubusercontent.com/1047696/49332202-f47ddc00-f5a8-11e8-8a97-80f002c9bfc2.png)
