### PR TITLE
[DI] move RegisterServiceSubscribersPass before DecoratorServicePass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -51,12 +51,12 @@ class PassConfig
         $this->optimizationPasses = array(array(
             new ResolveChildDefinitionsPass(),
             new ServiceLocatorTagPass(),
+            new RegisterServiceSubscribersPass(),
             new DecoratorServicePass(),
             new ResolveParameterPlaceHoldersPass(false),
             new ResolveFactoryClassPass(),
             new FactoryReturnTypePass($resolveClassPass),
             new CheckDefinitionValidityPass(),
-            new RegisterServiceSubscribersPass(),
             new ResolveNamedArgumentsPass(),
             new AutowireRequiredMethodsPass(),
             new ResolveBindingsPass(),

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 
 /**
  * This class tests the integration of the different compiler passes.
@@ -117,6 +118,21 @@ class IntegrationTest extends TestCase
         $this->assertFalse($container->hasDefinition('c'), 'Service C was not inlined.');
     }
 
+    public function testCanDecorateServiceSubscriber()
+    {
+        $container = new ContainerBuilder();
+        $container->register(ServiceSubscriberStub::class)
+            ->addTag('container.service_subscriber')
+            ->setPublic(true);
+
+        $container->register(DecoratedServiceSubscriber::class)
+            ->setDecoratedService(ServiceSubscriberStub::class);
+
+        $container->compile();
+
+        $this->assertInstanceOf(DecoratedServiceSubscriber::class, $container->get(ServiceSubscriberStub::class));
+    }
+
     /**
      * @dataProvider getYamlCompileTests
      */
@@ -205,6 +221,18 @@ class IntegrationTest extends TestCase
             'child_service_expected',
         );
     }
+}
+
+class ServiceSubscriberStub implements ServiceSubscriberInterface
+{
+    public static function getSubscribedServices()
+    {
+        return array();
+    }
+}
+
+class DecoratedServiceSubscriber
+{
 }
 
 class IntegrationTestStub extends IntegrationTestStubParent


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29550
| License       | MIT
| Doc PR        | n/a

From https://github.com/symfony/symfony/issues/29550#issuecomment-446351365: The fact that `RegisterServiceSubscribersPass` runs after `DecoratorServicePass` makes it impossible to decorate a service implementing `ServiceSubscriberInterface` if the decorator does not implement it.