### PR TITLE
[Console] Add specific replacement for help text in single command applications

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -74,7 +74,7 @@ class Application
     private $dispatcher;
     private $terminal;
     private $defaultCommand;
-    private $singleCommand;
+    private $singleCommand = false;
     private $initialized;
 
     /**
@@ -1160,6 +1160,14 @@ class Application
         }
 
         return $this;
+    }
+
+    /**
+     * @internal
+     */
+    public function isSingleCommand()
+    {
+        return $this->singleCommand;
     }
 
     private function splitStringByWidth($string, $width)

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -533,6 +533,7 @@ class Command
     public function getProcessedHelp()
     {
         $name = $this->name;
+        $isSingleCommand = $this->application && $this->application->isSingleCommand();
 
         $placeholders = array(
             '%command.name%',
@@ -540,7 +541,7 @@ class Command
         );
         $replacements = array(
             $name,
-            $_SERVER['PHP_SELF'].' '.$name,
+            $isSingleCommand ? $_SERVER['PHP_SELF'] : $_SERVER['PHP_SELF'].' '.$name,
         );
 
         return str_replace($placeholders, $replacements, $this->getHelp() ?: $this->getDescription());

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -166,6 +166,14 @@ class CommandTest extends TestCase
         $command = new \TestCommand();
         $command->setHelp('');
         $this->assertContains('description', $command->getProcessedHelp(), '->getProcessedHelp() falls back to the description');
+
+        $command = new \TestCommand();
+        $command->setHelp('The %command.name% command does... Example: php %command.full_name%.');
+        $application = new Application();
+        $application->add($command);
+        $application->setDefaultCommand('namespace:name', true);
+        $this->assertContains('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly in single command applications');
+        $this->assertNotContains('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name% in single command applications');
     }
 
     public function testGetSetAliases()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

Simply omits the command name in the help text of single command applications which was wrongly displayed before.

For example, if the default command of an application is `echo` and the application is located at `bin/echo`, previously the help text would display `php bin/echo echo <text>` which is incorrect for single command applications since the command name ~~can~~ **must** be omitted: `php bin/echo <text>`.