### PR TITLE
Allow running PHPUnit with "xdebug.scream" ON

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -862,7 +862,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             $fs->dumpFile($dir.$file, $code);
             @chmod($dir.$file, 0666 & ~umask());
         }
-        @unlink(\dirname($dir.$file).'.legacy');
+        $legacyFile = \dirname($dir.$file).'.legacy';
+        if (file_exists($legacyFile)) {
+            @unlink($legacyFile);
+        }
 
         $cache->write($rootCode, $container->getResources());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

Since https://github.com/symfony/symfony/pull/25733 the Kernel attempts to unlink the legacy container while being built.
This throws an error if the file did not exist, for example on a clean install, on the build, which is then silenced.

That's fine on production systems, but on our build we have enabled `xdebug.scream` in order to visualise every errors, which basically un-silences the errors. I believe there should not be a need to silence anything on a usual, clean usage of the system.
Making this `unlink` conditional fixes it.

Could you please approve and merge this PR?
Thanks
