### PR TITLE
Fixes sprintf(): Too few arguments in MessageFormatter::choiceFormat

### DIFF
--- a/src/Symfony/Component/Translation/Formatter/MessageFormatter.php
+++ b/src/Symfony/Component/Translation/Formatter/MessageFormatter.php
@@ -66,7 +66,7 @@ class MessageFormatter implements MessageFormatterInterface, IntlFormatterInterf
      */
     public function choiceFormat($message, $number, $locale, array $parameters = array())
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the format() one instead with a %count% parameter.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the format() one instead with a %%count%% parameter.', __METHOD__), E_USER_DEPRECATED);
 
         $parameters = array('%count%' => $number) + $parameters;
 


### PR DESCRIPTION
Similar to : https://github.com/symfony/symfony/pull/29344

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | related to a previous deprecation <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | I hope so
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Fixes the log produced when the method is called : 

Before : "sprintf(): Too few arguments"

After : "The "Symfony\Component\Translation\Formatter\MessageFormatter::choiceFormat()" method is deprecated since Symfony 4.2, use the format() one instead with a %count% parameter."

Reference : http://php.net/manual/function.sprintf.php
