### PR TITLE
[FrameworkBundle] Stop calling Kernel::boot() twice in cli

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -62,15 +62,13 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        $this->kernel->boot();
-
-        $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));
-
         $this->registerCommands();
 
         if ($this->registrationErrors) {
             $this->renderRegistrationErrors($input, $output);
         }
+
+        $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));
 
         return parent::doRun($input, $output);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -204,6 +204,7 @@ class ApplicationTest extends TestCase
         $container->setParameter('console.command.ids', array(ThrowingCommand::class => ThrowingCommand::class));
 
         $kernel = $this->getMockBuilder(KernelInterface::class)->getMock();
+        $kernel->expects($this->once())->method('boot');
         $kernel
             ->method('getBundles')
             ->willReturn(array($this->createBundleMock(
@@ -256,6 +257,7 @@ class ApplicationTest extends TestCase
         ;
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
+        $kernel->expects($this->once())->method('boot');
         $kernel
             ->expects($this->any())
             ->method('getBundles')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29505
| License       | MIT
| Doc PR        | n/a

Allows custom `Kernel::boot()` implementations to not be aware of the protected `Kernel::$booted` prop.