### PR TITLE
[Validator] Added IBAN format for Vatican City State

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -129,6 +129,7 @@ class IbanValidator extends ConstraintValidator
         'TN' => 'TN59\d{2}\d{3}\d{13}\d{2}', // Tunisia
         'TR' => 'TR\d{2}\d{5}[\dA-Z]{1}[\dA-Z]{16}', // Turkey
         'UA' => 'UA\d{2}\d{6}[\dA-Z]{19}', // Ukraine
+        'VA' => 'VA\d{2}\d{3}\d{15}', // Vatican City State
         'VG' => 'VG\d{2}[A-Z]{4}\d{16}', // Virgin Islands, British
         'WF' => 'FR\d{2}\d{5}\d{5}[\dA-Z]{11}\d{2}', // Wallis and Futuna Islands
         'XK' => 'XK\d{2}\d{4}\d{10}\d{2}', // Republic of Kosovo

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -156,6 +156,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
             array('TR330006100519786457841326'), //Turkey
             array('UA213223130000026007233566001'), //Ukraine
             array('AE260211000000230064016'), //United Arab Emirates
+            array('VA59001123000012345678'), //Vatican City State
         );
     }
 
@@ -274,6 +275,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
             array('TR3300061005197864578413261'), //Turkey
             array('UA21AAAA1300000260072335660012'), //Ukraine
             array('AE2602110000002300640161'), //United Arab Emirates
+            array('VA590011230000123456781'), //Vatican City State
         );
     }
 
@@ -385,6 +387,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
             array('TR330006100519786457841327'), //Turkey
             array('UA213223130000026007233566002'), //Ukraine
             array('AE260211000000230064017'), //United Arab Emirates
+            array('VA59001123000012345671'), //Vatican City State
         );
     }
 


### PR DESCRIPTION
IBAN for Vatican City State was added to [IBAN registry](https://www.swift.com/sites/default/files/resources/iban_registry.pdf) recently. This PR adds support for this new format in the `Iban` validator.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT