### PR TITLE
[Workflow] added could and getPossibleTransitions Methods to Workflow

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Extension;
 
 use Symfony\Component\Workflow\Registry;
 use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\Workflow;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -32,15 +33,23 @@ class WorkflowExtension extends AbstractExtension
 
     public function getFunctions()
     {
-        return array(
+        $functions = array(
             new TwigFunction('workflow_can', array($this, 'canTransition')),
-            new TwigFunction('workflow_could', array($this, 'couldTransition')),
             new TwigFunction('workflow_transitions', array($this, 'getEnabledTransitions')),
-            new TwigFunction('workflow_possible_transitions', array($this, 'getPossibleTransitions')),
             new TwigFunction('workflow_has_marked_place', array($this, 'hasMarkedPlace')),
             new TwigFunction('workflow_marked_places', array($this, 'getMarkedPlaces')),
             new TwigFunction('workflow_metadata', array($this, 'getMetadata')),
         );
+
+        if (method_exists(Workflow::class, 'could')) {
+            $functions[] = new TwigFunction('workflow_could', array($this, 'couldTransition'));
+        }
+
+        if (method_exists(Workflow::class, 'getPossibleTransitions')) {
+            $functions[] = new TwigFunction('workflow_possible_transitions', array($this, 'getPossibleTransitions'));
+        }
+
+        return $functions;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -67,7 +67,7 @@ class WorkflowExtension extends AbstractExtension
     }
 
     /**
-     * Returnstrue if there is a transition which is defined for the state.
+     * Returns true if there is a transition which is defined for the state.
      *
      * @param object $subject        A subject
      * @param string $transitionName A transition

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -58,7 +58,7 @@ class WorkflowExtension extends AbstractExtension
     }
 
     /**
-     * Returnstrue if there is a transition which is defined for the state
+     * Returnstrue if there is a transition which is defined for the state.
      *
      * @param object $subject        A subject
      * @param string $transitionName A transition
@@ -85,7 +85,7 @@ class WorkflowExtension extends AbstractExtension
     }
 
     /**
-     * Returns all transitions defined for the state
+     * Returns all transitions defined for the state.
      *
      * @param object $subject A subject
      * @param string $name    A workflow name

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -34,7 +34,9 @@ class WorkflowExtension extends AbstractExtension
     {
         return array(
             new TwigFunction('workflow_can', array($this, 'canTransition')),
+            new TwigFunction('workflow_could', array($this, 'couldTransition')),
             new TwigFunction('workflow_transitions', array($this, 'getEnabledTransitions')),
+            new TwigFunction('workflow_possible_transitions', array($this, 'getPossibleTransitions')),
             new TwigFunction('workflow_has_marked_place', array($this, 'hasMarkedPlace')),
             new TwigFunction('workflow_marked_places', array($this, 'getMarkedPlaces')),
             new TwigFunction('workflow_metadata', array($this, 'getMetadata')),
@@ -56,6 +58,20 @@ class WorkflowExtension extends AbstractExtension
     }
 
     /**
+     * Returnstrue if there is a transition which is defined for the state
+     *
+     * @param object $subject        A subject
+     * @param string $transitionName A transition
+     * @param string $name           A workflow name
+     *
+     * @return bool true if there is a transition which is defined for the state
+     */
+    public function couldTransition($subject, $transitionName, $name = null)
+    {
+        return $this->workflowRegistry->get($subject, $name)->could($subject, $transitionName);
+    }
+
+    /**
      * Returns all enabled transitions.
      *
      * @param object $subject A subject
@@ -66,6 +82,19 @@ class WorkflowExtension extends AbstractExtension
     public function getEnabledTransitions($subject, $name = null)
     {
         return $this->workflowRegistry->get($subject, $name)->getEnabledTransitions($subject);
+    }
+
+    /**
+     * Returns all transitions defined for the state
+     *
+     * @param object $subject A subject
+     * @param string $name    A workflow name
+     *
+     * @return Transition[] All defined transitions for the state
+     */
+    public function getPossibleTransitions($subject, $name = null)
+    {
+        return $this->workflowRegistry->get($subject, $name)->getPossibleTransitions($subject);
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -73,6 +73,7 @@ class WorkflowExtensionTest extends TestCase
     {
         if (!method_exists(Workflow::class, 'could')) {
             $this->markTestSkipped('Workflow has no \'could\' method');
+
             return;
         }
 
@@ -99,6 +100,7 @@ class WorkflowExtensionTest extends TestCase
     {
         if (!method_exists(Workflow::class, 'getPossibleTransitions')) {
             $this->markTestSkipped('Workflow has no \'getPossibleTransitions\' method');
+
             return;
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -71,6 +71,11 @@ class WorkflowExtensionTest extends TestCase
 
     public function testCouldTransition()
     {
+        if (!method_exists(Workflow::class, 'could')) {
+            $this->markTestSkipped('Workflow has no \'could\' method');
+            return;
+        }
+
         $subject = new \stdClass();
         $subject->marking = array();
 
@@ -92,6 +97,11 @@ class WorkflowExtensionTest extends TestCase
 
     public function testGetPossibleTransitions()
     {
+        if (!method_exists(Workflow::class, 'getPossibleTransitions')) {
+            $this->markTestSkipped('Workflow has no \'getPossibleTransitions\' method');
+            return;
+        }
+
         $subject = new \stdClass();
         $subject->marking = array();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -69,7 +69,6 @@ class WorkflowExtensionTest extends TestCase
         $this->assertFalse($this->extension->canTransition($subject, 't2'));
     }
 
-
     public function testCouldTransition()
     {
         $subject = new \stdClass();

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -69,12 +69,34 @@ class WorkflowExtensionTest extends TestCase
         $this->assertFalse($this->extension->canTransition($subject, 't2'));
     }
 
+
+    public function testCouldTransition()
+    {
+        $subject = new \stdClass();
+        $subject->marking = array();
+
+        $this->assertTrue($this->extension->couldTransition($subject, 't1'));
+        $this->assertFalse($this->extension->couldTransition($subject, 't2'));
+    }
+
     public function testGetEnabledTransitions()
     {
         $subject = new \stdClass();
         $subject->marking = array();
 
         $transitions = $this->extension->getEnabledTransitions($subject);
+
+        $this->assertCount(1, $transitions);
+        $this->assertInstanceOf(Transition::class, $transitions[0]);
+        $this->assertSame('t1', $transitions[0]->getName());
+    }
+
+    public function testGetPossibleTransitions()
+    {
+        $subject = new \stdClass();
+        $subject->marking = array();
+
+        $transitions = $this->extension->getPossibleTransitions($subject);
 
         $this->assertCount(1, $transitions);
         $this->assertInstanceOf(Transition::class, $transitions[0]);

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * Trigger `entered` event for subject entering in the Workflow for the first time
- * Added `could` and `getPossibleTransistions` which give a unguarded view on the defined transitions
+ * Added `could` and `getPossibleTransitions` which give an unguarded view on the defined transitions
 
 4.1.0
 -----

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Trigger `entered` event for subject entering in the Workflow for the first time
+ * Added `could` and `getPossibleTransistions` which give a unguarded view on the defined transitions
 
 4.1.0
 -----

--- a/src/Symfony/Component/Workflow/Tests/StateMachineTest.php
+++ b/src/Symfony/Component/Workflow/Tests/StateMachineTest.php
@@ -42,6 +42,36 @@ class StateMachineTest extends TestCase
         $this->assertTrue($net->can($subject, 't3'));
     }
 
+    public function testCould()
+    {
+        $definition = $this->createComplexStateMachineDefinition();
+
+        $net = new StateMachine($definition);
+        $subject = new \stdClass();
+
+        // If you are in place "a" you should be able to apply "t1"
+        $subject->marking = 'a';
+        $this->assertTrue($net->could($subject, 't1'));
+        $subject->marking = 'd';
+        $this->assertTrue($net->could($subject, 't1'));
+
+        $subject->marking = 'b';
+        $this->assertFalse($net->could($subject, 't1'));
+    }
+
+    public function testCouldWithMultipleTransition()
+    {
+        $definition = $this->createComplexStateMachineDefinition();
+
+        $net = new StateMachine($definition);
+        $subject = new \stdClass();
+
+        // If you are in place "b" you should be able to apply "t1" and "t2"
+        $subject->marking = 'b';
+        $this->assertTrue($net->could($subject, 't2'));
+        $this->assertTrue($net->could($subject, 't3'));
+    }
+
     public function testBuildTransitionBlockerList()
     {
         $definition = $this->createComplexStateMachineDefinition();

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -105,7 +105,7 @@ class Workflow implements WorkflowInterface
     }
 
     /**
-     * Returns true if there is a transition which is defined for the state
+     * Returns true if there is a transition which is defined for the state.
      *
      * @param object $subject        A subject
      * @param string $transitionName A transition
@@ -272,7 +272,7 @@ class Workflow implements WorkflowInterface
     }
 
     /**
-     * Returns all transitions defined for the state
+     * Returns all transitions defined for the state.
      *
      * @param object $subject A subject
      *

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -105,6 +105,35 @@ class Workflow implements WorkflowInterface
     }
 
     /**
+     * Returns true if there is a transition which is defined for the state
+     *
+     * @param object $subject        A subject
+     * @param string $transitionName A transition
+     *
+     * @return bool true if there is a transition which is defined for the state
+     */
+    public function could($subject, $transitionName)
+    {
+        $transitions = $this->definition->getTransitions();
+        $marking = $this->getMarking($subject);
+
+        foreach ($transitions as $transition) {
+            if ($transition->getName() !== $transitionName) {
+                continue;
+            }
+            foreach ($transition->getFroms() as $place) {
+                if (!$marking->has($place)) {
+                    continue 2;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildTransitionBlockerList($subject, string $transitionName): TransitionBlockerList
@@ -240,6 +269,30 @@ class Workflow implements WorkflowInterface
     public function getMetadataStore(): MetadataStoreInterface
     {
         return $this->definition->getMetadataStore();
+    }
+
+    /**
+     * Returns all transitions defined for the state
+     *
+     * @param object $subject A subject
+     *
+     * @return Transition[] All defined transitions for the state
+     */
+    public function getPossibleTransitions($subject)
+    {
+        $enabled = array();
+        $marking = $this->getMarking($subject);
+
+        foreach ($this->definition->getTransitions() as $transition) {
+            foreach ($transition->getFroms() as $place) {
+                if (!$marking->has($place)) {
+                    continue 2;
+                }
+            }
+            $enabled[] = $transition;
+        }
+
+        return $enabled;
     }
 
     private function buildTransitionBlockerListForTransition($subject, Marking $marking, Transition $transition)

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -114,10 +114,9 @@ class Workflow implements WorkflowInterface
      */
     public function could($subject, $transitionName)
     {
-        $transitions = $this->definition->getTransitions();
         $marking = $this->getMarking($subject);
 
-        foreach ($transitions as $transition) {
+        foreach ($this->definition->getTransitions() as $transition) {
             if ($transition->getName() !== $transitionName) {
                 continue;
             }


### PR DESCRIPTION
- added Twig extensions for workflow_could and workflow_possible_transitions

| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes  
| Fixed tickets | nope
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

I added the methods `could` and `getPossibleTransistions` to the Workflow class which 
give now the possibility to derive information about transitions if you ignore the guard events.
These to methods also reflects to Twig Extension filter `workflow_could` and `workflow_possible_transitions`
Sometimes I have transition which will arrive after some preparation (e.g. to be valid for some kind of validation). But they are blocked by the guard. Before you don't have an easy possibility to show these transitions in twig.
