### PR TITLE
[Messenger] Restore message handlers laziness

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -37,7 +37,6 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
-use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -1600,12 +1599,7 @@ class FrameworkExtension extends Extension
                 $senders[$sender] = new Reference($senderAliases[$sender] ?? $sender);
             }
 
-            $sendersId = 'messenger.senders.'.$message;
-            $container->register($sendersId, RewindableGenerator::class)
-                ->setFactory('current')
-                ->addArgument(array(new IteratorArgument($senders)));
-            $messageToSendersMapping[$message] = new Reference($sendersId);
-
+            $messageToSendersMapping[$message] = new IteratorArgument($senders);
             $messagesToSendAndHandle[$message] = $messageConfiguration['send_and_handle'];
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -651,10 +651,11 @@ abstract class FrameworkExtensionTest extends TestCase
         );
 
         $this->assertSame($messageToSendAndHandleMapping, $senderLocatorDefinition->getArgument(1));
+        $sendersMapping = $senderLocatorDefinition->getArgument(0);
         $this->assertEquals(array(
             'amqp' => new Reference('messenger.transport.amqp'),
             'audit' => new Reference('audit'),
-        ), $container->getDefinition('messenger.senders.'.DummyMessage::class)->getArgument(0)[0]->getValues());
+        ), $sendersMapping[DummyMessage::class]->getValues());
     }
 
     /**

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Messenger\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
-use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
@@ -163,11 +162,7 @@ class MessengerPass implements CompilerPassInterface
         foreach ($handlersByBusAndMessage as $bus => $handlersByMessage) {
             foreach ($handlersByMessage as $message => $handlerIds) {
                 $handlers = array_map(function (string $handlerId) { return new Reference($handlerId); }, $handlerIds);
-                $handlersId = "messenger.handlers.$bus.$message";
-                $definitions[$handlersId] = (new Definition(RewindableGenerator::class))
-                    ->setFactory('current')
-                    ->addArgument(array($handlers));
-                $handlersLocatorMappingByBus[$bus][$message] = new Reference($handlersId);
+                $handlersLocatorMappingByBus[$bus][$message] = new IteratorArgument($handlers);
             }
         }
         $container->addDefinitions($definitions);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The `HandlersLocator` introduced in 4.2 currently needs to instantiate all message handlers of the bus in order to be wired, while they were lazily loaded in 4.1 via ContainerHandlerLocator (removed).

Example:
```yaml
framework:
    messenger:
        buses:
            messenger.bus.command: ~
services:
    App\Messenger\:
        resource: '../src/Messenger/*Handler.php'
        tags:
            - { name: messenger.message_handler, bus: messenger.bus.command }
```

```php
namespace App\Messenger;

class BarCommand {}
class BarCommandHandler { public function __invoke(BarCommand $command): void {} }

class FooCommand {}
class FooCommandHandler { public function __invoke(FooCommand $command): void {} }
```
(Dumped `HandleMessageMiddleware` factory) Before:

```php
return $this->privates['messenger.bus.command.middleware.handle_message'] = new \Symfony\Component\Messenger\Middleware\HandleMessageMiddleware(new \Symfony\Component\Messenger\Handler\HandlersLocator(array(
    'App\\Messenger\\BarCommand' => \current(array(0 => array(0 => new \App\Messenger\BarCommandHandler()))), 
    'App\\Messenger\\FooCommand' => \current(array(0 => array(0 => new \App\Messenger\FooCommandHandler())))
)));
```

After:
```php
return $this->privates['messenger.bus.command.middleware.handle_message'] = new \Symfony\Component\Messenger\Middleware\HandleMessageMiddleware(new \Symfony\Component\Messenger\Handler\HandlersLocator(array(
    'App\\Messenger\\BarCommand' => new RewindableGenerator(function () {
        yield 0 => ($this->privates['App\Messenger\BarCommandHandler'] ?? ($this->privates['App\Messenger\BarCommandHandler'] = new \App\Messenger\BarCommandHandler()));
    }, 1), 
    'App\\Messenger\\FooCommand' => new RewindableGenerator(function () {
        yield 0 => ($this->privates['App\Messenger\FooCommandHandler'] ?? ($this->privates['App\Messenger\FooCommandHandler'] = new \App\Messenger\FooCommandHandler()));
    }, 1)
)));
```