### PR TITLE
[PHPUnit bridge] Bump php version of PHPUnit-bridge

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `ClassExistsMock`
+ * bumped PHP version from 5.3.3 to 5.5.9 
 
 4.1.0
 -----

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3 EVEN ON LATEST SYMFONY VERSIONS TO ALLOW USING",
+        "php": ">=5.5.9 EVEN ON LATEST SYMFONY VERSIONS TO ALLOW USING",
         "php": "THIS BRIDGE WHEN TESTING LOWEST SYMFONY VERSIONS.",
-        "php": ">=5.3.3"
+        "php": ">=5.5.9"
     },
     "suggest": {
         "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no (?)
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Related to https://github.com/symfony/symfony/pull/29623#issuecomment-450400625

I checked the BC page I think I couldn't find any related to BC changes... anyway...

As far as I understood from the comment above I must target `master` branch.