### PR TITLE
[Hackday][Messenger] Add an alias for transport.symfony_serializer so SerializerInterface can be autowired

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -70,6 +70,7 @@ use Symfony\Component\Lock\StoreInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -1530,6 +1531,7 @@ class FrameworkExtension extends Extension
                 $container->setAlias('messenger.transport.serializer', $config['serializer']['id']);
             } else {
                 $container->removeDefinition('messenger.transport.amqp.factory');
+                $container->removeDefinition(SerializerInterface::class);
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -22,6 +22,7 @@
             <argument /> <!-- Format -->
             <argument type="collection" /> <!-- Context -->
         </service>
+        <service id="Symfony\Component\Messenger\Transport\Serialization\SerializerInterface" alias="messenger.transport.serializer" />
 
         <!-- Middleware -->
         <service id="messenger.middleware.handle_message" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

cc @thePanz 

Use case:
Before:
```
    Pnz\Messenger\FilesystemTransport\FilesystemTransportFactory:
        arguments:
            - '@messenger.transport.symfony_serializer'
        tags: ['messenger.transport_factory']
```

After:
```
    Pnz\Messenger\FilesystemTransport\FilesystemTransportFactory:
        tags: ['messenger.transport_factory']
```
