### PR TITLE
[Security] Prefer clone() over unserialize(serialize()) for user refreshment

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -170,7 +170,7 @@ class ContextListener implements ListenerInterface
 
             try {
                 $refreshedUser = $provider->refreshUser($user);
-                $newToken = unserialize(serialize($token));
+                $newToken = clone $token;
                 $newToken->setUser($refreshedUser);
 
                 // tokens can be deauthenticated if the user has been changed.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29459 
| License       | MIT
| Doc PR        | n/a

To not hit the `serialize()` bug reported in the related ticket