### PR TITLE
[WIP] [Tests] Remove setMethods from mocks

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -32,13 +32,6 @@ class DoctrineExtensionTest extends TestCase
 
         $this->extension = $this
             ->getMockBuilder('Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension')
-            ->setMethods(array(
-                'getMappingResourceConfigDirectory',
-                'getObjectManagerElementName',
-                'getMappingObjectDefaultName',
-                'getMappingResourceExtension',
-                'load',
-            ))
             ->getMock()
         ;
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -34,6 +34,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
+            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
             ->getMock();
 
         $query->expects($this->once())
@@ -43,6 +44,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
+            ->setMethods(array('getQuery'))
             ->getMock();
 
         $qb->expects($this->once())
@@ -61,6 +63,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
+            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
             ->getMock();
 
         $query->expects($this->once())
@@ -70,6 +73,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
+            ->setMethods(array('getQuery'))
             ->getMock();
 
         $qb->expects($this->once())
@@ -91,6 +95,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
+            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
             ->getMock();
 
         $query->expects($this->once())
@@ -100,6 +105,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
+            ->setMethods(array('getQuery'))
             ->getMock();
 
         $qb->expects($this->once())
@@ -124,6 +130,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
+            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
             ->getMock();
 
         $query->expects($this->once())
@@ -133,6 +140,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
+            ->setMethods(array('getQuery'))
             ->getMock();
         $qb->expects($this->once())
             ->method('getQuery')

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -34,7 +34,6 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
-            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
             ->getMock();
 
         $query->expects($this->once())
@@ -44,7 +43,6 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
-            ->setMethods(array('getQuery'))
             ->getMock();
 
         $qb->expects($this->once())
@@ -63,7 +61,6 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
-            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
             ->getMock();
 
         $query->expects($this->once())
@@ -73,7 +70,6 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
-            ->setMethods(array('getQuery'))
             ->getMock();
 
         $qb->expects($this->once())
@@ -95,7 +91,6 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
-            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
             ->getMock();
 
         $query->expects($this->once())
@@ -105,7 +100,6 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
-            ->setMethods(array('getQuery'))
             ->getMock();
 
         $qb->expects($this->once())
@@ -130,7 +124,6 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $em = DoctrineTestHelper::createTestEntityManager();
 
         $query = $this->getMockBuilder('QueryMock')
-            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
             ->getMock();
 
         $query->expects($this->once())
@@ -140,7 +133,6 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->setConstructorArgs(array($em))
-            ->setMethods(array('getQuery'))
             ->getMock();
         $qb->expects($this->once())
             ->method('getQuery')

