### PR TITLE
[Tests] Remove equalTo from 'with'

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -166,20 +166,20 @@ class DoctrineDataCollectorTest extends TestCase
             ->getMock();
         $connection->expects($this->any())
             ->method('getDatabasePlatform')
-            ->will($this->returnValue(new MySqlPlatform()));
+            ->willReturn(new MySqlPlatform());
 
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $registry
             ->expects($this->any())
             ->method('getConnectionNames')
-            ->will($this->returnValue(array('default' => 'doctrine.dbal.default_connection')));
+            ->willReturn(array('default' => 'doctrine.dbal.default_connection'));
         $registry
             ->expects($this->any())
             ->method('getManagerNames')
-            ->will($this->returnValue(array('default' => 'doctrine.orm.default_entity_manager')));
+            ->willReturn(array('default' => 'doctrine.orm.default_entity_manager'));
         $registry->expects($this->any())
             ->method('getConnection')
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $logger = $this->getMockBuilder('Doctrine\DBAL\Logging\DebugStack')->getMock();
         $logger->queries = $queries;

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
@@ -34,47 +34,47 @@ class DoctrineOrmTypeGuesserTest extends TestCase
         // Simple field, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
         $classMetadata->fieldMappings['field'] = true;
-        $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(false));
+        $classMetadata->expects($this->once())->method('isNullable')->with('field')->willReturn(false);
 
         $return[] = array($classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE));
 
         // Simple field, nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
         $classMetadata->fieldMappings['field'] = true;
-        $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isNullable')->with('field')->willReturn(true);
 
         $return[] = array($classMetadata, new ValueGuess(false, Guess::MEDIUM_CONFIDENCE));
 
         // One-to-one, nullable (by default)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = array('joinColumns' => array(array()));
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = array($classMetadata, new ValueGuess(false, Guess::HIGH_CONFIDENCE));
 
         // One-to-one, nullable (explicit)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = array('joinColumns' => array(array('nullable' => true)));
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = array($classMetadata, new ValueGuess(false, Guess::HIGH_CONFIDENCE));
 
         // One-to-one, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = array('joinColumns' => array(array('nullable' => false)));
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = array($classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE));
 
         // One-to-many, no clue
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(false));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(false);
 
         $return[] = array($classMetadata, null);
 
