### PR TITLE
[HackDay][WebProfilerBundle]Display the main template on the debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -55,6 +55,12 @@
                 <span>{{ collector.route|default('n/a') }}</span>
             </div>
 
+            {%- set keystemplates = profile.collectors['twig'].getTemplates|keys|default(false) -%}
+            <div class="sf-toolbar-info-piece">
+                <b>Main template</b>
+                <span>{{ keystemplates|first }}</span>
+            </div>
+
             <div class="sf-toolbar-info-piece">
                 <b>Has session</b>
                 <span>{% if collector.sessionmetadata|length %}yes{% else %}no{% endif %}</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #
| License       | MIT
| Doc PR        | None

It's my first PR for the Symfony community. 
I thought it would be useful to display the main template in the debug toolbar.
Eg : 
<img width="319" alt="capture d ecran 2018-12-08 a 16 16 48" src="https://user-images.githubusercontent.com/7878654/49688632-09102600-fb0d-11e8-902e-8e33d50a13bb.png">


Thanks for all and thanks for you feedbacks.

#SymfonyConHackday2018
