### PR TITLE
 [Config] remove redundant method calls

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
@@ -42,17 +42,17 @@ class FileLoaderLoadException extends \Exception
 
             // show tweaked trace to complete the human readable sentence
             if (null === $sourceResource) {
-                $message .= sprintf('(which is loaded in resource "%s")', $this->varToString($resource));
+                $message .= sprintf('(which is loaded in resource "%s")', $resource);
             } else {
-                $message .= sprintf('(which is being imported from "%s")', $this->varToString($sourceResource));
+                $message .= sprintf('(which is being imported from "%s")', $sourceResource);
             }
             $message .= '.';
 
         // if there's no previous message, present it the default way
         } elseif (null === $sourceResource) {
-            $message .= sprintf('Cannot load resource "%s".', $this->varToString($resource));
+            $message .= sprintf('Cannot load resource "%s".', $resource);
         } else {
-            $message .= sprintf('Cannot import resource "%s" from "%s".', $this->varToString($resource), $this->varToString($sourceResource));
+            $message .= sprintf('Cannot import resource "%s" from "%s".', $resource, $sourceResource);
         }
 
         // Is the resource located inside a bundle?


### PR DESCRIPTION
rebase of #29665 

| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no     
| Deprecations? | no
| Tests pass?   | yes    
| License       | MIT

since `4.0`, `$resource` and `$sourceResource` are type hinted as `string` so there's not need to call `->varToString(): string`, method not removed for BC as the class is not marked final and the method is `protected`.