@@ -84,10 +84,10 @@ class DoctrineOrmTypeGuesserTest extends TestCase
     private function getGuesser(ClassMetadata $classMetadata)
     {
         $em = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
-        $em->expects($this->once())->method('getClassMetaData')->with('TestEntity')->will($this->returnValue($classMetadata));
+        $em->expects($this->once())->method('getClassMetaData')->with('TestEntity')->willReturn($classMetadata);
 
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
-        $registry->expects($this->once())->method('getManagers')->will($this->returnValue(array($em)));
+        $registry->expects($this->once())->method('getManagers')->willReturn(array($em));
 
         return new DoctrineOrmTypeGuesser($registry);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -36,11 +36,11 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
 
         $manager->expects($this->any())
             ->method('getManager')
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         $manager->expects($this->any())
             ->method('getManagerForClass')
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         return array(
             new CoreExtension(),

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1085,7 +1085,7 @@ class EntityTypeTest extends BaseTypeTest
         $this->emRegistry->expects($this->once())
             ->method('getManagerForClass')
             ->with(self::SINGLE_IDENT_CLASS)
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'class' => self::SINGLE_IDENT_CLASS,
@@ -1234,8 +1234,8 @@ class EntityTypeTest extends BaseTypeTest
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $registry->expects($this->any())
             ->method('getManager')
-            ->with($this->equalTo($name))
-            ->will($this->returnValue($em));
+            ->with($name)
+            ->willReturn($em);
 
         return $registry;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -187,8 +187,8 @@ class EntityUserProviderTest extends TestCase
         $manager = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $manager->expects($this->any())
             ->method('getManager')
-            ->with($this->equalTo($name))
-            ->will($this->returnValue($em));
+            ->with($name)
+            ->willReturn($em);
 
         return $manager;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -81,8 +81,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $registry->expects($this->any())
                  ->method('getManager')
-                 ->with($this->equalTo(self::EM_NAME))
-                 ->will($this->returnValue($em));
+                 ->with(self::EM_NAME)
+                 ->willReturn($em);
 
         return $registry;
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -63,11 +63,11 @@ class StopwatchExtensionTest extends TestCase
         foreach ($events as $eventName) {
             $stopwatch->expects($this->at(++$i))
                 ->method('start')
-                ->with($this->equalTo($eventName), 'template')
+                ->with($eventName, 'template')
             ;
             $stopwatch->expects($this->at(++$i))
                 ->method('stop')
-                ->with($this->equalTo($eventName))
+                ->with($eventName)
             ;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplateFinderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplateFinderTest.php
@@ -34,7 +34,7 @@ class TemplateFinderTest extends TestCase
         $kernel
             ->expects($this->once())
             ->method('getBundles')
-            ->will($this->returnValue(array('BaseBundle' => new BaseBundle())))
+            ->willReturn(array('BaseBundle' => new BaseBundle()))
         ;
 
         $parser = new TemplateFilenameParser();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -84,7 +84,7 @@ class TranslationDebugCommandTest extends TestCase
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel->expects($this->once())
             ->method('getBundle')
-            ->with($this->equalTo($this->translationDir))
+            ->with($this->translationDir)
             ->willThrowException(new \InvalidArgumentException());
 
         $tester = $this->createCommandTester(array('foo' => 'foo'), array('bar' => 'bar'), $kernel);
@@ -102,7 +102,7 @@ class TranslationDebugCommandTest extends TestCase
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel->expects($this->once())
             ->method('getBundle')
-            ->with($this->equalTo('dir'))
+            ->with('dir')
             ->willThrowException(new \InvalidArgumentException());
 
         $tester = $this->createCommandTester(array(), array(), $kernel);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -205,8 +205,8 @@ class ApplicationTest extends TestCase
             $container
                 ->expects($this->atLeastOnce())
                 ->method('get')
-                ->with($this->equalTo('event_dispatcher'))
-                ->will($this->returnValue($dispatcher));
+                ->with('event_dispatcher')
+                ->willReturn($dispatcher);
         }
 
         $container

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -71,8 +71,8 @@ class RedirectControllerTest extends TestCase
         $router
             ->expects($this->once())
             ->method('generate')
-            ->with($this->equalTo($route), $this->equalTo($expectedAttributes))
-            ->will($this->returnValue($url));
+            ->with($route, $expectedAttributes)
+            ->willReturn($url);
 
         $controller = new RedirectController($router);
 

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -119,7 +119,7 @@ class HelperSetTest extends TestCase
         if ($helperset) {
             $mock_helper->expects($this->any())
                 ->method('setHelperSet')
-                ->with($this->equalTo($helperset));
+                ->with($helperset);
         }
 
         return $mock_helper;

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -541,7 +541,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $helperSet = new HelperSet(array(new FormatterHelper()));
         $dialog->setHelperSet($helperSet);
 
-        $output->expects($this->once())->method('writeln')->with($this->equalTo($outputShown));
+        $output->expects($this->once())->method('writeln')->with($outputShown);
 
         $question = new ChoiceQuestion($question, $possibleChoices, 'foo');
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream("\n")), $output, $question);

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Test\Traits;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -18,6 +19,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 trait ValidatorExtensionTrait
 {
+    /**
+     * @var MockObject|ValidatorInterface
+     */
     protected $validator;
 
     protected function getValidatorExtension()

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -75,7 +75,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $child->expects($this->once())
             ->method('submit')
-            ->with($this->equalTo(null));
+            ->with(null);
 
         $this->form->submit(array('firstName' => null), false);
     }
@@ -88,7 +88,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $child->expects($this->once())
             ->method('submit')
-            ->with($this->equalTo(null));
+            ->with(null);
 
         $this->form->submit(array());
     }
@@ -126,7 +126,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $child->expects($this->once())
             ->method('submit')
-            ->with($this->equalTo('foo'), false);
+            ->with('foo', false);
 
         $this->form->submit(array('firstName' => 'foo'), false);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -42,8 +42,8 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
         $this->validator->expects($this->once())
             ->method('validate')
-            ->with($this->equalTo($form))
-            ->will($this->returnValue(new ConstraintViolationList()));
+            ->with($form)
+            ->willReturn(new ConstraintViolationList());
 
         // specific data is irrelevant
         $form->submit(array());

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
@@ -24,7 +24,7 @@ class UploadValidatorExtensionTest extends TypeTestCase
 
         $translator->expects($this->any())
             ->method('trans')
