### PR TITLE
Improve form errors

### DIFF
--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -193,6 +193,16 @@ class Button implements \IteratorAggregate, FormInterface
         return new FormErrorIterator($this, array());
     }
 
+    public function getErrorIterator($deep = false, $flatten = true)
+    {
+        return new FormErrorIterator($this, array());
+    }
+
+    public function getAllErrors()
+    {
+        return array();
+    }
+
     /**
      * Unsupported method.
      *

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -532,6 +532,11 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
             $submittedData = null;
         } elseif (is_scalar($submittedData)) {
             $submittedData = (string) $submittedData;
+        } elseif ($this->config->getOption('allow_file_upload')) {
+            // no-op
+        } elseif ($this->config->getRequestHandler()->isFileUpload($submittedData)) {
+            $submittedData = null;
+            $this->transformationFailure = new TransformationFailedException('Submitted data was expected to be text or number, file upload given.');
         }
 
         $dispatcher = $this->config->getEventDispatcher();
@@ -541,6 +546,10 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
         $viewData = null;
 
         try {
+            if (null !== $this->transformationFailure) {
+                throw $this->transformationFailure;
+            }
+
             // Hook to change content of the data submitted by the browser
             if ($dispatcher->hasListeners(FormEvents::PRE_SUBMIT)) {
                 $event = new FormEvent($this, $submittedData);

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -532,11 +532,6 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
             $submittedData = null;
         } elseif (is_scalar($submittedData)) {
             $submittedData = (string) $submittedData;
-        } elseif ($this->config->getOption('allow_file_upload')) {
-            // no-op
-        } elseif ($this->config->getRequestHandler()->isFileUpload($submittedData)) {
-            $submittedData = null;
-            $this->transformationFailure = new TransformationFailedException('Submitted data was expected to be text or number, file upload given.');
         }
 
         $dispatcher = $this->config->getEventDispatcher();
@@ -546,10 +541,6 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
         $viewData = null;
 
         try {
-            if (null !== $this->transformationFailure) {
-                throw $this->transformationFailure;
-            }
-
             // Hook to change content of the data submitted by the browser
             if ($dispatcher->hasListeners(FormEvents::PRE_SUBMIT)) {
                 $event = new FormEvent($this, $submittedData);
@@ -769,7 +760,25 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
     /**
      * {@inheritdoc}
      */
+    public function getAllErrors()
+    {
+        return $this->getErrorIterator(true, true)->all();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getErrors($deep = false, $flatten = true)
+    {
+        @trigger_error('Calling «getErrors» is deprecated.  Please use either getErrorIterator or getAllErrors', E_USER_DEPRECATED);
+
+        return $this->getErrorIterator($deep, $flatten);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorIterator($deep = false, $flatten = true)
     {
         $errors = $this->errors;
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -771,7 +771,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
      */
     public function getAllErrors()
     {
-        return $this->getErrorIterator(true, false)->all();
+        return $this->getErrorIterator(true, true)->all();
     }
 
     /**

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -771,7 +771,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
      */
     public function getAllErrors()
     {
-        return $this->getErrorIterator(true, true)->all();
+        return $this->getErrorIterator(true, false)->all();
     }
 
     /**

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -92,12 +92,12 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
         foreach ($this->errors as $error) {
             if ($error instanceof self) {
                 $subErrors = $error->all();
-                array_walk_recursive($subErrors, function($input) use (&$flattenedErrors) { $return[] = $x; });
+                array_walk_recursive($subErrors, function($input) use (&$flattenedErrors) { $flattenedErrors[] = $input; });
             } else {
                 $flattenedErrors[] = $error;
             }
         }
-        
+
         return $flattenedErrors;
     }
 

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -82,6 +82,26 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
     }
 
     /**
+     * Returns an array of ForError.
+     *
+     * @return array|FormError[]
+     */
+    public function all()
+    {
+        $flattenedErrors = array();
+        foreach ($this->errors as $error) {
+            if ($error instanceof self) {
+                $subErrors = $error->all();
+                array_walk_recursive($subErrors, function($input) use (&$flattenedErrors) { $return[] = $x; });
+            } else {
+                $flattenedErrors[] = $error;
+            }
+        }
+        
+        return $flattenedErrors;
+    }
+
+    /**
      * Returns the iterated form.
      *
      * @return FormInterface The form whose errors are iterated by this object

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -92,7 +92,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
         foreach ($this->errors as $error) {
             if ($error instanceof self) {
                 $subErrors = $error->all();
-                array_walk_recursive($subErrors, function($input) use (&$flattenedErrors) { $flattenedErrors[] = $input; });
+                array_walk_recursive($subErrors, function ($input) use (&$flattenedErrors) { $flattenedErrors[] = $input; });
             } else {
                 $flattenedErrors[] = $error;
             }

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -82,7 +82,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
     }
 
     /**
-     * Returns an array of ForError.
+     * Returns an array of FormError.
      *
      * @return array|FormError[]
      */

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -112,6 +112,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormErrorIterator An iterator over the {@link FormError}
      *                           instances that where added to this form
+     *
      * @deprecated Use either getErrorIterator or getAllErrors
      */
     public function getErrors($deep = false, $flatten = true);
@@ -119,7 +120,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns an array of errors for this form.
      *
-     * @return Array|FormError[] An array with all errors found in the form
+     * @return array|FormError[] An array with all errors found in the form
      */
     public function getAllErrors();
 
@@ -147,9 +148,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the normalized data of the field.
      *
-     * @return mixed When the field is not submitted, the default data is returned.
+     * @return mixed when the field is not submitted, the default data is returned.
      *               When the field is submitted, the normalized submitted data is
-     *               returned if the field is valid, null otherwise.
+     *               returned if the field is valid, null otherwise
      */
     public function getNormData();
 

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -101,7 +101,27 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * @return FormErrorIterator An iterator over the {@link FormError}
      *                           instances that where added to this form
      */
+    public function getErrorIterator($deep = false, $flatten = true);
+
+    /**
+     * Returns the errors of this form.
+     *
+     * @param bool $deep    Whether to include errors of child forms as well
+     * @param bool $flatten Whether to flatten the list of errors in case
+     *                      $deep is set to true
+     *
+     * @return FormErrorIterator An iterator over the {@link FormError}
+     *                           instances that where added to this form
+     * @deprecated Use either getErrorIterator or getAllErrors
+     */
     public function getErrors($deep = false, $flatten = true);
+
+    /**
+     * Returns an array of errors for this form.
+     *
+     * @return Array|FormError[] An array with all errors found in the form
+     */
+    public function getAllErrors();
 
     /**
      * Updates the form with default data.

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -808,12 +808,12 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertEquals(array('extra' => 'data'), $form->getExtraData());
     }
 
-    public function testGetErrors()
+    public function testgetErrorIterator()
     {
         $this->form->addError($error1 = new FormError('Error 1'));
         $this->form->addError($error2 = new FormError('Error 2'));
 
-        $errors = $this->form->getErrors();
+        $errors = $this->form->getErrorIterator();
 
         $this->assertSame(
              "ERROR: Error 1\n".
@@ -833,7 +833,7 @@ class CompoundFormTest extends AbstractFormTest
         $childForm->addError($nestedError = new FormError('Nested Error'));
         $this->form->add($childForm);
 
-        $errors = $this->form->getErrors(true);
+        $errors = $this->form->getErrorIterator(true);
 
         $this->assertSame(
              "ERROR: Error 1\n".
@@ -857,7 +857,7 @@ class CompoundFormTest extends AbstractFormTest
         $childForm->addError($nestedError = new FormError('Nested Error'));
         $this->form->add($childForm);
 
-        $errors = $this->form->getErrors(true, false);
+        $errors = $this->form->getErrorIterator(true, false);
 
         $this->assertSame(
              "ERROR: Error 1\n".
@@ -884,11 +884,11 @@ class CompoundFormTest extends AbstractFormTest
         $this->form->addError(new FormError('Error 1'));
         $this->form->addError(new FormError('Error 2'));
 
-        $this->assertCount(2, $this->form->getErrors());
+        $this->assertCount(2, $this->form->getErrorIterator());
 
         $this->form->clearErrors();
 
-        $this->assertCount(0, $this->form->getErrors());
+        $this->assertCount(0, $this->form->getErrorIterator());
     }
 
     public function testClearErrorsShallow()
@@ -902,8 +902,8 @@ class CompoundFormTest extends AbstractFormTest
 
         $this->form->clearErrors(false);
 
-        $this->assertCount(0, $this->form->getErrors(false));
-        $this->assertCount(1, $this->form->getErrors(true));
+        $this->assertCount(0, $this->form->getErrorIterator(false));
+        $this->assertCount(1, $this->form->getErrorIterator(true));
     }
 
     public function testClearErrorsDeep()
@@ -917,8 +917,28 @@ class CompoundFormTest extends AbstractFormTest
 
         $this->form->clearErrors(true);
 
-        $this->assertCount(0, $this->form->getErrors(false));
-        $this->assertCount(0, $this->form->getErrors(true));
+        $this->assertCount(0, $this->form->getErrorIterator(false));
+        $this->assertCount(0, $this->form->getErrorIterator(true));
+    }
+
+    public function testGetAllErrorsWithoutChildren()
+    {
+        $this->form->addError($error1 = new FormError('Error 1'));
+        $this->form->addError($error2 = new FormError('Error 2'));
+
+        $this->assertCount(2, $this->form->getAllErrors());
+    }
+
+    public function testGetAllErrorsWithChildren()
+    {
+        $this->form->addError($error1 = new FormError('Error 1'));
+        $this->form->addError($error2 = new FormError('Error 2'));
+
+        $childForm = $this->getBuilder('Child')->getForm();
+        $childForm->addError($nestedError = new FormError('Nested Error'));
+        $this->form->add($childForm);
+
+        $this->assertCount(3, $this->form->getAllErrors());
     }
 
     // Basic cases are covered in SimpleFormTest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #25738
| License       | MIT
| Doc PR        | Waiting for approve

Following the issue [#25738](https://github.com/symfony/symfony/issues/25738) this PR is a proposal to make form error more explicit for everyone.

Traditionnal `$form->getErrors()` is renamed as `$form->getErrorIterator()` with same signature and a new method called `getAllErrors()`, more explicit, will return an array of `FormErrors`

`getErrors()` method is kept but marked as deprecated.

I know this is a major change and it may be done differently.
Especially the `all()` method on `FormErrorsIterator`.

This is a proposal and I'm open to other ways of fixing this issue.

Tests are written to reflect this change (Yay!)

If this PR is approve, I'll make another PR to change doc accordingly.

#SymfonyConHackday2018
