### PR TITLE
[PhpUnitBridge] install PHPUnit 7 on PHP 7.1 and fix requir. for PHPUnit 6

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -45,14 +45,16 @@ $getEnvVar = function ($name, $default = false) {
     return $default;
 };
 
-if (PHP_VERSION_ID >= 70200) {
-    // PHPUnit 6 is required for PHP 7.2+
+if (PHP_VERSION_ID >= 70100) {
+    // PHPUnit 7 requires PHP 7.1+
+    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '7.4');
+} elseif (PHP_VERSION_ID >= 70000) {
+    // PHPUnit 6 requires PHP 7.0+
     $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '6.5');
 } elseif (PHP_VERSION_ID >= 50600) {
-    // PHPUnit 4 does not support PHP 7
+    // PHPUnit 5 requires PHP 5.6+
     $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '5.7');
 } else {
-    // PHPUnit 5.1 requires PHP 5.6+
     $PHPUNIT_VERSION = '4.8';
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Added support of PHPUnit 7.4 if PHP version is 7.1+ (release link: https://packagist.org/packages/phpunit/phpunit#7.4.5).
Also I found that PHPUnit 6.5 required PHP 7.0, not 7.2 (proof: https://packagist.org/packages/phpunit/phpunit#6.5.13)