### PR TITLE
[Cache] Fixed Memcached adapter doClear()to call flush()

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -192,4 +192,9 @@ class MemcachedAdapterTest extends AdapterTestCase
             array(\Memcached::OPT_SOCKET_RECV_SIZE => 1, \Memcached::OPT_SOCKET_SEND_SIZE => 2, \Memcached::OPT_RETRY_TIMEOUT => 8),
         );
     }
+
+    public function testClear()
+    {
+        $this->assertTrue($this->createCachePool()->clear());
+    }
 }

--- a/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
@@ -260,7 +260,7 @@ trait MemcachedTrait
      */
     protected function doClear($namespace)
     {
-        return false;
+        return '' === $namespace && $this->getClient()->flush();
     }
 
     private function checkResultCode($result)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29435
| License       | MIT
| Doc PR        | symfony/symfony-docs

MemcachedTrait now calls Memcached::flush via its client instead of just returning false.
