### PR TITLE
[Ldap] Entry move support 

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/EntryManagerInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/EntryManagerInterface.php
@@ -21,6 +21,8 @@ use Symfony\Component\Ldap\Exception\NotBoundException;
  * @author Charles Sarrazin <charles@sarraz.in>
  * @author Bob van de Vijver <bobvandevijver@hotmail.com>
  * @author Kevin Schuurmans <kevin.schuurmans@freshheads.com>
+ *
+ * @method void move(Entry $entry, string $newParent) Moves an entry on the Ldap server
  */
 interface EntryManagerInterface
 {

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added `EntryManager::move`, not implementing it is deprecated
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
@@ -341,4 +341,22 @@ class LdapManagerTest extends LdapTestCase
 
         $entryManager->applyOperations($entry->getDn(), $duplicateIterator);
     }
+
+    /**
+     * @group functional
+     */
+    public function testLdapMove()
+    {
+        $result = $this->executeSearchQuery(1);
+
+        $entry = $result[0];
+        $this->assertNotContains('ou=Ldap', $entry->getDn());
+
+        $entryManager = $this->adapter->getEntryManager();
+        $entryManager->move($entry, 'ou=Ldap,ou=Components,dc=symfony,dc=com');
+
+        $result = $this->executeSearchQuery(1);
+        $movedEntry = $result[0];
+        $this->assertContains('ou=Ldap', $movedEntry->getDn());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no (see [1])
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A (see [2])

Add Move support to the ldap EntryManagerInterface and the ExtLdap adapter. This is used to re-parent an entry to another part of the directory. The interface to do so need not be complicated, requiring only the entry to be moved and the parent DN to be moved to.

Underlying implementations may require a 'newrdn' attribute -- this is generally the RDN w.r.t. the immediate parent of the entry, which is easily parsed.

I've attempted to implement it as the rename functionality was originally implemented: adding an interface to be deprecated effective immediately, presumably to allow it to be backported without breaking existing interfaces, and then implementing this interface in the ExtLdap adapter.

[1] I do not have the capacity to run the ldap tests for this locally due to current $work situation; I have no reason to believe this test will fail as written, though. This functionality has been used as currently implemented (against Windows ADS) for some time in my production environment, so it has been functionally tested otherwise.

[2] No doc PR has been created for this feature addition, since it's a minor addition. The LDAP documentation should likely be amended to include rename functionality as well as this.