-            ->with($this->equalTo('old max {{ max }}!'))
+            ->with('old max {{ max }}!')
             ->willReturn('translated max {{ max }}!');
 
         $extension = new UploadValidatorExtension($translator);

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -171,8 +171,8 @@ class FileTest extends TestCase
         $guesser
             ->expects($this->once())
             ->method('guess')
-            ->with($this->equalTo($path))
-            ->will($this->returnValue($mimeType))
+            ->with($path)
+            ->willReturn($mimeType)
         ;
 
         return $guesser;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -148,7 +148,7 @@ class RouterListenerTest extends TestCase
         $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $logger->expects($this->once())
             ->method('info')
-            ->with($this->equalTo($log), $this->equalTo($parameters));
+            ->with($log, $parameters);
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $request = Request::create('http://localhost/');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
@@ -36,7 +36,7 @@ class TranslatorListenerTest extends TestCase
         $this->translator
             ->expects($this->once())
             ->method('setLocale')
-            ->with($this->equalTo('fr'));
+            ->with('fr');
 
         $event = new GetResponseEvent($this->createHttpKernel(), $this->createRequest('fr'), HttpKernelInterface::MASTER_REQUEST);
         $this->listener->onKernelRequest($event);
@@ -51,7 +51,7 @@ class TranslatorListenerTest extends TestCase
         $this->translator
             ->expects($this->at(1))
             ->method('setLocale')
-            ->with($this->equalTo('en'));
+            ->with('en');
 
         $event = new GetResponseEvent($this->createHttpKernel(), $this->createRequest('fr'), HttpKernelInterface::MASTER_REQUEST);
         $this->listener->onKernelRequest($event);
@@ -62,7 +62,7 @@ class TranslatorListenerTest extends TestCase
         $this->translator
             ->expects($this->once())
             ->method('setLocale')
-            ->with($this->equalTo('fr'));
+            ->with('fr');
 
         $this->setMasterRequest($this->createRequest('fr'));
         $event = new FinishRequestEvent($this->createHttpKernel(), $this->createRequest('de'), HttpKernelInterface::SUB_REQUEST);
@@ -88,7 +88,7 @@ class TranslatorListenerTest extends TestCase
         $this->translator
             ->expects($this->at(1))
             ->method('setLocale')
-            ->with($this->equalTo('en'));
+            ->with('en');
 
         $this->setMasterRequest($this->createRequest('fr'));
         $event = new FinishRequestEvent($this->createHttpKernel(), $this->createRequest('de'), HttpKernelInterface::SUB_REQUEST);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -322,7 +322,7 @@ class HttpKernelTest extends TestCase
         $request = new Request();
 
         $stack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->setMethods(array('push', 'pop'))->getMock();
-        $stack->expects($this->at(0))->method('push')->with($this->equalTo($request));
+        $stack->expects($this->at(0))->method('push')->with($request);
         $stack->expects($this->at(1))->method('pop');
 
         $dispatcher = new EventDispatcher();

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -45,8 +45,8 @@ class AuthorizationCheckerTest extends TestCase
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
-            ->with($this->equalTo($token))
-            ->will($this->returnValue($newToken));
+            ->with($token)
+            ->willReturn($newToken);
 
         // default with() isn't a strict check
         $tokenComparison = function ($value) use ($newToken) {
@@ -58,7 +58,7 @@ class AuthorizationCheckerTest extends TestCase
             ->expects($this->once())
             ->method('decide')
             ->with($this->callback($tokenComparison))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         // first run the token has not been re-authenticated yet, after isGranted is called, it should be equal
         $this->assertNotSame($newToken, $this->tokenStorage->getToken());

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
@@ -26,14 +26,14 @@ class UserPasswordEncoderTest extends TestCase
         $mockEncoder = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')->getMock();
         $mockEncoder->expects($this->any())
             ->method('encodePassword')
-            ->with($this->equalTo('plainPassword'), $this->equalTo('userSalt'))
-            ->will($this->returnValue('encodedPassword'));
+            ->with('plainPassword', 'userSalt')
+            ->willReturn('encodedPassword');
 
         $mockEncoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
         $mockEncoderFactory->expects($this->any())
             ->method('getEncoder')
-            ->with($this->equalTo($userMock))
-            ->will($this->returnValue($mockEncoder));
+            ->with($userMock)
+            ->willReturn($mockEncoder);
 
         $passwordEncoder = new UserPasswordEncoder($mockEncoderFactory);
 
@@ -46,22 +46,22 @@ class UserPasswordEncoderTest extends TestCase
         $userMock = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $userMock->expects($this->any())
             ->method('getSalt')
-            ->will($this->returnValue('userSalt'));
+            ->willReturn('userSalt');
         $userMock->expects($this->any())
             ->method('getPassword')
-            ->will($this->returnValue('encodedPassword'));
+            ->willReturn('encodedPassword');
 
         $mockEncoder = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')->getMock();
         $mockEncoder->expects($this->any())
             ->method('isPasswordValid')
-            ->with($this->equalTo('encodedPassword'), $this->equalTo('plainPassword'), $this->equalTo('userSalt'))
-            ->will($this->returnValue(true));
+            ->with('encodedPassword', 'plainPassword', 'userSalt')
+            ->willReturn(true);
 
         $mockEncoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
         $mockEncoderFactory->expects($this->any())
             ->method('getEncoder')
-            ->with($this->equalTo($userMock))
-            ->will($this->returnValue($mockEncoder));
+            ->with($userMock)
+            ->willReturn($mockEncoder);
 
         $passwordEncoder = new UserPasswordEncoder($mockEncoderFactory);
 

--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -24,7 +24,7 @@ class ChainUserProviderTest extends TestCase
         $provider1
             ->expects($this->once())
             ->method('loadUserByUsername')
-            ->with($this->equalTo('foo'))
+            ->with('foo')
             ->willThrowException(new UsernameNotFoundException('not found'))
         ;
 
@@ -32,8 +32,8 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('loadUserByUsername')
-            ->with($this->equalTo('foo'))
-            ->will($this->returnValue($account = $this->getAccount()))
+            ->with('foo')
+            ->willReturn($account = $this->getAccount())
         ;
 
         $provider = new ChainUserProvider(array($provider1, $provider2));
@@ -49,7 +49,7 @@ class ChainUserProviderTest extends TestCase
         $provider1
             ->expects($this->once())
             ->method('loadUserByUsername')
-            ->with($this->equalTo('foo'))
+            ->with('foo')
             ->willThrowException(new UsernameNotFoundException('not found'))
         ;
 
@@ -57,7 +57,7 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('loadUserByUsername')
-            ->with($this->equalTo('foo'))
+            ->with('foo')
             ->willThrowException(new UsernameNotFoundException('not found'))
         ;
 
@@ -134,7 +134,7 @@ class ChainUserProviderTest extends TestCase
         $provider1
             ->expects($this->once())
             ->method('supportsClass')
-            ->with($this->equalTo('foo'))
+            ->with('foo')
             ->will($this->returnValue(false))
         ;
 
@@ -142,7 +142,7 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('supportsClass')
-            ->with($this->equalTo('foo'))
+            ->with('foo')
             ->will($this->returnValue(true))
         ;
 
@@ -156,7 +156,7 @@ class ChainUserProviderTest extends TestCase
         $provider1
             ->expects($this->once())
             ->method('supportsClass')
-            ->with($this->equalTo('foo'))
+            ->with('foo')
             ->will($this->returnValue(false))
         ;
 
@@ -164,7 +164,7 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('supportsClass')
-            ->with($this->equalTo('foo'))
+            ->with('foo')
             ->will($this->returnValue(false))
         ;
 

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -50,8 +50,8 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->with($this->equalTo($this->request))
-            ->will($this->returnValue($credentials));
+            ->with($this->request)
+            ->willReturn($credentials);
 
         // a clone of the token that should be created internally
         $uniqueGuardKey = 'my_firewall_0';
@@ -60,8 +60,8 @@ class GuardAuthenticationListenerTest extends TestCase
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
-            ->with($this->equalTo($nonAuthedToken))
-            ->will($this->returnValue($authenticateToken));
+            ->with($nonAuthedToken)
+            ->willReturn($authenticateToken);
 
         $this->guardAuthenticatorHandler
             ->expects($this->once())
@@ -133,18 +133,18 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('supports')
-            ->with($this->equalTo($this->request))
+            ->with($this->request)
             ->willReturn(true);
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->with($this->equalTo($this->request))
-            ->will($this->returnValue(array('username' => 'anything_not_empty')));
+            ->with($this->request)
+            ->willReturn(array('username' => 'anything_not_empty'));
 
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
-            ->will($this->returnValue($authenticateToken));
+            ->willReturn($authenticateToken);
 
         $successResponse = new Response('Success!');
         $this->guardAuthenticatorHandler

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -40,7 +40,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $this->dispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with($this->equalTo(SecurityEvents::INTERACTIVE_LOGIN), $this->equalTo($loginEvent))
+            ->with(SecurityEvents::INTERACTIVE_LOGIN, $loginEvent)
         ;
 
         $handler = new GuardAuthenticatorHandler($this->tokenStorage, $this->dispatcher);

--- a/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
@@ -28,8 +28,8 @@ class FormAuthenticationEntryPointTest extends TestCase
         $httpUtils
             ->expects($this->once())
             ->method('createRedirectResponse')
-            ->with($this->equalTo($request), $this->equalTo('/the/login/path'))
-            ->will($this->returnValue($response))
+            ->with($request, '/the/login/path')
+            ->willReturn($response)
         ;
 
         $entryPoint = new FormAuthenticationEntryPoint($httpKernel, $httpUtils, '/the/login/path', false);
@@ -47,16 +47,16 @@ class FormAuthenticationEntryPointTest extends TestCase
         $httpUtils
             ->expects($this->once())
             ->method('createRequest')
-            ->with($this->equalTo($request), $this->equalTo('/the/login/path'))
-            ->will($this->returnValue($subRequest))
+            ->with($request, '/the/login/path')
+            ->willReturn($subRequest)
         ;
 
         $httpKernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $httpKernel
             ->expects($this->once())
             ->method('handle')
-            ->with($this->equalTo($subRequest), $this->equalTo(HttpKernelInterface::SUB_REQUEST))
-            ->will($this->returnValue($response))
+            ->with($subRequest, HttpKernelInterface::SUB_REQUEST)
+            ->willReturn($response)
         ;
 
         $entryPoint = new FormAuthenticationEntryPoint($httpKernel, $httpUtils, '/the/login/path', true);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
@@ -36,7 +36,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($token))
+            ->with($token)
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -44,7 +44,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken'))
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $listener = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener', array(
@@ -55,13 +55,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -219,7 +219,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo(null))
+            ->with(null)
         ;
 
         $exception = new AuthenticationException('Authentication failed.');

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -27,30 +27,30 @@ class AccessListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array('foo' => 'bar'), null)))
+            ->with($request)
+            ->willReturn(array(array('foo' => 'bar'), null))
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $accessDecisionManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock();
         $accessDecisionManager
             ->expects($this->once())
             ->method('decide')
