### PR TITLE
[Form] Add new block_prefix option for an easy form theming

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added `block_prefix` option to `BaseType`.
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -79,6 +79,9 @@ abstract class BaseType extends AbstractType
         for ($type = $form->getConfig()->getType(); null !== $type; $type = $type->getParent()) {
             array_unshift($blockPrefixes, $type->getBlockPrefix());
         }
+        if (null !== $options['block_prefix']) {
+            $blockPrefixes[] = $options['block_prefix'];
+        }
         $blockPrefixes[] = $uniqueBlockPrefix;
 
         $view->vars = array_replace($view->vars, array(
@@ -111,6 +114,7 @@ abstract class BaseType extends AbstractType
     {
         $resolver->setDefaults(array(
             'block_name' => null,
+            'block_prefix' => null,
             'disabled' => false,
             'label' => null,
             'label_format' => null,
@@ -119,6 +123,7 @@ abstract class BaseType extends AbstractType
             'auto_initialize' => true,
         ));
 
+        $resolver->setAllowedTypes('block_prefix', array('null', 'string'));
         $resolver->setAllowedTypes('attr', 'array');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -639,4 +639,16 @@ class FormTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull(array(), array(), array());
     }
+
+    public function testPassBlockPrefixToViewWithParent()
+    {
+        $view = $this->factory->createNamedBuilder('parent', static::TESTED_TYPE)
+            ->add('child', $this->getTestedType(), array(
+                'block_prefix' => 'child',
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertSame(array('form', 'child', '_parent_child'), $view['child']->vars['block_prefixes']);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -32,6 +32,7 @@
                 "attr",
                 "auto_initialize",
                 "block_name",
+                "block_prefix",
                 "by_reference",
                 "data",
                 "disabled",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -12,11 +12,12 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   choice_translation_domain   empty_data           attr                      csrf_protection        
   choice_value                error_bubbling       auto_initialize           csrf_token_id          
   choices                     trim                 block_name                csrf_token_manager     
-  expanded                                         by_reference                                     
-  group_by                                         data                                             
-  multiple                                         disabled                                         
-  placeholder                                      help                                             
-  preferred_choices                                help_attr                                        
+  expanded                                         block_prefix                                     
+  group_by                                         by_reference                                     
+  multiple                                         data                                             
+  placeholder                                      disabled                                         
+  preferred_choices                                help                                             
+                                                   help_attr                                        
                                                    inherit_data                                     
                                                    label                                            
                                                    label_attr                                       

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
@@ -8,6 +8,7 @@
             "attr",
             "auto_initialize",
             "block_name",
+            "block_prefix",
             "by_reference",
             "compound",
             "data",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
@@ -10,6 +10,7 @@ Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")
   attr                     
   auto_initialize          
   block_name               
+  block_prefix             
   by_reference             
   compound                 
   data                     


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29651
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10835