### PR TITLE
[Serializer] change timezone to fix tests on Windows

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -143,14 +143,14 @@ class DateTimeNormalizerTest extends TestCase
         );
 
         yield array(
-            '2018-12-01T21:03:06.067634',
+            '2018-12-01T19:03:06.067634',
             'Y-m-d\TH:i:s.u',
             \DateTime::createFromFormat(
                 'Y-m-d\TH:i:s.u',
                 '2018-12-01T18:03:06.067634',
                 new \DateTimeZone('UTC')
             ),
-            new \DateTimeZone('Europe/Moscow'),
+            new \DateTimeZone('Europe/Berlin'),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

As I understand the failing tests timezones have changed in Russia in 2016, but this is not reflected in the timezone database used on AppVeyor. Since the tests do not depend on a particular timezone (it's
only important for it to be different from UTC) we should safely be able to switch to another timezone.