### PR TITLE
[Workflow] Fixed BC break for Workflow metadata

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -525,7 +525,7 @@ class FrameworkExtension extends Extension
                     }
                     if ($transition['metadata']) {
                         $transitionsMetadataDefinition->addMethodCall('attach', array(
-                            $transitionDefinition,
+                            new Reference($transitionId),
                             $transition['metadata'],
                         ));
                     }
@@ -547,7 +547,7 @@ class FrameworkExtension extends Extension
                             }
                             if ($transition['metadata']) {
                                 $transitionsMetadataDefinition->addMethodCall('attach', array(
-                                    $transitionDefinition,
+                                    new Reference($transitionId),
                                     $transition['metadata'],
                                 ));
                             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -256,10 +256,8 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('attach', $transitionsMetadataCall[0]);
         $params = $transitionsMetadataCall[1];
         $this->assertCount(2, $params);
-        $this->assertInstanceOf(Definition::class, $params[0]);
-        $this->assertSame(Workflow\Transition::class, $params[0]->getClass());
-        $this->assertSame(array('submit', 'start', 'travis'), $params[0]->getArguments());
-        $this->assertSame(array('title' => 'transition submit title'), $params[1]);
+        $this->assertInstanceOf(Reference::class, $params[0]);
+        $this->assertSame('state_machine.pull_request.transition.0', (string) $params[0]);
 
         $serviceMarkingStoreWorkflowDefinition = $container->getDefinition('workflow.service_marking_store_workflow');
         /** @var Reference $markingStoreRef */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29427
| License       | MIT
| Doc PR        |

I used SplObjectStorage to store the transition metadata.
So we need to use the exact same PHP Object.