### PR TITLE
[Console] OutputFormatter: move strtolower to createStyleFromString

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -157,7 +157,7 @@ class OutputFormatter implements OutputFormatterInterface
             if (!$open && !$tag) {
                 // </>
                 $this->styleStack->pop();
-            } elseif (false === $style = $this->createStyleFromString(strtolower($tag))) {
+            } elseif (false === $style = $this->createStyleFromString($tag)) {
                 $output .= $this->applyCurrentStyle($text);
             } elseif ($open) {
                 $this->styleStack->push($style);
@@ -203,13 +203,14 @@ class OutputFormatter implements OutputFormatterInterface
         $style = new OutputFormatterStyle();
         foreach ($matches as $match) {
             array_shift($match);
+            $match[0] = strtolower($match[0]);
 
             if ('fg' == $match[0]) {
-                $style->setForeground($match[1]);
+                $style->setForeground(strtolower($match[1]));
             } elseif ('bg' == $match[0]) {
-                $style->setBackground($match[1]);
+                $style->setBackground(strtolower($match[1]));
             } elseif ('options' === $match[0]) {
-                preg_match_all('([^,;]+)', $match[1], $options);
+                preg_match_all('([^,;]+)', strtolower($match[1]), $options);
                 $options = array_shift($options);
                 foreach ($options as $option) {
                     try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | not really
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

While playing with the href feature that'll be available in 4.3,
I spotted href value [is lowercased](https://github.com/symfony/symfony/pull/29620). Which I guess could be an issue on case-sensitive filesystems.
This changes nothing for the current branch, but will allow when merging
to upper branches to fix the behavior described above, hence keep original case.