### PR TITLE
[Form] Changed UrlType input type to text when default_protocol is not null

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -2396,6 +2396,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     [@name="name"]
     [@class="my&class form-control"]
     [@value="http://www.google.com?foo1=bar1&foo2=bar2"]
+    [@inputmode="url"]
 '
         );
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -2388,7 +2388,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testUrlWithDefaultProtocol()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, array('default_protocol' => 'http'));
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, ['default_protocol' => 'http']);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
 '/input
@@ -2404,9 +2404,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testUrlWithoutDefaultProtocol()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, array('default_protocol' => null));
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, ['default_protocol' => null]);
 
-        $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
     [@type="url"]
     [@name="name"]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -2385,13 +2385,28 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
-    public function testUrl()
+    public function testUrlWithDefaultProtocol()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, array('default_protocol' => 'http'));
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
 '/input
+    [@type="text"]
+    [@name="name"]
+    [@class="my&class form-control"]
+    [@value="http://www.google.com?foo1=bar1&foo2=bar2"]
+'
+        );
+    }
+
+    public function testUrlWithoutDefaultProtocol()
+    {
+        $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, array('default_protocol' => null));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
+            '/input
     [@type="url"]
     [@name="name"]
     [@class="my&class form-control"]

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/asset": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
-        "symfony/form": "^3.4.16|^4.1.5",
+        "symfony/form": "^3.4.22|~4.1.11|^4.2.3",
         "symfony/http-foundation": "^3.3.11|~4.0",
         "symfony/http-kernel": "~3.2|~4.0",
         "symfony/polyfill-intl-icu": "~1.0",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -39,7 +39,7 @@
         "symfony/css-selector": "~2.8|~3.0|~4.0",
         "symfony/dom-crawler": "~2.8|~3.0|~4.0",
         "symfony/polyfill-intl-icu": "~1.0",
-        "symfony/form": "~3.4|~4.0",
+        "symfony/form": "^3.4.22|~4.1.11|^4.2.3",
         "symfony/expression-language": "~2.8|~3.0|~4.0",
         "symfony/process": "~2.8|~3.0|~4.0",
         "symfony/security-core": "~3.2|~4.0",

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UrlType extends AbstractType
@@ -26,6 +28,14 @@ class UrlType extends AbstractType
         if (null !== $options['default_protocol']) {
             $builder->addEventSubscriber(new FixUrlProtocolListener($options['default_protocol']));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['type'] = $options['default_protocol'] ? 'text' : 'url';
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -35,7 +35,10 @@ class UrlType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['type'] = $options['default_protocol'] ? 'text' : 'url';
+        if ($options['default_protocol']) {
+            $view->vars['attr']['inputmode'] = 'url';
+            $view->vars['type'] = 'text';
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2180,6 +2180,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [@type="text"]
     [@name="name"]
     [@value="http://www.google.com?foo1=bar1&foo2=bar2"]
+    [@inputmode="url"]
 '
         );
     }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2170,10 +2170,24 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
-    public function testUrl()
+    public function testUrlWithDefaultProtocol()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, array('default_protocol' => 'http'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/input
+    [@type="text"]
+    [@name="name"]
+    [@value="http://www.google.com?foo1=bar1&foo2=bar2"]
+'
+        );
+    }
+
+    public function testUrlWithoutDefaultProtocol()
+    {
+        $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, array('default_protocol' => null));
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
 '/input

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2173,9 +2173,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testUrlWithDefaultProtocol()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, array('default_protocol' => 'http'));
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, ['default_protocol' => 'http']);
 
-        $this->assertWidgetMatchesXpath($form->createView(), array(),
+        $this->assertWidgetMatchesXpath($form->createView(), [],
 '/input
     [@type="text"]
     [@name="name"]
@@ -2188,7 +2188,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testUrlWithoutDefaultProtocol()
     {
         $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, array('default_protocol' => null));
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, ['default_protocol' => null]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
 '/input


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29690 
| License       | MIT
