### PR TITLE
[Hackday][Messenger] Fix invalid closed tag

### DIFF
--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -84,7 +84,7 @@ EOF
             foreach ($handlersByMessage as $message => $handlers) {
                 $tableRows[] = array(sprintf('<fg=cyan>%s</fg=cyan>', $message));
                 foreach ($handlers as $handler) {
-                    $tableRows[] = array(sprintf('    handled by <info>%s</>', $handler));
+                    $tableRows[] = array(sprintf('    handled by <info>%s</info>', $handler));
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT


The bugfix repairs an invalid close html "info" tag.
