### PR TITLE
Adding PHPDocblock to findVariables method

### DIFF
--- a/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
+++ b/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
@@ -82,6 +82,13 @@ class EnvParametersResource implements SelfCheckingResourceInterface, \Serializa
         $this->variables = $unserialized['variables'];
     }
 
+    /**
+     *  Return an array containing server variables where the
+     *  array key starts with the $prefix variable defined
+     *  in the construsctor 
+     *
+     * @return array $variables
+     */
     private function findVariables()
     {
         $variables = array();

--- a/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
+++ b/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
@@ -85,7 +85,7 @@ class EnvParametersResource implements SelfCheckingResourceInterface, \Serializa
     /**
      *  Return an array containing server variables where the
      *  array key starts with the $prefix variable defined
-     *  in the construsctor 
+     *  in the construsctor.
      *
      * @return array $variables
      */

--- a/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
+++ b/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
@@ -83,11 +83,10 @@ class EnvParametersResource implements SelfCheckingResourceInterface, \Serializa
     }
 
     /**
-     *  Return an array containing server variables where the
-     *  array key starts with the $prefix variable defined
-     *  in the construsctor.
+     *  Find environment variables starting with
+     *  the $prefix property.
      *
-     * @return array $variables
+     * @return array
      */
     private function findVariables()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| License       | MIT

This update adds some PHPDockblock to the findVariables method 
