### PR TITLE
[Validator] Add tests in regex validator for objects with __toString method

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -62,6 +62,12 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
             array('0'),
             array('090909'),
             array(90909),
+            array(new class() {
+                public function __toString()
+                {
+                    return '090909';
+                }
+            }),
         );
     }
 
@@ -88,6 +94,12 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
         return array(
             array('abcd'),
             array('090foo'),
+            array(new class() {
+                public function __toString()
+                {
+                    return 'abcd';
+                }
+            }),
         );
     }
 }


### PR DESCRIPTION
This PR adds tests to cover objects implementing the `__toString` method for the `Regex` validator.

| Q             | A
| ------------- | ---
| Branch?       | 3.4 (careful when merging)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT