### PR TITLE
Don't use he in docs when its not needed

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -46,7 +46,7 @@ interface EventDispatcherInterface
     /**
      * Adds an event subscriber.
      *
-     * The subscriber is asked for all the events he is
+     * The subscriber is asked for all the events it is
      * interested in and added as a listener for these events.
      */
     public function addSubscriber(EventSubscriberInterface $subscriber);

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -396,7 +396,7 @@ class ChoiceType extends AbstractType
         if ($options['multiple']) {
             $choiceType = __NAMESPACE__.'\CheckboxType';
             // The user can check 0 or more checkboxes. If required
-            // is true, he is required to check all of them.
+            // is true, they are required to check all of them.
             $choiceOpts['required'] = false;
         } else {
             $choiceType = __NAMESPACE__.'\RadioType';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no 
| Tests pass?   | yes   
| License       | MIT

The documentation talks about a man, an event subscriber clearly isn't one

Similar to https://github.com/symfony/symfony/pull/29594 but in more places