### PR TITLE
[Tests] Remove annotation of excpectedException Batch #1

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -19,9 +19,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class RegisterEventListenersAndSubscribersPassTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testExceptionOnAbstractTaggedSubscriber()
     {
         $container = $this->createBuilder();
@@ -32,12 +29,10 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
 
         $container->setDefinition('a', $abstractDefinition);
 
+        $this->expectException(\InvalidArgumentException::class);
         $this->process($container);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testExceptionOnAbstractTaggedListener()
     {
         $container = $this->createBuilder();
@@ -48,6 +43,7 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
 
         $container->setDefinition('a', $abstractDefinition);
 
+        $this->expectException(\InvalidArgumentException::class);
         $this->process($container);
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -49,9 +49,6 @@ class DoctrineExtensionTest extends TestCase
             }));
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testFixManagersAutoMappingsWithTwoAutomappings()
     {
         $emConfigs = array(
@@ -72,6 +69,7 @@ class DoctrineExtensionTest extends TestCase
         $method = $reflection->getMethod('fixManagersAutoMappings');
         $method->setAccessible(true);
 
+        $this->expectException(\LogicException::class);
         $method->invoke($this->extension, $emConfigs, $bundles);
     }
 
@@ -238,10 +236,6 @@ class DoctrineExtensionTest extends TestCase
         $this->assertTrue($container->hasAlias('doctrine.orm.default_metadata_cache'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage "unrecognized_type" is an unrecognized Doctrine cache driver.
-     */
     public function testUnrecognizedCacheDriverException()
     {
         $cacheName = 'metadata_cache';
@@ -253,6 +247,8 @@ class DoctrineExtensionTest extends TestCase
             ),
         );
 
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"unrecognized_type" is an unrecognized Doctrine cache driver.');
         $this->invokeLoadCacheDriver($objectManager, $container, $cacheName);
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -167,9 +167,6 @@ class EntityUserProviderTest extends TestCase
         $provider->loadUserByUsername('name');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLoadUserByUserNameShouldDeclineInvalidInterface()
     {
         $repository = $this->getMockBuilder('\Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
@@ -179,6 +176,7 @@ class EntityUserProviderTest extends TestCase
             'Symfony\Bridge\Doctrine\Tests\Fixtures\User'
         );
 
+        $this->expectException(\InvalidArgumentException::class);
         $provider->loadUserByUsername('name');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -39,11 +39,9 @@ class RouterDebugCommandTest extends TestCase
         $this->assertContains('Route Name   | foo', $tester->getDisplay());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDebugInvalidRoute()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->createCommandTester()->execute(array('name' => 'test'));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -94,9 +94,6 @@ class TranslationDebugCommandTest extends TestCase
         $this->assertRegExp('/unused/', $tester->getDisplay());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDebugInvalidDirectory()
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
@@ -106,6 +103,8 @@ class TranslationDebugCommandTest extends TestCase
             ->willThrowException(new \InvalidArgumentException());
 
         $tester = $this->createCommandTester(array(), array(), $kernel);
+
+        $this->expectException(\InvalidArgumentException::class);
         $tester->execute(array('locale' => 'en', 'bundle' => 'dir'));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -24,8 +24,6 @@ class ProfilerPassTest extends TestCase
      * Thus, a fully-valid tag looks something like this:
      *
      *     <tag name="data_collector" template="YourBundle:Collector:templatename" id="your_collector_name" />
-     *
-     * @expectedException \InvalidArgumentException
      */
     public function testTemplateNoIdThrowsException()
     {
@@ -35,6 +33,8 @@ class ProfilerPassTest extends TestCase
             ->addTag('data_collector', array('template' => 'foo'));
 
         $profilerPass = new ProfilerPass();
+
+        $this->expectException(\InvalidArgumentException::class);
         $profilerPass->process($builder);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
@@ -77,12 +77,11 @@ class TemplateLocatorTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testThrowsAnExceptionWhenTemplateIsNotATemplateReferenceInterface()
     {
         $locator = new TemplateLocator($this->getFileLocator());
+
+        $this->expectException(\InvalidArgumentException::class);
         $locator->locate('template');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -43,15 +43,13 @@ class PhpEngineTest extends TestCase
         $this->assertEmpty($globals['app']->getRequest());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetInvalidHelper()
     {
         $container = $this->getContainer();
         $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
         $engine = new PhpEngine(new TemplateNameParser(), $container, $loader);
 
+        $this->expectException(\InvalidArgumentException::class);
         $engine->get('non-existing-helper');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -74,11 +74,9 @@ class TemplateNameParserTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testParseValidNameWithNotFoundBundle()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parse('BarBundle:Post:index.html.php');
     }
 

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -208,15 +208,13 @@ class ClassCollectionLoaderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUnableToLoadClassException()
     {
         if (is_file($file = sys_get_temp_dir().'/foo.php')) {
             unlink($file);
         }
 
+        $this->expectException(\InvalidArgumentException::class);
         ClassCollectionLoader::load(array('SomeNotExistingClass'), sys_get_temp_dir(), 'foo', false);
     }
 

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -63,13 +63,11 @@ class DirectoryResourceTest extends TestCase
         $this->assertEquals('bar', $resource->getPattern());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The directory ".*" does not exist./
-     */
     public function testResourceDoesNotExist()
     {
-        $resource = new DirectoryResource('/____foo/foobar'.mt_rand(1, 999999));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/The directory ".*" does not exist./');
+        new DirectoryResource('/____foo/foobar'.mt_rand(1, 999999));
     }
 
     public function testIsFresh()

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleStackTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleStackTest.php
@@ -59,13 +59,12 @@ class OutputFormatterStyleStackTest extends TestCase
         $this->assertEquals($s1, $stack->pop());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidPop()
     {
         $stack = new OutputFormatterStyleStack();
         $stack->push(new OutputFormatterStyle('white', 'black'));
+
+        $this->expectException(\InvalidArgumentException::class);
         $stack->pop(new OutputFormatterStyle('yellow', 'blue'));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -96,27 +96,21 @@ class InputOptionTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testEmptyNameIsInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new InputOption('');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDoubleDashNameIsInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new InputOption('--');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSingleDashOptionIsInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new InputOption('foo', '-');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
@@ -90,13 +90,11 @@ class ChildDefinitionTest extends TestCase
         $this->assertSame(array('index_0' => 'foo'), $def->getArguments());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testReplaceArgumentShouldRequireIntegerIndex()
     {
         $def = new ChildDefinition('foo');
 
+        $this->expectException(\InvalidArgumentException::class);
         $def->replaceArgument('0', 'foo');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
@@ -53,13 +53,12 @@ class ReplaceAliasByActualDefinitionPassTest extends TestCase
         $this->assertSame('b_alias', (string) $resolvedFactory[0]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testProcessWithInvalidAlias()
     {
         $container = new ContainerBuilder();
         $container->setAlias('a_alias', 'a');
+
+        $this->expectException(\InvalidArgumentException::class);
         $this->process($container);
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionDecoratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionDecoratorTest.php
@@ -92,13 +92,12 @@ class DefinitionDecoratorTest extends TestCase
         $this->assertEquals(array('index_0' => 'foo'), $def->getArguments());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+
     public function testReplaceArgumentShouldRequireIntegerIndex()
     {
         $def = new DefinitionDecorator('foo');
 
+        $this->expectException(\InvalidArgumentException::class);
         $def->replaceArgument('0', 'foo');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -149,13 +149,14 @@ class PhpDumperTest extends TestCase
 
     /**
      * @dataProvider provideInvalidParameters
-     * @expectedException \InvalidArgumentException
      */
     public function testExportParameters($parameters)
     {
         $container = new ContainerBuilder(new ParameterBag($parameters));
         $container->compile();
         $dumper = new PhpDumper($container);
+
+        $this->expectException(\InvalidArgumentException::class);
         $dumper->dump();
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -69,22 +69,19 @@ class CrawlerTest extends TestCase
         $this->assertEquals('Foo', $crawler->filterXPath('//body')->text(), '->add() adds nodes from a string');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAddInvalidType()
     {
         $crawler = new Crawler();
+        $this->expectException(\InvalidArgumentException::class);
         $crawler->add(1);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Attaching DOM nodes from multiple documents in the same crawler is forbidden.
-     */
     public function testAddMultipleDocumentNode()
     {
         $crawler = $this->createTestCrawler();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Attaching DOM nodes from multiple documents in the same crawler is forbidden.');
         $crawler->addHtmlContent('<html><div class="foo"></html>', 'UTF-8');
     }
 
@@ -769,23 +766,19 @@ HTML;
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The selected node should be instance of DOMElement
-     */
     public function testInvalidLink()
     {
         $crawler = $this->createTestCrawler('http://example.com/bar/');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
         $crawler->filterXPath('//li/text()')->link();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The selected node should be instance of DOMElement
-     */
     public function testInvalidLinks()
     {
         $crawler = $this->createTestCrawler('http://example.com/bar/');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
         $crawler->filterXPath('//li/text()')->link();
     }
 
@@ -886,13 +879,11 @@ HTML;
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The selected node should be instance of DOMElement
-     */
     public function testInvalidForm()
     {
         $crawler = $this->createTestCrawler('http://example.com/bar/');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
         $crawler->filterXPath('//li/text()')->form();
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -714,21 +714,17 @@ class FormTest extends TestCase
         $registry->remove('[t:dbt%3adate;]data_daterange_enddate_value');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testFormFieldRegistryGetThrowAnExceptionWhenTheFieldDoesNotExist()
     {
         $registry = new FormFieldRegistry();
+        $this->expectException(\InvalidArgumentException::class);
         $registry->get('foo');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testFormFieldRegistrySetThrowAnExceptionWhenTheFieldDoesNotExist()
     {
         $registry = new FormFieldRegistry();
+        $this->expectException(\InvalidArgumentException::class);
         $registry->set('foo', null);
     }
 
@@ -804,27 +800,21 @@ class FormTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot set value on a compound field "foo[bar]".
-     */
     public function testFormRegistrySetValueOnCompoundField()
     {
         $registry = new FormFieldRegistry();
         $registry->add($this->getFormFieldMock('foo[bar][baz]'));
-
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot set value on a compound field "foo[bar]".');
         $registry->set('foo[bar]', 'fbb');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unreachable field "0"
-     */
     public function testFormRegistrySetArrayOnNotCompoundField()
     {
         $registry = new FormFieldRegistry();
         $registry->add($this->getFormFieldMock('bar'));
-
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unreachable field "0"');
         $registry->set('bar', array('baz'));
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
@@ -27,14 +27,11 @@ class LinkTest extends TestCase
         new Link($dom->getElementsByTagName('div')->item(0), 'http://www.example.com/');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorWithAnInvalidCurrentUri()
     {
         $dom = new \DOMDocument();
         $dom->loadHTML('<html><a href="/foo">foo</a></html>');
-
+        $this->expectException(\InvalidArgumentException::class);
         new Link($dom->getElementsByTagName('a')->item(0), 'example.com');
     }
 

--- a/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -78,11 +78,9 @@ class GenericEventTest extends TestCase
         $this->assertEquals('Event', $this->event->getArgument('name'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetArgException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->event->getArgument('nameNotExist');
     }
 

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -288,12 +288,10 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($expected, $iterator);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInWithNonExistentDirectory()
     {
         $finder = new Finder();
+        $this->expectException(\InvalidArgumentException::class);
         $finder->in('foobar');
     }
 
@@ -305,12 +303,10 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsoluteFixtures(array('A/B/C/abc.dat', 'copy/A/B/C/abc.dat.copy')), $finder);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInWithNonDirectoryGlob()
     {
         $finder = new Finder();
+        $this->expectException(\InvalidArgumentException::class);
         $finder->in(__DIR__.'/Fixtures/A/a*');
     }
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/CustomFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/CustomFilterIteratorTest.php
@@ -15,11 +15,9 @@ use Symfony\Component\Finder\Iterator\CustomFilterIterator;
 
 class CustomFilterIteratorTest extends IteratorTestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testWithInvalidFilter()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new CustomFilterIterator(new Iterator(), array('foo'));
     }
 

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -109,11 +109,9 @@ TXT
         , $output);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDebugInvalidFormType()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->createCommandTester()->execute(array('class' => 'test'));
     }
 

--- a/src/Symfony/Component/Form/Tests/Guess/GuessTest.php
+++ b/src/Symfony/Component/Form/Tests/Guess/GuessTest.php
@@ -29,11 +29,9 @@ class GuessTest extends TestCase
         $this->assertSame($guess3, Guess::getBestGuess(array($guess1, $guess2, $guess3)));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGuessExpectsValidConfidence()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new TestGuess(5);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -41,18 +41,16 @@ class CookieTest extends TestCase
 
     /**
      * @dataProvider invalidNames
-     * @expectedException \InvalidArgumentException
      */
     public function testInstantiationThrowsExceptionIfCookieNameContainsInvalidCharacters($name)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Cookie($name);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidExpiration()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Cookie('MyCookie', 'foo', 'bar');
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -23,11 +23,9 @@ use Symfony\Component\HttpFoundation\FileBag;
  */
 class FileBagTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testFileMustBeAnArrayOrUploadedFile()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new FileBag(array('file' => 'foo'));
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -214,20 +214,16 @@ class JsonResponseTest extends TestCase
         $this->assertSame('{"foo":"bar"}', $response->getContent());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetCallbackInvalidIdentifier()
     {
         $response = new JsonResponse('foo');
+        $this->expectException(\InvalidArgumentException::class);
         $response->setCallback('+invalid');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetContent()
     {
+        $this->expectException(\InvalidArgumentException::class);
         JsonResponse::create("\xB1\x31");
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -26,20 +26,16 @@ class RedirectResponseTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRedirectResponseConstructorNullUrl()
     {
-        $response = new RedirectResponse(null);
+        $this->expectException(\InvalidArgumentException::class);
+        new RedirectResponse(null);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRedirectResponseConstructorWrongStatusCode()
     {
-        $response = new RedirectResponse('foo.bar', 404);
+        $this->expectException(\InvalidArgumentException::class);
+        new RedirectResponse('foo.bar', 404);
     }
 
     public function testGenerateLocationHeader()
@@ -65,12 +61,10 @@ class RedirectResponseTest extends TestCase
         $this->assertEquals('baz.beep', $response->getTargetUrl());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetTargetUrlNull()
     {
         $response = new RedirectResponse('foo.bar');
+        $this->expectException(\InvalidArgumentException::class);
         $response->setTargetUrl(null);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1919,21 +1919,22 @@ class RequestTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedException \InvalidArgumentException
      */
     public function testSetTrustedProxiesInvalidHeaderName()
     {
         Request::create('http://example.com/');
+
+        $this->expectException(\InvalidArgumentException::class);
         Request::setTrustedHeaderName('bogus name', 'X_MY_FOR');
     }
 
     /**
      * @group legacy
-     * @expectedException \InvalidArgumentException
      */
     public function testGetTrustedProxiesInvalidHeaderName()
     {
         Request::create('http://example.com/');
+        $this->expectException(\InvalidArgumentException::class);
         Request::getTrustedHeaderName('bogus name');
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -240,23 +240,19 @@ class ResponseHeaderBagTest extends TestCase
         $this->assertEquals(array(), $bag->getCookies());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetCookiesWithInvalidArgument()
     {
         $bag = new ResponseHeaderBag();
 
+        $this->expectException(\InvalidArgumentException::class);
         $bag->getCookies('invalid_argument');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMakeDispositionInvalidDisposition()
     {
         $headers = new ResponseHeaderBag();
 
+        $this->expectException(\InvalidArgumentException::class);
         $headers->makeDisposition('invalid', 'foo.html');
     }
 
@@ -298,12 +294,12 @@ class ResponseHeaderBagTest extends TestCase
 
     /**
      * @dataProvider provideMakeDispositionFail
-     * @expectedException \InvalidArgumentException
      */
     public function testMakeDispositionFail($disposition, $filename)
     {
         $headers = new ResponseHeaderBag();
 
+        $this->expectException(\InvalidArgumentException::class);
         $headers->makeDisposition($disposition, $filename);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -62,19 +62,15 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->storage = new MongoDbSessionHandler($this->mongo, $this->options);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorShouldThrowExceptionForInvalidMongo()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new MongoDbSessionHandler(new \stdClass(), $this->options);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorShouldThrowExceptionForMissingOptions()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new MongoDbSessionHandler($this->mongo, array());
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -59,12 +59,10 @@ class NativeFileSessionHandlerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructException()
     {
-        $handler = new NativeFileSessionHandler('something;invalid;with;too-many-args');
+        $this->expectException(\InvalidArgumentException::class);
+        new NativeFileSessionHandler('something;invalid;with;too-many-args');
     }
 
     public function testConstructDefault()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -48,15 +48,13 @@ class PdoSessionHandlerTest extends TestCase
         return $pdo;
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testWrongPdoErrMode()
     {
         $pdo = $this->getMemorySqlitePdo();
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_SILENT);
 
-        $storage = new PdoSessionHandler($pdo);
+        $this->expectException(\InvalidArgumentException::class);
+        new PdoSessionHandler($pdo);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -72,12 +72,11 @@ class NativeSessionStorageTest extends TestCase
         $this->assertSame($bag, $storage->getBag($bag->getName()));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRegisterBagException()
     {
         $storage = $this->getStorage();
+
+        $this->expectException(\InvalidArgumentException::class);
         $storage->getBag('non_existing');
     }
 
@@ -199,12 +198,11 @@ class NativeSessionStorageTest extends TestCase
         $this->assertSame('200', ini_get('session.cache_expire'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetSaveHandlerException()
     {
         $storage = $this->getStorage();
+
+        $this->expectException(\InvalidArgumentException::class);
         $storage->setSaveHandler(new \stdClass());
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -167,7 +167,6 @@ class ArgumentResolverTest extends TestCase
 
     /**
      * @requires PHP 5.6
-     * @expectedException \InvalidArgumentException
      */
     public function testGetVariadicArgumentsWithoutArrayInRequest()
     {
@@ -176,12 +175,12 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('bar', 'foo');
         $controller = array(new VariadicController(), 'action');
 
+        $this->expectException(\InvalidArgumentException::class);
         self::$resolver->getArguments($request, $controller);
     }
 
     /**
      * @requires PHP 5.6
-     * @expectedException \InvalidArgumentException
      */
     public function testGetArgumentWithoutArray()
     {
@@ -196,6 +195,8 @@ class ArgumentResolverTest extends TestCase
         $request->attributes->set('foo', 'foo');
         $request->attributes->set('bar', 'foo');
         $controller = array($this, 'controllerWithFooAndDefaultBar');
+
+        $this->expectException(\InvalidArgumentException::class);
         $resolver->getArguments($request, $controller);
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -90,15 +90,14 @@ class ControllerResolverTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest', $controller);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetControllerOnObjectWithoutInvokeMethod()
     {
         $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
         $request->attributes->set('_controller', new \stdClass());
+
+        $this->expectException(\InvalidArgumentException::class);
         $resolver->getController($request);
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -84,11 +84,9 @@ class RouterListenerTest extends TestCase
         return new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidMatcher()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new RouterListener(new \stdClass(), $this->requestStack);
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -36,22 +36,18 @@ class FragmentHandlerTest extends TestCase
         ;
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWhenRendererDoesNotExist()
     {
         $handler = new FragmentHandler($this->requestStack);
+        $this->expectException(\InvalidArgumentException::class);
         $handler->render('/', 'foo');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithUnknownRenderer()
     {
         $handler = $this->getHandler($this->returnValue(new Response('foo')));
 
+        $this->expectException(\InvalidArgumentException::class);
         $handler->render('/', 'bar');
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -388,11 +388,9 @@ EOF;
         $this->assertEquals($expected, $kernel->serialize());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLocateResourceThrowsExceptionWhenNameIsNotValid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->getKernel()->locateResource('Foo');
     }
 
@@ -404,17 +402,12 @@ EOF;
         $this->getKernel()->locateResource('@FooBundle/../bar');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLocateResourceThrowsExceptionWhenBundleDoesNotExist()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->getKernel()->locateResource('@FooBundle/config/routing.xml');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLocateResourceThrowsExceptionWhenResourceDoesNotExist()
     {
         $kernel = $this->getKernel(array('getBundle'));
@@ -424,6 +417,7 @@ EOF;
             ->will($this->returnValue(array($this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle'))))
         ;
 
+        $this->expectException(\InvalidArgumentException::class);
         $kernel->locateResource('@Bundle1Bundle/config/routing.xml');
     }
 

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -115,9 +115,6 @@ class PhpGeneratorDumperTest extends TestCase
         $this->assertEquals('/app.php/testing2', $relativeUrlWithoutParameter);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDumpWithoutRoutes()
     {
         file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump(array('class' => 'WithoutRoutesUrlGenerator')));
@@ -125,6 +122,7 @@ class PhpGeneratorDumperTest extends TestCase
 
         $projectUrlGenerator = new \WithoutRoutesUrlGenerator(new RequestContext('/app.php'));
 
+        $this->expectException(\InvalidArgumentException::class);
         $projectUrlGenerator->generate('Test', array());
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -26,19 +26,15 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->loader = $this->getClassLoader($this->reader);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLoadMissingClass()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->loader->load('MissingClass');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLoadAbstractClass()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\AbstractClass');
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
@@ -41,12 +41,12 @@ class ObjectRouteLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider getBadResourceStrings
      */
     public function testExceptionWithoutSyntax($resourceString)
     {
         $loader = new ObjectRouteLoaderForTest();
+        $this->expectException(\InvalidArgumentException::class);
         $loader->load($resourceString);
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -84,22 +84,22 @@ class XmlFileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles
      */
     public function testLoadThrowsExceptionWithInvalidFile($filePath)
     {
         $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $this->expectException(\InvalidArgumentException::class);
         $loader->load($filePath);
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles
      */
     public function testLoadThrowsExceptionWithInvalidFileEvenWithoutSchemaValidation($filePath)
     {
         $loader = new CustomXmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $this->expectException(\InvalidArgumentException::class);
         $loader->load($filePath);
     }
 
@@ -108,13 +108,11 @@ class XmlFileLoaderTest extends TestCase
         return array(array('nonvalidnode.xml'), array('nonvalidroute.xml'), array('nonvalid.xml'), array('missing_id.xml'), array('missing_path.xml'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Document types are not allowed.
-     */
     public function testDocTypeIsNotAllowed()
     {
         $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Document types are not allowed.');
         $loader->load('withdoctype.xml');
     }
 
@@ -318,13 +316,11 @@ class XmlFileLoaderTest extends TestCase
         $this->assertSame('AppBundle:Blog:list', $route->getDefault('_controller'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The routing file "[^"]*" must not specify both the "controller" attribute and the defaults key "_controller" for "app_blog"/
-     */
     public function testOverrideControllerInDefaults()
     {
         $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/controller')));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/The routing file "[^"]*" must not specify both the "controller" attribute and the defaults key "_controller" for "app_blog"/');
         $loader->load('override_defaults.xml');
     }
 
@@ -352,13 +348,11 @@ class XmlFileLoaderTest extends TestCase
         yield array('import__controller.xml');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The routing file "[^"]*" must not specify both the "controller" attribute and the defaults key "_controller" for the "import" tag/
-     */
     public function testImportWithOverriddenController()
     {
         $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/controller')));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/The routing file "[^"]*" must not specify both the "controller" attribute and the defaults key "_controller" for the "import" tag/');
         $loader->load('import_override_defaults.xml');
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -41,12 +41,12 @@ class YamlFileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles
      */
     public function testLoadThrowsExceptionWithInvalidFile($filePath)
     {
         $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $this->expectException(\InvalidArgumentException::class);
         $loader->load($filePath);
     }
 

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -124,11 +124,11 @@ class RouteTest extends TestCase
 
     /**
      * @dataProvider getInvalidRequirements
-     * @expectedException \InvalidArgumentException
      */
     public function testSetInvalidRequirement($req)
     {
         $route = new Route('/{foo}');
+        $this->expectException(\InvalidArgumentException::class);
         $route->setRequirement('foo', $req);
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -24,19 +24,15 @@ use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
 
 class AuthenticationProviderManagerTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAuthenticateWithoutProviders()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new AuthenticationProviderManager(array());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAuthenticateWithProvidersWithIncorrectInterface()
     {
+        $this->expectException(\InvalidArgumentException::class);
         (new AuthenticationProviderManager(array(
             new \stdClass(),
         )))->authenticate($this->getMockBuilder(TokenInterface::class)->getMock());

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -29,11 +29,9 @@ class RememberMeTokenTest extends TestCase
         $this->assertTrue($token->isAuthenticated());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorSecretCannotBeNull()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new RememberMeToken(
             $this->getUser(),
             null,
@@ -41,11 +39,9 @@ class RememberMeTokenTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorSecretCannotBeEmptyString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new RememberMeToken(
             $this->getUser(),
             '',

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -20,11 +20,9 @@ use Symfony\Component\Security\Core\Tests\Authorization\Stub\VoterWithoutInterfa
 
 class AccessDecisionManagerTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetUnsupportedStrategy()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new AccessDecisionManager(array($this->getVoter(VoterInterface::ACCESS_GRANTED)), 'fooBar');
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
@@ -22,19 +22,15 @@ class BCryptPasswordEncoderTest extends TestCase
     const PASSWORD = 'password';
     const VALID_COST = '04';
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCostBelowRange()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new BCryptPasswordEncoder(3);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCostAboveRange()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new BCryptPasswordEncoder(32);
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BasePasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BasePasswordEncoderTest.php
@@ -46,11 +46,9 @@ class BasePasswordEncoderTest extends TestCase
         $this->assertEquals('password', $this->invokeMergePasswordAndSalt('password', ''));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMergePasswordAndSaltWithException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->invokeMergePasswordAndSalt('password', '{foo}');
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/User/UserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/UserTest.php
@@ -16,11 +16,9 @@ use Symfony\Component\Security\Core\User\User;
 
 class UserTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new User('', 'superpass');
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -302,15 +302,13 @@ class GetSetMethodNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUncallableCallbacks()
     {
         $this->normalizer->setCallbacks(array('bar' => null));
 
         $obj = new GetConstructorDummy('baz', 'quux', true);
 
+        $this->expectException(\InvalidArgumentException::class);
         $this->normalizer->normalize($obj, 'any');
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -331,15 +331,13 @@ class ObjectNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUncallableCallbacks()
     {
         $this->normalizer->setCallbacks(array('bar' => null));
 
         $obj = new ObjectConstructorDummy('baz', 'quux', true);
 
+        $this->expectException(\InvalidArgumentException::class);
         $this->normalizer->normalize($obj, 'any');
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -132,15 +132,13 @@ class PropertyNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUncallableCallbacks()
     {
         $this->normalizer->setCallbacks(array('bar' => null));
 
         $obj = new PropertyConstructorDummy('baz', 'quux');
 
+        $this->expectException(\InvalidArgumentException::class);
         $this->normalizer->normalize($obj, 'any');
     }
 

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -154,11 +154,9 @@ class StopwatchEventTest extends TestCase
         $this->assertEquals(0, $event->getStartTime(), '', self::DELTA);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidOriginThrowsAnException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new StopwatchEvent('abc');
     }
 

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -124,13 +124,14 @@ class PhpEngineTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider forbiddenParameterNames
      */
     public function testRenderForbiddenParameter($name)
     {
         $engine = new ProjectTemplateEngine(new TemplateNameParser(), $this->loader);
         $this->loader->setTemplate('foo.php', 'bar');
+
+        $this->expectException(\InvalidArgumentException::class);
         $engine->render('foo.php', array($name => 'foo'));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -40,13 +40,13 @@ class YamlFileLoaderTest extends TestCase
 
     /**
      * @dataProvider provideInvalidYamlFiles
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidYamlFiles($path)
     {
         $loader = new YamlFileLoader(__DIR__.'/'.$path);
         $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
 
+        $this->expectException(\InvalidArgumentException::class);
         $loader->loadClassMetadata($metadata);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Tests pass?   | yes  
| License       | MIT

According to PHPUnit [latest release](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-7.5.md) annotations of `expected*` are deprecated and will be removed. 

I guess this is done because the annotation was misused. By not using the annotation you can make sure where the exception is thrown.

This PR is premature but it will be better to have it now and start writing new PRs in this way rather than keep submitting new features with the old way and pay it later with more places to change and also it promotes a "correct" way of testing exceptions.

At the current PR only `expectedException \InvalidArgumentException` are fixed.. 

Let me know if you agree on doing it partially each time.