### PR TITLE
[Yaml] ensures that the mb_internal_encoding is reset to its initial value

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -110,35 +110,37 @@ class Inline
             mb_internal_encoding('ASCII');
         }
 
-        $i = 0;
-        $tag = self::parseTag($value, $i, $flags);
-        switch ($value[$i]) {
-            case '[':
-                $result = self::parseSequence($value, $flags, $i, $references);
-                ++$i;
-                break;
-            case '{':
-                $result = self::parseMapping($value, $flags, $i, $references);
-                ++$i;
-                break;
-            default:
-                $result = self::parseScalar($value, $flags, null, $i, null === $tag, $references);
-        }
+        try {
+            $i = 0;
+            $tag = self::parseTag($value, $i, $flags);
+            switch ($value[$i]) {
+                case '[':
+                    $result = self::parseSequence($value, $flags, $i, $references);
+                    ++$i;
+                    break;
+                case '{':
+                    $result = self::parseMapping($value, $flags, $i, $references);
+                    ++$i;
+                    break;
+                default:
+                    $result = self::parseScalar($value, $flags, null, $i, null === $tag, $references);
+            }
 
-        if (null !== $tag) {
-            return new TaggedValue($tag, $result);
-        }
+            if (null !== $tag) {
+                return new TaggedValue($tag, $result);
+            }
 
-        // some comments are allowed at the end
-        if (preg_replace('/\s+#.*$/A', '', substr($value, $i))) {
-            throw new ParseException(sprintf('Unexpected characters near "%s".', substr($value, $i)), self::$parsedLineNumber + 1, $value, self::$parsedFilename);
-        }
+            // some comments are allowed at the end
+            if (preg_replace('/\s+#.*$/A', '', substr($value, $i))) {
+                throw new ParseException(sprintf('Unexpected characters near "%s".', substr($value, $i)), self::$parsedLineNumber + 1, $value, self::$parsedFilename);
+            }
 
-        if (isset($mbEncoding)) {
-            mb_internal_encoding($mbEncoding);
+            return $result;
+        } finally {
+            if (isset($mbEncoding)) {
+                mb_internal_encoding($mbEncoding);
+            }
         }
-
-        return $result;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When `Symfony\Component\Yaml\Inline::parse` sets the internal encoding to ASCII and the method does an early return or throws an exception, the internal encoding would not be reset.
This Patch ensures the reset of the encoding by moving it into a finally block.
