### PR TITLE
[FrameworkBundle] Fix empty output for debug:autowiring when reflection-docblock is not installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -292,7 +292,7 @@ abstract class Descriptor implements DescriptorInterface
      */
     public static function getClassDescription(string $class, string &$resolvedClass = null): string
     {
-        $resolvedClass = null;
+        $resolvedClass = $class;
 
         if (!interface_exists(DocBlockFactoryInterface::class)) {
             return '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29442 
| License       | MIT
| Doc PR        | n/a

![screenshot 2018-12-03 at 19 25 07](https://user-images.githubusercontent.com/7502063/49393383-549f8a00-f731-11e8-822c-43959514c69d.png)

instead of no output at all when phpdocumentor/reflection-docblock is not installed