-            ->with($this->equalTo($token), $this->equalTo(array('foo' => 'bar')), $this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->with($token, array('foo' => 'bar'), $request)
+            ->willReturn(false)
         ;
 
         $listener = new AccessListener(
@@ -78,50 +78,50 @@ class AccessListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array('foo' => 'bar'), null)))
+            ->with($request)
+            ->willReturn(array(array('foo' => 'bar'), null))
         ;
 
         $notAuthenticatedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $notAuthenticatedToken
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $authenticatedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $authenticatedToken
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $authManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
         $authManager
             ->expects($this->once())
             ->method('authenticate')
-            ->with($this->equalTo($notAuthenticatedToken))
-            ->will($this->returnValue($authenticatedToken))
+            ->with($notAuthenticatedToken)
+            ->willReturn($authenticatedToken)
         ;
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($notAuthenticatedToken))
+            ->willReturn($notAuthenticatedToken)
         ;
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($authenticatedToken))
+            ->with($authenticatedToken)
         ;
 
         $accessDecisionManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock();
         $accessDecisionManager
             ->expects($this->once())
             ->method('decide')
-            ->with($this->equalTo($authenticatedToken), $this->equalTo(array('foo' => 'bar')), $this->equalTo($request))
-            ->will($this->returnValue(true))
+            ->with($authenticatedToken, array('foo' => 'bar'), $request)
+            ->willReturn(true)
         ;
 
         $listener = new AccessListener(
@@ -149,8 +149,8 @@ class AccessListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(null, null)))
+            ->with($request)
+            ->willReturn(array(null, null))
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
@@ -39,7 +39,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($token))
+            ->with($token)
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -47,7 +47,7 @@ class BasicAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken'))
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -93,8 +93,8 @@ class BasicAuthenticationListenerTest extends TestCase
         $authenticationEntryPoint
             ->expects($this->any())
             ->method('start')
