### PR TITLE
Fixed public directory when configured in composer.json

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -65,7 +66,7 @@ class AssetsInstallCommand extends ContainerAwareCommand
     {
         $this
             ->setDefinition(array(
-                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'public'),
+                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', null),
             ))
             ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
             ->addOption('relative', null, InputOption::VALUE_NONE, 'Make relative symlinks')
@@ -106,6 +107,10 @@ EOT
 
         $kernel = $this->getApplication()->getKernel();
         $targetArg = rtrim($input->getArgument('target'), '/');
+
+        if (!$targetArg) {
+            $targetArg = $this->getPublicDirectory($this->getContainer());
+        }
 
         if (!is_dir($targetArg)) {
             $targetArg = (isset($baseDir) ? $baseDir : $kernel->getContainer()->getParameter('kernel.project_dir')).'/'.$targetArg;
@@ -287,5 +292,28 @@ EOT
         $this->filesystem->mirror($originDir, $targetDir, Finder::create()->ignoreDotFiles(false)->in($originDir));
 
         return self::METHOD_COPY;
+    }
+
+    private function getPublicDirectory(ContainerInterface $container)
+    {
+        $defaultPublicDir = 'public';
+
+        if (!$container->hasParameter('kernel.project_dir')) {
+            return $defaultPublicDir;
+        }
+
+        $composerFilePath = $container->getParameter('kernel.project_dir').'/composer.json';
+
+        if (!file_exists($composerFilePath)) {
+            return $defaultPublicDir;
+        }
+
+        $composerConfig = json_decode(file_get_contents($composerFilePath), true);
+
+        if (isset($composerConfig['extra']['public-dir'])) {
+            return $composerConfig['extra']['public-dir'];
+        }
+
+        return $defaultPublicDir;
     }
 }

--- a/src/Symfony/Bundle/WebServerBundle/DependencyInjection/WebServerExtension.php
+++ b/src/Symfony/Bundle/WebServerBundle/DependencyInjection/WebServerExtension.php
@@ -27,8 +27,31 @@ class WebServerExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('webserver.xml');
 
+        $publicDirectory = $this->getPublicDirectory($container);
+        $container->getDefinition('web_server.command.server_run')->replaceArgument(0, $publicDirectory);
+        $container->getDefinition('web_server.command.server_start')->replaceArgument(0, $publicDirectory);
+
         if (!class_exists(ConsoleFormatter::class)) {
             $container->removeDefinition('web_server.command.server_log');
         }
+    }
+
+    private function getPublicDirectory(ContainerBuilder $container)
+    {
+        $kernelProjectDir = $container->getParameter('kernel.project_dir');
+        $publicDir = 'public';
+        $composerFilePath = $kernelProjectDir.'/composer.json';
+
+        if (!file_exists($composerFilePath)) {
+            return $kernelProjectDir.'/'.$publicDir;
+        }
+
+        $composerConfig = json_decode(file_get_contents($composerFilePath), true);
+
+        if (isset($composerConfig['extra']['public-dir'])) {
+            $publicDir = $composerConfig['extra']['public-dir'];
+        }
+
+        return $kernelProjectDir.'/'.$publicDir;
     }
 }

--- a/src/Symfony/Bundle/WebServerBundle/Tests/DependencyInjection/WebServerExtensionTest.php
+++ b/src/Symfony/Bundle/WebServerBundle/Tests/DependencyInjection/WebServerExtensionTest.php
@@ -21,8 +21,17 @@ class WebServerExtensionTest extends TestCase
     public function testLoad()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', __DIR__);
         (new WebServerExtension())->load(array(), $container);
 
+        $this->assertSame(
+            __DIR__.'/test',
+            $container->getDefinition('web_server.command.server_run')->getArgument(0)
+        );
+        $this->assertSame(
+            __DIR__.'/test',
+            $container->getDefinition('web_server.command.server_start')->getArgument(0)
+        );
         $this->assertTrue($container->hasDefinition('web_server.command.server_run'));
         $this->assertTrue($container->hasDefinition('web_server.command.server_start'));
         $this->assertTrue($container->hasDefinition('web_server.command.server_stop'));

--- a/src/Symfony/Bundle/WebServerBundle/Tests/DependencyInjection/composer.json
+++ b/src/Symfony/Bundle/WebServerBundle/Tests/DependencyInjection/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "test-composer.json",
+    "extra": {
+        "public-dir": "test"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |  no
| Tests pass?   | yes
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

As documented you should be able to change the public-dir by composer.json so the server:run and assets:install should also use that configuration when available: 

https://symfony.com/doc/3.4/configuration/override_dir_structure.html#override-the-web-directory
https://symfony.com/doc/current/configuration/override_dir_structure.html#override-the-public-directory

#SymfonyConHackDay2018 
