### PR TITLE
Fix typos in doc blocks

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -50,7 +50,7 @@ class RedirectController
      * @param string     $route             The route name to redirect to
      * @param bool       $permanent         Whether the redirection is permanent
      * @param bool|array $ignoreAttributes  Whether to ignore attributes or an array of attributes to ignore
-     * @param bool       $keepRequestMethod Wheter redirect action should keep HTTP request method
+     * @param bool       $keepRequestMethod Whether redirect action should keep HTTP request method
      *
      * @throws HttpException In case the route name is empty
      */
@@ -94,7 +94,7 @@ class RedirectController
      * @param string|null $scheme            The URL scheme (null to keep the current one)
      * @param int|null    $httpPort          The HTTP port (null to keep the current one for the same scheme or the default configured port)
      * @param int|null    $httpsPort         The HTTPS port (null to keep the current one for the same scheme or the default configured port)
-     * @param bool        $keepRequestMethod Wheter redirect action should keep HTTP request method
+     * @param bool        $keepRequestMethod Whether redirect action should keep HTTP request method
      *
      * @throws HttpException In case the path is empty
      */


### PR DESCRIPTION
Change "wheter" to "whether" in doc blocks for redirectAction() and urlRedirectAction()

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no?
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Fixes two typos in the doc blocks for RedirectController:redirectAction() and RedirectController::urlRedirectAction()

One of the builds has a failing test, but surely that's not related to this PR? https://travis-ci.org/symfony/symfony/jobs/467149897