### PR TITLE
Proposed change due to Issue created

### DIFF
--- a/src/Symfony/Component/Security/Csrf/CsrfToken.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfToken.php
@@ -21,7 +21,7 @@ class CsrfToken
     private $id;
     private $value;
 
-    public function __construct(string $id, ?string $value)
+    public function __construct(\string $id, ?\string $value)
     {
         $this->id = $id;
         $this->value = $value ?? '';


### PR DESCRIPTION
Hey, in CustomUserMessageAuthenticationException is an typo in constructor argument, message is required to be a string, not \string which may false inform IDE about argument type, and it's open gate to bugs in future.

ISSUE: https://github.com/symfony/symfony/issues/29687

| Q             | A
| ------------- | ---
| Branch?       |  4.2.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not required
| Fixed tickets | #...  ISSUE ID: 29687
| License       | MIT


All details in issue linked in desc.