### PR TITLE
[Ldap] Implement pagination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,9 @@ before_install:
       set -e
       stty cols 120
       mkdir /tmp/slapd
+      if [ ! -e /tmp/slapd-modules ]; then
+          [ -d /usr/lib/openldap ] && ln -s /usr/lib/openldap /tmp/slapd-modules || ln -s /usr/lib/ldap /tmp/slapd-modules
+      fi
       slapd -f src/Symfony/Component/Ldap/Tests/Fixtures/conf/slapd.conf -h ldap://localhost:3389 &
       [ -d ~/.composer ] || mkdir ~/.composer
       cp .composer/* ~/.composer/

--- a/src/Symfony/Component/Ldap/Adapter/AbstractQuery.php
+++ b/src/Symfony/Component/Ldap/Adapter/AbstractQuery.php
@@ -35,6 +35,7 @@ abstract class AbstractQuery implements QueryInterface
             'deref' => static::DEREF_NEVER,
             'attrsOnly' => 0,
             'scope' => static::SCOPE_SUB,
+            'pageSize' => 0,
         ]);
         $resolver->setAllowedValues('deref', [static::DEREF_ALWAYS, static::DEREF_NEVER, static::DEREF_FINDING, static::DEREF_SEARCHING]);
         $resolver->setAllowedValues('scope', [static::SCOPE_BASE, static::SCOPE_ONE, static::SCOPE_SUB]);

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * Added pagination support to the ExtLdap adapter with the pageSize query option.
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Collection;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Query;
 use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\LdapException;
 use Symfony\Component\Ldap\Exception\NotBoundException;
 use Symfony\Component\Ldap\LdapInterface;
 
@@ -23,6 +24,12 @@ use Symfony\Component\Ldap\LdapInterface;
  */
 class AdapterTest extends LdapTestCase
 {
+    const PAGINATION_REQUIRED_CONFIG = [
+        'options' => [
+            'protocol_version' => 3,
+        ],
+    ];
+
     public function testLdapEscape()
     {
         $ldap = new Adapter();
@@ -110,5 +117,122 @@ class AdapterTest extends LdapTestCase
         $this->assertNotEquals($one_level_result->count(), $subtree_count);
         $this->assertEquals($one_level_result->count(), 1);
         $this->assertEquals($one_level_result[0]->getAttribute('ou'), ['Ldap']);
+    }
+
+    public function testLdapPagination()
+    {
+        $ldap = new Adapter(array_merge($this->getLdapConfig(), static::PAGINATION_REQUIRED_CONFIG));
+        $ldap->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
+        $entries = $this->setupTestUsers($ldap);
+
+        $unpaged_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+            'scope' => Query::SCOPE_ONE,
+        ]);
+        $fully_paged_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+            'scope' => Query::SCOPE_ONE,
+            'pageSize' => 25,
+        ]);
+        $paged_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+            'scope' => Query::SCOPE_ONE,
+            'pageSize' => 5,
+        ]);
+
+        try {
+            $unpaged_results = $unpaged_query->execute();
+            $fully_paged_results = $fully_paged_query->execute();
+            $paged_results = $paged_query->execute();
+
+            // All four of the above queries should result in the 25 'users' being returned
+            $this->assertEquals($unpaged_results->count(), 25);
+            $this->assertEquals($fully_paged_results->count(), 25);
+            $this->assertEquals($paged_results->count(), 25);
+
+            // They should also result in 1 or 25 / pageSize results
+            $this->assertEquals(\count($unpaged_query->getResources()), 1);
+            $this->assertEquals(\count($fully_paged_query->getResources()), 1);
+            $this->assertEquals(\count($paged_query->getResources()), 5);
+
+            if (PHP_MAJOR_VERSION > 7 || (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION >= 2)) {
+                // This last query is to ensure that we haven't botched the state of our connection
+                // by not resetting pagination properly. extldap <= PHP 7.1 do not implement the necessary
+                // bits to work around an implementation flaw, so we simply can't guarantee this to work there.
+                $final_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+                    'scope' => Query::SCOPE_ONE,
+                ]);
+
+                $final_results = $final_query->execute();
+
+                $this->assertEquals($final_results->count(), 25);
+                $this->assertEquals(\count($final_query->getResources()), 1);
+            }
+        } catch (LdapException $exc) {
+            $this->markTestSkipped('Test LDAP server does not support pagination');
+        }
+
+        $this->destroyEntries($ldap, $entries);
+    }
+
+    private function setupTestUsers($ldap)
+    {
+        $entries = [];
+
+        // Create 25 'users' that we'll query for in different page sizes
+        $em = $ldap->getEntryManager();
+        for ($i = 0; $i < 25; ++$i) {
+            $cn = sprintf('user%d', $i);
+            $entry = new Entry(sprintf('cn=%s,dc=symfony,dc=com', $cn));
+            $entry->setAttribute('objectClass', ['applicationProcess']);
+            $entry->setAttribute('cn', [$cn]);
+            try {
+                $em->add($entry);
+            } catch (LdapException $exc) {
+                // ignored
+            }
+            $entries[] = $entry;
+        }
+
+        return $entries;
+    }
+
+    private function destroyEntries($ldap, $entries)
+    {
+        $em = $ldap->getEntryManager();
+        foreach ($entries as $entry) {
+            $em->remove($entry);
+        }
+    }
+
+    public function testLdapPaginationLimits()
+    {
+        $ldap = new Adapter(array_merge($this->getLdapConfig(), static::PAGINATION_REQUIRED_CONFIG));
+        $ldap->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
+
+        $entries = $this->setupTestUsers($ldap);
+
+        $low_max_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+            'scope' => Query::SCOPE_ONE,
+            'pageSize' => 10,
+            'maxItems' => 5,
+        ]);
+        $high_max_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+            'scope' => Query::SCOPE_ONE,
+            'pageSize' => 10,
+            'maxItems' => 13,
+        ]);
+
+        try {
+            $low_max_results = $low_max_query->execute();
+            $high_max_results = $high_max_query->execute();
+
+            $this->assertEquals($low_max_results->count(), 5);
+            $this->assertEquals($high_max_results->count(), 13);
+
+            $this->assertEquals(\count($low_max_query->getResources()), 1);
+            $this->assertEquals(\count($high_max_query->getResources()), 2);
+        } catch (LdapException $exc) {
+            $this->markTestSkipped('Test LDAP server does not support pagination');
+        }
+
+        $this->destroyEntries($ldap, $entries);
     }
 }

