### PR TITLE
[DebugBundle] Added 'theme' option to change the color of dump() when rendered inside templates

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\DebugBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 /**
  * DebugExtension configuration structure.
@@ -28,8 +29,8 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('debug');
 
-        $treeBuilder->getRootNode()
-            ->children()
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode->children()
                 ->integerNode('max_items')
                     ->info('Max number of displayed items past the first level, -1 means no limit')
                     ->min(-1)
@@ -52,6 +53,19 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+
+        if (method_exists(HtmlDumper::class, 'setTheme')) {
+            $rootNode
+                ->children()
+                    ->enumNode('theme')
+                        ->info('Changes the color of the dump() output when rendered directly on the templating. "dark" (default) or "light"')
+                        ->example('dark')
+                        ->values(array('dark', 'light'))
+                        ->defaultValue('dark')
+                    ->end()
+                ->end()
+            ;
+        }
 
         return $treeBuilder;
     }

--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 /**
  * DebugExtension.
@@ -41,6 +42,11 @@ class DebugExtension extends Extension
             ->addMethodCall('setMaxItems', array($config['max_items']))
             ->addMethodCall('setMinDepth', array($config['min_depth']))
             ->addMethodCall('setMaxString', array($config['max_string_length']));
+
+        if (method_exists(HtmlDumper::class, 'setTheme') && 'dark' !== $config['theme']) {
+            $container->getDefinition('var_dumper.html_dumper')
+                ->addMethodCall('setTheme', array($config['theme']));
+        }
 
         if (null === $config['dump_destination']) {
             $container->getDefinition('var_dumper.command.server_dump')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes   
| License       | MIT

Added a html_dumper_theme option config to use the new HtmlDumper light theme when using dump() inside templates

#SymfonyConHackday2018
