### PR TITLE
[Form] Introduced proxy methods to allow easier handling of form errors

### DIFF
--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -198,7 +198,7 @@ class Button implements \IteratorAggregate, FormInterface
      */
     public function getAllErrors()
     {
-        return $this->getErrors(true);
+        return $this->getErrors();
     }
 
     /**

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -194,6 +194,22 @@ class Button implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getAllErrors()
+    {
+        return $this->getErrors(true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOnlyGlobalErrors()
+    {
+        return $this->getErrors();
+    }
+
+    /**
      * Unsupported method.
      *
      * This method should not be invoked.

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -802,6 +802,14 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
 
     /**
      * {@inheritdoc}
+     */
+    public function getAllErrors()
+    {
+        return $this->getErrors(true);
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @return $this
      */

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -810,6 +810,14 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
 
     /**
      * {@inheritdoc}
+     */
+    public function getOnlyGlobalErrors()
+    {
+        return $this->getErrors();
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @return $this
      */

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -107,7 +107,8 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * Returns the list of the current form and all child forms.
      *
      * @return FormErrorIterator An iterator over the {@link FormError}
-     *                           instances that where added to the form and the child forms.
+     *                           instances that where added to the form
+     *                           and the child forms.
      */
     public function getAllErrors();
 
@@ -115,7 +116,8 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * Returns the list of this form only - without child errors.
      *
      * @return FormErrorIterator an iterator over the {@link FormError}
-     *                           instances that where added to the top level of this form.
+     *                           instances that where added to the top
+     *                           level of this form.
      */
     public function getOnlyGlobalErrors();
 

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -104,6 +104,14 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function getErrors($deep = false, $flatten = true);
 
     /**
+     * Returns the list of the current form and all child forms.
+     *
+     * @return FormErrorIterator An iterator over the {@link FormError}
+     *                           instances that where added to the form and the child forms.
+     */
+    public function getAllErrors();
+
+    /**
      * Updates the form with default data.
      *
      * @param mixed $modelData The data formatted as expected for the underlying object

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -108,7 +108,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormErrorIterator An iterator over the {@link FormError}
      *                           instances that where added to the form
-     *                           and the child forms.
+     *                           and the child forms
      */
     public function getAllErrors();
 
@@ -117,7 +117,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormErrorIterator An iterator over the {@link FormError}
      *                           instances that where added to the top
-     *                           level of this form.
+     *                           level of this form
      */
     public function getOnlyGlobalErrors();
 

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -115,7 +115,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the list of this form only - without child errors.
      *
-     * @return FormErrorIterator an iterator over the {@link FormError}
+     * @return FormErrorIterator An iterator over the {@link FormError}
      *                           instances that where added to the top
      *                           level of this form.
      */

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -112,6 +112,14 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function getAllErrors();
 
     /**
+     * Returns the list of this form only - without child errors.
+     *
+     * @return FormErrorIterator an iterator over the {@link FormError}
+     *                           instances that where added to the top level of this form.
+     */
+    public function getOnlyGlobalErrors();
+
+    /**
      * Updates the form with default data.
      *
      * @param mixed $modelData The data formatted as expected for the underlying object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no - but the option is there
| Tests pass?   | yes 
| Fixed tickets | #25738
| License       | MIT
| Doc PR        | symfony/symfony-docs#... in progress|

In order to create a better experience for new developers the introduction of two proxy methods seem to be a good idea when handling with forms. As stated in the issue it isn't always obvious as to why `$form->isValid()` will return `false` and `$form->getErrors()` will leave you with nothing since you didn't think about the parameters to control the list of errors.
Now, I've added two methods: `getAllErrors()` which is a shortcut for `$form->getErrors(true)` and `getOnlyGlobalErrors()` an alias for the `$form->getErrors()` call.

#symfonyconhackday2018