### PR TITLE
[Hackday][Serializer] Deserialization ignores argument type hint from phpdoc for array in constructor argument

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -305,6 +305,18 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     }
 
     /**
+     * @internal
+     */
+    protected function denormalizeParameter(\ReflectionClass $class, \ReflectionParameter $parameter, $parameterName, $parameterData, array $context, $format = null)
+    {
+        if (null === $this->propertyTypeExtractor || null === $types = $this->propertyTypeExtractor->getTypes($class->getName(), $parameterName)) {
+            return parent::denormalizeParameter($class, $parameter, $parameterName, $parameterData, $context, $format);
+        }
+
+        return $this->validateAndDenormalize($class->getName(), $parameterName, $parameterData, $format, $context);
+    }
+
+    /**
      * Sets an attribute and apply the name converter if necessary.
      *
      * @param string $attribute

--- a/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class DeserializeNestedArrayOfObjectsTest extends TestCase
+{
+    public function provider()
+    {
+        return array(
+            //from property PhpDoc
+            array(Zoo::class),
+            //from argument constructor PhpDoc
+            array(ZooImmutable::class),
+        );
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testPropertyPhpDoc($class)
+    {
+        //GIVEN
+        $json = <<<EOF
+{
+    "animals": [
+        {"name": "Bug"}
+    ]
+}
+EOF;
+        $serializer = new Serializer(array(
+            new ObjectNormalizer(null, null, null, new PhpDocExtractor()),
+            new ArrayDenormalizer(),
+        ), array('json' => new JsonEncoder()));
+        //WHEN
+        /** @var Zoo $zoo */
+        $zoo = $serializer->deserialize($json, $class, 'json');
+        //THEN
+        self::assertCount(1, $zoo->getAnimals());
+        self::assertInstanceOf(Animal::class, $zoo->getAnimals()[0]);
+    }
+}
+
+class Zoo
+{
+    /** @var Animal[] */
+    private $animals = array();
+
+    /**
+     * @return Animal[]
+     */
+    public function getAnimals()
+    {
+        return $this->animals;
+    }
+
+    /**
+     * @param Animal[] $animals
+     */
+    public function setAnimals(array $animals)
+    {
+        $this->animals = $animals;
+    }
+}
+
+class ZooImmutable
+{
+    /** @var Animal[] */
+    private $animals = array();
+
+    /**
+     * @param Animal[] $animals
+     */
+    public function __construct(array $animals = array())
+    {
+        $this->animals = $animals;
+    }
+
+    /**
+     * @return Animal[]
+     */
+    public function getAnimals()
+    {
+        return $this->animals;
+    }
+}
+
+class Animal
+{
+    /** @var string */
+    private $name;
+
+    public function __construct()
+    {
+        echo '';
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string|null $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 and up to 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28825
| License       | MIT

This is a fix of #28825 big thanks @dunglas and @xabbuh
