### PR TITLE
[DX] rename unit test controller

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -200,7 +200,7 @@ class HttpKernelTest extends TestCase
     public function testHandleWhenTheControllerIsAnObjectWithInvoke()
     {
         $dispatcher = new EventDispatcher();
-        $kernel = $this->getHttpKernel($dispatcher, new Controller());
+        $kernel = $this->getHttpKernel($dispatcher, new TestController());
 
         $this->assertResponseEquals(new Response('foo'), $kernel->handle(new Request()));
     }
@@ -216,7 +216,7 @@ class HttpKernelTest extends TestCase
     public function testHandleWhenTheControllerIsAnArray()
     {
         $dispatcher = new EventDispatcher();
-        $kernel = $this->getHttpKernel($dispatcher, array(new Controller(), 'controller'));
+        $kernel = $this->getHttpKernel($dispatcher, array(new TestController(), 'controller'));
 
         $this->assertResponseEquals(new Response('foo'), $kernel->handle(new Request()));
     }
@@ -224,7 +224,7 @@ class HttpKernelTest extends TestCase
     public function testHandleWhenTheControllerIsAStaticArray()
     {
         $dispatcher = new EventDispatcher();
-        $kernel = $this->getHttpKernel($dispatcher, array('Symfony\Component\HttpKernel\Tests\Controller', 'staticcontroller'));
+        $kernel = $this->getHttpKernel($dispatcher, array('Symfony\Component\HttpKernel\Tests\TestController', 'staticcontroller'));
 
         $this->assertResponseEquals(new Response('foo'), $kernel->handle(new Request()));
     }
@@ -381,7 +381,7 @@ class HttpKernelTest extends TestCase
     }
 }
 
-class Controller
+class TestController
 {
     public function __invoke()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      |no
| New feature?  |no
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Whenever I create a new controller the actually needed controller shows up second in the list of auto-completion. The first suggestion is a class defined in the test and should not ever be extended in the application. This PR renames it so that doesn't happen anymore.

Example of the autocomplete issue:

<img width="748" alt="screenshot 2018-12-14 at 10 33 26" src="https://user-images.githubusercontent.com/534693/49995500-a09dca80-ff8c-11e8-80b5-18890ff058b1.png">

