### PR TITLE
Release v2.8.49

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,11 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.49 (2018-12-06)
+
+ * security #cve-2018-19790 [Security\Http] detect bad redirect targets using backslashes (xabbuh)
+ * security #cve-2018-19789 [Form] Filter file uploads out of regular form types (nicolas-grekas)
+
 * 2.8.48 (2018-11-26)
 
  * bug #28917 [DoctrineBridge] catch errors while converting to db values in data collector (alekitto)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,11 +59,11 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.48';
-    const VERSION_ID = 20848;
+    const VERSION = '2.8.49';
+    const VERSION_ID = 20849;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
-    const RELEASE_VERSION = 48;
+    const RELEASE_VERSION = 49;
     const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.8.48...v2.8.49)

 * security #cve-2018-19790 [Security\Http] detect bad redirect targets using backslashes (@xabbuh)
 * security #cve-2018-19789 [Form] Filter file uploads out of regular form types (@nicolas-grekas)
