### PR TITLE
[HttpFoundation] Fix request uri when it starts with double slashes

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1837,15 +1837,23 @@ class Request
         } elseif ($this->server->has('REQUEST_URI')) {
             $requestUri = $this->server->get('REQUEST_URI');
 
-            // HTTP proxy reqs setup request URI with scheme and host [and port] + the URL path, only use URL path
-            $uriComponents = parse_url($requestUri);
+            if ('' !== $requestUri && '/' === $requestUri[0]) {
+                // To only use path and query remove the fragment.
+                if (false !== $pos = strpos($requestUri, '#')) {
+                    $requestUri = substr($requestUri, 0, $pos);
+                }
+            } else {
+                // HTTP proxy reqs setup request URI with scheme and host [and port] + the URL path,
+                // only use URL path.
+                $uriComponents = parse_url($requestUri);
 
-            if (isset($uriComponents['path'])) {
-                $requestUri = $uriComponents['path'];
-            }
+                if (isset($uriComponents['path'])) {
+                    $requestUri = $uriComponents['path'];
+                }
 
-            if (isset($uriComponents['query'])) {
-                $requestUri .= '?'.$uriComponents['query'];
+                if (isset($uriComponents['query'])) {
+                    $requestUri .= '?'.$uriComponents['query'];
+                }
             }
         } elseif ($this->server->has('ORIG_PATH_INFO')) {
             // IIS 5.0, PHP as CGI

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -283,6 +283,55 @@ class RequestTest extends TestCase
         $this->assertEquals('http://test.com/foo', $request->getUri());
     }
 
+    /**
+     * @dataProvider getRequestUriData
+     */
+    public function testGetRequestUri($serverRequestUri, $expected, $message)
+    {
+        $request = new Request();
+        $request->server->add(array(
+            'REQUEST_URI' => $serverRequestUri,
+
+            // For having http://test.com
+            'SERVER_NAME' => 'test.com',
+            'SERVER_PORT' => 80,
+        ));
+
+        $this->assertSame($expected, $request->getRequestUri(), $message);
+        $this->assertSame($expected, $request->server->get('REQUEST_URI'), 'Normalize the request URI.');
+    }
+
+    public function getRequestUriData()
+    {
+        $message = 'Do not modify the path.';
+        yield array('/foo', '/foo', $message);
+        yield array('//bar/foo', '//bar/foo', $message);
+        yield array('///bar/foo', '///bar/foo', $message);
+
+        $message = 'Handle when the scheme, host are on REQUEST_URI.';
+        yield array('http://test.com/foo?bar=baz', '/foo?bar=baz', $message);
+
+        $message = 'Handle when the scheme, host and port are on REQUEST_URI.';
+        yield array('http://test.com:80/foo', '/foo', $message);
+        yield array('https://test.com:8080/foo', '/foo', $message);
+        yield array('https://test.com:443/foo', '/foo', $message);
+
+        $message = 'Fragment should not be included in the URI';
+        yield array('http://test.com/foo#bar', '/foo', $message);
+        yield array('/foo#bar', '/foo', $message);
+    }
+
+    public function testGetRequestUriWithoutRequiredHeader()
+    {
+        $expected = '';
+
+        $request = new Request();
+
+        $message = 'Fallback to empty URI when headers are missing.';
+        $this->assertSame($expected, $request->getRequestUri(), $message);
+        $this->assertSame($expected, $request->server->get('REQUEST_URI'), 'Normalize the request URI.');
+    }
+
     public function testCreateCheckPrecedence()
     {
         // server is used by default


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29478
| License       | MIT
| Doc PR        | ~

When the `REQUEST_URI` starts with a slash no need to `parse_url()`. However to keep the same behaviour regarding the fragment we need to add a logic to remove it. While `parse_url()` handle all cases itself.
