### PR TITLE
Update exception text in ManagerRegistry::resetService to avoid confusion.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -46,7 +46,7 @@ abstract class ManagerRegistry extends AbstractManagerRegistry
         $manager = $this->container->get($name);
 
         if (!$manager instanceof LazyLoadingInterface) {
-            throw new \LogicException(sprintf('Resetting a non-lazy manager service is not supported. Set the "%s" service as lazy and require "symfony/proxy-manager-bridge" in your composer.json file instead.', $name));
+            throw new \LogicException(sprintf('Resetting a non-lazy manager service is not supported. Require "symfony/proxy-manager-bridge" in your composer.json file to set the "%s" service as lazy.', $name));
         }
         $manager->setProxyInitializer(\Closure::bind(
             function (&$wrappedInstance, LazyLoadingInterface $manager) use ($name) {


### PR DESCRIPTION
Update ManagerRegistry.php with a better exception text how to make the manager service lazy in ManagerRegistry::resetService. See #29659 

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | N/A
| Fixed tickets | #29659 
| License       | MIT
| Doc PR        | N/A

From #29659:
Symfony\Bridge\Doctrine\ManagerRegistry::resetService throws a misleading exception:

> Resetting a non-lazy manager service is not supported. Set the "%s" service as lazy and require "symfony/proxy-manager-bridge" in your composer.json file instead.

Actually, installing "symfony/proxy-manager-bridge" is enough, there is no need to set the service manually as lazy. I've wasted several hours trying to find out how to do this, including asking in the support channel und ultimately creating a [question on stackoverflow](https://stackoverflow.com/questions/53857220/how-to-mark-a-doctrine-entity-manager-as-lazy-in-symfony-4-2/).
