### PR TITLE
Check provider supports user class

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.2.0
 -----
 
+* added a `supportsClass()` check prior to `refreshUser()` for each user provider
 * added the `is_granted()` function in security expressions
 * deprecated the `has_role()` function in security expressions, use `is_granted()` instead
 * Passing custom class names to the

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -171,7 +171,7 @@ class ContextListener implements ListenerInterface
             }
 
             try {
-                $userClass = \get_classs($user);
+                $userClass = \get_class($user);
                 if( !$provider->supportsClass($userClass) )
                 {
                     throw new UnsupportedUserException(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | potentially? shouldn't though.
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This feature checks that a user is compatible with a user provider prior to running refreshUser(). It eliminates the need for this logic inside the refreshUser method.