### PR TITLE
[DI] Fixed wrong factory method in exception

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -155,7 +155,7 @@ class ObjectsProvider
 
     public static function getCallables()
     {
-        $callables = array(
+        return array(
             'callable_1' => 'array_key_exists',
             'callable_2' => array('Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\CallableClass', 'staticMethod'),
             'callable_3' => array(new CallableClass(), 'method'),
@@ -163,13 +163,8 @@ class ObjectsProvider
             'callable_5' => array('Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\ExtendedCallableClass', 'parent::staticMethod'),
             'callable_6' => function () { return 'Closure'; },
             'callable_7' => new CallableClass(),
+            'callable_from_callable' => \Closure::fromCallable(new CallableClass()),
         );
-
-        if (\PHP_VERSION_ID >= 70100) {
-            $callables['callable_from_callable'] = \Closure::fromCallable(new CallableClass());
-        }
-
-        return $callables;
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -49,6 +49,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
                 if (null === $parameters) {
                     $r = $this->getReflectionMethod($value, $method);
                     $class = $r instanceof \ReflectionMethod ? $r->class : $this->currentId;
+                    $method = $r->getName();
                     $parameters = $r->getParameters();
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -16,9 +16,11 @@ use Symfony\Component\DependencyInjection\Compiler\ResolveNamedArgumentsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsVariadicsDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\SimilarArgumentsDummy;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -103,12 +105,31 @@ class ResolveNamedArgumentsPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy": method "__construct()" has no argument named "$notFound". Check your service definition.
      */
     public function testArgumentNotFound()
     {
         $container = new ContainerBuilder();
 
         $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
+        $definition->setArguments(array('$notFound' => '123'));
+
+        $pass = new ResolveNamedArgumentsPass();
+        $pass->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1": method "Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummy::create()" has no argument named "$notFound". Check your service definition.
+     */
+    public function testCorrectMethodReportedInException()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(FactoryDummy::class, FactoryDummy::class);
+
+        $definition = $container->register(TestDefinition1::class, TestDefinition1::class);
+        $definition->setFactory(array(FactoryDummy::class, 'create'));
         $definition->setArguments(array('$notFound' => '123'));
 
         $pass = new ResolveNamedArgumentsPass();

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
@@ -30,21 +30,16 @@ class WrappedListenerTest extends TestCase
 
     public function provideListenersToDescribe()
     {
-        $listeners = array(
+        return array(
             array(new FooListener(), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::__invoke'),
             array(array(new FooListener(), 'listen'), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listen'),
             array(array('Symfony\Component\EventDispatcher\Tests\Debug\FooListener', 'listenStatic'), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listenStatic'),
             array('var_dump', 'var_dump'),
             array(function () {}, 'closure'),
+            array(\Closure::fromCallable(array(new FooListener(), 'listen')), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listen'),
+            array(\Closure::fromCallable(array('Symfony\Component\EventDispatcher\Tests\Debug\FooListener', 'listenStatic')), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listenStatic'),
+            array(\Closure::fromCallable(function () {}), 'closure'),
         );
-
-        if (\PHP_VERSION_ID >= 70100) {
-            $listeners[] = array(\Closure::fromCallable(array(new FooListener(), 'listen')), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listen');
-            $listeners[] = array(\Closure::fromCallable(array('Symfony\Component\EventDispatcher\Tests\Debug\FooListener', 'listenStatic')), 'Symfony\Component\EventDispatcher\Tests\Debug\FooListener::listenStatic');
-            $listeners[] = array(\Closure::fromCallable(function () {}), 'closure');
-        }
-
-        return $listeners;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29678   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->

When a service definition with a factory defines invalid arguments, the [resulting exception message ](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php#L70)incorrectly specifies the factory constructor instead of the factory method as not having the specified named arguments.


<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
