### PR TITLE
[HttpKernel] Set the default locale early

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * made `Symfony\Component\HttpKernel\EventListenerLocaleListener` set the default locale early
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RequestContextAwareInterface;
 
@@ -42,10 +43,14 @@ class LocaleListener implements EventSubscriberInterface
         $this->router = $router;
     }
 
+    public function setDefaultLocale(KernelEvent $event)
+    {
+        $event->getRequest()->setDefaultLocale($this->defaultLocale);
+    }
+
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        $request->setDefaultLocale($this->defaultLocale);
 
         $this->setLocale($request);
         $this->setRouterContext($request);
@@ -75,8 +80,11 @@ class LocaleListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            // must be registered after the Router to have access to the _locale
-            KernelEvents::REQUEST => array(array('onKernelRequest', 16)),
+            KernelEvents::REQUEST => array(
+                array('setDefaultLocale', 100),
+                // must be registered after the Router to have access to the _locale
+                array('onKernelRequest', 16),
+            ),
             KernelEvents::FINISH_REQUEST => array(array('onKernelFinishRequest', 0)),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

Similar to #29186, the default locale isn't set till after the router so isn't available when trying to handle errors there (well, only the _default_ default locale is).