### PR TITLE
[Form] Fixed FormErrorIterator class phpdoc

### DIFF
--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -19,10 +19,9 @@ use Symfony\Component\Validator\ConstraintViolation;
 /**
  * Iterates over the errors of a form.
  *
- * Optionally, this class supports recursive iteration. In order to iterate
- * recursively, set the constructor argument $deep to true. Now each element
- * returned by the iterator is either an instance of {@link FormError} or of
- * {@link FormErrorIterator}, in case the errors belong to a sub-form.
+ * This class supports recursive iteration. In order to iterate recursively,
+ * pass a structure of {@link FormError} and {@link FormErrorIterator} objects
+ * to the $errors constructor argument.
  *
  * You can also wrap the iterator into a {@link \RecursiveIteratorIterator} to
  * flatten the recursive structure into a flat list of errors.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Fixed an outdated paragraph  in `FormErrorIterator` (since https://github.com/symfony/symfony/pull/10418).