### PR TITLE
Fix wrong calls to clearstatcache

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -697,7 +697,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         // restore original permissions
         chmod($testDir, 0777);
-        clearstatcache($testDir);
+        clearstatcache(true, $testDir);
 
         if ($couldRead) {
             $this->markTestSkipped('could read test files while test requires unreadable');
@@ -723,7 +723,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         // restore original permissions
         chmod($testDir, 0777);
-        clearstatcache($testDir);
+        clearstatcache(true, $testDir);
 
         if ($couldRead) {
             $this->markTestSkipped('could read test files while test requires unreadable');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

This was discovered while fixing https://github.com/doctrine/DoctrineMongoDBBundle/issues/510: The first argument is a bool, not the path string. It makes sense to also clear the realpath cache since it doesn't have any performance implications on the tests themselves.