### PR TITLE
Release v4.1.9

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -7,6 +7,28 @@ in 4.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.1.0...v4.1.1
 
+* 4.1.9 (2018-12-06)
+
+ * security #cve-2018-19790 [Security\Http] detect bad redirect targets using backslashes (xabbuh)
+ * security #cve-2018-19789 [Form] Filter file uploads out of regular form types (nicolas-grekas)
+ * bug #29436 [Cache] Fixed Memcached adapter doClear()to call flush() (raitocz)
+ * bug #29441 [Routing] ignore trailing slash for non-GET requests (nicolas-grekas)
+ * bug #29444 [Workflow] Fixed BC break for Workflow metadata (lyrixx)
+ * bug #29432 [DI] dont inline when lazy edges are found (nicolas-grekas)
+ * bug #29413 [Serializer] fixed DateTimeNormalizer to maintain microseconds when a different timezone required (rvitaliy)
+ * bug #29424 [Routing] fix taking verb into account when redirecting (nicolas-grekas)
+ * bug #29414 [DI] Fix dumping expressions accessing single-use private services (chalasr)
+ * bug #29375 [Validator] Allow `ConstraintViolation::__toString()` to expose codes that are not null or emtpy strings (phansys)
+ * bug #29376 [EventDispatcher] Fix eventListener wrapper loop in TraceableEventDispatcher (jderusse)
+ * bug #29386 undeprecate the single-colon notation for controllers (fbourigault)
+ * bug #29393 [DI] fix edge case in InlineServiceDefinitionsPass (nicolas-grekas)
+ * bug #29380 [Routing] fix greediness of trailing slash (nicolas-grekas)
+ * bug #29343 [Form] Handle all case variants of "nan" when parsing a number (mwhudson, xabbuh)
+ * bug #29373 [Routing] fix trailing slash redirection (nicolas-grekas)
+ * bug #29355 [PropertyAccess] calculate cache keys for property setters depending on the value (xabbuh)
+ * bug #29369 [DI] fix combinatorial explosion when analyzing the service graph (nicolas-grekas)
+ * bug #29349 [Debug] workaround opcache bug mutating "$this" !?! (nicolas-grekas)
+
 * 4.1.8 (2018-11-26)
 
  * bug #29318 [Console] Move back root exception to stack trace in verbose mode (chalasr)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -63,12 +63,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.1.9-DEV';
+    const VERSION = '4.1.9';
     const VERSION_ID = 40109;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 1;
     const RELEASE_VERSION = 9;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2019';
     const END_OF_LIFE = '07/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.1.8...v4.1.9)

 * security #cve-2018-19790 [Security\Http] detect bad redirect targets using backslashes (@xabbuh)
 * security #cve-2018-19789 [Form] Filter file uploads out of regular form types (@nicolas-grekas)
 * bug #29436 [Cache] Fixed Memcached adapter doClear()to call flush() (@raitocz)
 * bug #29441 [Routing] ignore trailing slash for non-GET requests (@nicolas-grekas)
 * bug #29444 [Workflow] Fixed BC break for Workflow metadata (@lyrixx)
 * bug #29432 [DI] dont inline when lazy edges are found (@nicolas-grekas)
 * bug #29413 [Serializer] fixed DateTimeNormalizer to maintain microseconds when a different timezone required (@rvitaliy)
 * bug #29424 [Routing] fix taking verb into account when redirecting (@nicolas-grekas)
 * bug #29414 [DI] Fix dumping expressions accessing single-use private services (@chalasr)
 * bug #29375 [Validator] Allow `ConstraintViolation::__toString()` to expose codes that are not null or emtpy strings (@phansys)
 * bug #29376 [EventDispatcher] Fix eventListener wrapper loop in TraceableEventDispatcher (@jderusse)
 * bug #29386 undeprecate the single-colon notation for controllers (@fbourigault)
 * bug #29393 [DI] fix edge case in InlineServiceDefinitionsPass (@nicolas-grekas)
 * bug #29380 [Routing] fix greediness of trailing slash (@nicolas-grekas)
 * bug #29343 [Form] Handle all case variants of "nan" when parsing a number (@mwhudson, @xabbuh)
 * bug #29373 [Routing] fix trailing slash redirection (@nicolas-grekas)
 * bug #29355 [PropertyAccess] calculate cache keys for property setters depending on the value (@xabbuh)
 * bug #29369 [DI] fix combinatorial explosion when analyzing the service graph (@nicolas-grekas)
 * bug #29349 [Debug] workaround opcache bug mutating "$this" !?! (@nicolas-grekas)
