### PR TITLE
[DebugBundle] add dumps count in the profiler menu

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
+++ b/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
@@ -37,6 +37,11 @@
     <span class="label {{ collector.dumpsCount == 0 ? 'disabled' }}">
         <span class="icon">{{ include('@Debug/Profiler/icon.svg') }}</span>
         <strong>Debug</strong>
+        {% if collector.dumpsCount > 0 %}
+            <span class="count">
+                <span>{{ collector.dumpsCount }}</span>
+            </span>
+        {% endif %}
     </span>
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When many dumps are expected, it would be convenient to have the dumps count displayed in the menu instead of going to the panel and perform a manual count.