### PR TITLE
Feature/add missing space

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -94,39 +94,40 @@ class ServiceLocator implements PsrContainerInterface
         $class = isset($class[2]['object']) ? \get_class($class[2]['object']) : null;
         $externalId = $this->externalId ?: $class;
 
-        $msg = sprintf('Service "%s" not found: ', $id);
+        $msg = array();
+        $msg[] = sprintf('Service "%s" not found:', $id);
 
         if (!$this->container) {
             $class = null;
         } elseif ($this->container->has($id) || isset($this->container->getRemovedIds()[$id])) {
-            $msg .= 'even though it exists in the app\'s container, ';
+            $msg[] = 'even though it exists in the app\'s container,';
         } else {
             try {
                 $this->container->get($id);
                 $class = null;
             } catch (ServiceNotFoundException $e) {
                 if ($e->getAlternatives()) {
-                    $msg .= sprintf(' did you mean %s? Anyway, ', $this->formatAlternatives($e->getAlternatives(), 'or'));
+                    $msg[] = sprintf('did you mean %s? Anyway,', $this->formatAlternatives($e->getAlternatives(), 'or'));
                 } else {
                     $class = null;
                 }
             }
         }
         if ($externalId) {
-            $msg .= sprintf('the container inside "%s" is a smaller service locator that %s', $externalId, $this->formatAlternatives());
+            $msg[] = sprintf('the container inside "%s" is a smaller service locator that %s', $externalId, $this->formatAlternatives());
         } else {
-            $msg .= sprintf('the current service locator %s', $this->formatAlternatives());
+            $msg[] = sprintf('the current service locator %s', $this->formatAlternatives());
         }
 
         if (!$class) {
             // no-op
         } elseif (is_subclass_of($class, ServiceSubscriberInterface::class)) {
-            $msg .= sprintf(' Unless you need extra laziness, try using dependency injection instead. Otherwise, you need to declare it using "%s::getSubscribedServices()".', preg_replace('/([^\\\\]++\\\\)++/', '', $class));
+            $msg[] = sprintf('Unless you need extra laziness, try using dependency injection instead. Otherwise, you need to declare it using "%s::getSubscribedServices()".', preg_replace('/([^\\\\]++\\\\)++/', '', $class));
         } else {
-            $msg .= 'Try using dependency injection instead.';
+            $msg[] = 'Try using dependency injection instead.';
         }
 
-        return $msg;
+        return implode(' ', $msg);
     }
 
     private function formatAlternatives(array $alternatives = null, $separator = 'and')

--- a/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
@@ -115,6 +115,20 @@ class ServiceLocatorTest extends TestCase
         $subscriber->getFoo();
     }
 
+    /**
+     * @expectedException        \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @expectedExceptionMessage Service "foo" not found: even though it exists in the app's container, the container inside "foo" is a smaller service locator that is empty... Try using dependency injection instead.
+     */
+    public function testGetThrowsServiceNotFoundException()
+    {
+        $container = new Container();
+        $container->set('foo', new \stdClass());
+
+        $locator = new ServiceLocator(array());
+        $locator = $locator->withContext('foo', $container);
+        $locator->get('foo');
+    }
+
     public function testInvoke()
     {
         $locator = new ServiceLocator(array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Adding a much needed space in the serviceLocator createNotFoundException error message.

from
`Service "foo" not found: even though it exists in the app's container, the container inside "foo" is a smaller service locator that is empty...Try using dependency injection instead.
`
to
`Service "foo" not found: even though it exists in the app's container, the container inside "foo" is a smaller service locator that is empty... Try using dependency injection instead.
`
#SymfonyConHackday2018