-            ->with($this->equalTo($request), $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
-            ->will($this->returnValue($response))
+            ->with($request, $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
+            ->willReturn($response)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -108,12 +108,12 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with($this->equalTo($response))
+            ->with($response)
         ;
 
         $listener->handle($event);
@@ -222,8 +222,8 @@ class BasicAuthenticationListenerTest extends TestCase
         $authenticationEntryPoint
             ->expects($this->any())
             ->method('start')
-            ->with($this->equalTo($request), $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
-            ->will($this->returnValue($response))
+            ->with($request, $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
+            ->willReturn($response)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -242,7 +242,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with($this->equalTo($response))
+            ->with($response)
         ;
 
         $listener->handle($event);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
@@ -30,7 +30,7 @@ class ChannelListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
+            ->with($request)
             ->will($this->returnValue(array(array(), 'http')))
         ;
 
@@ -68,7 +68,7 @@ class ChannelListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
+            ->with($request)
             ->will($this->returnValue(array(array(), 'https')))
         ;
 
@@ -108,7 +108,7 @@ class ChannelListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
+            ->with($request)
             ->will($this->returnValue(array(array(), 'https')))
         ;
 
@@ -116,7 +116,7 @@ class ChannelListenerTest extends TestCase
         $entryPoint
             ->expects($this->once())
             ->method('start')
-            ->with($this->equalTo($request))
+            ->with($request)
             ->will($this->returnValue($response))
         ;
 
@@ -129,7 +129,7 @@ class ChannelListenerTest extends TestCase
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with($this->equalTo($response))
+            ->with($response)
         ;
 
         $listener = new ChannelListener($accessMap, $entryPoint);
@@ -151,7 +151,7 @@ class ChannelListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
+            ->with($request)
             ->will($this->returnValue(array(array(), 'http')))
         ;
 
@@ -159,7 +159,7 @@ class ChannelListenerTest extends TestCase
         $entryPoint
             ->expects($this->once())
             ->method('start')
-            ->with($this->equalTo($request))
+            ->with($request)
             ->will($this->returnValue($response))
         ;
 
@@ -172,7 +172,7 @@ class ChannelListenerTest extends TestCase
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with($this->equalTo($response))
+            ->with($response)
         ;
 
         $listener = new ChannelListener($accessMap, $entryPoint);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -202,7 +202,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($token))
+            ->with($token)
         ;
 
         $manager
@@ -241,7 +241,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($token))
+            ->with($token)
         ;
 
         $manager
@@ -306,7 +306,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($token))
+            ->with($token)
         ;
 
         $manager
@@ -369,7 +369,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($token))
+            ->with($token)
         ;
 
         $manager

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -33,13 +33,13 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $this->tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($this->token))
+            ->with($this->token)
         ;
 
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
-            ->with($this->equalTo($this->token))
+            ->with($this->token)
             ->will($this->returnValue($this->token))
         ;
 
@@ -47,8 +47,8 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $simpleAuthenticator
             ->expects($this->once())
             ->method('createToken')
-            ->with($this->equalTo($this->request), $this->equalTo('secured_area'))
-            ->will($this->returnValue($this->token))
+            ->with($this->request, 'secured_area')
+            ->willReturn($this->token)
         ;
 
         $loginEvent = new InteractiveLoginEvent($this->request, $this->token);
@@ -56,7 +56,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $this->dispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with($this->equalTo(SecurityEvents::INTERACTIVE_LOGIN), $this->equalTo($loginEvent))
+            ->with(SecurityEvents::INTERACTIVE_LOGIN, $loginEvent)
         ;
 
         $listener = new SimplePreAuthenticationListener($this->tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
@@ -71,21 +71,21 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
-            ->with($this->equalTo($this->token))
+            ->with($this->token)
             ->willThrowException($exception)
         ;
 
         $this->tokenStorage->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo(null))
+            ->with(null)
         ;
 
         $simpleAuthenticator = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface')->getMock();
         $simpleAuthenticator
             ->expects($this->once())
             ->method('createToken')
