### PR TITLE
Fix TransChoiceTokenParser deprecation message

### DIFF
--- a/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
@@ -40,7 +40,7 @@ class TransChoiceTokenParser extends TransTokenParser
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
 
-        @trigger_error(sprintf('The "transchoice" tag is deprecated since Symfony 4.2, use the "trans" one instead with a "%count%" parameter in %s line %d.', $stream->getSourceContext()->getName(), $lineno), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "transchoice" tag is deprecated since Symfony 4.2, use the "trans" one instead with a "%%count%%" parameter in %s line %d.', $stream->getSourceContext()->getName(), $lineno), E_USER_DEPRECATED);
 
         $vars = new ArrayExpression(array(), $lineno);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

While debugging a `cache:clear`, I found the following errors on stderr:
```
PHP Warning: sprintf(): Too few arguments in .../vendor/symfony/twig-bridge/TokenParser/TransChoiceTokenParser.php on line 43
```

This was caused by using unescaped `%` in the `sprintf` format string.

This fix the `sprintf` format string so the deprecation message will now works.