### PR TITLE
[VarDumper] Add descriptors tests

### DIFF
--- a/src/Symfony/Component/VarDumper/Command/Descriptor/HtmlDescriptor.php
+++ b/src/Symfony/Component/VarDumper/Command/Descriptor/HtmlDescriptor.php
@@ -57,7 +57,7 @@ class HtmlDescriptor implements DumpDescriptorInterface
         $sourceDescription = '';
         if (isset($context['source'])) {
             $source = $context['source'];
-            $projectDir = $source['project_dir'];
+            $projectDir = $source['project_dir'] ?? null;
             $sourceDescription = sprintf('%s on line %d', $source['name'], $source['line']);
             if (isset($source['file_link'])) {
                 $sourceDescription = sprintf('<a href="%s">%s</a>', $source['file_link'], $sourceDescription);

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Command\Descriptor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Command\Descriptor\CliDescriptor;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+
+class CliDescriptorTest extends TestCase
+{
+    private static $timezone;
+
+    public static function setUpBeforeClass()
+    {
+        self::$timezone = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        date_default_timezone_set(self::$timezone);
+    }
+
+    /**
+     * @dataProvider provideContext
+     */
+    public function testDescribe(array $context, string $expectedOutput)
+    {
+        $output = new BufferedOutput();
+        $descriptor = new CliDescriptor(new CliDumper(function ($s) {
+            return $s;
+        }));
+
+        $descriptor->describe($output, new Data(array(array(123))), $context + array('timestamp' => 1544804268.3668), 1);
+
+        $this->assertStringMatchesFormat(trim($expectedOutput), str_replace(PHP_EOL, "\n", trim($output->fetch())));
+    }
+
+    public function provideContext()
+    {
+        yield 'source' => array(
+            array(
+                'source' => array(
+                    'name' => 'CliDescriptorTest.php',
+                    'line' => 30,
+                    'file' => '/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php',
+                ),
+            ),
+            <<<TXT
+Received from client #1
+-----------------------
+
+ -------- --------------------------------------------------------------------------------------------------- 
+  date     Fri, 14 Dec 2018 16:17:48 +0000                                                                    
+  source   CliDescriptorTest.php on line 30                                                                   
+  file     /Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php  
+ -------- ---------------------------------------------------------------------------------------------------
+TXT
+        );
+
+        yield 'source full' => array(
+            array(
+                'source' => array(
+                    'name' => 'CliDescriptorTest.php',
+                    'line' => 30,
+                    'file_relative' => 'src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php',
+                    'file' => '/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php',
+                    'file_link' => 'phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30',
+                ),
+            ),
+            <<<TXT
+Received from client #1
+-----------------------
+
+ -------- -------------------------------------------------------------------------------- 
+  date     Fri, 14 Dec 2018 16:17:48 +0000                                                 
+  source   CliDescriptorTest.php on line 30                                                
+  file     src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php  
+ -------- -------------------------------------------------------------------------------- 
+
+Open source in your IDE/browser:
+phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30
+TXT
+        );
+
+        yield 'cli' => array(
+            array(
+                'cli' => array(
+                    'identifier' => 'd8bece1c',
+                    'command_line' => 'bin/phpunit',
+                ),
+            ),
+            <<<TXT
+$ bin/phpunit
+-------------
+
+ ------ --------------------------------- 
+  date   Fri, 14 Dec 2018 16:17:48 +0000  
+ ------ ---------------------------------
+TXT
+        );
+
+        yield 'request' => array(
+            array(
+                'request' => array(
+                    'identifier' => 'd8bece1c',
+                    'controller' => new Data(array(array('FooController.php'))),
+                    'method' => 'GET',
+                    'uri' => 'http://localhost/foo',
+                ),
+            ),
+            <<<TXT
+GET http://localhost/foo
+------------------------
+
+ ------------ --------------------------------- 
+  date         Fri, 14 Dec 2018 16:17:48 +0000  
+  controller   "FooController.php"              
+ ------------ --------------------------------- 
+TXT
+        );
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Command\Descriptor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Command\Descriptor\HtmlDescriptor;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+
+class HtmlDescriptorTest extends TestCase
+{
+    private static $timezone;
+
+    public static function setUpBeforeClass()
+    {
+        self::$timezone = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        date_default_timezone_set(self::$timezone);
+    }
+
+    public function testItOutputsStylesAndScriptsOnFirstDescribeCall()
+    {
+        $output = new BufferedOutput();
+        $dumper = $this->createMock(HtmlDumper::class);
+        $dumper->method('dump')->willReturn('[DUMPED]');
+        $descriptor = new HtmlDescriptor($dumper);
+
+        $descriptor->describe($output, new Data(array(array(123))), array('timestamp' => 1544804268.3668), 1);
+
+        $this->assertStringMatchesFormat('<style>%A</style><script>%A</script>%A', $output->fetch(), 'styles & scripts are output');
+
+        $descriptor->describe($output, new Data(array(array(123))), array('timestamp' => 1544804268.3668), 1);
+
+        $this->assertStringNotMatchesFormat('<style>%A</style><script>%A</script>%A', $output->fetch(), 'styles & scripts are output only once');
+    }
+
+    /**
+     * @dataProvider provideContext
+     */
+    public function testDescribe(array $context, string $expectedOutput)
+    {
+        $output = new BufferedOutput();
+        $dumper = $this->createMock(HtmlDumper::class);
+        $dumper->method('dump')->willReturn('[DUMPED]');
+        $descriptor = new HtmlDescriptor($dumper);
+
+        $descriptor->describe($output, new Data(array(array(123))), $context + array('timestamp' => 1544804268.3668), 1);
+
+        $this->assertStringMatchesFormat(trim($expectedOutput), trim(preg_replace('@<style>.*</style><script>.*</script>@s', '', $output->fetch())));
+    }
+
+    public function provideContext()
+    {
+        yield 'source' => array(
+            array(
+                'source' => array(
+                    'name' => 'CliDescriptorTest.php',
+                    'line' => 30,
+                    'file' => '/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php',
+                ),
+            ),
+            <<<TXT
+<article data-dedup-id="%s">
+    <header>
+        <div class="row">
+            <h2 class="col">-</h2>
+            <time class="col text-small" title="2018-12-14T16:17:48+00:00" datetime="2018-12-14T16:17:48+00:00">
+                Fri, 14 Dec 2018 16:17:48 +0000
+            </time>
+        </div>
+        
+    </header>
+    <section class="body">
+        <p class="text-small">
+            CliDescriptorTest.php on line 30
+        </p>
+        [DUMPED]
+    </section>
+</article>
+TXT
+        );
+
+        yield 'source full' => array(
+            array(
+                'source' => array(
+                    'name' => 'CliDescriptorTest.php',
+                    'project_dir' => 'src/Symfony/',
+                    'line' => 30,
+                    'file_relative' => 'src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php',
+                    'file' => '/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php',
+                    'file_link' => 'phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30',
+                ),
+            ),
+            <<<TXT
+<article data-dedup-id="%s">
+    <header>
+        <div class="row">
+            <h2 class="col">-</h2>
+            <time class="col text-small" title="2018-12-14T16:17:48+00:00" datetime="2018-12-14T16:17:48+00:00">
+                Fri, 14 Dec 2018 16:17:48 +0000
+            </time>
+        </div>
+        <div class="row">
+    <ul class="tags">
+        <li><span class="badge">project dir</span>src/Symfony/</li>
+    </ul>
+</div>
+    </header>
+    <section class="body">
+        <p class="text-small">
+            <a href="phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30">CliDescriptorTest.php on line 30</a>
+        </p>
+        [DUMPED]
+    </section>
+</article>
+TXT
+        );
+
+        yield 'cli' => array(
+            array(
+                'cli' => array(
+                    'identifier' => 'd8bece1c',
+                    'command_line' => 'bin/phpunit',
+                ),
+            ),
+            <<<TXT
+<article data-dedup-id="d8bece1c">
+    <header>
+        <div class="row">
+            <h2 class="col"><code>$ </code>bin/phpunit</h2>
+            <time class="col text-small" title="2018-12-14T16:17:48+00:00" datetime="2018-12-14T16:17:48+00:00">
+                Fri, 14 Dec 2018 16:17:48 +0000
+            </time>
+        </div>
+        
+    </header>
+    <section class="body">
+        <p class="text-small">
+            
+        </p>
+        [DUMPED]
+    </section>
+</article>
+TXT
+        );
+
+        yield 'request' => array(
+            array(
+                'request' => array(
+                    'identifier' => 'd8bece1c',
+                    'controller' => new Data(array(array('FooController.php'))),
+                    'method' => 'GET',
+                    'uri' => 'http://localhost/foo',
+                ),
+            ),
+            <<<TXT
+<article data-dedup-id="d8bece1c">
+    <header>
+        <div class="row">
+            <h2 class="col"><code>GET</code> <a href="http://localhost/foo">http://localhost/foo</a></h2>
+            <time class="col text-small" title="2018-12-14T16:17:48+00:00" datetime="2018-12-14T16:17:48+00:00">
+                Fri, 14 Dec 2018 16:17:48 +0000
+            </time>
+        </div>
+        <div class="row">
+    <ul class="tags">
+        <li><span class="badge">controller</span><span class='dumped-tag'>[DUMPED]</span></li>
+    </ul>
+</div>
+    </header>
+    <section class="body">
+        <p class="text-small">
+            
+        </p>
+        [DUMPED]
+    </section>
+</article>
+TXT
+        );
+    }
+}

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "ext-iconv": "*",
+        "symfony/console": "~3.4|~4.0",
         "symfony/process": "~3.4|~4.0",
         "twig/twig": "~1.34|~2.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Just adding some tests for these classes & fixing a small issue with the optional `project_dir` entry from `source` context provider.

If merged before #29613, I'll update tests in it (796ca6b4c6b6f758383ec37ebec952d0fe0ccfe0) (otherwise could be picked on merge).