-            ->with($this->equalTo($this->request), $this->equalTo('secured_area'))
-            ->will($this->returnValue($this->token))
+            ->with($this->request, 'secured_area')
+            ->willReturn($this->token)
         ;
 
         $listener = new SimplePreAuthenticationListener($this->tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);

--- a/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
@@ -27,8 +27,8 @@ class FirewallMapTest extends TestCase
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->with($request)
+            ->willReturn(false)
         ;
 
         $map->add($notMatchingMatcher, array($this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock()));
@@ -37,8 +37,8 @@ class FirewallMapTest extends TestCase
         $matchingMatcher
             ->expects($this->once())
             ->method('matches')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(true))
+            ->with($request)
+            ->willReturn(true)
         ;
         $theListener = $this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock();
         $theException = $this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ExceptionListener')->disableOriginalConstructor()->getMock();
@@ -69,7 +69,7 @@ class FirewallMapTest extends TestCase
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
-            ->with($this->equalTo($request))
+            ->with($request)
             ->will($this->returnValue(false))
         ;
 
@@ -104,7 +104,7 @@ class FirewallMapTest extends TestCase
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
-            ->with($this->equalTo($request))
+            ->with($request)
             ->will($this->returnValue(false))
         ;
 

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -27,7 +27,7 @@ class FirewallTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('register')
-            ->with($this->equalTo($dispatcher))
+            ->with($dispatcher)
         ;
 
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
@@ -36,8 +36,8 @@ class FirewallTest extends TestCase
         $map
             ->expects($this->once())
             ->method('getListeners')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array(), $listener)))
+            ->with($request)
+            ->will(array(array(), $listener))
         ;
 
         $event = new GetResponseEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $request, HttpKernelInterface::MASTER_REQUEST);

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -37,7 +37,7 @@ class FirewallTest extends TestCase
             ->expects($this->once())
             ->method('getListeners')
             ->with($request)
-            ->will(array(array(), $listener))
+            ->willReturn(array(array(), $listener))
         ;
 
         $event = new GetResponseEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $request, HttpKernelInterface::MASTER_REQUEST);
@@ -48,8 +48,6 @@ class FirewallTest extends TestCase
 
     public function testOnKernelRequestStopsWhenThereIsAResponse()
     {
-        $response = new Response();
-
         $first = $this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock();
         $first
             ->expects($this->once())

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -117,8 +117,8 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('deleteTokenBySeries')
-            ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(null))
+            ->with('fooseries')
+            ->willReturn(null)
         ;
 
         try {
@@ -140,8 +140,8 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('loadTokenBySeries')
-            ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(new PersistentToken('fooclass', 'username', 'fooseries', 'foovalue', new \DateTime('yesterday'))))
+            ->with('fooseries')
+            ->willReturn(new PersistentToken('fooclass', 'username', 'fooseries', 'foovalue', new \DateTime('yesterday')))
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -162,8 +162,8 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $userProvider
             ->expects($this->once())
             ->method('loadUserByUsername')
-            ->with($this->equalTo('foouser'))
-            ->will($this->returnValue($user))
+            ->with('foouser')
+            ->willReturn($user)
         ;
 
         $service = $this->getService($userProvider, array('name' => 'foo', 'path' => null, 'domain' => null, 'secure' => false, 'httponly' => false, 'always_remember_me' => true, 'lifetime' => 3600));
@@ -174,8 +174,8 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('loadTokenBySeries')
-            ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(new PersistentToken('fooclass', 'foouser', 'fooseries', 'foovalue', new \DateTime())))
+            ->with('fooseries')
+            ->willReturn(new PersistentToken('fooclass', 'foouser', 'fooseries', 'foovalue', new \DateTime()))
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -199,8 +199,8 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('deleteTokenBySeries')
-            ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(null))
+            ->with('fooseries')
+            ->willReturn(null)
         ;
         $service->setTokenProvider($tokenProvider);
 

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -73,8 +73,8 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $userProvider
             ->expects($this->once())
             ->method('loadUserByUsername')
-            ->with($this->equalTo('foouser'))
-            ->will($this->returnValue($user))
+            ->with('foouser')
+            ->willReturn($user)
         ;
 
         $this->assertNull($service->autoLogin($request));
@@ -92,14 +92,14 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
 
         $userProvider
             ->expects($this->once())
             ->method('loadUserByUsername')
