### PR TITLE
[Cache] Fix undefined variable in ArrayTrait

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -124,7 +124,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
 
             return true;
         }
-        if ($this->storeSerialized && null === $value = $this->freeze($value)) {
+        if ($this->storeSerialized && null === $value = $this->freeze($value, $key)) {
             return false;
         }
         if (null === $expiry && 0 < $item["\0*\0defaultLifetime"]) {

--- a/src/Symfony/Component/Cache/Simple/ArrayCache.php
+++ b/src/Symfony/Component/Cache/Simple/ArrayCache.php
@@ -129,7 +129,7 @@ class ArrayCache implements CacheInterface, LoggerAwareInterface, ResettableInte
         $expiry = 0 < $ttl ? microtime(true) + $ttl : PHP_INT_MAX;
 
         foreach ($valuesArray as $key => $value) {
-            if ($this->storeSerialized && null === $value = $this->freeze($value)) {
+            if ($this->storeSerialized && null === $value = $this->freeze($value, $key)) {
                 return false;
             }
             $this->values[$key] = $value;

--- a/src/Symfony/Component/Cache/Traits/ArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ArrayTrait.php
@@ -113,7 +113,7 @@ trait ArrayTrait
         }
     }
 
-    private function freeze($value)
+    private function freeze($value, $key)
     {
         if (null === $value) {
             return 'N;';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

After upgrading my project to 4.2 my tests failed with a message that `$key` variable is missing here: https://github.com/symfony/symfony/blob/e81285249b780a11ed209a79fa77c1f6ea6da67b/src/Symfony/Component/Cache/Traits/ArrayTrait.php#L131 which seems to be introduced with PR https://github.com/symfony/symfony/pull/27563.

So I added that variable to the trait and method calls (are there any other?). This is internal class so I guess noone is using it anywhere. 

Anyway, my tests pass with this fix.