### PR TITLE
[Validator] Add support for UATP card validation

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added options `iban` and `ibanPropertyPath` to Bic constraint
+ * added UATP cards support to `CardSchemeValidator`
 
 4.2.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -78,6 +78,10 @@ class CardSchemeValidator extends ConstraintValidator
             '/^5[1-5][0-9]{14}$/',
             '/^2(22[1-9][0-9]{12}|2[3-9][0-9]{13}|[3-6][0-9]{14}|7[0-1][0-9]{13}|720[0-9]{12})$/',
         ),
+        // All UATP card numbers start with a 1 and have a length of 15 digits.
+        'UATP' => array(
+            '/^1[0-9]{14}$/',
+        ),
         // All Visa card numbers start with a 4 and have a length of 13, 16, or 19 digits.
         'VISA' => array(
             '/^4([0-9]{12}|[0-9]{15}|[0-9]{18})$/',

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -103,6 +103,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
             array('MASTERCARD', '2699999999999999'),
             array('MASTERCARD', '2709999999999999'),
             array('MASTERCARD', '2720995105105100'),
+            array('UATP', '110165309696173'),
             array('VISA', '4111111111111111'),
             array('VISA', '4012888888881881'),
             array('VISA', '4222222222222'),
@@ -133,6 +134,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
             array('DISCOVER', '1117', CardScheme::INVALID_FORMAT_ERROR), // only last 4 digits
             array('MASTERCARD', '2721001234567890', CardScheme::INVALID_FORMAT_ERROR), // Not assigned yet
             array('MASTERCARD', '2220991234567890', CardScheme::INVALID_FORMAT_ERROR), // Not assigned yet
+            array('UATP', '11016530969617', CardScheme::INVALID_FORMAT_ERROR), // invalid length
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

[UATP](https://en.wikipedia.org/wiki/Universal_Air_Travel_Plan) (Universal Air Travel Plan) is the airline owned payment network accepted by thousands of merchants for rail, air, hotel and travel agency payments. This PR adds support for UATP cards so they can be validated using the Symfony Validator component.

According to https://en.wikipedia.org/wiki/Payment_card_number, all UATP cards start with `1`, have a length of 15 digits and follow the [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm). Test card numbers can be generated from https://www.myfakeinfo.com/creditcard/uatp-debit-card.php