### PR TITLE
[Debug] Improve docblock of FormFactoryInterface

### DIFF
--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -12,6 +12,14 @@
 namespace Symfony\Component\Form;
 
 /**
+ * The form factory object should be used to create any and all form objects in your application.
+ *
+ * Regardless of how you architect your application, remember that you should
+ * only have one form factory and that you'll need to be able to access it
+ * throughout your application.
+ *
+ * @see https://symfony.com/doc/current/components/form.html#accessing-the-form-factory
+ *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface FormFactoryInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Add a better **docblock** to the `Symfony\Component\Form\FormFactoryInterface`.
This comment will be shown in `debug:autowiring` command.

I added a `@see` which link to the official documentation - in the extends docblock of the Class - but, It seems the Symfony Core never do that kind of thing. As I never contribute to Symfony before there is a lot of unknown convention to me.

_PS: 
I work on this during the Hackday of SymfonyCon2018 at Lisbon.
As my first contribution to Symfony, I certainly not follow every convention to create this PR - so every help is welcome._

#SymfonyConHackday2018