### PR TITLE
[Process] Fix: Method can also return null

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -46,7 +46,7 @@ class ExecutableFinder
      * @param string $default   The default to return if no executable is found
      * @param array  $extraDirs Additional dirs to check into
      *
-     * @return string The executable path or default value
+     * @return string|null The executable path or default value
      */
     public function find($name, $default = null, array $extraDirs = array())
     {

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -65,6 +65,21 @@ class ExecutableFinderTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testFindWithNullAsDefault()
+    {
+        if (ini_get('open_basedir')) {
+            $this->markTestSkipped('Cannot test when open_basedir is set');
+        }
+
+        $this->setPath('');
+
+        $finder = new ExecutableFinder();
+
+        $result = $finder->find('foo');
+
+        $this->assertNull($result);
+    }
+
     public function testFindWithExtraDirs()
     {
         if (ini_get('open_basedir')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR

* [x] adjusts a DocBlock and also provides a corresponding test that asserts that `ExecutableFinder::find()` may return `null`