### PR TITLE
[Lock] Fix lock test random failure

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
@@ -45,10 +45,10 @@ trait ExpiringStoreTestTrait
         $store = $this->getStore();
 
         $store->save($key);
-        $store->putOffExpiration($key, $clockDelay / 1000000);
+        $store->putOffExpiration($key, 2 * $clockDelay / 1000000);
         $this->assertTrue($store->exists($key));
 
-        usleep(2 * $clockDelay);
+        usleep(3 * $clockDelay);
         $this->assertFalse($store->exists($key));
     }
 
@@ -85,10 +85,10 @@ trait ExpiringStoreTestTrait
         $store = $this->getStore();
 
         $store->save($key);
-        $store->putOffExpiration($key, $clockDelay / 1000000);
+        $store->putOffExpiration($key, 2 * $clockDelay / 1000000);
         $this->assertTrue($store->exists($key));
 
-        usleep(2 * $clockDelay);
+        usleep(3 * $clockDelay);
         $this->assertFalse($store->exists($key));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | NA

The expiration of some store (PDO and Memcached) have a precision of 1 second.

The current test suite of the component tries to putof the expiration to time + 1 second then tries to check the value of the lock. This could generate test failure (see https://travis-ci.org/symfony/symfony/jobs/473530213#L3389)