### PR TITLE
[PhpunitBridge][HttpKernel]Always display container deprecations in simple phpunit

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -133,6 +133,7 @@ class DeprecationErrorHandler
         if ($deprecation->originatesFromAnObject()) {
             $class = $deprecation->originatingClass();
             $method = $deprecation->originatingMethod();
+            $msg = $deprecation->getMessage();
 
             if (0 !== error_reporting()) {
                 $group = 'unsilenced';

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -37,6 +37,8 @@ abstract class KernelTestCase extends TestCase
      */
     protected static $container;
 
+    private static $compilerDeprecationsTriggered = false;
+
     protected function doTearDown(): void
     {
         static::ensureKernelShutdown();
@@ -131,5 +133,19 @@ abstract class KernelTestCase extends TestCase
             }
         }
         static::$container = null;
+    }
+
+    public static function tearDownAfterClass()
+    {
+        if (!self::$compilerDeprecationsTriggered) {
+            $compilerDeprecated = getenv('SYMFONY_COMPILER_DEPRECATIONS');
+            if ($compilerDeprecated && file_exists($compilerDeprecated)) {
+                foreach (unserialize(file_get_contents($compilerDeprecated)) as $log) {
+                    @trigger_error(serialize($log), E_USER_DEPRECATED);
+                }
+                self::$compilerDeprecationsTriggered = true;
+            }
+        }
+        parent::tearDownAfterClass();
     }
 }

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Marked `Response` final.
  * Deprecated `Response::buildHeader()`
  * Deprecated `Response::getStatus()`, use `Response::getStatusCode()` instead
+ * Allowed to always display container deprecations
 
 4.2.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

When the container is not built or not fresh, simple-phpunit may trigger deprecations which occured during container built. If simple-phpunit is launched again, the deprecations are not displayed since the container hasn't be built this time.

Deprecations can make tests fail. So the behavior is currently inconsistent. With the same code base, the tests may pass if the container has been built before and may fail if the container is built during the process.

The suggested fix is to retrieve container compile deprecations from a file created by Symfony. It's the file which is used to display container compile deprecations in Logger data collector.

Some deprecations are generated during cache warmup. Without cache warmup, these deprecations can be triggered from anywhere. For this reason, without cache warmup, we can't memorize them to display them on all test launches.  **So to keep test launches consistent, it could be a good practice to warmup the cache before**.

Note: since phpunit-bridge create a new phpunit project with a phpunit-bridge dependency, the phpunit-bridge version used for the CI tests hasn't the modification of this PR. So the tests fail. Reporting the `DeprecationErrorHandler` modifications in the created phpunit project allows tests to be successful.

Some very minor bugs has been detected after #29211; it could be a good think to fix the bugs treated by #31478 before merging this PR.