### PR TITLE
Fix @throws DocBlock about LogicException

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -113,7 +113,7 @@ abstract class Client
      *
      * @param bool $insulated Whether to insulate the requests or not
      *
-     * @throws \RuntimeException When Symfony Process Component is not installed
+     * @throws \LogicException When Symfony Process Component is not installed
      */
     public function insulate($insulated = true)
     {

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -42,7 +42,7 @@ class XmlUtils
      *
      * @throws XmlParsingException When parsing of XML file returns error
      * @throws InvalidXmlException When parsing of XML with schema or callable produces any errors unrelated to the XML parsing itself
-     * @throws \RuntimeException   When DOM extension is missing
+     * @throws \LogicException     When DOM extension is missing
      */
     public static function parse($content, $schemaOrCallable = null)
     {

--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -32,8 +32,8 @@ trait LockableTrait
      *
      * @return bool
      *
-     * @throws LogicException When Symfony Lock Component is not installed
-     *                        or when a lock is already in place.
+     * @throws LogicException when Symfony Lock Component is not installed
+     *                        or when a lock is already in place
      */
     private function lock($name = null, $blocking = false)
     {

--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -31,6 +31,9 @@ trait LockableTrait
      * Locks a command.
      *
      * @return bool
+     *
+     * @throws LogicException When Symfony Lock Component is not installed
+     *                        or when a lock is already in place.
      */
     private function lock($name = null, $blocking = false)
     {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -42,6 +42,8 @@ class YamlDumper extends Dumper
      * Dumps the service container as an YAML string.
      *
      * @return string A YAML string representing of the service container
+     *
+     * @throws LogicException When Symfony Yaml Component is not installed.
      */
     public function dump(array $options = array())
     {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -43,7 +43,7 @@ class YamlDumper extends Dumper
      *
      * @return string A YAML string representing of the service container
      *
-     * @throws LogicException When Symfony Yaml Component is not installed.
+     * @throws LogicException when Symfony Yaml Component is not installed
      */
     public function dump(array $options = array())
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1175,7 +1175,7 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @throws \RuntimeException If the CssSelector Component is not available
+     * @throws \LogicException If the CssSelector Component is not available
      */
     private function createCssSelectorConverter(): CssSelectorConverter
     {

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -47,7 +47,7 @@ class Serializer implements SerializerInterface
      *
      * @return self
      *
-     * @throws LogicException When Symfony Serializer Component is not installed.
+     * @throws LogicException when Symfony Serializer Component is not installed
      */
     public static function create(): self
     {

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -43,10 +43,6 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * Create a new Transport Serializer.
-     *
-     * @return self
-     *
      * @throws LogicException when Symfony Serializer Component is not installed
      */
     public static function create(): self

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -42,6 +42,13 @@ class Serializer implements SerializerInterface
         $this->context = $context;
     }
 
+    /**
+     * Create a new Transport Serializer.
+     *
+     * @return self
+     *
+     * @throws LogicException When Symfony Serializer Component is not installed.
+     */
     public static function create(): self
     {
         if (!class_exists(SymfonySerializer::class)) {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -135,7 +135,7 @@ class Process implements \IteratorAggregate
      * @param mixed|null     $input   The input as stream resource, scalar or \Traversable, or null for no input
      * @param int|float|null $timeout The timeout in seconds or null to disable
      *
-     * @throws RuntimeException When proc_open is not installed
+     * @throws LogicException When proc_open is not installed
      */
     public function __construct($command, string $cwd = null, array $env = null, $input = null, ?float $timeout = 60)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -795,7 +795,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @return AdapterInterface
      *
-     * @throws RuntimeException When the Cache Component isn't available
+     * @throws \LogicException When the Symfony Cache Component isn't available
      */
     public static function createCache($namespace, $defaultLifetime, $version, LoggerInterface $logger = null)
     {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -51,7 +51,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
      * @param string[]|null            $accessorPrefixes
      * @param string[]|null            $arrayMutatorPrefixes
      *
-     * @throws \LogicException When "phpdocumentor/reflection-docblock" package is not installed.
+     * @throws \LogicException when "phpdocumentor/reflection-docblock" package is not installed
      */
     public function __construct(DocBlockFactoryInterface $docBlockFactory = null, array $mutatorPrefixes = null, array $accessorPrefixes = null, array $arrayMutatorPrefixes = null)
     {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -50,6 +50,8 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
      * @param string[]|null            $mutatorPrefixes
      * @param string[]|null            $accessorPrefixes
      * @param string[]|null            $arrayMutatorPrefixes
+     *
+     * @throws \LogicException When "phpdocumentor/reflection-docblock" package is not installed.
      */
     public function __construct(DocBlockFactoryInterface $docBlockFactory = null, array $mutatorPrefixes = null, array $accessorPrefixes = null, array $arrayMutatorPrefixes = null)
     {

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -27,7 +27,7 @@ class AnnotationFileLoader extends FileLoader
     protected $loader;
 
     /**
-     * @throws \LogicException When PHP Tokenizer extension is not installed.
+     * @throws \LogicException when PHP Tokenizer extension is not installed
      */
     public function __construct(FileLocatorInterface $locator, AnnotationClassLoader $loader)
     {

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -27,7 +27,7 @@ class AnnotationFileLoader extends FileLoader
     protected $loader;
 
     /**
-     * @throws \RuntimeException
+     * @throws \LogicException When PHP Tokenizer extension is not installed.
      */
     public function __construct(FileLocatorInterface $locator, AnnotationClassLoader $loader)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is a follow-up of #28536. `\RuntimeException` were replaced by `\LogicException` but the DocBlock documentation wasn't updated accordingly.

When working on it, I found some inconsistency: In some component the exception raised is from the SPL (`\LogicException`) and in other the exception is from the component itself (when the `LogicException` exist). What is the policy in this case ?