### PR TITLE
[DI] dont inline when lazy edges are found

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -130,7 +130,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
         $isReferencedByConstructor = false;
         foreach ($graph->getNode($id)->getInEdges() as $edge) {
             $isReferencedByConstructor = $isReferencedByConstructor || $edge->isReferencedByConstructor();
-            if ($edge->isWeak()) {
+            if ($edge->isWeak() || $edge->isLazy()) {
                 return false;
             }
             $ids[] = $edge->getSourceNode()->getId();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29412, #29391
| License       | MIT
| Doc PR        | -

I'm not able to create a reproducer to hit this situation, but on 4.2, this check makes the difference.
I'm merging to fix the issue as that's still the proper fix.