### PR TITLE
Add a docblock for FormFactoryInterface

### DIFF
--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Form;
 
 /**
+ * Allows creating a form based on a name, a class or a property.
+ *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface FormFactoryInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | #
| License       | MIT
| Doc PR        | None

Added a docblock for FormFactoryInterface so it will be shown in `debug:autowiring` command

#SymfonyConHackday2018
