### PR TITLE
[Validator] NotBlank: add a new option to allow null values

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added options `iban` and `ibanPropertyPath` to Bic constraint
  * added UATP cards support to `CardSchemeValidator`
+ * added option `allowNull` to NotBlank constraint
 
 4.2.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/NotBlank.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlank.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraint;
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  */
 class NotBlank extends Constraint
 {
@@ -28,4 +29,5 @@ class NotBlank extends Constraint
     ];
 
     public $message = 'This value should not be blank.';
+    public $allowNull = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  */
 class NotBlankValidator extends ConstraintValidator
 {
@@ -27,6 +28,10 @@ class NotBlankValidator extends ConstraintValidator
     {
         if (!$constraint instanceof NotBlank) {
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\NotBlank');
+        }
+
+        if ($constraint->allowNull && null === $value) {
+            return;
         }
 
         if (false === $value || (empty($value) && '0' != $value)) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -98,4 +98,30 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
             ->setCode(NotBlank::IS_BLANK_ERROR)
             ->assertRaised();
     }
+
+    public function testAllowNullTrue()
+    {
+        $constraint = new NotBlank([
+            'message' => 'myMessage',
+            'allowNull' => true,
+        ]);
+
+        $this->validator->validate(null, $constraint);
+        $this->assertNoViolation();
+    }
+
+    public function testAllowNullFalse()
+    {
+        $constraint = new NotBlank([
+            'message' => 'myMessage',
+            'allowNull' => false,
+        ]);
+
+        $this->validator->validate(null, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'null')
+            ->setCode(NotBlank::IS_BLANK_ERROR)
+            ->assertRaised();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27876
| License       | MIT
| Doc PR        | todo

This PR adds a new option to the `@NotBlank` constraint to allow null values. As described in #27876, this is particularly useful when creating web APIs.