--- a/src/Symfony/Component/Ldap/Tests/Fixtures/conf/slapd.conf
+++ b/src/Symfony/Component/Ldap/Tests/Fixtures/conf/slapd.conf
@@ -7,9 +7,10 @@ include   /etc/ldap/schema/nis.schema
 pidfile  /tmp/slapd/slapd.pid
 argsfile /tmp/slapd/slapd.args
 
-modulepath /usr/lib/openldap
+modulepath /tmp/slapd-modules
+moduleload back_hdb
 
-database  ldif
+database  hdb
 directory /tmp/slapd
 
 suffix    "dc=symfony,dc=com"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yno
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | N/A (cannot test at the moment)
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Implement pagination support in the ExtLdap adapter. In a more abstract sense, other adapters should use a query's pageSize option to determine if pagination is being needed. Pagination is required in some environments that frequently query for more results than the remote server is willing to allow.

BC break was avoided by having Query->getResource() return the first result, if available.

A small hack is included to work around php-ldap failing to reset pagination properly; the LDAP_OPT_SERVER_CONTROLS are sent with every request, whether pagination has been 'reset' by sending a 0-page request or not. This appears to be a php-ldap bug that will need to be addressed there, but we can work-around it for now by doing both: setting the 0-page option *and* unsetting the OID directly. This was resulting in odd results, like queries returning 0 results or returning < server_page_size results for a query that should have returned >= server_page_size.