-            ->with($this->equalTo('foouser'))
-            ->will($this->returnValue($user))
+            ->with('foouser')
+            ->willReturn($user)
         ;
 
         $this->assertNull($service->autoLogin($request));
@@ -129,8 +129,8 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $userProvider
             ->expects($this->once())
             ->method('loadUserByUsername')
-            ->with($this->equalTo($username))
-            ->will($this->returnValue($user))
+            ->with($username)
+            ->willReturn($user)
         ;
 
         $service = $this->getService($userProvider, array('name' => 'foo', 'always_remember_me' => true, 'lifetime' => 3600));

--- a/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
@@ -41,7 +41,7 @@ class SessionAuthenticationStrategyTest extends TestCase
     public function testSessionIsMigrated()
     {
         $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
-        $session->expects($this->once())->method('migrate')->with($this->equalTo(true));
+        $session->expects($this->once())->method('migrate')->with(true);
 
         $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE);
         $strategy->onAuthentication($this->getRequest($session), $this->getToken());

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -291,11 +291,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $file
             ->expects($this->once())
             ->method('getPathname')
-            ->will($this->returnValue($this->path));
+            ->willReturn($this->path);
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue('image/jpg'));
+            ->willReturn('image/jpg');
 
         $constraint = new File(array(
             'mimeTypes' => array('image/png', 'image/jpg'),
@@ -315,11 +315,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $file
             ->expects($this->once())
             ->method('getPathname')
-            ->will($this->returnValue($this->path));
+            ->willReturn($this->path);
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue('image/jpg'));
+            ->willReturn('image/jpg');
 
         $constraint = new File(array(
             'mimeTypes' => array('image/*'),
@@ -339,11 +339,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $file
             ->expects($this->once())
             ->method('getPathname')
-            ->will($this->returnValue($this->path));
+            ->willReturn($this->path);
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue('application/pdf'));
+            ->willReturn('application/pdf');
 
         $constraint = new File(array(
             'mimeTypes' => array('image/png', 'image/jpg'),
@@ -369,11 +369,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $file
             ->expects($this->once())
             ->method('getPathname')
-            ->will($this->returnValue($this->path));
+            ->willReturn($this->path);
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue('application/pdf'));
+            ->willReturn('application/pdf');
 
         $constraint = new File(array(
             'mimeTypes' => array('image/*', 'image/jpg'),

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
@@ -31,7 +31,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->cache->write($meta);
 
@@ -51,7 +51,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->assertFalse($this->cache->has('Foo\\Bar'), 'has() returns false when there is no entry');
 
@@ -68,7 +68,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->assertFalse($this->cache->read('Foo\\Bar'), 'read() returns false when there is no entry');
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -97,7 +97,7 @@ class LazyLoadingMetadataFactoryTest extends TestCase
                   array($this->equalTo(self::PARENT_CLASS)),
                   array($this->equalTo(self::INTERFACE_A_CLASS))
               )
-              ->will($this->returnValue(false));
+              ->willReturn(false);
         $cache->expects($this->exactly(2))
               ->method('write')
               ->withConsecutive(
@@ -177,7 +177,7 @@ class LazyLoadingMetadataFactoryTest extends TestCase
 
         $cache->expects($this->any())
             ->method('read')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
         $metadata->addConstraint(new Callback(function () {}));

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/LoaderChainTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/LoaderChainTest.php
@@ -24,12 +24,12 @@ class LoaderChainTest extends TestCase
         $loader1 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader1->expects($this->once())
             ->method('loadClassMetadata')
-            ->with($this->equalTo($metadata));
+            ->with($metadata);
 
         $loader2 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader2->expects($this->once())
             ->method('loadClassMetadata')
-            ->with($this->equalTo($metadata));
+            ->with($metadata);
 
         $chain = new LoaderChain(array(
             $loader1,
@@ -46,12 +46,12 @@ class LoaderChainTest extends TestCase
         $loader1 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader1->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $loader2 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader2->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $chain = new LoaderChain(array(
             $loader1,
@@ -68,12 +68,12 @@ class LoaderChainTest extends TestCase
         $loader1 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader1->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $loader2 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader2->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $chain = new LoaderChain(array(
             $loader1,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| License       | MIT

Improve tests by

- Replace some `->will($this->returnValue('something'))` with `->willReturn('something')`
- Remove all `equalTo` that where wrapped inside a `with` function.
