### PR TITLE
[VarDumper] Use hyperlinks in CliDescriptor

### DIFF
--- a/src/Symfony/Component/VarDumper/Command/Descriptor/CliDescriptor.php
+++ b/src/Symfony/Component/VarDumper/Command/Descriptor/CliDescriptor.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarDumper\Command\Descriptor;
 
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -28,10 +29,12 @@ class CliDescriptor implements DumpDescriptorInterface
 {
     private $dumper;
     private $lastIdentifier;
+    private $supportsHref;
 
     public function __construct(CliDumper $dumper)
     {
         $this->dumper = $dumper;
+        $this->supportsHref = method_exists(OutputFormatterStyle::class, 'setHref');
     }
 
     public function describe(OutputInterface $output, Data $data, array $context, int $clientId): void
@@ -62,15 +65,19 @@ class CliDescriptor implements DumpDescriptorInterface
 
         if (isset($context['source'])) {
             $source = $context['source'];
-            $rows[] = array('source', sprintf('%s on line %d', $source['name'], $source['line']));
+            $sourceInfo = sprintf('%s on line %d', $source['name'], $source['line']);
+            $fileLink = $source['file_link'] ?? null;
+            if ($this->supportsHref && $fileLink) {
+                $sourceInfo = sprintf('<href=%s>%s</>', $fileLink, $sourceInfo);
+            }
+            $rows[] = array('source', $sourceInfo);
             $file = $source['file_relative'] ?? $source['file'];
             $rows[] = array('file', $file);
-            $fileLink = $source['file_link'] ?? null;
         }
 
         $io->table(array(), $rows);
 
-        if (isset($fileLink)) {
+        if (!$this->supportsHref && isset($fileLink)) {
             $io->writeln(array('<info>Open source in your IDE/browser:</info>', $fileLink));
             $io->newLine();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Part of #29585   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Leverages #29168 to add the hyperlink directly on the source text instead of printing below:

#### Before (or with `symfony/console < 4.3`)

![capture d ecran 2018-12-14 a 16 37 18](https://user-images.githubusercontent.com/2211145/50012891-1e2efe00-ffc0-11e8-9e07-b5358cb057bd.png)

#### After

![capture d ecran 2018-12-14 a 16 12 13](https://user-images.githubusercontent.com/2211145/50012921-25560c00-ffc0-11e8-92cd-d6efd43419f9.png)
