### PR TITLE
[Console][VarDumper] Ignore href for PhpStorm terminal emulator

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -54,6 +54,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     private $background;
     private $href;
     private $options = array();
+    private $handlesHrefGracefully;
 
     /**
      * Initializes output formatter style.
@@ -185,6 +186,10 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         $setCodes = array();
         $unsetCodes = array();
 
+        if (null === $this->handlesHrefGracefully) {
+            $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR');
+        }
+
         if (null !== $this->foreground) {
             $setCodes[] = $this->foreground['set'];
             $unsetCodes[] = $this->foreground['unset'];
@@ -199,7 +204,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
             $unsetCodes[] = $option['unset'];
         }
 
-        if (null !== $this->href) {
+        if (null !== $this->href && $this->handlesHrefGracefully) {
             $text = "\033]8;;$this->href\033\\$text\033]8;;\033\\";
         }
 

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
@@ -97,4 +97,19 @@ class OutputFormatterStyleTest extends TestCase
             $this->assertContains('Invalid option specified: "foo"', $e->getMessage(), '->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
         }
     }
+
+    public function testHref()
+    {
+        $prevTerminalEmulator = getenv('TERMINAL_EMULATOR');
+        putenv('TERMINAL_EMULATOR');
+
+        $style = new OutputFormatterStyle();
+
+        try {
+            $style->setHref('idea://open/?file=/path/SomeFile.php&line=12');
+            $this->assertSame("\e]8;;idea://open/?file=/path/SomeFile.php&line=12\e\\some URL\e]8;;\e\\", $style->apply('some URL'));
+        } finally {
+            putenv('TERMINAL_EMULATOR'.($prevTerminalEmulator ? "=$prevTerminalEmulator" : ''));
+        }
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -241,10 +241,17 @@ class OutputFormatterTest extends TestCase
     /**
      * @dataProvider provideDecoratedAndNonDecoratedOutput
      */
-    public function testNotDecoratedFormatter(string $input, string $expectedNonDecoratedOutput, string $expectedDecoratedOutput)
+    public function testNotDecoratedFormatter(string $input, string $expectedNonDecoratedOutput, string $expectedDecoratedOutput, string $terminalEmulator = 'foo')
     {
-        $this->assertEquals($expectedDecoratedOutput, (new OutputFormatter(true))->format($input));
-        $this->assertEquals($expectedNonDecoratedOutput, (new OutputFormatter(false))->format($input));
+        $prevTerminalEmulator = getenv('TERMINAL_EMULATOR');
+        putenv('TERMINAL_EMULATOR='.$terminalEmulator);
+
+        try {
+            $this->assertEquals($expectedDecoratedOutput, (new OutputFormatter(true))->format($input));
+            $this->assertEquals($expectedNonDecoratedOutput, (new OutputFormatter(false))->format($input));
+        } finally {
+            putenv('TERMINAL_EMULATOR'.($prevTerminalEmulator ? "=$prevTerminalEmulator" : ''));
+        }
     }
 
     public function provideDecoratedAndNonDecoratedOutput()
@@ -256,6 +263,7 @@ class OutputFormatterTest extends TestCase
             array('<question>some question</question>', 'some question', "\033[30;46msome question\033[39;49m"),
             array('<fg=red>some text with inline style</>', 'some text with inline style', "\033[31msome text with inline style\033[39m"),
             array('<href=idea://open/?file=/path/SomeFile.php&line=12>some URL</>', 'some URL', "\033]8;;idea://open/?file=/path/SomeFile.php&line=12\033\\some URL\033]8;;\033\\"),
+            array('<href=idea://open/?file=/path/SomeFile.php&line=12>some URL</>', 'some URL', 'some URL', 'JetBrains-JediTerm'),
         );
     }
 

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -59,6 +59,8 @@ class CliDumper extends AbstractDumper
         'fileLinkFormat' => null,
     );
 
+    private $handlesHrefGracefully;
+
     /**
      * {@inheritdoc}
      */
@@ -431,6 +433,10 @@ class CliDumper extends AbstractDumper
             $this->colors = $this->supportsColors();
         }
 
+        if (null === $this->handlesHrefGracefully) {
+            $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR');
+        }
+
         if (isset($attr['ellipsis'], $attr['ellipsis-type'])) {
             $prefix = substr($value, 0, -$attr['ellipsis']);
             if ('cli' === \PHP_SAPI && 'path' === $attr['ellipsis-type'] && isset($_SERVER[$pwd = '\\' === \DIRECTORY_SEPARATOR ? 'CD' : 'PWD']) && 0 === strpos($prefix, $_SERVER[$pwd])) {
@@ -477,7 +483,7 @@ class CliDumper extends AbstractDumper
         }
 
         href:
-        if ($this->colors) {
+        if ($this->colors && $this->handlesHrefGracefully) {
             if (isset($attr['file']) && $href = $this->getSourceLink($attr['file'], isset($attr['line']) ? $attr['line'] : 0)) {
                 $attr['href'] = $href;
             }

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
@@ -21,16 +21,21 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
 class CliDescriptorTest extends TestCase
 {
     private static $timezone;
+    private static $prevTerminalEmulator;
 
     public static function setUpBeforeClass()
     {
         self::$timezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
+
+        self::$prevTerminalEmulator = getenv('TERMINAL_EMULATOR');
+        putenv('TERMINAL_EMULATOR');
     }
 
     public static function tearDownAfterClass()
     {
         date_default_timezone_set(self::$timezone);
+        putenv('TERMINAL_EMULATOR'.(self::$prevTerminalEmulator ? '='.self::$prevTerminalEmulator : ''));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/symfony/symfony/pull/29613#issuecomment-449473541   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

So, as explained in https://github.com/symfony/symfony/pull/29613#issuecomment-449473541, the hyperlink feature currently breaks the PhpStorm terminal (the output stops abruptly, sometimes the whole terminal emulator freezes). Currently, a simple `dump(new \Exception());` would be enough to break it.
Hence I think we should at least ignore hyperlinks for this terminal emulator.

📝 https://youtrack.jetbrains.com/issue/IDEA-204536 feature request has been opened on JetBrains YouTrack. 