### PR TITLE
Adjust tests to work in the armhf architecture. Fixes #29281.

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
@@ -35,7 +35,7 @@ SplFileInfo {
   aTime: %s-%s-%d %d:%d:%d
   mTime: %s-%s-%d %d:%d:%d
   cTime: %s-%s-%d %d:%d:%d
-  inode: %d
+  inode: %i
   size: %d
   perms: 0%d
   owner: %d
@@ -85,7 +85,7 @@ SplFileObject {
   aTime: %s-%s-%d %d:%d:%d
   mTime: %s-%s-%d %d:%d:%d
   cTime: %s-%s-%d %d:%d:%d
-  inode: %d
+  inode: %i
   size: %d
   perms: 0%d
   owner: %d
@@ -105,7 +105,7 @@ SplFileObject {
   maxLineLen: 0
   fstat: array:26 [
     "dev" => %d
-    "ino" => %d
+    "ino" => %i
     "nlink" => %d
     "rdev" => 0
     "blksize" => %i


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | can't verify
| Fixed tickets | #29281 
| License       | MIT

We saw VarDumper errors in armhf, but they are hard to reproduce interactively. In the issue report, it was suggested to replace %d with %i, and that's what I did in this branch. I'm sorry I can't give you confidence that this fixes the issue, and I'm just filing this PR because it was suggested and I'm trying to be helpful. I'm hoping there is CI here that can verify it.