### PR TITLE
[FrameworkBundle] decouple debug:autowiring from phpdocumentor/reflection-docblock

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 
-use phpDocumentor\Reflection\DocBlockFactory;
-use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Symfony\Component\Console\Descriptor\DescriptorInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Alias;
@@ -293,21 +291,16 @@ abstract class Descriptor implements DescriptorInterface
     public static function getClassDescription(string $class, string &$resolvedClass = null): string
     {
         $resolvedClass = $class;
-
-        if (!interface_exists(DocBlockFactoryInterface::class)) {
-            return '';
-        }
-
         try {
             $r = new \ReflectionClass($class);
             $resolvedClass = $r->name;
 
             if ($docComment = $r->getDocComment()) {
-                return DocBlockFactory::createInstance()
-                    ->create($docComment)
-                    ->getSummary();
+                $docComment = preg_split('#\n\s*\*\s*[\n@]#', substr($docComment, 3, -2), 2)[0];
+
+                return trim(preg_replace('#\s*\n\s*\*\s*#', ' ', $docComment));
             }
-        } catch (\ReflectionException | \InvalidArgumentException $e) {
+        } catch (\ReflectionException $e) {
         }
 
         return '';

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -195,6 +195,22 @@ abstract class AbstractDescriptorTest extends TestCase
         return $this->getDescriptionTestData(ObjectsProvider::getCallables());
     }
 
+    /** @dataProvider getClassDescriptionTestData */
+    public function testGetClassDecription($object, $expectedDescription)
+    {
+        $this->assertEquals($expectedDescription, $this->getDescriptor()->getClassDescription($object));
+    }
+
+    public function getClassDescriptionTestData()
+    {
+        return array(
+            array(ClassWithDocCommentOnMultipleLines::class, 'This is the first line of the description. This is the second line.'),
+            array(ClassWithDocCommentWithoutInitialSpace::class, 'Foo.'),
+            array(ClassWithoutDocComment::class, ''),
+            array(ClassWithDocComment::class, 'This is a class with a doc comment.'),
+        );
+    }
+
     abstract protected function getDescriptor();
 
     abstract protected function getFormat();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -221,3 +221,24 @@ class ClassWithoutDocComment
 class ClassWithDocComment
 {
 }
+
+/**
+ * This is the first line of the description.
+ * This is the second line.
+ *
+ * This is the third and shouldn't be shown.
+ *
+ * @annot should not be parsed
+ */
+class ClassWithDocCommentOnMultipleLines
+{
+}
+
+/**
+ *Foo.
+ *
+ * @annot should not be parsed
+ */
+class ClassWithDocCommentWithoutInitialSpace
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -80,7 +80,6 @@
     },
     "suggest": {
         "ext-apcu": "For best performance of the system caches",
-        "phpdocumentor/reflection-docblock": "For display additional information in debug:container",
         "symfony/console": "For using the console commands",
         "symfony/form": "For using forms",
         "symfony/serializer": "For using the serializer service",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
New feature?  | no 
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT

When phpDocumentor isn't installed the *debug:autowiring* returns an empty string for class description. With this fallback the end user will get a description even phpDocumentor isn't installed.

**Edit:** Usage of phpDocumentor is completely removed from debug:autowiring command. 