### PR TITLE
[TwigBridge][Form] Prevent multiple rendering of form collection prototypes

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -24,7 +24,7 @@
 {%- endblock form_widget_compound -%}
 
 {%- block collection_widget -%}
-    {% if prototype is defined %}
+    {% if prototype is defined and not prototype.rendered %}
         {%- set attr = attr|merge({'data-prototype': form_row(prototype) }) -%}
     {% endif %}
     {{- block('form_widget') -}}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29489   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

prevents attemt to render of prototype in CollectionType when it has been rendered already.
(see [Deprecated calling FormRenderer::searchAndRenderBlock for fields which were already rendered.](https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#form)) 
