### PR TITLE
[VarExporter] fix dumping protected property from abstract classes

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -125,8 +125,7 @@ class Exporter
                     $c = 'stdClass';
                 } elseif ('*' === $n[1]) {
                     $n = substr($n, 3);
-                    $c = $reflector->getProperty($n)->class;
-                    if ('Error' === $c) {
+                    if ('Error' === $c = $class) {
                         $c = 'TypeError';
                     } elseif ('Exception' === $c) {
                         $c = 'ErrorException';

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/abstract-parent.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/abstract-parent.php
@@ -1,0 +1,17 @@
+<?php
+
+return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
+    $o = [
+        clone (\Symfony\Component\VarExporter\Internal\Registry::$prototypes['Symfony\\Component\\VarExporter\\Tests\\ConcreteClass'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('Symfony\\Component\\VarExporter\\Tests\\ConcreteClass')),
+    ],
+    null,
+    [
+        'Symfony\\Component\\VarExporter\\Tests\\ConcreteClass' => [
+            'foo' => [
+                123,
+            ],
+        ],
+    ],
+    $o[0],
+    []
+);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/final-error.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/final-error.php
@@ -6,7 +6,7 @@ return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
     ]),
     null,
     [
-        'TypeError' => [
+        'Symfony\\Component\\VarExporter\\Tests\\FinalError' => [
             'file' => [
                 \dirname(__DIR__).\DIRECTORY_SEPARATOR.'VarExporterTest.php',
             ],

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/private.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/private.php
@@ -10,11 +10,15 @@ return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
         'Symfony\\Component\\VarExporter\\Tests\\MyPrivateValue' => [
             'prot' => [
                 123,
-                123,
             ],
             'priv' => [
                 234,
                 234,
+            ],
+        ],
+        'Symfony\\Component\\VarExporter\\Tests\\MyPrivateChildValue' => [
+            'prot' => [
+                1 => 123,
             ],
         ],
     ],

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -192,6 +192,8 @@ class VarExporterTest extends TestCase
         $value->bis = new \ReflectionClass($value);
 
         yield array('wakeup-refl', $value);
+
+        yield array('abstract-parent', new ConcreteClass());
     }
 }
 
@@ -318,5 +320,18 @@ final class FinalStdClass extends \stdClass
     public function __clone()
     {
         throw new \BadMethodCallException('Should not be called.');
+    }
+}
+
+abstract class AbstractClass
+{
+    protected $foo;
+}
+
+class ConcreteClass extends AbstractClass
+{
+    public function __construct()
+    {
+        $this->foo = 123;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29406
| License       | MIT
| Doc PR        | -