### PR TITLE
Release v2.7.50

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,11 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.50 (2018-12-06)
+
+ * security #cve-2018-19790 [Security\Http] detect bad redirect targets using backslashes (xabbuh)
+ * security #cve-2018-19789 [Form] Filter file uploads out of regular form types (nicolas-grekas)
+
 * 2.7.49 (2018-08-01)
 
  * security #cve-2018-14774 [HttpKernel] fix trusted headers management in HttpCache and InlineFragmentRenderer (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,11 +58,11 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.49';
-    const VERSION_ID = 20749;
+    const VERSION = '2.7.50';
+    const VERSION_ID = 20750;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
-    const RELEASE_VERSION = 49;
+    const RELEASE_VERSION = 50;
     const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.7.49...v2.7.50)

 * security #cve-2018-19790 [Security\Http] detect bad redirect targets using backslashes (@xabbuh)
 * security #cve-2018-19789 [Form] Filter file uploads out of regular form types (@nicolas-grekas)
