### PR TITLE
[HttpFoundation] Fix erasing cookies issue

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -44,7 +44,7 @@ class AddSecurityVotersPass implements CompilerPassInterface
         }
 
         $debug = $container->getParameter('kernel.debug');
-
+        $voterServices = array();
         foreach ($voters as $voter) {
             $voterServiceId = (string) $voter;
             $definition = $container->getDefinition($voterServiceId);
@@ -56,17 +56,18 @@ class AddSecurityVotersPass implements CompilerPassInterface
             }
 
             if ($debug) {
-                // Decorate original voters with TraceableVoter
-                $debugVoterServiceId = 'debug.security.voter.'.$voterServiceId;
+                $voterServices[] = new Reference($debugVoterServiceId = 'debug.security.voter.'.$voterServiceId);
+
                 $container
                     ->register($debugVoterServiceId, TraceableVoter::class)
-                    ->setDecoratedService($voterServiceId)
-                    ->addArgument(new Reference($debugVoterServiceId.'.inner'))
+                    ->addArgument($voter)
                     ->addArgument(new Reference('event_dispatcher'));
+            } else {
+                $voterServices[] = $voter;
             }
         }
 
-        $adm = $container->getDefinition('security.access.decision_manager');
-        $adm->replaceArgument(0, new IteratorArgument($voters));
+        $container->getDefinition('security.access.decision_manager')
+            ->replaceArgument(0, new IteratorArgument($voterServices));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -72,10 +72,7 @@ class AddSecurityVotersPassTest extends TestCase
         $this->assertCount(4, $refs);
     }
 
-    /**
-     * Test that in debug mode, voters are correctly decorated.
-     */
-    public function testThatVotersAreDecoratedInDebugMode(): void
+    public function testThatVotersAreTraceableInDebugMode(): void
     {
         $container = new ContainerBuilder();
 
@@ -96,21 +93,18 @@ class AddSecurityVotersPassTest extends TestCase
         $compilerPass->process($container);
 
         $def1 = $container->getDefinition('debug.security.voter.voter1');
-        $this->assertEquals(array('voter1', null, 0), $def1->getDecoratedService(), 'voter1: wrong return from getDecoratedService');
-        $this->assertEquals(new Reference('debug.security.voter.voter1.inner'), $def1->getArgument(0), 'voter1: wrong decorator argument');
+        $this->assertNull($def1->getDecoratedService(), 'voter1: should not be decorated');
+        $this->assertEquals(new Reference('voter1'), $def1->getArgument(0), 'voter1: wrong argument');
 
         $def2 = $container->getDefinition('debug.security.voter.voter2');
-        $this->assertEquals(array('voter2', null, 0), $def2->getDecoratedService(), 'voter2: wrong return from getDecoratedService');
-        $this->assertEquals(new Reference('debug.security.voter.voter2.inner'), $def2->getArgument(0), 'voter2: wrong decorator argument');
+        $this->assertNull($def2->getDecoratedService(), 'voter2: should not be decorated');
+        $this->assertEquals(new Reference('voter2'), $def2->getArgument(0), 'voter2: wrong argument');
 
         $voters = $container->findTaggedServiceIds('security.voter');
         $this->assertCount(2, $voters, 'Incorrect count of voters');
     }
 
-    /**
-     * Test that voters are not decorated if the application is not in debug mode.
-     */
-    public function testThatVotersAreNotDecoratedWithoutDebugMode(): void
+    public function testThatVotersAreNotTraceableWithoutDebugMode(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', false);
@@ -130,8 +124,8 @@ class AddSecurityVotersPassTest extends TestCase
         $compilerPass = new AddSecurityVotersPass();
         $compilerPass->process($container);
 
-        $this->assertFalse($container->has('debug.security.voter.voter1'), 'voter1 should not be decorated');
-        $this->assertFalse($container->has('debug.security.voter.voter2'), 'voter2 should not be decorated');
+        $this->assertFalse($container->has('debug.security.voter.voter1'), 'voter1 should not be traced');
+        $this->assertFalse($container->has('debug.security.voter.voter2'), 'voter2 should not be traced');
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -61,7 +61,7 @@ class ProcessHelper extends Helper
             $process = $cmd[0];
             unset($cmd[0]);
         } else {
-            throw new \InvalidArgumentException(sprintf('Invalid command provided to "%s()": the command should an array whose first is element is either the path to the binary to run of a "Process" object.', __METHOD__));
+            throw new \InvalidArgumentException(sprintf('Invalid command provided to "%s()": the command should be an array whose first element is either the path to the binary to run or a "Process" object.', __METHOD__));
         }
 
         if ($verbosity <= $output->getVerbosity()) {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -153,7 +153,7 @@ class NativeSessionStorage implements SessionStorageInterface
         if (null !== $this->emulateSameSite) {
             $originalCookie = SessionUtils::popSessionCookie(session_name(), session_id());
             if (null !== $originalCookie) {
-                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite));
+                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite), false);
             }
         }
 
@@ -225,7 +225,7 @@ class NativeSessionStorage implements SessionStorageInterface
         if (null !== $this->emulateSameSite) {
             $originalCookie = SessionUtils::popSessionCookie(session_name(), session_id());
             if (null !== $originalCookie) {
-                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite));
+                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite), false);
             }
         }
 

--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -232,7 +232,7 @@ class Exporter
                 if (!\is_int($k) || 1 !== $k - $j) {
                     $code .= self::export($k, $subIndent).' => ';
                 }
-                if (\is_int($k)) {
+                if (\is_int($k) && $k > $j) {
                     $j = $k;
                 }
                 $code .= self::export($v, $subIndent).",\n";

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/partially-indexed-array.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/partially-indexed-array.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    5 => true,
+    1 => true,
+    2 => true,
+    true,
+];

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -112,6 +112,7 @@ class VarExporterTest extends TestCase
 
         yield array('bool', true, true);
         yield array('simple-array', array(123, array('abc')), true);
+        yield array('partially-indexed-array', array(5 => true, 1 => true, 2 => true, 6 => true), true);
         yield array('datetime', \DateTime::createFromFormat('U', 0));
 
         $value = new \ArrayObject();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 (to be switched when merging)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     
| Deprecations? | no
| Tests pass?   | yes    
| Fixed tickets | #29675
| License       | MIT

Prevent replacing existing cookies when starting or regenerating session on PHP < 7.3 with 'cookie_samesite' option.
See issue #29675