### PR TITLE
[Routing] Allow force-generation of trailing parameters using eg "/exports/news.{!_format}"

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -111,7 +111,7 @@ class RouteCompiler implements RouteCompilerInterface
 
         // Match all variables enclosed in "{}" and iterate over them. But we only want to match the innermost variable
         // in case of nested "{}", e.g. {foo{bar}}. This in ensured because \w does not match "{" or "}" itself.
-        preg_match_all('#\{\w+\}#', $pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        preg_match_all('#\{!?\w+\}#', $pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
         foreach ($matches as $match) {
             $varName = substr($match[0][0], 1, -1);
             // get all static text preceding the current variable
@@ -184,6 +184,9 @@ class RouteCompiler implements RouteCompilerInterface
             }
 
             $tokens[] = array('variable', $isSeparator ? $precedingChar : '', $regexp, $varName);
+            if ('!' === $varName[0]) {
+                $varName = substr($varName, 1);
+            }
             $variables[] = $varName;
         }
 
@@ -283,6 +286,10 @@ class RouteCompiler implements RouteCompilerInterface
             // Text tokens
             return preg_quote($token[1], self::REGEX_DELIMITER);
         } else {
+            if ('variable' === $token[0] && '!' === $token[3][0]) {
+                $token[3] = substr($token[3], 1);
+            }
+
             // Variable tokens
             if (0 === $index && 0 === $firstOptional) {
                 // When the only token is an optional variable token, the separator is required

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -397,6 +397,27 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/index.mobile.html', $generator->generate('test', array('page' => 'index', '_format' => 'mobile.html')));
     }
 
+    public function testImportantVariable()
+    {
+        $routes = $this->getRoutes('test', (new Route('/{page}.{!_format}'))->addDefaults(array('_format' => 'mobile.html')));
+        $generator = $this->getGenerator($routes);
+
+        $this->assertSame('/app.php/index.xml', $generator->generate('test', array('page' => 'index', '_format' => 'xml')));
+        $this->assertSame('/app.php/index.mobile.html', $generator->generate('test', array('page' => 'index', '_format' => 'mobile.html')));
+        $this->assertSame('/app.php/index.mobile.html', $generator->generate('test', array('page' => 'index')));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\MissingMandatoryParametersException
+     */
+    public function testImportantVariableWithNoDefault()
+    {
+        $routes = $this->getRoutes('test', new Route('/{page}.{!_format}'));
+        $generator = $this->getGenerator($routes);
+
+        $generator->generate('test', array('page' => 'index'));
+    }
+
     /**
      * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
      */

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -177,6 +177,15 @@ class UrlMatcherTest extends TestCase
         $this->assertEquals(array('_route' => '$péß^a|'), $matcher->match('/bar'));
     }
 
+    public function testMatchImportantVariable()
+    {
+        $collection = new RouteCollection();
+        $collection->add('index', new Route('/index.{!_format}', array('_format' => 'xml')));
+
+        $matcher = $this->getUrlMatcher($collection);
+        $this->assertEquals(array('_route' => 'index', '_format' => 'xml'), $matcher->match('/index.xml'));
+    }
+
     /**
      * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29593
| License       | MIT

When a route is defined as path: `/exports/news.{!_format}`, we should force `_format` be defined in `defaults` and the generator should generate URLs with that default when none is provided (should work with any parameter of course).