--- a/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
@@ -21,19 +21,10 @@ class DbalLoggerTest extends TestCase
      */
     public function testLog($sql, $params, $logParams)
     {
-        $logger = $this->getMockBuilder('Psr\\Log\\LoggerInterface')->getMock();
+        $logger = $this->getMockBuilder(\Psr\Log\LoggerInterface::class)->getMock();
+        $logger->expects($this->once())->method('debug')->with($sql, $logParams);
 
-        $dbalLogger = $this
-            ->getMockBuilder(DbalLogger::class)
-            ->setConstructorArgs(array($logger, null))
-            ->getMock()
-        ;
-
-        $dbalLogger
-            ->expects($this->once())
-            ->method('log')
-            ->with($sql, $logParams)
-        ;
+        $dbalLogger = new DbalLogger($logger);
 
         $dbalLogger->startQuery($sql, $params);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
@@ -24,7 +24,7 @@ class DbalLoggerTest extends TestCase
         $logger = $this->getMockBuilder('Psr\\Log\\LoggerInterface')->getMock();
 
         $dbalLogger = $this
-            ->getMockBuilder('Symfony\\Bridge\\Doctrine\\Logger\\DbalLogger')
+            ->getMockBuilder(DbalLogger::class)
             ->setConstructorArgs(array($logger, null))
             ->getMock()
         ;

--- a/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
@@ -21,7 +21,7 @@ class DbalLoggerTest extends TestCase
      */
     public function testLog($sql, $params, $logParams)
     {
-        $logger = $this->getMockBuilder(\Psr\Log\LoggerInterface::class)->getMock();
+        $logger = $this->getMockBuilder('Psr\\Log\\LoggerInterface')->getMock();
         $logger->expects($this->once())->method('debug')->with($sql, $logParams);
 
         $dbalLogger = new DbalLogger($logger);

--- a/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
@@ -26,7 +26,6 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder('Symfony\\Bridge\\Doctrine\\Logger\\DbalLogger')
             ->setConstructorArgs(array($logger, null))
-            ->setMethods(array('log'))
             ->getMock()
         ;
 
@@ -58,7 +57,6 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder('Symfony\\Bridge\\Doctrine\\Logger\\DbalLogger')
             ->setConstructorArgs(array($logger, null))
-            ->setMethods(array('log'))
             ->getMock()
         ;
 
@@ -81,7 +79,6 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder('Symfony\\Bridge\\Doctrine\\Logger\\DbalLogger')
             ->setConstructorArgs(array($logger, null))
-            ->setMethods(array('log'))
             ->getMock()
         ;
 
@@ -112,7 +109,6 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder('Symfony\\Bridge\\Doctrine\\Logger\\DbalLogger')
             ->setConstructorArgs(array($logger, null))
-            ->setMethods(array('log'))
             ->getMock()
         ;
 
@@ -140,7 +136,6 @@ class DbalLoggerTest extends TestCase
         $dbalLogger = $this
             ->getMockBuilder('Symfony\\Bridge\\Doctrine\\Logger\\DbalLogger')
             ->setConstructorArgs(array($logger, null))
-            ->setMethods(array('log'))
             ->getMock()
         ;
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -196,7 +196,6 @@ class EntityUserProviderTest extends TestCase
     private function getObjectManager($repository)
     {
         $em = $this->getMockBuilder('\Doctrine\Common\Persistence\ObjectManager')
-            ->setMethods(array('getClassMetadata', 'getRepository'))
             ->getMockForAbstractClass();
         $em->expects($this->any())
             ->method('getRepository')

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -89,11 +89,10 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     protected function createRepositoryMock()
     {
-        $repository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')
+        return $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')
+            ->setMethods(array('findByCustom', 'find', 'findAll', 'findOneBy', 'findBy', 'getClassName'))
             ->getMock()
         ;
-
-        return $repository;
     }
 
     protected function createEntityManagerMock($repositoryMock)

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -90,7 +90,6 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
     protected function createRepositoryMock()
     {
         $repository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')
-            ->setMethods(array('findByCustom', 'find', 'findAll', 'findOneBy', 'findBy', 'getClassName'))
             ->getMock()
         ;
 
@@ -119,7 +118,6 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         ;
         $refl = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionProperty')
             ->setConstructorArgs(array($reflParser, 'property-name'))
-            ->setMethods(array('getValue'))
             ->getMock()
         ;
         $refl

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -57,21 +57,9 @@ class ConsoleHandlerTest extends TestCase
             '->isHandling returns correct value depending on console verbosity and log level'
         );
 
-        // check that the handler actually outputs the record if it handles it
-        $levelName = Logger::getLevelName($level);
-        $levelName = sprintf('%-9s', $levelName);
-
-        $realOutput = $this->getMockBuilder('Symfony\Component\Console\Output\Output')->getMock();
+        $realOutput = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
         $realOutput->setVerbosity($verbosity);
-        if ($realOutput->isDebug()) {
-            $log = "16:21:54 $levelName [app] My info message\n";
-        } else {
-            $log = "16:21:54 $levelName [app] My info message\n";
-        }
-        $realOutput
-            ->expects($isHandling ? $this->once() : $this->never())
-            ->method('doWrite')
-            ->with($log, false);
+
         $handler = new ConsoleHandler($realOutput, true, $map);
 
         $infoRecord = array(

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -61,7 +61,7 @@ class ConsoleHandlerTest extends TestCase
         $levelName = Logger::getLevelName($level);
         $levelName = sprintf('%-9s', $levelName);
 
-        $realOutput = $this->getMockBuilder('Symfony\Component\Console\Output\Output')->setMethods(array('doWrite'))->getMock();
+        $realOutput = $this->getMockBuilder('Symfony\Component\Console\Output\Output')->getMock();
         $realOutput->setVerbosity($verbosity);
         if ($realOutput->isDebug()) {
             $log = "16:21:54 $levelName [app] My info message\n";

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
@@ -39,12 +39,10 @@ class TemplatePathsCacheWarmerTest extends TestCase
     {
         $this->templateFinder = $this
             ->getMockBuilder(TemplateFinderInterface::class)
-            ->setMethods(array('findAllTemplates'))
             ->getMock();
 
         $this->fileLocator = $this
             ->getMockBuilder(FileLocator::class)
-            ->setMethods(array('locate'))
             ->setConstructorArgs(array('/path/to/fallback'))
             ->getMock();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ClientTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ClientTest.php
@@ -54,7 +54,6 @@ class ClientTest extends WebTestCase
     private function getKernelMock()
     {
         $mock = $this->getMockBuilder($this->getKernelClass())
-            ->setMethods(array('shutdown', 'boot', 'handle'))
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Routing;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -251,13 +252,8 @@ class RouterTest extends TestCase
             ->will($this->returnValue($routes))
         ;
 
-        $sc = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Container')->getMock();
-
-        $sc
-            ->expects($this->once())
-            ->method('get')
-            ->will($this->returnValue($loader))
-        ;
+        $sc = new Container();
+        $sc->set('routing.loader', $loader);
 
         return $sc;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -251,7 +251,7 @@ class RouterTest extends TestCase
             ->will($this->returnValue($routes))
         ;
 
-        $sc = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Container')->setMethods(array('get'))->getMock();
+        $sc = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Container')->getMock();
 
         $sc
             ->expects($this->once())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
@@ -90,7 +90,6 @@ class TemplateLocatorTest extends TestCase
     {
         return $this
             ->getMockBuilder('Symfony\Component\Config\FileLocator')
-            ->setMethods(array('locate'))
             ->setConstructorArgs(array('/path/to/fallback'))
             ->getMock()
         ;

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -286,7 +286,7 @@ class WebDebugToolbarListenerTest extends TestCase
 
     protected function getRequestMock($isXmlHttpRequest = false, $requestFormat = 'html', $hasSession = true)
     {
-        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->setMethods(array('getSession', 'isXmlHttpRequest', 'getRequestFormat'))->disableOriginalConstructor()->getMock();
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->getMock();
         $request->expects($this->any())
             ->method('isXmlHttpRequest')
             ->will($this->returnValue($isXmlHttpRequest));

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -20,7 +20,6 @@ class MaxIdLengthAdapterTest extends TestCase
     {
         $cache = $this->getMockBuilder(MaxIdLengthAdapter::class)
             ->setConstructorArgs(array(str_repeat('-', 10)))
-            ->setMethods(array('doHave', 'doFetch', 'doDelete', 'doSave', 'doClear'))
             ->getMock();
 
         $cache->expects($this->exactly(2))

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -762,7 +762,7 @@ class ApplicationTest extends TestCase
 
     public function testRenderExceptionLineBreaks()
     {
-        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
+        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->setMethods(array('getTerminalWidth'))->getMock();
         $application->setAutoExit(false);
         $application->expects($this->any())
             ->method('getTerminalWidth')

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -619,7 +619,7 @@ class ApplicationTest extends TestCase
 
     public function testFindNamespaceDoesNotFailOnDeepSimilarNamespaces()
     {
-        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->setMethods(array('getNamespaces'))->getMock();
+        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
         $application->expects($this->once())
             ->method('getNamespaces')
             ->will($this->returnValue(array('foo:sublong', 'bar:sub')));
@@ -762,7 +762,7 @@ class ApplicationTest extends TestCase
 
     public function testRenderExceptionLineBreaks()
     {
-        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->setMethods(array('getTerminalWidth'))->getMock();
+        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
         $application->setAutoExit(false);
         $application->expects($this->any())
             ->method('getTerminalWidth')
@@ -915,7 +915,7 @@ class ApplicationTest extends TestCase
     {
         $exception = new \Exception('', 4);
 
-        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->setMethods(array('doRun'))->getMock();
+        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
         $application->setAutoExit(false);
         $application->expects($this->once())
             ->method('doRun')
@@ -954,7 +954,7 @@ class ApplicationTest extends TestCase
     {
         $exception = new \Exception('', 0);
 
-        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->setMethods(array('doRun'))->getMock();
+        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
         $application->setAutoExit(false);
         $application->expects($this->once())
             ->method('doRun')

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -72,7 +72,6 @@ class PhpMatcherDumperTest extends TestCase
         $class = $this->generateDumpedMatcher($collection, true);
 
         $matcher = $this->getMockBuilder($class)
-                        ->setMethods(array('redirect'))
                         ->setConstructorArgs(array(new RequestContext()))
                         ->getMock();
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -188,7 +188,7 @@ class AuthenticationProviderManagerTest extends TestCase
         } elseif (null !== $exception) {
             $provider->expects($this->once())
                      ->method('authenticate')
-                     ->willThrowException($this->getMockBuilder($exception)->setMethods(null)->getMock())
+                     ->willThrowException($this->getMockBuilder($exception)->getMock())
             ;
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -58,7 +58,7 @@ class AuthenticationTrustResolverTest extends TestCase
 
     protected function getRememberMeToken()
     {
-        return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(array('setPersistent'))->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->disableOriginalConstructor()->getMock();
     }
 
     protected function getResolver()

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
@@ -55,7 +55,7 @@ class AnonymousAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken($secret)
     {
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setMethods(array('getSecret'))->disableOriginalConstructor()->getMock();
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->disableOriginalConstructor()->getMock();
         $token->expects($this->any())
               ->method('getSecret')
               ->will($this->returnValue($secret))

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -261,7 +261,7 @@ class DaoAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken()
     {
-        $mock = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Authentication\\Token\\UsernamePasswordToken')->setMethods(array('getCredentials', 'getUser', 'getProviderKey'))->disableOriginalConstructor()->getMock();
+        $mock = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Authentication\\Token\\UsernamePasswordToken')->disableOriginalConstructor()->getMock();
         $mock
             ->expects($this->any())
             ->method('getProviderKey')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -95,7 +95,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken($user = false, $credentials = false)
     {
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken')->setMethods(array('getUser', 'getCredentials', 'getProviderKey'))->disableOriginalConstructor()->getMock();
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken')->disableOriginalConstructor()->getMock();
         if (false !== $user) {
             $token->expects($this->once())
                   ->method('getUser')

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -65,7 +65,7 @@ class AuthenticatedVoterTest extends TestCase
         if ('fully' === $authenticated) {
             return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         } elseif ('remembered' === $authenticated) {
-            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(array('setPersistent'))->disableOriginalConstructor()->getMock();
+            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->disableOriginalConstructor()->getMock();
         } else {
             return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setConstructorArgs(array('', ''))->getMock();
         }

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -434,7 +434,6 @@ class GuardAuthenticationListenerTest extends TestCase
 
         $this->event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
             ->disableOriginalConstructor()
-            ->setMethods(array('getRequest'))
             ->getMock();
         $this->event
             ->expects($this->any())

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -35,7 +35,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
         $this->session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
         $this->request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
         $this->request->expects($this->any())->method('getSession')->will($this->returnValue($this->session));
-        $this->exception = $this->getMockBuilder('Symfony\Component\Security\Core\Exception\AuthenticationException')->setMethods(array('getMessage'))->getMock();
+        $this->exception = $this->getMockBuilder('Symfony\Component\Security\Core\Exception\AuthenticationException')->getMock();
     }
 
     public function testForward()

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -70,7 +70,6 @@ class FirewallTest extends TestCase
         ;
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
-            ->setMethods(array('hasResponse'))
             ->setConstructorArgs(array(
                 $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(),
                 $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock(),

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
@@ -26,7 +26,6 @@ abstract class AbstractCacheTest extends TestCase
     {
         $meta = $this->getMockBuilder(ClassMetadata::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getClassName'))
             ->getMock();
 
         $meta->expects($this->once())
@@ -46,7 +45,6 @@ abstract class AbstractCacheTest extends TestCase
     {
         $meta = $this->getMockBuilder(ClassMetadata::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getClassName'))
             ->getMock();
 
         $meta->expects($this->once())
@@ -63,7 +61,6 @@ abstract class AbstractCacheTest extends TestCase
     {
         $meta = $this->getMockBuilder(ClassMetadata::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getClassName'))
             ->getMock();
 
         $meta->expects($this->once())

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -56,7 +56,6 @@ class RecursiveValidatorTest extends AbstractTest
         $validator = $this
             ->getMockBuilder('Symfony\Component\Validator\Validator\RecursiveValidator')
             ->disableOriginalConstructor()
-            ->setMethods(array('startContext'))
             ->getMock();
         $validator
             ->expects($this->once())
@@ -90,7 +89,6 @@ class RecursiveValidatorTest extends AbstractTest
         $validator = $this
             ->getMockBuilder('Symfony\Component\Validator\Validator\RecursiveValidator')
             ->disableOriginalConstructor()
-            ->setMethods(array('startContext'))
             ->getMock();
         $validator
             ->expects($this->once())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| License       | MIT

When you create a mock `setMethods` is not having any actual affect.  If I remember correct for years in the docs of phpunit it used to be there as an example and people where copy pasting it blindly...