### PR TITLE
[tests] refactor will/with mock calls to specific alternatives

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -44,9 +44,9 @@ class DoctrineExtensionTest extends TestCase
 
         $this->extension->expects($this->any())
             ->method('getObjectManagerElementName')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 return 'doctrine.orm.'.$name;
-            }));
+            });
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/ExpressionLanguage/DoctrineParserCacheTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ExpressionLanguage/DoctrineParserCacheTest.php
@@ -26,7 +26,7 @@ class DoctrineParserCacheTest extends TestCase
 
         $doctrineCacheMock->expects($this->once())
             ->method('fetch')
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar');
 
         $result = $parserCache->fetch('foo');
 
@@ -41,7 +41,7 @@ class DoctrineParserCacheTest extends TestCase
         $doctrineCacheMock
             ->expects($this->once())
             ->method('fetch')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->assertNull($parserCache->fetch(''));
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
@@ -34,47 +34,47 @@ class DoctrineOrmTypeGuesserTest extends TestCase
         // Simple field, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
         $classMetadata->fieldMappings['field'] = true;
-        $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(false));
+        $classMetadata->expects($this->once())->method('isNullable')->with('field')->willReturn(false);
 
         $return[] = array($classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE));
 
         // Simple field, nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
         $classMetadata->fieldMappings['field'] = true;
-        $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isNullable')->with('field')->willReturn(true);
 
         $return[] = array($classMetadata, new ValueGuess(false, Guess::MEDIUM_CONFIDENCE));
 
         // One-to-one, nullable (by default)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = array('joinColumns' => array(array()));
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = array($classMetadata, new ValueGuess(false, Guess::HIGH_CONFIDENCE));
 
         // One-to-one, nullable (explicit)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = array('joinColumns' => array(array('nullable' => true)));
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = array($classMetadata, new ValueGuess(false, Guess::HIGH_CONFIDENCE));
 
         // One-to-one, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = array('joinColumns' => array(array('nullable' => false)));
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = array($classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE));
 
         // One-to-many, no clue
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(false));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(false);
 
         $return[] = array($classMetadata, null);
 
@@ -84,10 +84,10 @@ class DoctrineOrmTypeGuesserTest extends TestCase
     private function getGuesser(ClassMetadata $classMetadata)
     {
         $em = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
-        $em->expects($this->once())->method('getClassMetaData')->with('TestEntity')->will($this->returnValue($classMetadata));
+        $em->expects($this->once())->method('getClassMetaData')->with('TestEntity')->willReturn($classMetadata);
 
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
-        $registry->expects($this->once())->method('getManagers')->will($this->returnValue(array($em)));
+        $registry->expects($this->once())->method('getManagers')->willReturn(array($em));
 
         return new DoctrineOrmTypeGuesser($registry);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -36,11 +36,11 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
 
         $manager->expects($this->any())
             ->method('getManager')
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         $manager->expects($this->any())
             ->method('getManagerForClass')
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         return array(
             new CoreExtension(),

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1085,7 +1085,7 @@ class EntityTypeTest extends BaseTypeTest
         $this->emRegistry->expects($this->once())
             ->method('getManagerForClass')
             ->with(self::SINGLE_IDENT_CLASS)
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'class' => self::SINGLE_IDENT_CLASS,
@@ -1234,8 +1234,8 @@ class EntityTypeTest extends BaseTypeTest
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $registry->expects($this->any())
             ->method('getManager')
-            ->with($this->equalTo($name))
-            ->will($this->returnValue($em));
+            ->with($name)
+            ->willReturn($em);
 
         return $registry;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -187,8 +187,8 @@ class EntityUserProviderTest extends TestCase
         $manager = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $manager->expects($this->any())
             ->method('getManager')
-            ->with($this->equalTo($name))
-            ->will($this->returnValue($em));
+            ->with($name)
+            ->willReturn($em);
 
         return $manager;
     }

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -50,7 +50,7 @@ class ConsoleHandlerTest extends TestCase
         $output
             ->expects($this->atLeastOnce())
             ->method('getVerbosity')
-            ->will($this->returnValue($verbosity))
+            ->willReturn($verbosity)
         ;
         $handler = new ConsoleHandler($output, true, $map);
         $this->assertSame($isHandling, $handler->isHandling(array('level' => $level)),
@@ -114,12 +114,12 @@ class ConsoleHandlerTest extends TestCase
         $output
             ->expects($this->at(0))
             ->method('getVerbosity')
-            ->will($this->returnValue(OutputInterface::VERBOSITY_QUIET))
+            ->willReturn(OutputInterface::VERBOSITY_QUIET)
         ;
         $output
             ->expects($this->at(1))
             ->method('getVerbosity')
-            ->will($this->returnValue(OutputInterface::VERBOSITY_DEBUG))
+            ->willReturn(OutputInterface::VERBOSITY_DEBUG)
         ;
         $handler = new ConsoleHandler($output);
         $this->assertFalse($handler->isHandling(array('level' => Logger::NOTICE)),
@@ -144,7 +144,7 @@ class ConsoleHandlerTest extends TestCase
         $output
             ->expects($this->any())
             ->method('getVerbosity')
-            ->will($this->returnValue(OutputInterface::VERBOSITY_DEBUG))
+            ->willReturn(OutputInterface::VERBOSITY_DEBUG)
         ;
         $output
             ->expects($this->once())

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -95,10 +95,10 @@ class WebProcessorTest extends TestCase
             ->getMock();
         $event->expects($this->any())
             ->method('isMasterRequest')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
 
         return array($event, $server);
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -62,7 +62,7 @@ class HttpKernelExtensionTest extends TestCase
     protected function getFragmentHandler($return)
     {
         $strategy = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\Fragment\\FragmentRendererInterface')->getMock();
-        $strategy->expects($this->once())->method('getName')->will($this->returnValue('inline'));
+        $strategy->expects($this->once())->method('getName')->willReturn('inline');
         $strategy->expects($this->once())->method('render')->will($return);
 
         $context = $this->getMockBuilder('Symfony\\Component\\HttpFoundation\\RequestStack')
@@ -70,7 +70,7 @@ class HttpKernelExtensionTest extends TestCase
             ->getMock()
         ;
 
-        $context->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $context->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         return new FragmentHandler($context, array($strategy), false);
     }
@@ -82,9 +82,9 @@ class HttpKernelExtensionTest extends TestCase
         $twig->addExtension(new HttpKernelExtension());
 
         $loader = $this->getMockBuilder('Twig\RuntimeLoader\RuntimeLoaderInterface')->getMock();
-        $loader->expects($this->any())->method('load')->will($this->returnValueMap(array(
+        $loader->expects($this->any())->method('load')->willReturnMap(array(
             array('Symfony\Bridge\Twig\Extension\HttpKernelRuntime', new HttpKernelRuntime($renderer)),
-        )));
+        ));
         $twig->addRuntimeLoader($loader);
 
         return $twig->render('index');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -63,11 +63,11 @@ class StopwatchExtensionTest extends TestCase
         foreach ($events as $eventName) {
             $stopwatch->expects($this->at(++$i))
                 ->method('start')
-                ->with($this->equalTo($eventName), 'template')
+                ->with($eventName, 'template')
             ;
             $stopwatch->expects($this->at(++$i))
                 ->method('stop')
-                ->with($this->equalTo($eventName))
+                ->with($eventName)
             ;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplateFinderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplateFinderTest.php
@@ -34,7 +34,7 @@ class TemplateFinderTest extends TestCase
         $kernel
             ->expects($this->once())
             ->method('getBundles')
-            ->will($this->returnValue(array('BaseBundle' => new BaseBundle())))
+            ->willReturn(array('BaseBundle' => new BaseBundle()))
         ;
 
         $parser = new TemplateFilenameParser();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -82,7 +82,7 @@ class RouterDebugCommandTest extends TestCase
         $router
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->will($this->returnValue($routeCollection));
+            ->willReturn($routeCollection);
 
         return $router;
     }
@@ -93,13 +93,13 @@ class RouterDebugCommandTest extends TestCase
         $container
             ->expects($this->atLeastOnce())
             ->method('has')
-            ->will($this->returnCallback(function ($id) {
+            ->willReturnCallback(function ($id) {
                 if ('console.command_loader' === $id) {
                     return false;
                 }
 
                 return true;
-            }))
+            })
         ;
         $container
             ->expects($this->any())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -80,11 +80,11 @@ class RouterMatchCommandTest extends TestCase
         $router
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->will($this->returnValue($routeCollection));
+            ->willReturn($routeCollection);
         $router
             ->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($requestContext));
+            ->willReturn($requestContext);
 
         return $router;
     }
@@ -95,13 +95,13 @@ class RouterMatchCommandTest extends TestCase
         $container
             ->expects($this->atLeastOnce())
             ->method('has')
-            ->will($this->returnCallback(function ($id) {
+            ->willReturnCallback(function ($id) {
                 if ('console.command_loader' === $id) {
                     return false;
                 }
 
                 return true;
-            }))
+            })
         ;
         $container
             ->expects($this->any())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -84,7 +84,7 @@ class TranslationDebugCommandTest extends TestCase
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel->expects($this->once())
             ->method('getBundle')
-            ->with($this->equalTo($this->translationDir))
+            ->with($this->translationDir)
             ->willThrowException(new \InvalidArgumentException());
 
         $tester = $this->createCommandTester(array('foo' => 'foo'), array('bar' => 'bar'), $kernel);
@@ -102,7 +102,7 @@ class TranslationDebugCommandTest extends TestCase
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel->expects($this->once())
             ->method('getBundle')
-            ->with($this->equalTo('dir'))
+            ->with('dir')
             ->willThrowException(new \InvalidArgumentException());
 
         $tester = $this->createCommandTester(array(), array(), $kernel);
@@ -136,26 +136,26 @@ class TranslationDebugCommandTest extends TestCase
         $translator
             ->expects($this->any())
             ->method('getFallbackLocales')
-            ->will($this->returnValue(array('en')));
+            ->willReturn(array('en'));
 
         $extractor = $this->getMockBuilder('Symfony\Component\Translation\Extractor\ExtractorInterface')->getMock();
         $extractor
             ->expects($this->any())
             ->method('extract')
-            ->will(
-                $this->returnCallback(function ($path, $catalogue) use ($extractedMessages) {
+            ->willReturnCallback(
+                function ($path, $catalogue) use ($extractedMessages) {
                     $catalogue->add($extractedMessages);
-                })
+                }
             );
 
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Reader\TranslationReader')->getMock();
         $loader
             ->expects($this->any())
             ->method('read')
-            ->will(
-                $this->returnCallback(function ($path, $catalogue) use ($loadedMessages) {
+            ->willReturnCallback(
+                function ($path, $catalogue) use ($loadedMessages) {
                     $catalogue->add($loadedMessages);
-                })
+                }
             );
 
         if (null === $kernel) {
@@ -173,7 +173,7 @@ class TranslationDebugCommandTest extends TestCase
             $kernel
                 ->expects($this->any())
                 ->method('getBundle')
-                ->will($this->returnValueMap($returnValues));
+                ->willReturnMap($returnValues);
         }
 
         $kernel
@@ -214,23 +214,23 @@ class TranslationDebugCommandTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue(array()));
+            ->willReturn(array());
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->any())
             ->method('get')
-            ->will($this->returnValueMap(array(
+            ->willReturnMap(array(
                 array('translation.extractor', 1, $extractor),
                 array('translation.reader', 1, $loader),
                 array('translator', 1, $translator),
                 array('kernel', 1, $kernel),
-            )));
+            ));
 
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($container));
+            ->willReturn($container);
 
         $command = new TranslationDebugCommand();
         $command->setContainer($container);
@@ -250,7 +250,7 @@ class TranslationDebugCommandTest extends TestCase
         $bundle
             ->expects($this->any())
             ->method('getPath')
-            ->will($this->returnValue($path))
+            ->willReturn($path)
         ;
 
         return $bundle;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -114,36 +114,36 @@ class TranslationUpdateCommandTest extends TestCase
         $translator
             ->expects($this->any())
             ->method('getFallbackLocales')
-            ->will($this->returnValue(array('en')));
+            ->willReturn(array('en'));
 
         $extractor = $this->getMockBuilder('Symfony\Component\Translation\Extractor\ExtractorInterface')->getMock();
         $extractor
             ->expects($this->any())
             ->method('extract')
-            ->will(
-                $this->returnCallback(function ($path, $catalogue) use ($extractedMessages) {
+            ->willReturnCallback(
+                function ($path, $catalogue) use ($extractedMessages) {
                     foreach ($extractedMessages as $domain => $messages) {
                         $catalogue->add($messages, $domain);
                     }
-                })
+                }
             );
 
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Reader\TranslationReader')->getMock();
         $loader
             ->expects($this->any())
             ->method('read')
-            ->will(
-                $this->returnCallback(function ($path, $catalogue) use ($loadedMessages) {
+            ->willReturnCallback(
+                function ($path, $catalogue) use ($loadedMessages) {
                     $catalogue->add($loadedMessages);
-                })
+                }
             );
 
         $writer = $this->getMockBuilder('Symfony\Component\Translation\Writer\TranslationWriter')->getMock();
         $writer
             ->expects($this->any())
             ->method('getFormats')
-            ->will(
-                $this->returnValue(array('xlf', 'yml'))
+            ->willReturn(
+                array('xlf', 'yml')
             );
 
         if (null === $kernel) {
@@ -161,7 +161,7 @@ class TranslationUpdateCommandTest extends TestCase
             $kernel
                 ->expects($this->any())
                 ->method('getBundle')
-                ->will($this->returnValueMap($returnValues));
+                ->willReturnMap($returnValues);
         }
 
         $kernel
@@ -203,24 +203,24 @@ class TranslationUpdateCommandTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue(array()));
+            ->willReturn(array());
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->any())
             ->method('get')
-            ->will($this->returnValueMap(array(
+            ->willReturnMap(array(
                 array('translation.extractor', 1, $extractor),
                 array('translation.reader', 1, $loader),
                 array('translation.writer', 1, $writer),
                 array('translator', 1, $translator),
                 array('kernel', 1, $kernel),
-            )));
+            ));
 
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($container));
+            ->willReturn($container);
 
         $command = new TranslationUpdateCommand();
         $command->setContainer($container);
@@ -240,7 +240,7 @@ class TranslationUpdateCommandTest extends TestCase
         $bundle
             ->expects($this->any())
             ->method('getPath')
-            ->will($this->returnValue($path))
+            ->willReturn($path)
         ;
 
         return $bundle;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -205,8 +205,8 @@ class ApplicationTest extends TestCase
             $container
                 ->expects($this->atLeastOnce())
                 ->method('get')
-                ->with($this->equalTo('event_dispatcher'))
-                ->will($this->returnValue($dispatcher));
+                ->with('event_dispatcher')
+                ->willReturn($dispatcher);
         }
 
         $container
@@ -226,12 +226,12 @@ class ApplicationTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue($bundles))
+            ->willReturn($bundles)
         ;
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($container))
+            ->willReturn($container)
         ;
 
         return $kernel;
@@ -243,9 +243,9 @@ class ApplicationTest extends TestCase
         $bundle
             ->expects($this->once())
             ->method('registerCommands')
-            ->will($this->returnCallback(function (Application $application) use ($commands) {
+            ->willReturnCallback(function (Application $application) use ($commands) {
                 $application->addCommands($commands);
-            }))
+            })
         ;
 
         return $bundle;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -156,13 +156,13 @@ class ControllerNameParserTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundle')
-            ->will($this->returnCallback(function ($bundle) use ($bundles) {
+            ->willReturnCallback(function ($bundle) use ($bundles) {
                 if (!isset($bundles[$bundle])) {
                     throw new \InvalidArgumentException(sprintf('Invalid bundle name "%s"', $bundle));
                 }
 
                 return $bundles[$bundle];
-            }))
+            })
         ;
 
         $bundles = array(
@@ -175,7 +175,7 @@ class ControllerNameParserTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue($bundles))
+            ->willReturn($bundles)
         ;
 
         return new ControllerNameParser($kernel);
@@ -184,8 +184,8 @@ class ControllerNameParserTest extends TestCase
     private function getBundle($namespace, $name)
     {
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
-        $bundle->expects($this->any())->method('getName')->will($this->returnValue($name));
-        $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue($namespace));
+        $bundle->expects($this->any())->method('getName')->willReturn($name);
+        $bundle->expects($this->any())->method('getNamespace')->willReturn($namespace);
 
         return $bundle;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -41,9 +41,9 @@ abstract class ControllerTraitTest extends TestCase
         $requestStack->push($request);
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+        $kernel->expects($this->once())->method('handle')->willReturnCallback(function (Request $request) {
             return new Response($request->getRequestFormat().'--'.$request->getLocale());
-        }));
+        });
 
         $container = new Container();
         $container->set('request_stack', $requestStack);
@@ -108,7 +108,7 @@ abstract class ControllerTraitTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $container = new Container();
         $container->set('security.token_storage', $tokenStorage);
@@ -135,7 +135,7 @@ abstract class ControllerTraitTest extends TestCase
             ->expects($this->once())
             ->method('serialize')
             ->with(array(), 'json', array('json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS))
-            ->will($this->returnValue('[]'));
+            ->willReturn('[]');
 
         $container->set('serializer', $serializer);
 
@@ -156,7 +156,7 @@ abstract class ControllerTraitTest extends TestCase
             ->expects($this->once())
             ->method('serialize')
             ->with(array(), 'json', array('json_encode_options' => 0, 'other' => 'context'))
-            ->will($this->returnValue('[]'));
+            ->willReturn('[]');
 
         $container->set('serializer', $serializer);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -71,8 +71,8 @@ class RedirectControllerTest extends TestCase
         $router
             ->expects($this->once())
             ->method('generate')
-            ->with($this->equalTo($route), $this->equalTo($expectedAttributes))
-            ->will($this->returnValue($url));
+            ->with($route, $expectedAttributes)
+            ->willReturn($url);
 
         $controller = new RedirectController($router);
 
@@ -250,23 +250,23 @@ class RedirectControllerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('getScheme')
-            ->will($this->returnValue($scheme));
+            ->willReturn($scheme);
         $request
             ->expects($this->any())
             ->method('getHost')
-            ->will($this->returnValue($host));
+            ->willReturn($host);
         $request
             ->expects($this->any())
             ->method('getPort')
-            ->will($this->returnValue($port));
+            ->willReturn($port);
         $request
             ->expects($this->any())
             ->method('getBaseUrl')
-            ->will($this->returnValue($baseUrl));
+            ->willReturn($baseUrl);
         $request
             ->expects($this->any())
             ->method('getQueryString')
-            ->will($this->returnValue($queryString));
+            ->willReturn($queryString);
 
         return $request;
     }
@@ -287,25 +287,25 @@ class RedirectControllerTest extends TestCase
             $container
                 ->expects($this->once())
                 ->method('hasParameter')
-                ->with($this->equalTo('request_listener.http_port'))
-                ->will($this->returnValue(true));
+                ->with('request_listener.http_port')
+                ->willReturn(true);
             $container
                 ->expects($this->once())
                 ->method('getParameter')
-                ->with($this->equalTo('request_listener.http_port'))
-                ->will($this->returnValue($httpPort));
+                ->with('request_listener.http_port')
+                ->willReturn($httpPort);
         }
         if (null !== $httpsPort) {
             $container
                 ->expects($this->once())
                 ->method('hasParameter')
-                ->with($this->equalTo('request_listener.https_port'))
-                ->will($this->returnValue(true));
+                ->with('request_listener.https_port')
+                ->willReturn(true);
             $container
                 ->expects($this->once())
                 ->method('getParameter')
-                ->with($this->equalTo('request_listener.https_port'))
-                ->will($this->returnValue($httpsPort));
+                ->with('request_listener.https_port')
+                ->willReturn($httpsPort);
         }
 
         $controller = new RedirectController();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -49,9 +49,9 @@ class TemplateControllerTest extends TestCase
         $twig->expects($this->once())->method('render')->willReturn('bar');
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $container->expects($this->at(0))->method('has')->will($this->returnValue(false));
-        $container->expects($this->at(1))->method('has')->will($this->returnValue(true));
-        $container->expects($this->at(2))->method('get')->will($this->returnValue($twig));
+        $container->expects($this->at(0))->method('has')->willReturn(false);
+        $container->expects($this->at(1))->method('has')->willReturn(true);
+        $container->expects($this->at(2))->method('get')->willReturn($twig);
 
         $controller = new TemplateController();
         $controller->setContainer($container);
@@ -69,7 +69,7 @@ class TemplateControllerTest extends TestCase
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->at(0))->method('has')->willReturn(true);
-        $container->expects($this->at(1))->method('get')->will($this->returnValue($templating));
+        $container->expects($this->at(1))->method('get')->willReturn($templating);
 
         $controller = new TemplateController();
         $controller->setContainer($container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -248,7 +248,7 @@ class RouterTest extends TestCase
         $loader
             ->expects($this->any())
             ->method('load')
-            ->will($this->returnValue($routes))
+            ->willReturn($routes)
         ;
 
         $sc = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Container')->setMethods(array('get'))->getMock();
@@ -256,7 +256,7 @@ class RouterTest extends TestCase
         $sc
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($loader))
+            ->willReturn($loader)
         ;
 
         return $sc;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/DelegatingEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/DelegatingEngineTest.php
@@ -91,7 +91,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('supports')
             ->with($template)
-            ->will($this->returnValue($supports));
+            ->willReturn($supports);
 
         return $engine;
     }
@@ -103,7 +103,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('supports')
             ->with($template)
-            ->will($this->returnValue($supports));
+            ->willReturn($supports);
 
         return $engine;
     }
@@ -117,7 +117,7 @@ class DelegatingEngineTest extends TestCase
             $container->expects($this->at($i++))
                 ->method('get')
                 ->with($id)
-                ->will($this->returnValue($service));
+                ->willReturn($service);
         }
 
         return $container;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
@@ -47,7 +47,7 @@ class GlobalVariablesTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue('token'));
+            ->willReturn('token');
 
         $this->assertSame('token', $this->globals->getToken());
     }
@@ -77,12 +77,12 @@ class GlobalVariablesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $this->assertSame($expectedUser, $this->globals->getUser());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -26,13 +26,13 @@ class TemplateNameParserTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundle')
-            ->will($this->returnCallback(function ($bundle) {
+            ->willReturnCallback(function ($bundle) {
                 if (\in_array($bundle, array('SensioFooBundle', 'SensioCmsFooBundle', 'FooBundle'))) {
                     return true;
                 }
 
                 throw new \InvalidArgumentException();
-            }))
+            })
         ;
         $this->parser = new TemplateNameParser($kernel);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TimedPhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TimedPhpEngineTest.php
@@ -56,7 +56,7 @@ class TimedPhpEngineTest extends TestCase
         $templateNameParser = $this->getMockBuilder('Symfony\Component\Templating\TemplateNameParserInterface')->getMock();
         $templateNameParser->expects($this->any())
             ->method('parse')
-            ->will($this->returnValue($templateReference));
+            ->willReturn($templateReference);
 
         return $templateNameParser;
     }
@@ -91,7 +91,7 @@ class TimedPhpEngineTest extends TestCase
         $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
         $loader->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($storage));
+            ->willReturn($storage);
 
         return $loader;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -147,7 +147,7 @@ class TranslatorTest extends TestCase
             ->expects($this->once())
             ->method('getParameter')
             ->with('kernel.default_locale')
-            ->will($this->returnValue('en'))
+            ->willReturn('en')
         ;
         $translator = new Translator($container, new MessageFormatter());
 
@@ -357,53 +357,53 @@ class TranslatorTest extends TestCase
         $loader
             ->expects($this->at(0))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('fr', array(
+            ->willReturn($this->getCatalogue('fr', array(
                 'foo' => 'foo (FR)',
-            ))))
+            )))
         ;
         $loader
             ->expects($this->at(1))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('en', array(
+            ->willReturn($this->getCatalogue('en', array(
                 'foo' => 'foo (EN)',
                 'bar' => 'bar (EN)',
                 'choice' => '{0} choice 0 (EN)|{1} choice 1 (EN)|]1,Inf] choice inf (EN)',
-            ))))
+            )))
         ;
         $loader
             ->expects($this->at(2))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('es', array(
+            ->willReturn($this->getCatalogue('es', array(
                 'foobar' => 'foobar (ES)',
-            ))))
+            )))
         ;
         $loader
             ->expects($this->at(3))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('pt-PT', array(
+            ->willReturn($this->getCatalogue('pt-PT', array(
                 'foobarfoo' => 'foobarfoo (PT-PT)',
-            ))))
+            )))
         ;
         $loader
             ->expects($this->at(4))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('pt_BR', array(
+            ->willReturn($this->getCatalogue('pt_BR', array(
                 'other choice' => '{0} other choice 0 (PT-BR)|{1} other choice 1 (PT-BR)|]1,Inf] other choice inf (PT-BR)',
-            ))))
+            )))
         ;
         $loader
             ->expects($this->at(5))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('fr.UTF-8', array(
+            ->willReturn($this->getCatalogue('fr.UTF-8', array(
                 'foobarbaz' => 'foobarbaz (fr.UTF-8)',
-            ))))
+            )))
         ;
         $loader
             ->expects($this->at(6))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('sr@latin', array(
+            ->willReturn($this->getCatalogue('sr@latin', array(
                 'foobarbax' => 'foobarbax (sr@latin)',
-            ))))
+            )))
         ;
 
         return $loader;
@@ -415,7 +415,7 @@ class TranslatorTest extends TestCase
         $container
             ->expects($this->any())
             ->method('get')
-            ->will($this->returnValue($loader))
+            ->willReturn($loader)
         ;
 
         return $container;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
@@ -68,7 +68,7 @@ class ConstraintValidatorFactoryTest extends TestCase
         $constraint
             ->expects($this->exactly(2))
             ->method('validatedBy')
-            ->will($this->returnValue('Fully\\Qualified\\ConstraintValidator\\Class\\Name'));
+            ->willReturn('Fully\\Qualified\\ConstraintValidator\\Class\\Name');
 
         $factory = new ConstraintValidatorFactory(new Container());
         $factory->getInstance($constraint);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -132,17 +132,17 @@ class AbstractFactoryTest extends TestCase
         $factory
             ->expects($this->once())
             ->method('createAuthProvider')
-            ->will($this->returnValue('auth_provider'))
+            ->willReturn('auth_provider')
         ;
         $factory
             ->expects($this->atLeastOnce())
             ->method('getListenerId')
-            ->will($this->returnValue('abstract_listener'))
+            ->willReturn('abstract_listener')
         ;
         $factory
             ->expects($this->any())
             ->method('getKey')
-            ->will($this->returnValue('abstract_factory'))
+            ->willReturn('abstract_factory')
         ;
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -24,7 +24,7 @@ class FilesystemLoaderTest extends TestCase
         $locator
             ->expects($this->once())
             ->method('locate')
-            ->will($this->returnValue(__DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig'))
+            ->willReturn(__DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig')
         ;
         $loader = new FilesystemLoader($locator, $parser);
         $loader->addPath(__DIR__.'/../DependencyInjection/Fixtures/Resources/views', 'namespace');
@@ -44,7 +44,7 @@ class FilesystemLoaderTest extends TestCase
         $locator
             ->expects($this->once())
             ->method('locate')
-            ->will($this->returnValue($template = __DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig'))
+            ->willReturn($template = __DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig')
         ;
         $loader = new FilesystemLoader($locator, $parser);
 
@@ -61,7 +61,7 @@ class FilesystemLoaderTest extends TestCase
             ->expects($this->once())
             ->method('parse')
             ->with('name.format.engine')
-            ->will($this->returnValue(new TemplateReference('', '', 'name', 'format', 'engine')))
+            ->willReturn(new TemplateReference('', '', 'name', 'format', 'engine'))
         ;
 
         $locator = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
@@ -85,14 +85,14 @@ class FilesystemLoaderTest extends TestCase
             ->expects($this->once())
             ->method('parse')
             ->with('name.format.engine')
-            ->will($this->returnValue(new TemplateReference('', '', 'name', 'format', 'engine')))
+            ->willReturn(new TemplateReference('', '', 'name', 'format', 'engine'))
         ;
 
         $locator = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
         $locator
             ->expects($this->once())
             ->method('locate')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $loader = new FilesystemLoader($locator, $parser);

--- a/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
@@ -18,13 +18,13 @@ class TemplateIteratorTest extends TestCase
     public function testGetIterator()
     {
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
-        $bundle->expects($this->any())->method('getName')->will($this->returnValue('BarBundle'));
-        $bundle->expects($this->any())->method('getPath')->will($this->returnValue(__DIR__.'/Fixtures/templates/BarBundle'));
+        $bundle->expects($this->any())->method('getName')->willReturn('BarBundle');
+        $bundle->expects($this->any())->method('getPath')->willReturn(__DIR__.'/Fixtures/templates/BarBundle');
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Kernel')->disableOriginalConstructor()->getMock();
-        $kernel->expects($this->any())->method('getBundles')->will($this->returnValue(array(
+        $kernel->expects($this->any())->method('getBundles')->willReturn(array(
             $bundle,
-        )));
+        ));
         $iterator = new TemplateIterator($kernel, __DIR__.'/Fixtures/templates', array(__DIR__.'/Fixtures/templates/Foo' => 'Foo'), __DIR__.'/DependencyInjection/Fixtures/templates');
 
         $sorted = iterator_to_array($iterator);

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -97,11 +97,11 @@ class ProfilerControllerTest extends TestCase
         $profiler
             ->expects($this->exactly(2))
             ->method('loadProfile')
-            ->will($this->returnCallback(function ($token) {
+            ->willReturnCallback(function ($token) {
                 if ('found' == $token) {
                     return new Profile($token);
                 }
-            }))
+            })
         ;
 
         $controller = $this->createController($profiler, $twig, $withCsp);
@@ -149,7 +149,7 @@ class ProfilerControllerTest extends TestCase
         $profiler
             ->expects($this->once())
             ->method('find')
-            ->will($this->returnValue($tokens));
+            ->willReturn($tokens);
 
         $request = Request::create('/_profiler/empty/search/results', 'GET', array(
             'limit' => 2,
@@ -160,7 +160,7 @@ class ProfilerControllerTest extends TestCase
 
         $twig->expects($this->once())
             ->method('render')
-            ->with($this->stringEndsWith('results.html.twig'), $this->equalTo(array(
+            ->with($this->stringEndsWith('results.html.twig'), array(
                 'token' => 'empty',
                 'profile' => null,
                 'tokens' => $tokens,
@@ -173,7 +173,7 @@ class ProfilerControllerTest extends TestCase
                 'limit' => 2,
                 'panel' => null,
                 'request' => $request,
-            )));
+            ));
 
         $response = $controller->searchResultsAction($request, 'empty');
         $this->assertEquals(200, $response->getStatusCode());

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Csp/ContentSecurityPolicyHandlerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Csp/ContentSecurityPolicyHandlerTest.php
@@ -200,7 +200,7 @@ class ContentSecurityPolicyHandlerTest extends TestCase
 
         $generator->expects($this->any())
             ->method('generate')
-            ->will($this->returnValue($value));
+            ->willReturn($value);
 
         return $generator;
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -289,10 +289,10 @@ class WebDebugToolbarListenerTest extends TestCase
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->setMethods(array('getSession', 'isXmlHttpRequest', 'getRequestFormat'))->disableOriginalConstructor()->getMock();
         $request->expects($this->any())
             ->method('isXmlHttpRequest')
-            ->will($this->returnValue($isXmlHttpRequest));
+            ->willReturn($isXmlHttpRequest);
         $request->expects($this->any())
             ->method('getRequestFormat')
-            ->will($this->returnValue($requestFormat));
+            ->willReturn($requestFormat);
 
         $request->headers = new HeaderBag();
 
@@ -300,7 +300,7 @@ class WebDebugToolbarListenerTest extends TestCase
             $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')->disableOriginalConstructor()->getMock();
             $request->expects($this->any())
                 ->method('getSession')
-                ->will($this->returnValue($session));
+                ->willReturn($session);
         }
 
         return $request;
@@ -311,7 +311,7 @@ class WebDebugToolbarListenerTest extends TestCase
         $templating = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
         $templating->expects($this->any())
             ->method('render')
-            ->will($this->returnValue($render));
+            ->willReturn($render);
 
         return $templating;
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -134,14 +134,14 @@ class TemplateManagerTest extends TestCase
 
         $this->twigEnvironment->expects($this->any())
             ->method('loadTemplate')
-            ->will($this->returnValue('loadedTemplate'));
+            ->willReturn('loadedTemplate');
 
         if (interface_exists('Twig\Loader\SourceContextLoaderInterface')) {
             $loader = $this->getMockBuilder('Twig\Loader\SourceContextLoaderInterface')->getMock();
         } else {
             $loader = $this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock();
         }
-        $this->twigEnvironment->expects($this->any())->method('getLoader')->will($this->returnValue($loader));
+        $this->twigEnvironment->expects($this->any())->method('getLoader')->willReturn($loader);
 
         return $this->twigEnvironment;
     }

--- a/src/Symfony/Component/Asset/Tests/PathPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PathPackageTest.php
@@ -89,7 +89,7 @@ class PathPackageTest extends TestCase
     private function getContext($basePath)
     {
         $context = $this->getMockBuilder('Symfony\Component\Asset\Context\ContextInterface')->getMock();
-        $context->expects($this->any())->method('getBasePath')->will($this->returnValue($basePath));
+        $context->expects($this->any())->method('getBasePath')->willReturn($basePath);
 
         return $context;
     }

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -107,7 +107,7 @@ class UrlPackageTest extends TestCase
     private function getContext($secure)
     {
         $context = $this->getMockBuilder('Symfony\Component\Asset\Context\ContextInterface')->getMock();
-        $context->expects($this->any())->method('isSecure')->will($this->returnValue($secure));
+        $context->expects($this->any())->method('isSecure')->willReturn($secure);
 
         return $context;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -80,7 +80,7 @@ class ChainAdapterTest extends AdapterTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         return $pruneable;
     }
@@ -97,7 +97,7 @@ class ChainAdapterTest extends AdapterTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         return $pruneable;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -173,7 +173,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         return $pruneable;
     }
@@ -190,7 +190,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         return $pruneable;
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
@@ -78,7 +78,7 @@ class ChainCacheTest extends CacheTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         return $pruneable;
     }
@@ -95,7 +95,7 @@ class ChainCacheTest extends CacheTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         return $pruneable;
     }

--- a/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
@@ -35,12 +35,12 @@ class DelegatingLoaderTest extends TestCase
     public function testSupports()
     {
         $loader1 = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader1->expects($this->once())->method('supports')->will($this->returnValue(true));
+        $loader1->expects($this->once())->method('supports')->willReturn(true);
         $loader = new DelegatingLoader(new LoaderResolver(array($loader1)));
         $this->assertTrue($loader->supports('foo.xml'), '->supports() returns true if the resource is loadable');
 
         $loader1 = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader1->expects($this->once())->method('supports')->will($this->returnValue(false));
+        $loader1->expects($this->once())->method('supports')->willReturn(false);
         $loader = new DelegatingLoader(new LoaderResolver(array($loader1)));
         $this->assertFalse($loader->supports('foo.foo'), '->supports() returns false if the resource is not loadable');
     }
@@ -48,7 +48,7 @@ class DelegatingLoaderTest extends TestCase
     public function testLoad()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader->expects($this->once())->method('supports')->will($this->returnValue(true));
+        $loader->expects($this->once())->method('supports')->willReturn(true);
         $loader->expects($this->once())->method('load');
         $resolver = new LoaderResolver(array($loader));
         $loader = new DelegatingLoader($resolver);
@@ -62,7 +62,7 @@ class DelegatingLoaderTest extends TestCase
     public function testLoadThrowsAnExceptionIfTheResourceCannotBeLoaded()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader->expects($this->once())->method('supports')->will($this->returnValue(false));
+        $loader->expects($this->once())->method('supports')->willReturn(false);
         $resolver = new LoaderResolver(array($loader));
         $loader = new DelegatingLoader($resolver);
 

--- a/src/Symfony/Component/Config/Tests/Loader/LoaderResolverTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/LoaderResolverTest.php
@@ -32,7 +32,7 @@ class LoaderResolverTest extends TestCase
         $this->assertFalse($resolver->resolve('foo.foo'), '->resolve() returns false if no loader is able to load the resource');
 
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader->expects($this->once())->method('supports')->will($this->returnValue(true));
+        $loader->expects($this->once())->method('supports')->willReturn(true);
         $resolver = new LoaderResolver(array($loader));
         $this->assertEquals($loader, $resolver->resolve(function () {}), '->resolve() returns the loader for the given resource');
     }

--- a/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
@@ -34,7 +34,7 @@ class LoaderTest extends TestCase
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('foo.xml')
-            ->will($this->returnValue($resolvedLoader));
+            ->willReturn($resolvedLoader);
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);
@@ -52,7 +52,7 @@ class LoaderTest extends TestCase
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('FOOBAR')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);
@@ -66,13 +66,13 @@ class LoaderTest extends TestCase
         $resolvedLoader->expects($this->once())
             ->method('load')
             ->with('foo')
-            ->will($this->returnValue('yes'));
+            ->willReturn('yes');
 
         $resolver = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderResolverInterface')->getMock();
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('foo')
-            ->will($this->returnValue($resolvedLoader));
+            ->willReturn($resolvedLoader);
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);
@@ -86,13 +86,13 @@ class LoaderTest extends TestCase
         $resolvedLoader->expects($this->once())
             ->method('load')
             ->with('foo', 'bar')
-            ->will($this->returnValue('yes'));
+            ->willReturn('yes');
 
         $resolver = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderResolverInterface')->getMock();
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('foo', 'bar')
-            ->will($this->returnValue($resolvedLoader));
+            ->willReturn($resolvedLoader);
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);

--- a/src/Symfony/Component/Console/Tests/Helper/AbstractQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/AbstractQuestionHelperTest.php
@@ -21,7 +21,7 @@ abstract class AbstractQuestionHelperTest extends TestCase
         $mock = $this->getMockBuilder(StreamableInputInterface::class)->getMock();
         $mock->expects($this->any())
             ->method('isInteractive')
-            ->will($this->returnValue($interactive));
+            ->willReturn($interactive);
 
         if ($stream) {
             $mock->expects($this->any())

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -114,12 +114,12 @@ class HelperSetTest extends TestCase
         $mock_helper = $this->getMockBuilder('\Symfony\Component\Console\Helper\HelperInterface')->getMock();
         $mock_helper->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name));
+            ->willReturn($name);
 
         if ($helperset) {
             $mock_helper->expects($this->any())
                 ->method('setHelperSet')
-                ->with($this->equalTo($helperset));
+                ->with($helperset);
         }
 
         return $mock_helper;

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -541,7 +541,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $helperSet = new HelperSet(array(new FormatterHelper()));
         $dialog->setHelperSet($helperSet);
 
-        $output->expects($this->once())->method('writeln')->with($this->equalTo($outputShown));
+        $output->expects($this->once())->method('writeln')->with($outputShown);
 
         $question = new ChoiceQuestion($question, $possibleChoices, 'foo');
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream("\n")), $output, $question);
@@ -892,7 +892,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $helperSet = new HelperSet(array(new FormatterHelper()));
         $dialog->setHelperSet($helperSet);
 
-        $output->expects($this->once())->method('writeln')->with($this->equalTo($outputShown));
+        $output->expects($this->once())->method('writeln')->with($outputShown);
 
         $question = new ChoiceQuestion($question, $possibleChoices, 'foo');
         $dialog->ask($this->createInputInterfaceMock(), $output, $question);
@@ -987,7 +987,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $mock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
         $mock->expects($this->any())
             ->method('isInteractive')
-            ->will($this->returnValue($interactive));
+            ->willReturn($interactive);
 
         return $mock;
     }

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -154,7 +154,7 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
         $mock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
         $mock->expects($this->any())
             ->method('isInteractive')
-            ->will($this->returnValue($interactive));
+            ->willReturn($interactive);
 
         return $mock;
     }

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -231,7 +231,7 @@ class ErrorHandlerTest extends TestCase
             $logger
                 ->expects($this->once())
                 ->method('log')
-                ->will($this->returnCallback($warnArgCheck))
+                ->willReturnCallback($warnArgCheck)
             ;
 
             $handler = ErrorHandler::register();
@@ -259,7 +259,7 @@ class ErrorHandlerTest extends TestCase
             $logger
                 ->expects($this->once())
                 ->method('log')
-                ->will($this->returnCallback($logArgCheck))
+                ->willReturnCallback($logArgCheck)
             ;
 
             $handler = ErrorHandler::register();
@@ -315,7 +315,7 @@ class ErrorHandlerTest extends TestCase
         $logger
             ->expects($this->once())
             ->method('log')
-            ->will($this->returnCallback($logArgCheck))
+            ->willReturnCallback($logArgCheck)
         ;
 
         $handler = new ErrorHandler();
@@ -344,7 +344,7 @@ class ErrorHandlerTest extends TestCase
             $logger
                 ->expects($this->exactly(2))
                 ->method('log')
-                ->will($this->returnCallback($logArgCheck))
+                ->willReturnCallback($logArgCheck)
             ;
 
             $handler->setDefaultLogger($logger, E_ERROR);
@@ -498,7 +498,7 @@ class ErrorHandlerTest extends TestCase
             $logger
                 ->expects($this->once())
                 ->method('log')
-                ->will($this->returnCallback($logArgCheck))
+                ->willReturnCallback($logArgCheck)
             ;
 
             $handler->setDefaultLogger($logger, E_PARSE);
@@ -546,8 +546,8 @@ class ErrorHandlerTest extends TestCase
                 ->expects($this->once())
                 ->method('log')
                 ->with(
-                    $this->equalTo(LogLevel::CRITICAL),
-                    $this->equalTo('Fatal Error: foo')
+                    LogLevel::CRITICAL,
+                    'Fatal Error: foo'
                 )
             ;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
@@ -31,13 +31,13 @@ class AutowireExceptionPassTest extends TestCase
         $autowireException = new AutowiringFailedException('foo_service_id', 'An autowiring exception message');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
-            ->will($this->returnValue(array($autowireException)));
+            ->willReturn(array($autowireException));
 
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
             ->method('getInlinedServiceIds')
-            ->will($this->returnValue(array()));
+            ->willReturn(array());
 
         $container = new ContainerBuilder();
         $container->register('foo_service_id');
@@ -60,18 +60,18 @@ class AutowireExceptionPassTest extends TestCase
         $autowireException = new AutowiringFailedException('a_service', 'An autowiring exception message');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
-            ->will($this->returnValue(array($autowireException)));
+            ->willReturn(array($autowireException));
 
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
             ->method('getInlinedServiceIds')
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 // a_service inlined into b_service
                 'a_service' => array('b_service'),
                 // b_service inlined into c_service
                 'b_service' => array('c_service'),
-            )));
+            ));
 
         $container = new ContainerBuilder();
         // ONLY register c_service in the final container
@@ -95,18 +95,18 @@ class AutowireExceptionPassTest extends TestCase
         $autowireException = new AutowiringFailedException('a_service', 'An autowiring exception message');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
-            ->will($this->returnValue(array($autowireException)));
+            ->willReturn(array($autowireException));
 
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
             ->method('getInlinedServiceIds')
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 // a_service inlined into b_service
                 'a_service' => array('b_service'),
                 // b_service inlined into c_service
                 'b_service' => array('c_service'),
-            )));
+            ));
 
         // do NOT register c_service in the container
         $container = new ContainerBuilder();
@@ -126,13 +126,13 @@ class AutowireExceptionPassTest extends TestCase
         $autowireException = new AutowiringFailedException('non_existent_service');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
-            ->will($this->returnValue(array($autowireException)));
+            ->willReturn(array($autowireException));
 
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
             ->method('getInlinedServiceIds')
-            ->will($this->returnValue(array()));
+            ->willReturn(array());
 
         $container = new ContainerBuilder();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -30,18 +30,18 @@ class MergeExtensionConfigurationPassTest extends TestCase
         $extension = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface')->getMock();
         $extension->expects($this->any())
             ->method('getXsdValidationBasePath')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $extension->expects($this->any())
             ->method('getNamespace')
-            ->will($this->returnValue('http://example.org/schema/dic/foo'));
+            ->willReturn('http://example.org/schema/dic/foo');
         $extension->expects($this->any())
             ->method('getAlias')
-            ->will($this->returnValue('foo'));
+            ->willReturn('foo');
         $extension->expects($this->once())
             ->method('load')
-            ->will($this->returnCallback(function (array $config, ContainerBuilder $container) use (&$tmpProviders) {
+            ->willReturnCallback(function (array $config, ContainerBuilder $container) use (&$tmpProviders) {
                 $tmpProviders = $container->getExpressionLanguageProviders();
-            }));
+            });
 
         $provider = $this->getMockBuilder('Symfony\\Component\\ExpressionLanguage\\ExpressionFunctionProviderInterface')->getMock();
         $container = new ContainerBuilder(new ParameterBag());
@@ -76,7 +76,7 @@ class MergeExtensionConfigurationPassTest extends TestCase
         $extension = $this->getMockBuilder(FooExtension::class)->setMethods(array('getConfiguration'))->getMock();
         $extension->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->will($this->returnValue(new FooConfiguration()));
+            ->willReturn(new FooConfiguration());
 
         $container = new ContainerBuilder(new ParameterBag());
         $container->registerExtension($extension);

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
@@ -67,10 +67,10 @@ class ContainerParametersResourceCheckerTest extends TestCase
                     array($this->equalTo('locales')),
                     array($this->equalTo('default_locale'))
                 )
-                ->will($this->returnValueMap(array(
+                ->willReturnMap(array(
                     array('locales', array('fr', 'en')),
                     array('default_locale', 'fr'),
-                )))
+                ))
             ;
         }, true);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1027,7 +1027,7 @@ class ContainerBuilderTest extends TestCase
     public function testRegisteredButNotLoadedExtension()
     {
         $extension = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface')->getMock();
-        $extension->expects($this->once())->method('getAlias')->will($this->returnValue('project'));
+        $extension->expects($this->once())->method('getAlias')->willReturn('project');
         $extension->expects($this->never())->method('load');
 
         $container = new ContainerBuilder();
@@ -1039,7 +1039,7 @@ class ContainerBuilderTest extends TestCase
     public function testRegisteredAndLoadedExtension()
     {
         $extension = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface')->getMock();
-        $extension->expects($this->exactly(2))->method('getAlias')->will($this->returnValue('project'));
+        $extension->expects($this->exactly(2))->method('getAlias')->willReturn('project');
         $extension->expects($this->once())->method('load')->with(array(array('foo' => 'bar')));
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -862,13 +862,13 @@ class FormTest extends TestCase
         $field
             ->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name))
+            ->willReturn($name)
         ;
 
         $field
             ->expects($this->any())
             ->method('getValue')
-            ->will($this->returnValue($value))
+            ->willReturn($value)
         ;
 
         return $field;

--- a/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
@@ -43,7 +43,7 @@ class ImmutableEventDispatcherTest extends TestCase
         $this->innerDispatcher->expects($this->once())
             ->method('dispatch')
             ->with('event', $event)
-            ->will($this->returnValue('result'));
+            ->willReturn('result');
 
         $this->assertSame('result', $this->dispatcher->dispatch('event', $event));
     }
@@ -53,7 +53,7 @@ class ImmutableEventDispatcherTest extends TestCase
         $this->innerDispatcher->expects($this->once())
             ->method('getListeners')
             ->with('event')
-            ->will($this->returnValue('result'));
+            ->willReturn('result');
 
         $this->assertSame('result', $this->dispatcher->getListeners('event'));
     }
@@ -63,7 +63,7 @@ class ImmutableEventDispatcherTest extends TestCase
         $this->innerDispatcher->expects($this->once())
             ->method('hasListeners')
             ->with('event')
-            ->will($this->returnValue('result'));
+            ->willReturn('result');
 
         $this->assertSame('result', $this->dispatcher->hasListeners('event'));
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -36,18 +36,18 @@ class ExpressionLanguageTest extends TestCase
         $cacheItemMock
             ->expects($this->exactly(2))
             ->method('get')
-            ->will($this->returnCallback(function () use (&$savedParsedExpression) {
+            ->willReturnCallback(function () use (&$savedParsedExpression) {
                 return $savedParsedExpression;
-            }))
+            })
         ;
 
         $cacheItemMock
             ->expects($this->exactly(1))
             ->method('set')
             ->with($this->isInstanceOf(ParsedExpression::class))
-            ->will($this->returnCallback(function ($parsedExpression) use (&$savedParsedExpression) {
+            ->willReturnCallback(function ($parsedExpression) use (&$savedParsedExpression) {
                 $savedParsedExpression = $parsedExpression;
-            }))
+            })
         ;
 
         $cacheMock
@@ -85,9 +85,9 @@ class ExpressionLanguageTest extends TestCase
             ->expects($this->exactly(1))
             ->method('save')
             ->with('1%20%2B%201%2F%2F', $this->isInstanceOf(ParsedExpression::class))
-            ->will($this->returnCallback(function ($key, $expression) use (&$savedParsedExpression) {
+            ->willReturnCallback(function ($key, $expression) use (&$savedParsedExpression) {
                 $savedParsedExpression = $expression;
-            }))
+            })
         ;
 
         $parsedExpression = $expressionLanguage->parse('1 + 1', array());
@@ -213,18 +213,18 @@ class ExpressionLanguageTest extends TestCase
         $cacheItemMock
             ->expects($this->exactly(2))
             ->method('get')
-            ->will($this->returnCallback(function () use (&$savedParsedExpression) {
+            ->willReturnCallback(function () use (&$savedParsedExpression) {
                 return $savedParsedExpression;
-            }))
+            })
         ;
 
         $cacheItemMock
             ->expects($this->exactly(1))
             ->method('set')
             ->with($this->isInstanceOf(ParsedExpression::class))
-            ->will($this->returnCallback(function ($parsedExpression) use (&$savedParsedExpression) {
+            ->willReturnCallback(function ($parsedExpression) use (&$savedParsedExpression) {
                 $savedParsedExpression = $parsedExpression;
-            }))
+            })
         ;
 
         $cacheMock

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilterIteratorTest.php
@@ -26,9 +26,9 @@ class FilterIteratorTest extends RealIteratorTestCase
         $i = $this->getMockForAbstractClass('Symfony\Component\Finder\Iterator\FilterIterator', array($i));
         $i->expects($this->any())
             ->method('accept')
-            ->will($this->returnCallback(function () use ($i) {
+            ->willReturnCallback(function () use ($i) {
                 return (bool) preg_match('/\.php/', (string) $i->current());
-            })
+            }
         );
 
         $c = 0;

--- a/src/Symfony/Component/Form/Tests/AbstractFormTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractFormTest.php
@@ -77,10 +77,10 @@ abstract class AbstractFormTest extends TestCase
 
         $form->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name));
+            ->willReturn($name);
         $form->expects($this->any())
             ->method('getConfig')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
 
         return $form;
     }

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -376,18 +376,18 @@ abstract class AbstractRequestHandlerTest extends TestCase
         $config = $this->getMockBuilder('Symfony\Component\Form\FormConfigInterface')->getMock();
         $config->expects($this->any())
             ->method('getMethod')
-            ->will($this->returnValue($method));
+            ->willReturn($method);
         $config->expects($this->any())
             ->method('getCompound')
-            ->will($this->returnValue($compound));
+            ->willReturn($compound);
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Test\FormInterface')->getMock();
         $form->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name));
+            ->willReturn($name);
         $form->expects($this->any())
             ->method('getConfig')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
 
         return $form;
     }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -42,7 +42,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with(array())
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices(array()));
         $this->assertSame($list, $this->factory->createListFromChoices(array()));
@@ -58,7 +58,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices2)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list, $this->factory->createListFromChoices($choices2));
@@ -73,7 +73,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices1)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list, $this->factory->createListFromChoices($choices2));
@@ -91,7 +91,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices1)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list, $this->factory->createListFromChoices($choices2));
@@ -110,11 +110,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromChoices')
             ->with($choices1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromChoices')
             ->with($choices2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list2, $this->factory->createListFromChoices($choices2));
@@ -129,7 +129,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices, $closure)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices($choices, $closure));
         $this->assertSame($list, $this->factory->createListFromChoices($choices, $closure));
@@ -146,11 +146,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromChoices')
             ->with($choices, $closure1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromChoices')
             ->with($choices, $closure2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromChoices($choices, $closure1));
         $this->assertSame($list2, $this->factory->createListFromChoices($choices, $closure2));
@@ -164,7 +164,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromLoader($loader));
         $this->assertSame($list, $this->factory->createListFromLoader($loader));
@@ -180,11 +180,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromLoader')
             ->with($loader1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromLoader')
             ->with($loader2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromLoader($loader1));
         $this->assertSame($list2, $this->factory->createListFromLoader($loader2));
@@ -199,7 +199,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader, $closure)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromLoader($loader, $closure));
         $this->assertSame($list, $this->factory->createListFromLoader($loader, $closure));
@@ -216,11 +216,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromLoader')
             ->with($loader, $closure1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromLoader')
             ->with($loader, $closure2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromLoader($loader, $closure1));
         $this->assertSame($list2, $this->factory->createListFromLoader($loader, $closure2));
@@ -235,7 +235,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $preferred)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, $preferred));
         $this->assertSame($view, $this->factory->createView($list, $preferred));
@@ -252,11 +252,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, $preferred1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, $preferred2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, $preferred1));
         $this->assertSame($view2, $this->factory->createView($list, $preferred2));
@@ -271,7 +271,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $preferred)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, $preferred));
         $this->assertSame($view, $this->factory->createView($list, $preferred));
@@ -288,11 +288,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, $preferred1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, $preferred2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, $preferred1));
         $this->assertSame($view2, $this->factory->createView($list, $preferred2));
@@ -307,7 +307,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, $labels)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, $labels));
         $this->assertSame($view, $this->factory->createView($list, null, $labels));
@@ -324,11 +324,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, $labels1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, $labels2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, $labels1));
         $this->assertSame($view2, $this->factory->createView($list, null, $labels2));
@@ -343,7 +343,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, $index)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, null, $index));
         $this->assertSame($view, $this->factory->createView($list, null, null, $index));
@@ -360,11 +360,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, null, $index1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, null, $index2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, $index1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, $index2));
@@ -379,7 +379,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, $groupBy)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, null, null, $groupBy));
         $this->assertSame($view, $this->factory->createView($list, null, null, null, $groupBy));
@@ -396,11 +396,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, null, null, $groupBy1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, null, null, $groupBy2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, $groupBy1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, $groupBy2));
@@ -415,7 +415,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, null, $attr)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, null, null, null, $attr));
         $this->assertSame($view, $this->factory->createView($list, null, null, null, null, $attr));
@@ -432,11 +432,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, null, null, null, $attr1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, null, null, null, $attr2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, null, $attr1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, null, $attr2));
@@ -451,7 +451,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, null, $attr)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, null, null, null, $attr));
         $this->assertSame($view, $this->factory->createView($list, null, null, null, null, $attr));
@@ -468,11 +468,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, null, null, null, $attr1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, null, null, null, $attr2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, null, $attr1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, null, $attr2));

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
@@ -43,9 +43,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($choices, $callback) {
+            ->willReturnCallback(function ($choices, $callback) {
                 return array_map($callback, $choices);
-            }));
+            });
 
         $this->assertSame(array('value'), $this->factory->createListFromChoices($choices, 'property'));
     }
@@ -57,9 +57,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($choices, $callback) {
+            ->willReturnCallback(function ($choices, $callback) {
                 return array_map($callback, $choices);
-            }));
+            });
 
         $this->assertSame(array('value'), $this->factory->createListFromChoices($choices, new PropertyPath('property')));
     }
@@ -86,9 +86,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($loader, $callback) {
+            ->willReturnCallback(function ($loader, $callback) {
                 return $callback((object) array('property' => 'value'));
-            }));
+            });
 
         $this->assertSame('value', $this->factory->createListFromLoader($loader, 'property'));
     }
@@ -116,9 +116,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($choices, $callback) {
+            ->willReturnCallback(function ($choices, $callback) {
                 return array_map($callback, $choices);
-            }));
+            });
 
         $this->assertSame(array(null), $this->factory->createListFromChoices($choices, 'property'));
     }
@@ -131,9 +131,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($loader, $callback) {
+            ->willReturnCallback(function ($loader, $callback) {
                 return $callback(null);
-            }));
+            });
 
         $this->assertNull($this->factory->createListFromLoader($loader, 'property'));
     }
@@ -145,9 +145,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($loader, $callback) {
+            ->willReturnCallback(function ($loader, $callback) {
                 return $callback((object) array('property' => 'value'));
-            }));
+            });
 
         $this->assertSame('value', $this->factory->createListFromLoader($loader, new PropertyPath('property')));
     }
@@ -159,9 +159,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred) {
+            ->willReturnCallback(function ($list, $preferred) {
                 return $preferred((object) array('property' => true));
-            }));
+            });
 
         $this->assertTrue($this->factory->createView(
             $list,
@@ -194,9 +194,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred) {
+            ->willReturnCallback(function ($list, $preferred) {
                 return $preferred((object) array('property' => true));
-            }));
+            });
 
         $this->assertTrue($this->factory->createView(
             $list,
@@ -212,9 +212,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred) {
+            ->willReturnCallback(function ($list, $preferred) {
                 return $preferred((object) array('category' => null));
-            }));
+            });
 
         $this->assertFalse($this->factory->createView(
             $list,
@@ -229,9 +229,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label) {
+            ->willReturnCallback(function ($list, $preferred, $label) {
                 return $label((object) array('property' => 'label'));
-            }));
+            });
 
         $this->assertSame('label', $this->factory->createView(
             $list,
@@ -266,9 +266,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label) {
+            ->willReturnCallback(function ($list, $preferred, $label) {
                 return $label((object) array('property' => 'label'));
-            }));
+            });
 
         $this->assertSame('label', $this->factory->createView(
             $list,
@@ -284,9 +284,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index) {
                 return $index((object) array('property' => 'index'));
-            }));
+            });
 
         $this->assertSame('index', $this->factory->createView(
             $list,
@@ -323,9 +323,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index) {
                 return $index((object) array('property' => 'index'));
-            }));
+            });
 
         $this->assertSame('index', $this->factory->createView(
             $list,
@@ -342,9 +342,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
                 return $groupBy((object) array('property' => 'group'));
-            }));
+            });
 
         $this->assertSame('group', $this->factory->createView(
             $list,
@@ -383,9 +383,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
                 return $groupBy((object) array('property' => 'group'));
-            }));
+            });
 
         $this->assertSame('group', $this->factory->createView(
             $list,
@@ -404,9 +404,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
                 return $groupBy((object) array('group' => null));
-            }));
+            });
 
         $this->assertNull($this->factory->createView(
             $list,
@@ -424,9 +424,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
                 return $attr((object) array('property' => 'attr'));
-            }));
+            });
 
         $this->assertSame('attr', $this->factory->createView(
             $list,
@@ -467,9 +467,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
                 return $attr((object) array('property' => 'attr'));
-            }));
+            });
 
         $this->assertSame('attr', $this->factory->createView(
             $list,

--- a/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
@@ -50,12 +50,12 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getChoices')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getChoices());
         $this->assertSame('RESULT', $this->list->getChoices());
@@ -79,7 +79,7 @@ class LazyChoiceListTest extends TestCase
         // The same list is returned by the lazy choice list
         $this->loadedList->expects($this->exactly(2))
             ->method('getChoices')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getChoices());
         $this->assertSame('RESULT', $this->list->getChoices());
@@ -90,12 +90,12 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getValues')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getValues());
         $this->assertSame('RESULT', $this->list->getValues());
@@ -106,12 +106,12 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getStructuredValues')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getStructuredValues());
         $this->assertSame('RESULT', $this->list->getStructuredValues());
@@ -122,12 +122,12 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getOriginalKeys')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getOriginalKeys());
         $this->assertSame('RESULT', $this->list->getOriginalKeys());
@@ -138,7 +138,7 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoicesForValues')
             ->with(array('a', 'b'))
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getChoicesForValues(array('a', 'b')));
         $this->assertSame('RESULT', $this->list->getChoicesForValues(array('a', 'b')));
@@ -151,7 +151,7 @@ class LazyChoiceListTest extends TestCase
             ->with($this->value)
             // For BC, the same choice loaded list is returned 3 times
             // It should only twice in 4.0
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         $this->loader->expects($this->never())
             ->method('loadChoicesForValues');
@@ -159,7 +159,7 @@ class LazyChoiceListTest extends TestCase
         $this->loadedList->expects($this->exactly(2))
             ->method('getChoicesForValues')
             ->with(array('a', 'b'))
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         // load choice list
         $this->list->getChoices();
@@ -176,7 +176,7 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadValuesForChoices')
             ->with(array('a', 'b'))
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getValuesForChoices(array('a', 'b')));
         $this->assertSame('RESULT', $this->list->getValuesForChoices(array('a', 'b')));
@@ -189,7 +189,7 @@ class LazyChoiceListTest extends TestCase
             ->with($this->value)
             // For BC, the same choice loaded list is returned 3 times
             // It should only twice in 4.0
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         $this->loader->expects($this->never())
             ->method('loadValuesForChoices');
@@ -197,7 +197,7 @@ class LazyChoiceListTest extends TestCase
         $this->loadedList->expects($this->exactly(2))
             ->method('getValuesForChoices')
             ->with(array('a', 'b'))
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         // load choice list
         $this->list->getChoices();

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -75,7 +75,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $child->expects($this->once())
             ->method('submit')
-            ->with($this->equalTo(null));
+            ->with(null);
 
         $this->form->submit(array('firstName' => null), false);
     }
@@ -88,7 +88,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $child->expects($this->once())
             ->method('submit')
-            ->with($this->equalTo(null));
+            ->with(null);
 
         $this->form->submit(array());
     }
@@ -126,7 +126,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $child->expects($this->once())
             ->method('submit')
-            ->with($this->equalTo('foo'), false);
+            ->with('foo', false);
 
         $this->form->submit(array('firstName' => 'foo'), false);
     }
@@ -148,7 +148,7 @@ class CompoundFormTest extends AbstractFormTest
         $child = $this->getMockForm();
         $child->expects($this->once())
             ->method('isEmpty')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->form->setData(null);
         $this->form->add($child);
@@ -409,10 +409,10 @@ class CompoundFormTest extends AbstractFormTest
 
         $child->expects($this->once())
             ->method('setData')
-            ->will($this->returnCallback(function () use ($form, $childToBeAdded) {
+            ->willReturnCallback(function () use ($form, $childToBeAdded) {
                 $form->remove('removed');
                 $form->add($childToBeAdded);
-            }));
+            });
 
         $childToBeRemoved->expects($this->never())
             ->method('setData');
@@ -443,10 +443,10 @@ class CompoundFormTest extends AbstractFormTest
         $mapper->expects($this->once())
             ->method('mapDataToForms')
             ->with('bar', $this->isInstanceOf('\RecursiveIteratorIterator'))
-            ->will($this->returnCallback(function ($data, \RecursiveIteratorIterator $iterator) use ($child1, $child2) {
+            ->willReturnCallback(function ($data, \RecursiveIteratorIterator $iterator) use ($child1, $child2) {
                 $this->assertInstanceOf('Symfony\Component\Form\Util\InheritDataAwareIterator', $iterator->getInnerIterator());
                 $this->assertSame(array('firstName' => $child1, 'lastName' => $child2), iterator_to_array($iterator));
-            }));
+            });
 
         $form->setData('foo');
     }
@@ -464,10 +464,10 @@ class CompoundFormTest extends AbstractFormTest
 
         $child->expects($this->once())
             ->method('submit')
-            ->will($this->returnCallback(function () use ($form, $childToBeAdded) {
+            ->willReturnCallback(function () use ($form, $childToBeAdded) {
                 $form->remove('removed');
                 $form->add($childToBeAdded);
-            }));
+            });
 
         $childToBeRemoved->expects($this->never())
             ->method('submit');
@@ -570,10 +570,10 @@ class CompoundFormTest extends AbstractFormTest
         $mapper->expects($this->once())
             ->method('mapFormsToData')
             ->with($this->isInstanceOf('\RecursiveIteratorIterator'), $object)
-            ->will($this->returnCallback(function (\RecursiveIteratorIterator $iterator) use ($child) {
+            ->willReturnCallback(function (\RecursiveIteratorIterator $iterator) use ($child) {
                 $this->assertInstanceOf('Symfony\Component\Form\Util\InheritDataAwareIterator', $iterator->getInnerIterator());
                 $this->assertSame(array('name' => $child), iterator_to_array($iterator));
-            }));
+            });
 
         $form->submit(array(
             'name' => 'Bernhard',
@@ -904,30 +904,30 @@ class CompoundFormTest extends AbstractFormTest
         // First create the view
         $type->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         // Then build it for the form itself
         $type->expects($this->once())
             ->method('buildView')
             ->with($view, $this->form, $options)
-            ->will($this->returnCallback($assertChildViewsEqual(array())));
+            ->willReturnCallback($assertChildViewsEqual(array()));
 
         // Then add the first child form
         $field1->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($field1View));
+            ->willReturn($field1View);
 
         // Then the second child form
         $field2->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($field2View));
+            ->willReturn($field2View);
 
         // Again build the view for the form itself. This time the child views
         // exist.
         $type->expects($this->once())
             ->method('finishView')
             ->with($view, $this->form, $options)
-            ->will($this->returnCallback($assertChildViewsEqual(array('foo' => $field1View, 'bar' => $field2View))));
+            ->willReturnCallback($assertChildViewsEqual(array('foo' => $field1View, 'bar' => $field2View)));
 
         $this->assertSame($view, $this->form->createView());
     }
@@ -946,7 +946,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $button->expects($this->any())
             ->method('isClicked')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $parentForm = $this->getBuilder('parent')->getForm();
         $nestedForm = $this->getBuilder('nested')->getForm();
@@ -968,7 +968,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $button->expects($this->any())
             ->method('isClicked')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->form->add($button);
         $this->form->submit(array());
@@ -987,7 +987,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $nestedForm->expects($this->any())
             ->method('getClickedButton')
-            ->will($this->returnValue($button));
+            ->willReturn($button);
 
         $this->form->add($nestedForm);
         $this->form->submit(array());
@@ -1006,7 +1006,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $parentForm->expects($this->any())
             ->method('getClickedButton')
-            ->will($this->returnValue($button));
+            ->willReturn($button);
 
         $this->form->setParent($parentForm);
         $this->form->submit(array());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -67,11 +67,11 @@ class PropertyPathMapperTest extends TestCase
 
         $form->expects($this->any())
             ->method('isSynchronized')
-            ->will($this->returnValue($synchronized));
+            ->willReturn($synchronized);
 
         $form->expects($this->any())
             ->method('isSubmitted')
-            ->will($this->returnValue($submitted));
+            ->willReturn($submitted);
 
         return $form;
     }
@@ -85,7 +85,7 @@ class PropertyPathMapperTest extends TestCase
         $this->propertyAccessor->expects($this->once())
             ->method('getValue')
             ->with($car, $propertyPath)
-            ->will($this->returnValue($engine));
+            ->willReturn($engine);
 
         $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
         $config->setByReference(true);
@@ -108,7 +108,7 @@ class PropertyPathMapperTest extends TestCase
         $this->propertyAccessor->expects($this->once())
             ->method('getValue')
             ->with($car, $propertyPath)
-            ->will($this->returnValue($engine));
+            ->willReturn($engine);
 
         $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
         $config->setByReference(false);
@@ -253,7 +253,7 @@ class PropertyPathMapperTest extends TestCase
         $this->propertyAccessor->expects($this->once())
             ->method('getValue')
             ->with($car, $propertyPath)
-            ->will($this->returnValue($engine));
+            ->willReturn($engine);
 
         $this->propertyAccessor->expects($this->never())
             ->method('setValue');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DataTransformerChainTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DataTransformerChainTest.php
@@ -22,12 +22,12 @@ class DataTransformerChainTest extends TestCase
         $transformer1->expects($this->once())
             ->method('transform')
             ->with($this->identicalTo('foo'))
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar');
         $transformer2 = $this->getMockBuilder('Symfony\Component\Form\DataTransformerInterface')->getMock();
         $transformer2->expects($this->once())
             ->method('transform')
             ->with($this->identicalTo('bar'))
-            ->will($this->returnValue('baz'));
+            ->willReturn('baz');
 
         $chain = new DataTransformerChain(array($transformer1, $transformer2));
 
@@ -40,12 +40,12 @@ class DataTransformerChainTest extends TestCase
         $transformer2->expects($this->once())
             ->method('reverseTransform')
             ->with($this->identicalTo('foo'))
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar');
         $transformer1 = $this->getMockBuilder('Symfony\Component\Form\DataTransformerInterface')->getMock();
         $transformer1->expects($this->once())
             ->method('reverseTransform')
             ->with($this->identicalTo('bar'))
-            ->will($this->returnValue('baz'));
+            ->willReturn('baz');
 
         $chain = new DataTransformerChain(array($transformer1, $transformer2));
 

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -56,7 +56,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $form = $this->createBuilder('name')
             ->setType($type)
@@ -77,7 +77,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $options = array(
             'b' => 'foo',
@@ -111,7 +111,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $options = array(
             'b' => 'foo',
@@ -142,7 +142,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $grandParent = $this->createBuilder('grandParent')
             ->setCompound(true)

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -99,7 +99,7 @@ class ValidationListenerTest extends TestCase
 
         $this->validator->expects($this->once())
             ->method('validate')
-            ->will($this->returnValue(array($violation)));
+            ->willReturn(array($violation));
 
         $this->violationMapper->expects($this->once())
             ->method('mapViolation')
@@ -115,7 +115,7 @@ class ValidationListenerTest extends TestCase
 
         $this->validator->expects($this->once())
             ->method('validate')
-            ->will($this->returnValue(array($violation)));
+            ->willReturn(array($violation));
 
         $this->violationMapper->expects($this->once())
             ->method('mapViolation')
@@ -151,7 +151,7 @@ class ValidationListenerTest extends TestCase
         $this->validator
             ->expects($this->once())
             ->method('validate')
-            ->will($this->returnValue(new ConstraintViolationList()));
+            ->willReturn(new ConstraintViolationList());
 
         $this->violationMapper
             ->expects($this->never())

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
@@ -24,7 +24,7 @@ class UploadValidatorExtensionTest extends TypeTestCase
 
         $translator->expects($this->any())
             ->method('trans')
-            ->with($this->equalTo('old max {{ max }}!'))
+            ->with('old max {{ max }}!')
             ->willReturn('translated max {{ max }}!');
 
         $extension = new UploadValidatorExtension($translator);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Util/ServerParamsTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Util/ServerParamsTest.php
@@ -33,7 +33,7 @@ class ServerParamsTest extends TestCase
     {
         $request = Request::create('http://foo', 'GET', array(), array(), array(), array('CONTENT_LENGTH' => 1024));
         $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->setMethods(array('getCurrentRequest'))->getMock();
-        $requestStack->expects($this->once())->method('getCurrentRequest')->will($this->returnValue($request));
+        $requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
         $serverParams = new ServerParams($requestStack);
 
         $this->assertEquals(1024, $serverParams->getContentLength());
@@ -46,7 +46,7 @@ class ServerParamsTest extends TestCase
         $serverParams
             ->expects($this->any())
             ->method('getNormalizedIniPostMaxSize')
-            ->will($this->returnValue(strtoupper($size)));
+            ->willReturn(strtoupper($size));
 
         $this->assertEquals($bytes, $serverParams->getPostMaxSize());
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -29,7 +29,7 @@ class ValidatorExtensionTest extends TestCase
         $validator->expects($this->once())
             ->method('getMetadataFor')
             ->with($this->identicalTo('Symfony\Component\Form\Form'))
-            ->will($this->returnValue($metadata));
+            ->willReturn($metadata);
 
         // Verify that the constraints are added
         $metadata->expects($this->once())

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -56,7 +56,7 @@ class ValidatorTypeGuesserTest extends TestCase
         $this->metadataFactory->expects($this->any())
             ->method('getMetadataFor')
             ->with(self::TEST_CLASS)
-            ->will($this->returnValue($this->metadata));
+            ->willReturn($this->metadata);
         $this->guesser = new ValidatorTypeGuesser($this->metadataFactory);
     }
 

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -236,7 +236,7 @@ class FormBuilderTest extends TestCase
 
         $mock->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name));
+            ->willReturn($name);
 
         return $mock;
     }

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -58,10 +58,10 @@ class FormFactoryTest extends TestCase
 
         $this->registry->expects($this->any())
             ->method('getTypeGuesser')
-            ->will($this->returnValue(new FormTypeGuesserChain(array(
+            ->willReturn(new FormTypeGuesserChain(array(
                 $this->guesser1,
                 $this->guesser2,
-            ))));
+            )));
     }
 
     public function testCreateNamedBuilderWithTypeName()
@@ -73,7 +73,7 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->once())
             ->method('getType')
             ->with('type')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
@@ -82,7 +82,7 @@ class FormFactoryTest extends TestCase
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -101,7 +101,7 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->once())
             ->method('getType')
             ->with('type')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
@@ -110,7 +110,7 @@ class FormFactoryTest extends TestCase
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -128,7 +128,7 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->once())
             ->method('getType')
             ->with('type')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
@@ -137,7 +137,7 @@ class FormFactoryTest extends TestCase
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -181,16 +181,16 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->any())
             ->method('getType')
             ->with('TYPE')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
             ->with($this->factory, 'TYPE_PREFIX', $options)
-            ->will($this->returnValue($this->builder));
+            ->willReturn($this->builder);
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -198,7 +198,7 @@ class FormFactoryTest extends TestCase
 
         $this->builder->expects($this->once())
             ->method('getForm')
-            ->will($this->returnValue('FORM'));
+            ->willReturn('FORM');
 
         $this->assertSame('FORM', $this->factory->create('TYPE', null, $options));
     }
@@ -212,7 +212,7 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->once())
             ->method('getType')
             ->with('type')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
@@ -221,7 +221,7 @@ class FormFactoryTest extends TestCase
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -229,7 +229,7 @@ class FormFactoryTest extends TestCase
 
         $this->builder->expects($this->once())
             ->method('getForm')
-            ->will($this->returnValue('FORM'));
+            ->willReturn('FORM');
 
         $this->assertSame('FORM', $this->factory->createNamed('name', 'type', null, $options));
     }
@@ -245,7 +245,7 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array())
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
 
@@ -257,20 +257,20 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessType')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new TypeGuess(
+            ->willReturn(new TypeGuess(
                 'Symfony\Component\Form\Extension\Core\Type\TextType',
                 array('attr' => array('maxlength' => 10)),
                 Guess::MEDIUM_CONFIDENCE
-            )));
+            ));
 
         $this->guesser2->expects($this->once())
             ->method('guessType')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new TypeGuess(
+            ->willReturn(new TypeGuess(
                 'Symfony\Component\Form\Extension\Core\Type\PasswordType',
                 array('attr' => array('maxlength' => 7)),
                 Guess::HIGH_CONFIDENCE
-            )));
+            ));
 
         $factory = $this->getMockFactory(array('createNamedBuilder'));
 
@@ -289,7 +289,7 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessType')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $factory = $this->getMockFactory(array('createNamedBuilder'));
 
@@ -308,11 +308,11 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessType')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new TypeGuess(
+            ->willReturn(new TypeGuess(
                 'Symfony\Component\Form\Extension\Core\Type\TextType',
                 array('attr' => array('class' => 'foo', 'maxlength' => 10)),
                 Guess::MEDIUM_CONFIDENCE
-            )));
+            ));
 
         $factory = $this->getMockFactory(array('createNamedBuilder'));
 
@@ -336,18 +336,18 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessMaxLength')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     15,
                     Guess::MEDIUM_CONFIDENCE
-                )));
+                ));
 
         $this->guesser2->expects($this->once())
             ->method('guessMaxLength')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     20,
                     Guess::HIGH_CONFIDENCE
-                )));
+                ));
 
         $factory = $this->getMockFactory(array('createNamedBuilder'));
 
@@ -369,18 +369,18 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessMaxLength')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                 20,
                 Guess::HIGH_CONFIDENCE
-            )));
+            ));
 
         $this->guesser2->expects($this->once())
             ->method('guessPattern')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                 '.{5,}',
                 Guess::HIGH_CONFIDENCE
-            )));
+            ));
 
         $factory = $this->getMockFactory(array('createNamedBuilder'));
 
@@ -404,18 +404,18 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessRequired')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     true,
                     Guess::MEDIUM_CONFIDENCE
-                )));
+                ));
 
         $this->guesser2->expects($this->once())
             ->method('guessRequired')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     false,
                     Guess::HIGH_CONFIDENCE
-                )));
+                ));
 
         $factory = $this->getMockFactory(array('createNamedBuilder'));
 
@@ -437,18 +437,18 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessPattern')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     '[a-z]',
                     Guess::MEDIUM_CONFIDENCE
-                )));
+                ));
 
         $this->guesser2->expects($this->once())
             ->method('guessPattern')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     '[a-zA-Z]',
                     Guess::HIGH_CONFIDENCE
-                )));
+                ));
 
         $factory = $this->getMockFactory(array('createNamedBuilder'));
 

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -98,21 +98,21 @@ class ResolvedFormTypeTest extends TestCase
         // First the default options are generated for the super type
         $this->parentType->expects($this->once())
             ->method('configureOptions')
-            ->will($this->returnCallback($assertIndexAndAddOption(0, 'a', 'a_default')));
+            ->willReturnCallback($assertIndexAndAddOption(0, 'a', 'a_default'));
 
         // The form type itself
         $this->type->expects($this->once())
             ->method('configureOptions')
-            ->will($this->returnCallback($assertIndexAndAddOption(1, 'b', 'b_default')));
+            ->willReturnCallback($assertIndexAndAddOption(1, 'b', 'b_default'));
 
         // And its extensions
         $this->extension1->expects($this->once())
             ->method('configureOptions')
-            ->will($this->returnCallback($assertIndexAndAddOption(2, 'c', 'c_default')));
+            ->willReturnCallback($assertIndexAndAddOption(2, 'c', 'c_default'));
 
         $this->extension2->expects($this->once())
             ->method('configureOptions')
-            ->will($this->returnCallback($assertIndexAndAddOption(3, 'd', 'd_default')));
+            ->willReturnCallback($assertIndexAndAddOption(3, 'd', 'd_default'));
 
         $givenOptions = array('a' => 'a_custom', 'c' => 'c_custom');
         $resolvedOptions = array('a' => 'a_custom', 'b' => 'b_default', 'c' => 'c_custom', 'd' => 'd_default');
@@ -135,12 +135,12 @@ class ResolvedFormTypeTest extends TestCase
 
         $this->resolvedType->expects($this->once())
             ->method('getOptionsResolver')
-            ->will($this->returnValue($optionsResolver));
+            ->willReturn($optionsResolver);
 
         $optionsResolver->expects($this->once())
             ->method('resolve')
             ->with($givenOptions)
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $factory = $this->getMockFormFactory();
         $builder = $this->resolvedType->createBuilder($factory, 'name', $givenOptions);
@@ -163,12 +163,12 @@ class ResolvedFormTypeTest extends TestCase
 
         $this->resolvedType->expects($this->once())
             ->method('getOptionsResolver')
-            ->will($this->returnValue($optionsResolver));
+            ->willReturn($optionsResolver);
 
         $optionsResolver->expects($this->once())
             ->method('resolve')
             ->with($givenOptions)
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $factory = $this->getMockFormFactory();
         $builder = $this->resolvedType->createBuilder($factory, 'name', $givenOptions);
@@ -197,24 +197,24 @@ class ResolvedFormTypeTest extends TestCase
         $this->parentType->expects($this->once())
             ->method('buildForm')
             ->with($builder, $options)
-            ->will($this->returnCallback($assertIndex(0)));
+            ->willReturnCallback($assertIndex(0));
 
         // Then the type itself
         $this->type->expects($this->once())
             ->method('buildForm')
             ->with($builder, $options)
-            ->will($this->returnCallback($assertIndex(1)));
+            ->willReturnCallback($assertIndex(1));
 
         // Then its extensions
         $this->extension1->expects($this->once())
             ->method('buildForm')
             ->with($builder, $options)
-            ->will($this->returnCallback($assertIndex(2)));
+            ->willReturnCallback($assertIndex(2));
 
         $this->extension2->expects($this->once())
             ->method('buildForm')
             ->with($builder, $options)
-            ->will($this->returnCallback($assertIndex(3)));
+            ->willReturnCallback($assertIndex(3));
 
         $this->resolvedType->buildForm($builder, $options);
     }
@@ -260,24 +260,24 @@ class ResolvedFormTypeTest extends TestCase
         $this->parentType->expects($this->once())
             ->method('buildView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(0)));
+            ->willReturnCallback($assertIndex(0));
 
         // Then the type itself
         $this->type->expects($this->once())
             ->method('buildView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(1)));
+            ->willReturnCallback($assertIndex(1));
 
         // Then its extensions
         $this->extension1->expects($this->once())
             ->method('buildView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(2)));
+            ->willReturnCallback($assertIndex(2));
 
         $this->extension2->expects($this->once())
             ->method('buildView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(3)));
+            ->willReturnCallback($assertIndex(3));
 
         $this->resolvedType->buildView($view, $form, $options);
     }
@@ -302,24 +302,24 @@ class ResolvedFormTypeTest extends TestCase
         $this->parentType->expects($this->once())
             ->method('finishView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(0)));
+            ->willReturnCallback($assertIndex(0));
 
         // Then the type itself
         $this->type->expects($this->once())
             ->method('finishView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(1)));
+            ->willReturnCallback($assertIndex(1));
 
         // Then its extensions
         $this->extension1->expects($this->once())
             ->method('finishView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(2)));
+            ->willReturnCallback($assertIndex(2));
 
         $this->extension2->expects($this->once())
             ->method('finishView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(3)));
+            ->willReturnCallback($assertIndex(3));
 
         $this->resolvedType->finishView($view, $form, $options);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -171,8 +171,8 @@ class FileTest extends TestCase
         $guesser
             ->expects($this->once())
             ->method('guess')
-            ->with($this->equalTo($path))
-            ->will($this->returnValue($mimeType))
+            ->with($path)
+            ->willReturn($mimeType)
         ;
 
         return $guesser;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -95,7 +95,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         // defining the timeout before the actual method call
         // allows to test for "greater than" values in the $criteria
@@ -143,7 +143,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $data = array();
 
@@ -197,7 +197,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $data = array();
 
@@ -237,7 +237,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $data = array();
 
@@ -266,7 +266,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $methodName = phpversion('mongodb') ? 'deleteOne' : 'remove';
 
@@ -284,7 +284,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $methodName = phpversion('mongodb') ? 'deleteMany' : 'remove';
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -147,7 +147,7 @@ class PdoSessionHandlerTest extends TestCase
         $stream = $this->createStream($content);
 
         $pdo->prepareResult->expects($this->once())->method('fetchAll')
-            ->will($this->returnValue(array(array($stream, 42, time()))));
+            ->willReturn(array(array($stream, 42, time())));
 
         $storage = new PdoSessionHandler($pdo);
         $result = $storage->read('foo');
@@ -177,14 +177,14 @@ class PdoSessionHandlerTest extends TestCase
         $exception = null;
 
         $selectStmt->expects($this->atLeast(2))->method('fetchAll')
-            ->will($this->returnCallback(function () use (&$exception, $stream) {
+            ->willReturnCallback(function () use (&$exception, $stream) {
                 return $exception ? array(array($stream, 42, time())) : array();
-            }));
+            });
 
         $insertStmt->expects($this->once())->method('execute')
-            ->will($this->returnCallback(function () use (&$exception) {
+            ->willReturnCallback(function () use (&$exception) {
                 throw $exception = new \PDOException('', '23');
-            }));
+            });
 
         $storage = new PdoSessionHandler($pdo);
         $result = $storage->read('foo');

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/WriteCheckSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/WriteCheckSessionHandlerTest.php
@@ -30,7 +30,7 @@ class WriteCheckSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('close')
             ->with()
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($writeCheckSessionHandler->close());
@@ -45,7 +45,7 @@ class WriteCheckSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('write')
             ->with('foo', 'bar')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($writeCheckSessionHandler->write('foo', 'bar'));
@@ -60,7 +60,7 @@ class WriteCheckSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('read')
             ->with('foo')
-            ->will($this->returnValue('bar'))
+            ->willReturn('bar')
         ;
 
         $wrappedSessionHandlerMock
@@ -81,14 +81,14 @@ class WriteCheckSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('read')
             ->with('foo')
-            ->will($this->returnValue('bar'))
+            ->willReturn('bar')
         ;
 
         $wrappedSessionHandlerMock
             ->expects($this->once())
             ->method('write')
             ->with('foo', 'baZZZ')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertEquals('bar', $writeCheckSessionHandler->read('foo'));

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -39,7 +39,7 @@ class BundleTest extends TestCase
     {
         $cmd = new FooCommand();
         $app = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
-        $app->expects($this->once())->method('add')->with($this->equalTo($cmd));
+        $app->expects($this->once())->method('add')->with($cmd);
 
         $bundle = new ExtensionPresentBundle();
         $bundle->registerCommands($app);

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -157,7 +157,7 @@ class ClientTest extends TestCase
 
         $file->expects($this->once())
             ->method('getSize')
-            ->will($this->returnValue(INF))
+            ->willReturn(INF)
         ;
 
         $client->request('POST', '/', array(), array($file));

--- a/src/Symfony/Component/HttpKernel/Tests/Config/FileLocatorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Config/FileLocatorTest.php
@@ -23,7 +23,7 @@ class FileLocatorTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('locateResource')
             ->with('@BundleName/some/path', null, true)
-            ->will($this->returnValue('/bundle-name/some/path'));
+            ->willReturn('/bundle-name/some/path');
         $locator = new FileLocator($kernel);
         $this->assertEquals('/bundle-name/some/path', $locator->locate('@BundleName/some/path'));
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
@@ -122,19 +122,19 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->at(0))
             ->method('has')
             ->with(ImpossibleConstructController::class)
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $container->expects($this->at(1))
             ->method('has')
             ->with(ImpossibleConstructController::class)
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $container->expects($this->atLeastOnce())
             ->method('getRemovedIds')
             ->with()
-            ->will($this->returnValue(array(ImpossibleConstructController::class => true)))
+            ->willReturn(array(ImpossibleConstructController::class => true))
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -189,13 +189,13 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->at(0))
             ->method('has')
             ->with('app.my_controller')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $container->expects($this->atLeastOnce())
             ->method('getRemovedIds')
             ->with()
-            ->will($this->returnValue(array('app.my_controller' => true)))
+            ->willReturn(array('app.my_controller' => true))
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -215,12 +215,12 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->once())
             ->method('has')
             ->with('app.my_controller')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $container->expects($this->once())
             ->method('get')
             ->with('app.my_controller')
-            ->will($this->returnValue(new ImpossibleConstructController('toto', 'controller')))
+            ->willReturn(new ImpossibleConstructController('toto', 'controller'))
         ;
 
         $resolver = $this->createControllerResolver(null, $container);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -226,7 +226,7 @@ class ControllerResolverTest extends TestCase
     public function testCreateControllerCanReturnAnyCallable()
     {
         $mock = $this->getMockBuilder('Symfony\Component\HttpKernel\Controller\ControllerResolver')->setMethods(array('createController'))->getMock();
-        $mock->expects($this->once())->method('createController')->will($this->returnValue('Symfony\Component\HttpKernel\Tests\Controller\some_controller_function'));
+        $mock->expects($this->once())->method('createController')->willReturn('Symfony\Component\HttpKernel\Tests\Controller\some_controller_function');
 
         $request = Request::create('/');
         $request->attributes->set('_controller', 'foobar');

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -49,7 +49,7 @@ class TraceableEventDispatcherTest extends TestCase
             ->getMock();
         $stopwatch->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch);
 
@@ -65,7 +65,7 @@ class TraceableEventDispatcherTest extends TestCase
             ->getMock();
         $stopwatch->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $stopwatch->expects($this->once())
             ->method('stop');
         $stopwatch->expects($this->once())
@@ -112,9 +112,9 @@ class TraceableEventDispatcherTest extends TestCase
     protected function getHttpKernel($dispatcher, $controller)
     {
         $controllerResolver = $this->getMockBuilder('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface')->getMock();
-        $controllerResolver->expects($this->once())->method('getController')->will($this->returnValue($controller));
+        $controllerResolver->expects($this->once())->method('getController')->willReturn($controller);
         $argumentResolver = $this->getMockBuilder('Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface')->getMock();
-        $argumentResolver->expects($this->once())->method('getArguments')->will($this->returnValue(array()));
+        $argumentResolver->expects($this->once())->method('getArguments')->willReturn(array());
 
         return new HttpKernel($dispatcher, $controllerResolver, new RequestStack(), $argumentResolver);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
@@ -25,14 +25,14 @@ class LazyLoadingFragmentHandlerTest extends TestCase
     public function testRenderWithLegacyMapping()
     {
         $renderer = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface')->getMock();
-        $renderer->expects($this->once())->method('getName')->will($this->returnValue('foo'));
-        $renderer->expects($this->any())->method('render')->will($this->returnValue(new Response()));
+        $renderer->expects($this->once())->method('getName')->willReturn('foo');
+        $renderer->expects($this->any())->method('render')->willReturn(new Response());
 
         $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
-        $requestStack->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $requestStack->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $container->expects($this->once())->method('get')->will($this->returnValue($renderer));
+        $container->expects($this->once())->method('get')->willReturn($renderer);
 
         $handler = new LazyLoadingFragmentHandler($container, $requestStack, false);
         $handler->addRendererService('foo', 'foo');
@@ -46,15 +46,15 @@ class LazyLoadingFragmentHandlerTest extends TestCase
     public function testRender()
     {
         $renderer = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface')->getMock();
-        $renderer->expects($this->once())->method('getName')->will($this->returnValue('foo'));
-        $renderer->expects($this->any())->method('render')->will($this->returnValue(new Response()));
+        $renderer->expects($this->once())->method('getName')->willReturn('foo');
+        $renderer->expects($this->any())->method('render')->willReturn(new Response());
 
         $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
-        $requestStack->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $requestStack->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         $container = $this->getMockBuilder('Psr\Container\ContainerInterface')->getMock();
         $container->expects($this->once())->method('has')->with('foo')->willReturn(true);
-        $container->expects($this->once())->method('get')->will($this->returnValue($renderer));
+        $container->expects($this->once())->method('get')->willReturn($renderer);
 
         $handler = new LazyLoadingFragmentHandler($container, $requestStack, false);
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
@@ -77,7 +77,7 @@ class AddRequestFormatsListenerTest extends TestCase
 
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
 
         return $event;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -94,7 +94,7 @@ class DebugHandlersListenerTest extends TestCase
         $dispatcher = new EventDispatcher();
         $listener = new DebugHandlersListener(null);
         $app = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
-        $app->expects($this->once())->method('getHelperSet')->will($this->returnValue(new HelperSet()));
+        $app->expects($this->once())->method('getHelperSet')->willReturn(new HelperSet());
         $command = new Command(__FUNCTION__);
         $command->setApplication($app);
         $event = new ConsoleEvent($command, new ArgvInput(), new ConsoleOutput());

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -112,9 +112,9 @@ class ExceptionListenerTest extends TestCase
         $listener = new ExceptionListener('foo', $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock());
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+        $kernel->expects($this->once())->method('handle')->willReturnCallback(function (Request $request) {
             return new Response($request->getRequestFormat());
-        }));
+        });
 
         $request = Request::create('/');
         $request->setRequestFormat('xml');
@@ -130,9 +130,9 @@ class ExceptionListenerTest extends TestCase
     {
         $dispatcher = new EventDispatcher();
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+        $kernel->expects($this->once())->method('handle')->willReturnCallback(function (Request $request) {
             return new Response($request->getRequestFormat());
-        }));
+        });
 
         $listener = new ExceptionListener('foo', $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock(), true);
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -55,7 +55,7 @@ class LocaleListenerTest extends TestCase
         $context->expects($this->once())->method('setParameter')->with('_locale', 'es');
 
         $router = $this->getMockBuilder('Symfony\Component\Routing\Router')->setMethods(array('getContext'))->disableOriginalConstructor()->getMock();
-        $router->expects($this->once())->method('getContext')->will($this->returnValue($context));
+        $router->expects($this->once())->method('getContext')->willReturn($context);
 
         $request = Request::create('/');
 
@@ -71,7 +71,7 @@ class LocaleListenerTest extends TestCase
         $context->expects($this->once())->method('setParameter')->with('_locale', 'es');
 
         $router = $this->getMockBuilder('Symfony\Component\Routing\Router')->setMethods(array('getContext'))->disableOriginalConstructor()->getMock();
-        $router->expects($this->once())->method('getContext')->will($this->returnValue($context));
+        $router->expects($this->once())->method('getContext')->willReturn($context);
 
         $parentRequest = Request::create('/');
         $parentRequest->setLocale('es');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
@@ -37,7 +37,7 @@ class ProfilerListenerTest extends TestCase
 
         $profiler->expects($this->once())
             ->method('collect')
-            ->will($this->returnValue($profile));
+            ->willReturn($profile);
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -49,7 +49,7 @@ class RouterListenerTest extends TestCase
         $context->setHttpsPort($defaultHttpsPort);
         $urlMatcher->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($context));
+            ->willReturn($context);
 
         $listener = new RouterListener($urlMatcher, $this->requestStack);
         $event = $this->createGetResponseEventForUri($uri);
@@ -102,7 +102,7 @@ class RouterListenerTest extends TestCase
         $requestMatcher->expects($this->once())
                        ->method('matchRequest')
                        ->with($this->isInstanceOf('Symfony\Component\HttpFoundation\Request'))
-                       ->will($this->returnValue(array()));
+                       ->willReturn(array());
 
         $listener = new RouterListener($requestMatcher, $this->requestStack, new RequestContext());
         $listener->onKernelRequest($event);
@@ -118,7 +118,7 @@ class RouterListenerTest extends TestCase
         $requestMatcher->expects($this->any())
                        ->method('matchRequest')
                        ->with($this->isInstanceOf('Symfony\Component\HttpFoundation\Request'))
-                       ->will($this->returnValue(array()));
+                       ->willReturn(array());
 
         $context = new RequestContext();
 
@@ -143,12 +143,12 @@ class RouterListenerTest extends TestCase
         $requestMatcher = $this->getMockBuilder('Symfony\Component\Routing\Matcher\RequestMatcherInterface')->getMock();
         $requestMatcher->expects($this->once())
             ->method('matchRequest')
-            ->will($this->returnValue($parameter));
+            ->willReturn($parameter);
 
         $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $logger->expects($this->once())
             ->method('info')
-            ->with($this->equalTo($log), $this->equalTo($parameters));
+            ->with($log, $parameters);
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $request = Request::create('http://localhost/');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -47,7 +47,7 @@ class TestSessionListenerTest extends TestCase
         $this->session = $this->getSession();
         $this->listener->expects($this->any())
              ->method('getSession')
-             ->will($this->returnValue($this->session));
+             ->willReturn($this->session);
     }
 
     public function testShouldSaveMasterRequestSession()
@@ -214,7 +214,7 @@ class TestSessionListenerTest extends TestCase
             ->getMock();
 
         // set return value for getName()
-        $mock->expects($this->any())->method('getName')->will($this->returnValue('MOCKSESSID'));
+        $mock->expects($this->any())->method('getName')->willReturn('MOCKSESSID');
 
         return $mock;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -32,7 +32,7 @@ class FragmentHandlerTest extends TestCase
         $this->requestStack
             ->expects($this->any())
             ->method('getCurrentRequest')
-            ->will($this->returnValue(Request::create('/')))
+            ->willReturn(Request::create('/'))
         ;
     }
 
@@ -79,7 +79,7 @@ class FragmentHandlerTest extends TestCase
         $renderer
             ->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $e = $renderer
             ->expects($this->any())

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -64,9 +64,9 @@ class InlineFragmentRendererTest extends TestCase
         $resolver
             ->expects($this->once())
             ->method('getController')
-            ->will($this->returnValue(function (\stdClass $object, Bar $object1) {
+            ->willReturn(function (\stdClass $object, Bar $object1) {
                 return new Response($object1->getBar());
-            }))
+            })
         ;
 
         $kernel = new HttpKernel(new EventDispatcher(), $resolver, new RequestStack());
@@ -85,9 +85,9 @@ class InlineFragmentRendererTest extends TestCase
         $resolver
             ->expects($this->once())
             ->method('getController')
-            ->will($this->returnValue(function (\stdClass $object, Bar $object1) {
+            ->willReturn(function (\stdClass $object, Bar $object1) {
                 return new Response($object1->getBar());
-            }))
+            })
         ;
 
         $kernel = new HttpKernel(new EventDispatcher(), $resolver, new RequestStack(), new ArgumentResolver());
@@ -162,18 +162,18 @@ class InlineFragmentRendererTest extends TestCase
         $controllerResolver
             ->expects($this->once())
             ->method('getController')
-            ->will($this->returnValue(function () {
+            ->willReturn(function () {
                 ob_start();
                 echo 'bar';
                 throw new \RuntimeException();
-            }))
+            })
         ;
 
         $argumentResolver = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface')->getMock();
         $argumentResolver
             ->expects($this->once())
             ->method('getArguments')
-            ->will($this->returnValue(array()))
+            ->willReturn(array())
         ;
 
         $kernel = new HttpKernel(new EventDispatcher(), $controllerResolver, new RequestStack(), $argumentResolver);
@@ -302,7 +302,7 @@ class InlineFragmentRendererTest extends TestCase
         $kernel
             ->expects($this->once())
             ->method('handle')
-            ->with($this->equalTo($request, 1))
+            ->with($request)
             ->willReturn(new Response('foo'));
 
         return $kernel;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -229,7 +229,7 @@ class EsiTest extends TestCase
         $cache = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpCache\HttpCache')->setMethods(array('getRequest', 'handle'))->disableOriginalConstructor()->getMock();
         $cache->expects($this->any())
               ->method('getRequest')
-              ->will($this->returnValue($request))
+              ->willReturn($request)
         ;
         if (\is_array($response)) {
             $cache->expects($this->any())
@@ -239,7 +239,7 @@ class EsiTest extends TestCase
         } else {
             $cache->expects($this->any())
                   ->method('handle')
-                  ->will($this->returnValue($response))
+                  ->willReturn($response)
             ;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -196,7 +196,7 @@ class SsiTest extends TestCase
         $cache = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpCache\HttpCache')->setMethods(array('getRequest', 'handle'))->disableOriginalConstructor()->getMock();
         $cache->expects($this->any())
               ->method('getRequest')
-              ->will($this->returnValue($request))
+              ->willReturn($request)
         ;
         if (\is_array($response)) {
             $cache->expects($this->any())
@@ -206,7 +206,7 @@ class SsiTest extends TestCase
         } else {
             $cache->expects($this->any())
                   ->method('handle')
-                  ->will($this->returnValue($response))
+                  ->willReturn($response)
             ;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -322,7 +322,7 @@ class HttpKernelTest extends TestCase
         $request = new Request();
 
         $stack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->setMethods(array('push', 'pop'))->getMock();
-        $stack->expects($this->at(0))->method('push')->with($this->equalTo($request));
+        $stack->expects($this->at(0))->method('push')->with($request);
         $stack->expects($this->at(1))->method('pop');
 
         $dispatcher = new EventDispatcher();
@@ -363,13 +363,13 @@ class HttpKernelTest extends TestCase
         $controllerResolver
             ->expects($this->any())
             ->method('getController')
-            ->will($this->returnValue($controller));
+            ->willReturn($controller);
 
         $argumentResolver = $this->getMockBuilder(ArgumentResolverInterface::class)->getMock();
         $argumentResolver
             ->expects($this->any())
             ->method('getArguments')
-            ->will($this->returnValue($arguments));
+            ->willReturn($arguments);
 
         return new HttpKernel($eventDispatcher, $controllerResolver, $requestStack, $argumentResolver);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -72,7 +72,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->assertSame(self::$data, $this->reader->read(self::RES_DIR, 'root'));
     }
@@ -82,12 +82,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$fallbackData));
+            ->willReturn(self::$fallbackData);
 
         $this->assertSame(self::$mergedData, $this->reader->readEntry(self::RES_DIR, 'en', array()));
     }
@@ -97,7 +97,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->assertSame('Bar', $this->reader->readEntry(self::RES_DIR, 'root', array('Entries', 'Foo')));
     }
@@ -110,7 +110,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->reader->readEntry(self::RES_DIR, 'root', array('Entries', 'NonExisting'));
     }
@@ -120,12 +120,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$fallbackData));
+            ->willReturn(self::$fallbackData);
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Entries', 'Bam')));
     }
@@ -138,7 +138,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Entries', 'Bam'), false);
     }
@@ -153,7 +153,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$fallbackData));
+            ->willReturn(self::$fallbackData);
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Entries', 'Bam')));
     }
@@ -193,17 +193,17 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue($childData));
+                ->willReturn($childData);
 
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'root')
-                ->will($this->returnValue($parentData));
+                ->willReturn($parentData);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue($childData));
+                ->willReturn($childData);
         }
 
         $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en', array(), true));
@@ -217,7 +217,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue($childData));
+            ->willReturn($childData);
 
         $this->assertSame($childData, $this->reader->readEntry(self::RES_DIR, 'en_GB', array(), false));
     }
@@ -231,17 +231,17 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $childData))));
+                ->willReturn(array('Foo' => array('Bar' => $childData)));
 
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'root')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $parentData))));
+                ->willReturn(array('Foo' => array('Bar' => $parentData)));
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $childData))));
+                ->willReturn(array('Foo' => array('Bar' => $childData)));
         }
 
         $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en', array('Foo', 'Bar'), true));
@@ -255,12 +255,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(array('Foo' => 'Baz')));
+            ->willReturn(array('Foo' => 'Baz'));
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(array('Foo' => array('Bar' => $parentData))));
+            ->willReturn(array('Foo' => array('Bar' => $parentData)));
 
         $this->assertSame($parentData, $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Foo', 'Bar'), true));
     }
@@ -274,17 +274,17 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $childData))));
+                ->willReturn(array('Foo' => array('Bar' => $childData)));
 
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue(array('Foo' => 'Bar')));
+                ->willReturn(array('Foo' => 'Bar'));
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $childData))));
+                ->willReturn(array('Foo' => array('Bar' => $childData)));
         }
 
         $this->assertSame($childData, $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Foo', 'Bar'), true));
@@ -298,12 +298,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(array('Foo' => 'Baz')));
+            ->willReturn(array('Foo' => 'Baz'));
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(array('Foo' => 'Bar')));
+            ->willReturn(array('Foo' => 'Bar'));
 
         $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Foo', 'Bar'), true);
     }
@@ -320,17 +320,17 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $childData))));
+                ->willReturn(array('Foo' => array('Bar' => $childData)));
 
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $parentData))));
+                ->willReturn(array('Foo' => array('Bar' => $parentData)));
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $childData))));
+                ->willReturn(array('Foo' => array('Bar' => $childData)));
         }
 
         $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Foo', 'Bar'), true));
@@ -347,18 +347,18 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'ro_MD')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $childData))));
+                ->willReturn(array('Foo' => array('Bar' => $childData)));
 
             // Read fallback locale of aliased locale ("ro_MD" -> "ro")
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'ro')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $parentData))));
+                ->willReturn(array('Foo' => array('Bar' => $parentData)));
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'ro_MD')
-                ->will($this->returnValue(array('Foo' => array('Bar' => $childData))));
+                ->willReturn(array('Foo' => array('Bar' => $childData)));
         }
 
         $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'mo', array('Foo', 'Bar'), true));

--- a/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
@@ -70,7 +70,7 @@ class LdapClientTest extends LdapTestCase
         $collection
             ->expects($this->once())
             ->method('getIterator')
-            ->will($this->returnValue(new \ArrayIterator(array(
+            ->willReturn(new \ArrayIterator(array(
                 new Entry('cn=qux,dc=foo,dc=com', array(
                     'cn' => array('qux'),
                     'dc' => array('com', 'foo'),
@@ -81,13 +81,13 @@ class LdapClientTest extends LdapTestCase
                     'dc' => array('com', 'foo'),
                     'givenName' => array('Baz'),
                 )),
-            ))))
+            )))
         ;
         $query = $this->getMockBuilder(QueryInterface::class)->getMock();
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($collection))
+            ->willReturn($collection)
         ;
         $this->ldap
             ->expects($this->once())

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -42,7 +42,7 @@ class LdapTest extends TestCase
         $this->adapter
             ->expects($this->once())
             ->method('getConnection')
-            ->will($this->returnValue($connection))
+            ->willReturn($connection)
         ;
         $this->ldap->bind('foo', 'bar');
     }

--- a/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
@@ -27,7 +27,7 @@ class ProcessFailedExceptionTest extends TestCase
         $process = $this->getMockBuilder('Symfony\Component\Process\Process')->setMethods(array('isSuccessful'))->setConstructorArgs(array('php'))->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         if (method_exists($this, 'expectException')) {
             $this->expectException(\InvalidArgumentException::class);
@@ -55,31 +55,31 @@ class ProcessFailedExceptionTest extends TestCase
         $process = $this->getMockBuilder('Symfony\Component\Process\Process')->setMethods(array('isSuccessful', 'getOutput', 'getErrorOutput', 'getExitCode', 'getExitCodeText', 'isOutputDisabled', 'getWorkingDirectory'))->setConstructorArgs(array($cmd))->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $process->expects($this->once())
             ->method('getOutput')
-            ->will($this->returnValue($output));
+            ->willReturn($output);
 
         $process->expects($this->once())
             ->method('getErrorOutput')
-            ->will($this->returnValue($errorOutput));
+            ->willReturn($errorOutput);
 
         $process->expects($this->once())
             ->method('getExitCode')
-            ->will($this->returnValue($exitCode));
+            ->willReturn($exitCode);
 
         $process->expects($this->once())
             ->method('getExitCodeText')
-            ->will($this->returnValue($exitText));
+            ->willReturn($exitText);
 
         $process->expects($this->once())
             ->method('isOutputDisabled')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $process->expects($this->once())
             ->method('getWorkingDirectory')
-            ->will($this->returnValue($workingDirectory));
+            ->willReturn($workingDirectory);
 
         $exception = new ProcessFailedException($process);
 
@@ -103,7 +103,7 @@ class ProcessFailedExceptionTest extends TestCase
         $process = $this->getMockBuilder('Symfony\Component\Process\Process')->setMethods(array('isSuccessful', 'isOutputDisabled', 'getExitCode', 'getExitCodeText', 'getOutput', 'getErrorOutput', 'getWorkingDirectory'))->setConstructorArgs(array($cmd))->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $process->expects($this->never())
             ->method('getOutput');
@@ -113,19 +113,19 @@ class ProcessFailedExceptionTest extends TestCase
 
         $process->expects($this->once())
             ->method('getExitCode')
-            ->will($this->returnValue($exitCode));
+            ->willReturn($exitCode);
 
         $process->expects($this->once())
             ->method('getExitCodeText')
-            ->will($this->returnValue($exitText));
+            ->willReturn($exitText);
 
         $process->expects($this->once())
             ->method('isOutputDisabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $process->expects($this->once())
             ->method('getWorkingDirectory')
-            ->will($this->returnValue($workingDirectory));
+            ->willReturn($workingDirectory);
 
         $exception = new ProcessFailedException($process);
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -128,11 +128,11 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
         $car->expects($this->any())
             ->method('getStructure')
-            ->will($this->returnValue($structure));
+            ->willReturn($structure);
 
         $structure->expects($this->at(0))
             ->method('getAxes')
-            ->will($this->returnValue($axesBefore));
+            ->willReturn($axesBefore);
         $structure->expects($this->at(1))
             ->method('removeAxis')
             ->with('fourth');
@@ -158,7 +158,7 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
         $car->expects($this->any())
             ->method('getAxes')
-            ->will($this->returnValue($axesBefore));
+            ->willReturn($axesBefore);
 
         $this->propertyAccessor->setValue($car, 'axes', $axesAfter);
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
@@ -89,7 +89,7 @@ class ObjectRouteLoaderTest extends TestCase
             ->getMock();
         $service->expects($this->once())
             ->method('loadRoutes')
-            ->will($this->returnValue('NOT_A_COLLECTION'));
+            ->willReturn('NOT_A_COLLECTION');
 
         $loader = new ObjectRouteLoaderForTest();
         $loader->loaderMap = array('my_service' => $service);

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -28,7 +28,7 @@ class RouteCollectionBuilderTest extends TestCase
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('admin_routing.yml', 'yaml')
-            ->will($this->returnValue($resolvedLoader));
+            ->willReturn($resolvedLoader);
 
         $originalRoute = new Route('/foo/path');
         $expectedCollection = new RouteCollection();
@@ -39,12 +39,12 @@ class RouteCollectionBuilderTest extends TestCase
             ->expects($this->once())
             ->method('load')
             ->with('admin_routing.yml', 'yaml')
-            ->will($this->returnValue($expectedCollection));
+            ->willReturn($expectedCollection);
 
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
         $loader->expects($this->any())
             ->method('getResolver')
-            ->will($this->returnValue($resolver));
+            ->willReturn($resolver);
 
         // import the file!
         $routes = new RouteCollectionBuilder($loader);
@@ -107,11 +107,11 @@ class RouteCollectionBuilderTest extends TestCase
         // make this loader able to do the import - keeps mocking simple
         $loader->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $loader
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($importedCollection));
+            ->willReturn($importedCollection);
 
         $routes = new RouteCollectionBuilder($loader);
 
@@ -296,11 +296,11 @@ class RouteCollectionBuilderTest extends TestCase
         // make this loader able to do the import - keeps mocking simple
         $loader->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $loader
             ->expects($this->any())
             ->method('load')
-            ->will($this->returnValue($importedCollection));
+            ->willReturn($importedCollection);
         // import this from the /admin route builder
         $adminRoutes->import('admin.yml', '/imported');
 
@@ -347,11 +347,11 @@ class RouteCollectionBuilderTest extends TestCase
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
         $loader->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $loader
             ->expects($this->any())
             ->method('load')
-            ->will($this->returnValue(array($firstCollection, $secondCollection)));
+            ->willReturn(array($firstCollection, $secondCollection));
 
         $routeCollectionBuilder = new RouteCollectionBuilder($loader);
         $routeCollectionBuilder->import('/directory/recurse/*', '/other/', 'glob');

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -139,7 +139,7 @@ class AuthenticationProviderManagerTest extends TestCase
         $dispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with(AuthenticationEvents::AUTHENTICATION_FAILURE, $this->equalTo(new AuthenticationFailureEvent($token, $exception)));
+            ->with(AuthenticationEvents::AUTHENTICATION_FAILURE, new AuthenticationFailureEvent($token, $exception));
 
         $manager = new AuthenticationProviderManager(array($provider));
         $manager->setEventDispatcher($dispatcher);
@@ -164,7 +164,7 @@ class AuthenticationProviderManagerTest extends TestCase
         $dispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with(AuthenticationEvents::AUTHENTICATION_SUCCESS, $this->equalTo(new AuthenticationEvent($token)));
+            ->with(AuthenticationEvents::AUTHENTICATION_SUCCESS, new AuthenticationEvent($token));
 
         $manager = new AuthenticationProviderManager(array($provider));
         $manager->setEventDispatcher($dispatcher);
@@ -177,13 +177,13 @@ class AuthenticationProviderManagerTest extends TestCase
         $provider = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface')->getMock();
         $provider->expects($this->once())
                  ->method('supports')
-                 ->will($this->returnValue($supports))
+                 ->willReturn($supports)
         ;
 
         if (null !== $token) {
             $provider->expects($this->once())
                      ->method('authenticate')
-                     ->will($this->returnValue($token))
+                     ->willReturn($token)
             ;
         } elseif (null !== $exception) {
             $provider->expects($this->once())

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
@@ -58,7 +58,7 @@ class AnonymousAuthenticationProviderTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setMethods(array('getSecret'))->disableOriginalConstructor()->getMock();
         $token->expects($this->any())
               ->method('getSecret')
-              ->will($this->returnValue($secret))
+              ->willReturn($secret)
         ;
 
         return $token;

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -95,7 +95,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $userProvider = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface')->getMock();
         $userProvider->expects($this->once())
                      ->method('loadUserByUsername')
-                     ->will($this->returnValue($user))
+                     ->willReturn($user)
         ;
 
         $provider = new DaoAuthenticationProvider($userProvider, $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface')->getMock(), 'key', $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface')->getMock());
@@ -140,7 +140,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $encoder
             ->expects($this->once())
             ->method('isPasswordValid')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $provider = $this->getProvider(null, null, $encoder);
@@ -169,7 +169,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $encoder = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\PasswordEncoderInterface')->getMock();
         $encoder->expects($this->once())
                 ->method('isPasswordValid')
-                ->will($this->returnValue(false))
+                ->willReturn(false)
         ;
 
         $provider = $this->getProvider(null, null, $encoder);
@@ -193,7 +193,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getPassword')
-             ->will($this->returnValue('foo'))
+             ->willReturn('foo')
         ;
 
         $token = $this->getSupportedToken();
@@ -204,7 +204,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $dbUser = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $dbUser->expects($this->once())
                ->method('getPassword')
-               ->will($this->returnValue('newFoo'))
+               ->willReturn('newFoo')
         ;
 
         $provider = $this->getProvider();
@@ -218,7 +218,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getPassword')
-             ->will($this->returnValue('foo'))
+             ->willReturn('foo')
         ;
 
         $token = $this->getSupportedToken();
@@ -229,7 +229,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $dbUser = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $dbUser->expects($this->once())
                ->method('getPassword')
-               ->will($this->returnValue('foo'))
+               ->willReturn('foo')
         ;
 
         $provider = $this->getProvider();
@@ -243,7 +243,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $encoder = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\PasswordEncoderInterface')->getMock();
         $encoder->expects($this->once())
                 ->method('isPasswordValid')
-                ->will($this->returnValue(true))
+                ->willReturn(true)
         ;
 
         $provider = $this->getProvider(null, null, $encoder);
@@ -265,7 +265,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $mock
             ->expects($this->any())
             ->method('getProviderKey')
-            ->will($this->returnValue('key'))
+            ->willReturn('key')
         ;
 
         return $mock;
@@ -277,7 +277,7 @@ class DaoAuthenticationProviderTest extends TestCase
         if (null !== $user) {
             $userProvider->expects($this->once())
                          ->method('loadUserByUsername')
-                         ->will($this->returnValue($user))
+                         ->willReturn($user)
             ;
         }
 
@@ -293,7 +293,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $encoderFactory
             ->expects($this->any())
             ->method('getEncoder')
-            ->will($this->returnValue($passwordEncoder))
+            ->willReturn($passwordEncoder)
         ;
 
         return new DaoAuthenticationProvider($userProvider, $userChecker, 'key', $encoderFactory);

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
@@ -113,7 +113,7 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($collection))
+            ->willReturn($collection)
         ;
 
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
@@ -121,13 +121,13 @@ class LdapBindAuthenticationProviderTest extends TestCase
             ->expects($this->once())
             ->method('escape')
             ->with('foo', '')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
             ->with('{username}', 'foobar')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
         $userChecker = $this->getMockBuilder(UserCheckerInterface::class)->getMock();
 
@@ -153,14 +153,14 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($collection))
+            ->willReturn($collection)
         ;
 
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
         $userChecker = $this->getMockBuilder(UserCheckerInterface::class)->getMock();
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -31,7 +31,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getProviderKey')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $this->assertFalse($provider->supports($token));
     }
@@ -62,7 +62,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue(array()))
+            ->willReturn(array())
         ;
         $provider = $this->getProvider($user);
 
@@ -99,20 +99,20 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         if (false !== $user) {
             $token->expects($this->once())
                   ->method('getUser')
-                  ->will($this->returnValue($user))
+                  ->willReturn($user)
             ;
         }
         if (false !== $credentials) {
             $token->expects($this->once())
                   ->method('getCredentials')
-                  ->will($this->returnValue($credentials))
+                  ->willReturn($credentials)
             ;
         }
 
         $token
             ->expects($this->any())
             ->method('getProviderKey')
-            ->will($this->returnValue('key'))
+            ->willReturn('key')
         ;
 
         $token->setAttributes(array('foo' => 'bar'));
@@ -126,7 +126,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         if (null !== $user) {
             $userProvider->expects($this->once())
                          ->method('loadUserByUsername')
-                         ->will($this->returnValue($user))
+                         ->willReturn($user)
             ;
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -69,7 +69,7 @@ class RememberMeAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $user->expects($this->exactly(2))
              ->method('getRoles')
-             ->will($this->returnValue(array('ROLE_FOO')));
+             ->willReturn(array('ROLE_FOO'));
 
         $provider = $this->getProvider();
 
@@ -89,14 +89,14 @@ class RememberMeAuthenticationProviderTest extends TestCase
             $user
                 ->expects($this->any())
                 ->method('getRoles')
-                ->will($this->returnValue(array()));
+                ->willReturn(array());
         }
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(array('getProviderKey'))->setConstructorArgs(array($user, 'foo', $secret))->getMock();
         $token
             ->expects($this->once())
             ->method('getProviderKey')
-            ->will($this->returnValue('foo'));
+            ->willReturn('foo');
 
         return $token;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
@@ -29,7 +29,7 @@ class SimpleAuthenticationProviderTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
         $userChecker->expects($this->once())
@@ -39,7 +39,7 @@ class SimpleAuthenticationProviderTest extends TestCase
         $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
         $authenticator->expects($this->once())
             ->method('authenticateToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $provider = $this->getProvider($authenticator, null, $userChecker);
 
@@ -56,7 +56,7 @@ class SimpleAuthenticationProviderTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
         $userChecker->expects($this->once())
@@ -66,7 +66,7 @@ class SimpleAuthenticationProviderTest extends TestCase
         $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
         $authenticator->expects($this->once())
             ->method('authenticateToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $provider = $this->getProvider($authenticator, null, $userChecker);
 
@@ -78,11 +78,11 @@ class SimpleAuthenticationProviderTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue('string-user'));
+            ->willReturn('string-user');
         $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
         $authenticator->expects($this->once())
             ->method('authenticateToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $this->assertSame($token, $this->getProvider($authenticator, null, new UserChecker())->authenticate($token));
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -165,7 +165,7 @@ class UserAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getRoles')
-             ->will($this->returnValue(array('ROLE_FOO')))
+             ->willReturn(array('ROLE_FOO'))
         ;
 
         $provider = $this->getProvider();
@@ -199,7 +199,7 @@ class UserAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getRoles')
-             ->will($this->returnValue(array('ROLE_FOO')))
+             ->willReturn(array('ROLE_FOO'))
         ;
 
         $provider = $this->getProvider();
@@ -236,7 +236,7 @@ class UserAuthenticationProviderTest extends TestCase
         $mock
             ->expects($this->any())
             ->method('getProviderKey')
-            ->will($this->returnValue('key'))
+            ->willReturn('key')
         ;
 
         $mock->setAttributes(array('foo' => 'bar'));

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -59,7 +59,7 @@ class RememberMeTokenTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue($roles))
+            ->willReturn($roles)
         ;
 
         return $user;

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -72,10 +72,10 @@ class AccessDecisionManagerTest extends TestCase
         $voter = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface')->getMock();
         $voter->expects($this->any())
               ->method('vote')
-              ->will($this->returnValueMap(array(
+              ->willReturnMap(array(
                   array($token, null, array('ROLE_FOO'), $vote1),
                   array($token, null, array('ROLE_BAR'), $vote2),
-              )))
+              ))
         ;
 
         return $voter;
@@ -137,7 +137,7 @@ class AccessDecisionManagerTest extends TestCase
         $voter = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface')->getMock();
         $voter->expects($this->any())
               ->method('vote')
-              ->will($this->returnValue($vote));
+              ->willReturn($vote);
 
         return $voter;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -83,7 +83,7 @@ class AuthorizationCheckerTest extends TestCase
         $token
             ->expects($this->once())
             ->method('isAuthenticated')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->accessDecisionManager
             ->expects($this->once())

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
@@ -51,7 +51,7 @@ class ExpressionVoterTest extends TestCase
         if ($tokenExpectsGetRoles) {
             $token->expects($this->once())
                 ->method('getRoles')
-                ->will($this->returnValue($roles));
+                ->willReturn($roles);
         }
 
         return $token;
@@ -64,7 +64,7 @@ class ExpressionVoterTest extends TestCase
         if ($expressionLanguageExpectsEvaluate) {
             $mock->expects($this->once())
                 ->method('evaluate')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         }
 
         return $mock;

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
@@ -54,7 +54,7 @@ class RoleVoterTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token->expects($this->once())
               ->method('getRoles')
-              ->will($this->returnValue($roles));
+              ->willReturn($roles);
 
         return $token;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
@@ -21,19 +21,19 @@ class UserPasswordEncoderTest extends TestCase
         $userMock = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $userMock->expects($this->any())
             ->method('getSalt')
-            ->will($this->returnValue('userSalt'));
+            ->willReturn('userSalt');
 
         $mockEncoder = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')->getMock();
         $mockEncoder->expects($this->any())
             ->method('encodePassword')
-            ->with($this->equalTo('plainPassword'), $this->equalTo('userSalt'))
-            ->will($this->returnValue('encodedPassword'));
+            ->with('plainPassword', 'userSalt')
+            ->willReturn('encodedPassword');
 
         $mockEncoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
         $mockEncoderFactory->expects($this->any())
             ->method('getEncoder')
-            ->with($this->equalTo($userMock))
-            ->will($this->returnValue($mockEncoder));
+            ->with($userMock)
+            ->willReturn($mockEncoder);
 
         $passwordEncoder = new UserPasswordEncoder($mockEncoderFactory);
 
@@ -46,22 +46,22 @@ class UserPasswordEncoderTest extends TestCase
         $userMock = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $userMock->expects($this->any())
             ->method('getSalt')
-            ->will($this->returnValue('userSalt'));
+            ->willReturn('userSalt');
         $userMock->expects($this->any())
             ->method('getPassword')
-            ->will($this->returnValue('encodedPassword'));
+            ->willReturn('encodedPassword');
 
         $mockEncoder = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')->getMock();
         $mockEncoder->expects($this->any())
             ->method('isPasswordValid')
-            ->with($this->equalTo('encodedPassword'), $this->equalTo('plainPassword'), $this->equalTo('userSalt'))
-            ->will($this->returnValue(true));
+            ->with('encodedPassword', 'plainPassword', 'userSalt')
+            ->willReturn(true);
 
         $mockEncoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
         $mockEncoderFactory->expects($this->any())
             ->method('getEncoder')
-            ->with($this->equalTo($userMock))
-            ->will($this->returnValue($mockEncoder));
+            ->with($userMock)
+            ->willReturn($mockEncoder);
 
         $passwordEncoder = new UserPasswordEncoder($mockEncoderFactory);
 

--- a/src/Symfony/Component/Security/Core/Tests/SecurityTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/SecurityTest.php
@@ -29,7 +29,7 @@ class SecurityTest extends TestCase
 
         $tokenStorage->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $container = $this->createContainer('security.token_storage', $tokenStorage);
 
@@ -45,12 +45,12 @@ class SecurityTest extends TestCase
         $token = $this->getMockBuilder(TokenInterface::class)->getMock();
         $token->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($userInToken));
+            ->willReturn($userInToken);
         $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
 
         $tokenStorage->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $container = $this->createContainer('security.token_storage', $tokenStorage);
 
@@ -75,7 +75,7 @@ class SecurityTest extends TestCase
         $authorizationChecker->expects($this->once())
             ->method('isGranted')
             ->with('SOME_ATTRIBUTE', 'SOME_SUBJECT')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $container = $this->createContainer('security.authorization_checker', $authorizationChecker);
 
@@ -90,7 +90,7 @@ class SecurityTest extends TestCase
         $container->expects($this->atLeastOnce())
             ->method('get')
             ->with($serviceId)
-            ->will($this->returnValue($serviceObject));
+            ->willReturn($serviceObject);
 
         return $container;
     }

--- a/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
@@ -50,23 +50,23 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(0))
+            ->willReturn(0)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
@@ -83,23 +83,23 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(2))
+            ->willReturn(2)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
@@ -116,33 +116,33 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', array(
+            ->willReturn(new Entry('foo', array(
                     'sAMAccountName' => array('foo'),
                     'userpassword' => array('bar', 'baz'),
                 )
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, array(), 'sAMAccountName', '({uid_key}={username})', 'userpassword');
@@ -159,29 +159,29 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', array())))
+            ->willReturn(new Entry('foo', array()))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, array(), 'sAMAccountName', '({uid_key}={username})');
@@ -201,32 +201,32 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', array(
+            ->willReturn(new Entry('foo', array(
                     'sAMAccountName' => array('foo'),
                 )
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, array(), 'sAMAccountName', '({uid_key}={username})', 'userpassword');
@@ -243,32 +243,32 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', array(
+            ->willReturn(new Entry('foo', array(
                     'sAMAccountName' => array('foo'),
                 )
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
@@ -285,32 +285,32 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', array(
+            ->willReturn(new Entry('foo', array(
                     'sAMAccountName' => array('foo'),
                 )
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('Foo'))
+            ->willReturn('Foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
@@ -324,33 +324,33 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', array(
+            ->willReturn(new Entry('foo', array(
                     'sAMAccountName' => array('foo'),
                     'userpassword' => array('bar'),
                 )
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, array(), 'sAMAccountName', '({uid_key}={username})', 'userpassword');

--- a/src/Symfony/Component/Security/Core/Tests/User/UserCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/UserCheckerTest.php
@@ -28,7 +28,7 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isCredentialsNonExpired')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isCredentialsNonExpired')->willReturn(true);
 
         $this->assertNull($checker->checkPostAuth($account));
     }
@@ -41,7 +41,7 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isCredentialsNonExpired')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isCredentialsNonExpired')->willReturn(false);
 
         $checker->checkPostAuth($account);
     }
@@ -58,9 +58,9 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isEnabled')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isAccountNonExpired')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isAccountNonLocked')->willReturn(true);
+        $account->expects($this->once())->method('isEnabled')->willReturn(true);
+        $account->expects($this->once())->method('isAccountNonExpired')->willReturn(true);
 
         $this->assertNull($checker->checkPreAuth($account));
     }
@@ -73,7 +73,7 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isAccountNonLocked')->willReturn(false);
 
         $checker->checkPreAuth($account);
     }
@@ -86,8 +86,8 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isEnabled')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isAccountNonLocked')->willReturn(true);
+        $account->expects($this->once())->method('isEnabled')->willReturn(false);
 
         $checker->checkPreAuth($account);
     }
@@ -100,9 +100,9 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isEnabled')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isAccountNonExpired')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isAccountNonLocked')->willReturn(true);
+        $account->expects($this->once())->method('isEnabled')->willReturn(true);
+        $account->expects($this->once())->method('isAccountNonExpired')->willReturn(false);
 
         $checker->checkPreAuth($account);
     }

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -50,8 +50,8 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->with($this->equalTo($this->request))
-            ->will($this->returnValue($credentials));
+            ->with($this->request)
+            ->willReturn($credentials);
 
         // a clone of the token that should be created internally
         $uniqueGuardKey = 'my_firewall_0';
@@ -133,13 +133,13 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('supports')
-            ->with($this->equalTo($this->request))
+            ->with($this->request)
             ->willReturn(true);
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->with($this->equalTo($this->request))
-            ->will($this->returnValue(array('username' => 'anything_not_empty')));
+            ->with($this->request)
+            ->willReturn(array('username' => 'anything_not_empty'));
 
         $this->authenticationManager
             ->expects($this->once())
@@ -163,7 +163,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $listener->setRememberMeServices($this->rememberMeServices);
         $authenticator->expects($this->once())
             ->method('supportsRememberMe')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         // should be called - we do have a success Response
         $this->rememberMeServices
             ->expects($this->once())
@@ -219,7 +219,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticatorA
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         // this is not called
         $this->authenticationManager
@@ -255,8 +255,8 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->with($this->equalTo($this->request))
-            ->will($this->returnValue($credentials));
+            ->with($this->request)
+            ->willReturn($credentials);
 
         // a clone of the token that should be created internally
         $uniqueGuardKey = 'my_firewall_0';
@@ -307,11 +307,11 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticatorA
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $authenticatorB
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         // this is not called
         $this->authenticationManager
@@ -341,7 +341,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('supports')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         // this is not called
         $authenticator
@@ -370,13 +370,13 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         // this will raise exception
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $listener = new GuardAuthenticationListener(
             $this->guardAuthenticatorHandler,
@@ -401,13 +401,13 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         // this will raise exception
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $listener = new GuardAuthenticationListener(
             $this->guardAuthenticatorHandler,
@@ -439,7 +439,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $this->event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($this->request));
+            ->willReturn($this->request);
 
         $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $this->rememberMeServices = $this->getMockBuilder('Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface')->getMock();

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -90,7 +90,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
             ->getMock();
         $token->expects($this->any())
             ->method('getProviderKey')
-            ->will($this->returnValue($tokenProviderKey));
+            ->willReturn($tokenProviderKey);
 
         $this->tokenStorage->expects($this->never())
             ->method('setToken')

--- a/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
@@ -61,18 +61,18 @@ class GuardAuthenticationProviderTest extends TestCase
         $authenticatorB->expects($this->once())
             ->method('getUser')
             ->with($enteredCredentials, $this->userProvider)
-            ->will($this->returnValue($mockedUser));
+            ->willReturn($mockedUser);
         // checkCredentials is called
         $authenticatorB->expects($this->once())
             ->method('checkCredentials')
             ->with($enteredCredentials, $mockedUser)
             // authentication works!
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $authedToken = $this->getMockBuilder(TokenInterface::class)->getMock();
         $authenticatorB->expects($this->once())
             ->method('createAuthenticatedToken')
             ->with($mockedUser, $providerKey)
-            ->will($this->returnValue($authedToken));
+            ->willReturn($authedToken);
 
         // user checker should be called
         $this->userChecker->expects($this->once())
@@ -123,18 +123,18 @@ class GuardAuthenticationProviderTest extends TestCase
         $authenticatorB->expects($this->once())
             ->method('getUser')
             ->with($enteredCredentials, $this->userProvider)
-            ->will($this->returnValue($mockedUser));
+            ->willReturn($mockedUser);
         // checkCredentials is called
         $authenticatorB->expects($this->once())
             ->method('checkCredentials')
             ->with($enteredCredentials, $mockedUser)
             // authentication works!
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $authedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $authenticatorB->expects($this->once())
             ->method('createAuthenticatedToken')
             ->with($mockedUser, $providerKey)
-            ->will($this->returnValue($authedToken));
+            ->willReturn($authedToken);
 
         // user checker should be called
         $this->userChecker->expects($this->once())
@@ -171,12 +171,12 @@ class GuardAuthenticationProviderTest extends TestCase
         $mockedUser = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $authenticator->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($mockedUser));
+            ->willReturn($mockedUser);
         // checkCredentials is called
         $authenticator->expects($this->once())
             ->method('checkCredentials')
             // authentication fails :(
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $provider = new GuardAuthenticationProvider(array($authenticator), $this->userProvider, $providerKey, $this->userChecker);
         $provider->authenticate($this->preAuthenticationToken);

--- a/src/Symfony/Component/Security/Http/Tests/AccessMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessMapTest.php
@@ -45,7 +45,7 @@ class AccessMapTest extends TestCase
         $requestMatcher = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestMatcherInterface')->getMock();
         $requestMatcher->expects($this->once())
             ->method('matches')->with($request)
-            ->will($this->returnValue($matches));
+            ->willReturn($matches);
 
         return $requestMatcher;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -34,7 +34,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
         $this->session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
         $this->request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
-        $this->request->expects($this->any())->method('getSession')->will($this->returnValue($this->session));
+        $this->request->expects($this->any())->method('getSession')->willReturn($this->session);
         $this->exception = $this->getMockBuilder('Symfony\Component\Security\Core\Exception\AuthenticationException')->setMethods(array('getMessage'))->getMock();
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -24,7 +24,7 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     public function testRequestRedirections(Request $request, $options, $redirectedUrl)
     {
         $urlGenerator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
-        $urlGenerator->expects($this->any())->method('generate')->will($this->returnValue('http://localhost/login'));
+        $urlGenerator->expects($this->any())->method('generate')->willReturn('http://localhost/login');
         $httpUtils = new HttpUtils($urlGenerator);
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $handler = new DefaultAuthenticationSuccessHandler($httpUtils, $options);
@@ -37,7 +37,7 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     public function getRequestRedirections()
     {
         $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
-        $session->expects($this->once())->method('get')->with('_security.admin.target_path')->will($this->returnValue('/admin/dashboard'));
+        $session->expects($this->once())->method('get')->with('_security.admin.target_path')->willReturn('/admin/dashboard');
         $session->expects($this->once())->method('remove')->with('_security.admin.target_path');
         $requestWithSession = Request::create('/');
         $requestWithSession->setSession($session);

--- a/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
@@ -28,8 +28,8 @@ class FormAuthenticationEntryPointTest extends TestCase
         $httpUtils
             ->expects($this->once())
             ->method('createRedirectResponse')
-            ->with($this->equalTo($request), $this->equalTo('/the/login/path'))
-            ->will($this->returnValue($response))
+            ->with($request, '/the/login/path')
+            ->willReturn($response)
         ;
 
         $entryPoint = new FormAuthenticationEntryPoint($httpKernel, $httpUtils, '/the/login/path', false);
@@ -47,16 +47,16 @@ class FormAuthenticationEntryPointTest extends TestCase
         $httpUtils
             ->expects($this->once())
             ->method('createRequest')
-            ->with($this->equalTo($request), $this->equalTo('/the/login/path'))
-            ->will($this->returnValue($subRequest))
+            ->with($request, '/the/login/path')
+            ->willReturn($subRequest)
         ;
 
         $httpKernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $httpKernel
             ->expects($this->once())
             ->method('handle')
-            ->with($this->equalTo($subRequest), $this->equalTo(HttpKernelInterface::SUB_REQUEST))
-            ->will($this->returnValue($response))
+            ->with($subRequest, HttpKernelInterface::SUB_REQUEST)
+            ->willReturn($response)
         ;
 
         $entryPoint = new FormAuthenticationEntryPoint($httpKernel, $httpUtils, '/the/login/path', true);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
@@ -31,12 +31,12 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($token))
+            ->with($token)
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -44,7 +44,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken'))
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $listener = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener', array(
@@ -55,13 +55,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -77,7 +77,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->never())
@@ -101,13 +101,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -125,7 +125,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
         $tokenStorage
             ->expects($this->never())
@@ -149,13 +149,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -173,7 +173,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -190,13 +190,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -214,12 +214,12 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo(null))
+            ->with(null)
         ;
 
         $exception = new AuthenticationException('Authentication failed.');
@@ -239,13 +239,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -27,30 +27,30 @@ class AccessListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array('foo' => 'bar'), null)))
+            ->with($request)
+            ->willReturn(array(array('foo' => 'bar'), null))
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $accessDecisionManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock();
         $accessDecisionManager
             ->expects($this->once())
             ->method('decide')
-            ->with($this->equalTo($token), $this->equalTo(array('foo' => 'bar')), $this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->with($token, array('foo' => 'bar'), $request)
+            ->willReturn(false)
         ;
 
         $listener = new AccessListener(
@@ -64,7 +64,7 @@ class AccessListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -78,50 +78,50 @@ class AccessListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array('foo' => 'bar'), null)))
+            ->with($request)
+            ->willReturn(array(array('foo' => 'bar'), null))
         ;
 
         $notAuthenticatedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $notAuthenticatedToken
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $authenticatedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $authenticatedToken
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $authManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
         $authManager
             ->expects($this->once())
             ->method('authenticate')
-            ->with($this->equalTo($notAuthenticatedToken))
-            ->will($this->returnValue($authenticatedToken))
+            ->with($notAuthenticatedToken)
+            ->willReturn($authenticatedToken)
         ;
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($notAuthenticatedToken))
+            ->willReturn($notAuthenticatedToken)
         ;
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($authenticatedToken))
+            ->with($authenticatedToken)
         ;
 
         $accessDecisionManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock();
         $accessDecisionManager
             ->expects($this->once())
             ->method('decide')
-            ->with($this->equalTo($authenticatedToken), $this->equalTo(array('foo' => 'bar')), $this->equalTo($request))
-            ->will($this->returnValue(true))
+            ->with($authenticatedToken, array('foo' => 'bar'), $request)
+            ->willReturn(true)
         ;
 
         $listener = new AccessListener(
@@ -135,7 +135,7 @@ class AccessListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -149,8 +149,8 @@ class AccessListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(null, null)))
+            ->with($request)
+            ->willReturn(array(null, null))
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
@@ -163,7 +163,7 @@ class AccessListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $listener = new AccessListener(
@@ -177,7 +177,7 @@ class AccessListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -192,7 +192,7 @@ class AccessListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $listener = new AccessListener(

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -23,7 +23,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock())
         ;
         $tokenStorage
             ->expects($this->never())
@@ -46,7 +46,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $anonymousToken = new AnonymousToken('TheSecret', 'anon.', array());
@@ -58,7 +58,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
             ->with($this->callback(function ($token) {
                 return 'TheSecret' === $token->getSecret();
             }))
-            ->will($this->returnValue($anonymousToken))
+            ->willReturn($anonymousToken)
         ;
 
         $tokenStorage

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
@@ -34,12 +34,12 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo($token))
+            ->with($token)
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -47,7 +47,7 @@ class BasicAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken'))
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -61,7 +61,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -80,7 +80,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->never())
@@ -93,8 +93,8 @@ class BasicAuthenticationListenerTest extends TestCase
         $authenticationEntryPoint
             ->expects($this->any())
             ->method('start')
-            ->with($this->equalTo($request), $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
-            ->will($this->returnValue($response))
+            ->with($request, $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
+            ->willReturn($response)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -108,12 +108,12 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with($this->equalTo($response))
+            ->with($response)
         ;
 
         $listener->handle($event);
@@ -140,7 +140,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -156,7 +156,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -176,7 +176,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -209,7 +209,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
         $tokenStorage
             ->expects($this->never())
@@ -222,8 +222,8 @@ class BasicAuthenticationListenerTest extends TestCase
         $authenticationEntryPoint
             ->expects($this->any())
             ->method('start')
-            ->with($this->equalTo($request), $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
-            ->will($this->returnValue($response))
+            ->with($request, $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
+            ->willReturn($response)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -237,12 +237,12 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with($this->equalTo($response))
+            ->with($response)
         ;
 
         $listener->handle($event);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
@@ -23,15 +23,15 @@ class ChannelListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('isSecure')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array(), 'http')))
+            ->with($request)
+            ->willReturn(array(array(), 'http'))
         ;
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
@@ -44,7 +44,7 @@ class ChannelListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->never())
@@ -61,15 +61,15 @@ class ChannelListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('isSecure')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array(), 'https')))
+            ->with($request)
+            ->willReturn(array(array(), 'https'))
         ;
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
@@ -82,7 +82,7 @@ class ChannelListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->never())
@@ -99,7 +99,7 @@ class ChannelListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('isSecure')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $response = new Response();
@@ -108,28 +108,28 @@ class ChannelListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array(), 'https')))
+            ->with($request)
+            ->willReturn(array(array(), 'https'))
         ;
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
         $entryPoint
             ->expects($this->once())
             ->method('start')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue($response))
+            ->with($request)
+            ->willReturn($response)
         ;
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with($this->equalTo($response))
+            ->with($response)
         ;
 
         $listener = new ChannelListener($accessMap, $entryPoint);
@@ -142,7 +142,7 @@ class ChannelListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('isSecure')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $response = new Response();
@@ -151,28 +151,28 @@ class ChannelListenerTest extends TestCase
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array(), 'http')))
+            ->with($request)
+            ->willReturn(array(array(), 'http'))
         ;
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
         $entryPoint
             ->expects($this->once())
             ->method('start')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue($response))
+            ->with($request)
+            ->willReturn($response)
         ;
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())
             ->method('setResponse')
-            ->with($this->equalTo($response))
+            ->with($response)
         ;
 
         $listener = new ChannelListener($accessMap, $entryPoint);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -151,17 +151,17 @@ class ContextListenerTest extends TestCase
 
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
         $request->expects($this->any())
             ->method('hasPreviousSession')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $request->expects($this->any())
             ->method('getSession')
-            ->will($this->returnValue($session));
+            ->willReturn($session);
         $session->expects($this->any())
             ->method('get')
             ->with('_security_key123')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
         $tokenStorage->expects($this->once())
             ->method('setToken')
             ->with(null);
@@ -193,10 +193,10 @@ class ContextListenerTest extends TestCase
 
         $event->expects($this->any())
             ->method('isMasterRequest')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock()));
+            ->willReturn($this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock());
 
         $dispatcher->expects($this->once())
             ->method('addListener')
@@ -218,14 +218,14 @@ class ContextListenerTest extends TestCase
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
         $request->expects($this->any())
             ->method('hasSession')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $event->expects($this->any())
             ->method('isMasterRequest')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
 
         $dispatcher->expects($this->once())
             ->method('removeListener')
@@ -237,12 +237,12 @@ class ContextListenerTest extends TestCase
     public function testHandleRemovesTokenIfNoPreviousSessionWasFound()
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
-        $request->expects($this->any())->method('hasPreviousSession')->will($this->returnValue(false));
+        $request->expects($this->any())->method('hasPreviousSession')->willReturn(false);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
             ->disableOriginalConstructor()
             ->getMock();
-        $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
+        $event->expects($this->any())->method('getRequest')->willReturn($request);
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage->expects($this->once())->method('setToken')->with(null);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/DigestAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/DigestAuthenticationListenerTest.php
@@ -47,12 +47,12 @@ class DigestAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->once())
             ->method('setToken')
-            ->with($this->equalTo(new UsernamePasswordToken($user, $password, $providerKey)))
+            ->with(new UsernamePasswordToken($user, $password, $providerKey))
         ;
 
         $userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();
@@ -64,7 +64,7 @@ class DigestAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -77,7 +77,7 @@ class ExceptionListenerTest extends TestCase
         $event = $this->createEvent(new AuthenticationException());
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
-        $entryPoint->expects($this->once())->method('start')->will($this->returnValue('NOT A RESPONSE'));
+        $entryPoint->expects($this->once())->method('start')->willReturn('NOT A RESPONSE');
 
         $listener = $this->createExceptionListener(null, null, null, $entryPoint);
         $listener->onKernelException($event);
@@ -106,12 +106,12 @@ class ExceptionListenerTest extends TestCase
     public function testAccessDeniedExceptionFullFledgedAndWithoutAccessDeniedHandlerAndWithErrorPage(\Exception $exception, \Exception $eventException = null)
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnValue(new Response('Unauthorized', 401)));
+        $kernel->expects($this->once())->method('handle')->willReturn(new Response('Unauthorized', 401));
 
         $event = $this->createEvent($exception, $kernel);
 
         $httpUtils = $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')->getMock();
-        $httpUtils->expects($this->once())->method('createRequest')->will($this->returnValue(Request::create('/error')));
+        $httpUtils->expects($this->once())->method('createRequest')->willReturn(Request::create('/error'));
 
         $listener = $this->createExceptionListener(null, $this->createTrustResolver(true), $httpUtils, null, '/error');
         $listener->onKernelException($event);
@@ -131,7 +131,7 @@ class ExceptionListenerTest extends TestCase
         $event = $this->createEvent($exception);
 
         $accessDeniedHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface')->getMock();
-        $accessDeniedHandler->expects($this->once())->method('handle')->will($this->returnValue(new Response('error')));
+        $accessDeniedHandler->expects($this->once())->method('handle')->willReturn(new Response('error'));
 
         $listener = $this->createExceptionListener(null, $this->createTrustResolver(true), null, null, null, $accessDeniedHandler);
         $listener->onKernelException($event);
@@ -148,7 +148,7 @@ class ExceptionListenerTest extends TestCase
         $event = $this->createEvent($exception);
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
-        $tokenStorage->expects($this->once())->method('getToken')->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()));
+        $tokenStorage->expects($this->once())->method('getToken')->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
 
         $listener = $this->createExceptionListener($tokenStorage, $this->createTrustResolver(false), null, $this->createEntryPoint());
         $listener->onKernelException($event);
@@ -171,7 +171,7 @@ class ExceptionListenerTest extends TestCase
     private function createEntryPoint(Response $response = null)
     {
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
-        $entryPoint->expects($this->once())->method('start')->will($this->returnValue($response ?: new Response('OK')));
+        $entryPoint->expects($this->once())->method('start')->willReturn($response ?: new Response('OK'));
 
         return $entryPoint;
     }
@@ -179,7 +179,7 @@ class ExceptionListenerTest extends TestCase
     private function createTrustResolver($fullFledged)
     {
         $trustResolver = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface')->getMock();
-        $trustResolver->expects($this->once())->method('isFullFledged')->will($this->returnValue($fullFledged));
+        $trustResolver->expects($this->once())->method('isFullFledged')->willReturn($fullFledged);
 
         return $trustResolver;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -189,7 +189,7 @@ class LogoutListenerTest extends TestCase
 
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request = new Request()));
+            ->willReturn($request = new Request());
 
         return array($event, $request);
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -254,20 +254,20 @@ class RememberMeListenerTest extends TestCase
         $session
             ->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $request = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Request')->getMock();
         $request
             ->expects($this->once())
             ->method('hasSession')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $request
             ->expects($this->once())
             ->method('getSession')
-            ->will($this->returnValue($session))
+            ->willReturn($session)
         ;
 
         $event = $this->getGetResponseEvent();
@@ -319,7 +319,7 @@ class RememberMeListenerTest extends TestCase
         $session
             ->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $session
             ->expects($this->once())
@@ -330,13 +330,13 @@ class RememberMeListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('hasSession')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $request
             ->expects($this->any())
             ->method('getSession')
-            ->will($this->returnValue($session))
+            ->willReturn($session)
         ;
 
         $event = $this->getGetResponseEvent();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -47,8 +47,8 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $simpleAuthenticator
             ->expects($this->once())
             ->method('createToken')
-            ->with($this->equalTo($this->request), $this->equalTo('secured_area'))
-            ->will($this->returnValue($this->token))
+            ->with($this->request, 'secured_area')
+            ->willReturn($this->token)
         ;
 
         $loginEvent = new InteractiveLoginEvent($this->request, $this->token);
@@ -84,8 +84,8 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $simpleAuthenticator
             ->expects($this->once())
             ->method('createToken')
-            ->with($this->equalTo($this->request), $this->equalTo('secured_area'))
-            ->will($this->returnValue($this->token))
+            ->with($this->request, 'secured_area')
+            ->willReturn($this->token)
         ;
 
         $listener = new SimplePreAuthenticationListener($this->tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
@@ -108,7 +108,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $this->event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($this->request))
+            ->willReturn($this->request)
         ;
 
         $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
@@ -27,8 +27,8 @@ class FirewallMapTest extends TestCase
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->with($request)
+            ->willReturn(false)
         ;
 
         $map->add($notMatchingMatcher, array($this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock()));
@@ -37,8 +37,8 @@ class FirewallMapTest extends TestCase
         $matchingMatcher
             ->expects($this->once())
             ->method('matches')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(true))
+            ->with($request)
+            ->willReturn(true)
         ;
         $theListener = $this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock();
         $theException = $this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ExceptionListener')->disableOriginalConstructor()->getMock();
@@ -69,8 +69,8 @@ class FirewallMapTest extends TestCase
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->with($request)
+            ->willReturn(false)
         ;
 
         $map->add($notMatchingMatcher, array($this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock()));
@@ -104,8 +104,8 @@ class FirewallMapTest extends TestCase
         $notMatchingMatcher
             ->expects($this->once())
             ->method('matches')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->with($request)
+            ->willReturn(false)
         ;
 
         $map->add($notMatchingMatcher, array($this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock()));

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -27,7 +27,7 @@ class FirewallTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('register')
-            ->with($this->equalTo($dispatcher))
+            ->with($dispatcher)
         ;
 
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
@@ -36,8 +36,8 @@ class FirewallTest extends TestCase
         $map
             ->expects($this->once())
             ->method('getListeners')
-            ->with($this->equalTo($request))
-            ->will($this->returnValue(array(array(), $listener)))
+            ->with($request)
+            ->willReturn(array(array(), $listener))
         ;
 
         $event = new GetResponseEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $request, HttpKernelInterface::MASTER_REQUEST);
@@ -66,7 +66,7 @@ class FirewallTest extends TestCase
         $map
             ->expects($this->once())
             ->method('getListeners')
-            ->will($this->returnValue(array(array($first, $second), null)))
+            ->willReturn(array(array($first, $second), null))
         ;
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
@@ -81,7 +81,7 @@ class FirewallTest extends TestCase
         $event
             ->expects($this->at(0))
             ->method('hasResponse')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $firewall = new Firewall($map, $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock());

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -92,12 +92,12 @@ class HttpUtilsTest extends TestCase
             ->expects($this->any())
             ->method('generate')
             ->with('foobar', array(), UrlGeneratorInterface::ABSOLUTE_URL)
-            ->will($this->returnValue('http://localhost/foo/bar'))
+            ->willReturn('http://localhost/foo/bar')
         ;
         $urlGenerator
             ->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock())
         ;
 
         $response = $utils->createRedirectResponse($this->getRequest(), 'foobar');
@@ -125,12 +125,12 @@ class HttpUtilsTest extends TestCase
         $urlGenerator
             ->expects($this->once())
             ->method('generate')
-            ->will($this->returnValue('/foo/bar'))
+            ->willReturn('/foo/bar')
         ;
         $urlGenerator
             ->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock())
         ;
 
         $subRequest = $utils->createRequest($this->getRequest(), 'foobar');
@@ -229,7 +229,7 @@ class HttpUtilsTest extends TestCase
             ->expects($this->any())
             ->method('match')
             ->with('/foo/bar')
-            ->will($this->returnValue(array('_route' => 'foobar')))
+            ->willReturn(array('_route' => 'foobar'))
         ;
 
         $utils = new HttpUtils(null, $urlMatcher);
@@ -244,7 +244,7 @@ class HttpUtilsTest extends TestCase
             ->expects($this->any())
             ->method('matchRequest')
             ->with($request)
-            ->will($this->returnValue(array('_route' => 'foobar')))
+            ->willReturn(array('_route' => 'foobar'))
         ;
 
         $utils = new HttpUtils(null, $urlMatcher);
@@ -323,7 +323,7 @@ class HttpUtilsTest extends TestCase
         $urlGenerator
             ->expects($this->any())
             ->method('generate')
-            ->will($this->returnValue($generatedUrl))
+            ->willReturn($generatedUrl)
         ;
 
         return $urlGenerator;

--- a/src/Symfony/Component/Security/Http/Tests/Logout/DefaultLogoutSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/DefaultLogoutSuccessHandlerTest.php
@@ -26,7 +26,7 @@ class DefaultLogoutSuccessHandlerTest extends TestCase
         $httpUtils->expects($this->once())
             ->method('createRedirectResponse')
             ->with($request, '/dashboard')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $handler = new DefaultLogoutSuccessHandler($httpUtils, '/dashboard');
         $result = $handler->onLogoutSuccess($request);

--- a/src/Symfony/Component/Security/Http/Tests/Logout/SessionLogoutHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/SessionLogoutHandlerTest.php
@@ -28,7 +28,7 @@ class SessionLogoutHandlerTest extends TestCase
         $request
             ->expects($this->once())
             ->method('getSession')
-            ->will($this->returnValue($session))
+            ->willReturn($session)
         ;
 
         $session

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -67,7 +67,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue(array()))
+            ->willReturn(array())
         ;
 
         $service
@@ -131,7 +131,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
 
         $service
@@ -154,7 +154,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $service
@@ -178,7 +178,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $service
@@ -205,7 +205,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $service
@@ -232,7 +232,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $service
@@ -296,7 +296,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $provider
             ->expects($this->any())
             ->method('supportsClass')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         return $provider;

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -84,7 +84,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('loadTokenBySeries')
-            ->will($this->returnValue(new PersistentToken('fooclass', 'fooname', 'fooseries', 'foovalue', new \DateTime())))
+            ->willReturn(new PersistentToken('fooclass', 'fooname', 'fooseries', 'foovalue', new \DateTime()))
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -111,14 +111,14 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('loadTokenBySeries')
-            ->will($this->returnValue(new PersistentToken('fooclass', 'foouser', 'fooseries', 'anotherFooValue', new \DateTime())))
+            ->willReturn(new PersistentToken('fooclass', 'foouser', 'fooseries', 'anotherFooValue', new \DateTime()))
         ;
 
         $tokenProvider
             ->expects($this->once())
             ->method('deleteTokenBySeries')
-            ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(null))
+            ->with('fooseries')
+            ->willReturn(null)
         ;
 
         try {
@@ -140,8 +140,8 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('loadTokenBySeries')
-            ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(new PersistentToken('fooclass', 'username', 'fooseries', 'foovalue', new \DateTime('yesterday'))))
+            ->with('fooseries')
+            ->willReturn(new PersistentToken('fooclass', 'username', 'fooseries', 'foovalue', new \DateTime('yesterday')))
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -155,7 +155,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue(array('ROLE_FOO')))
+            ->willReturn(array('ROLE_FOO'))
         ;
 
         $userProvider = $this->getProvider();
@@ -174,8 +174,8 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('loadTokenBySeries')
-            ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(new PersistentToken('fooclass', 'foouser', 'fooseries', 'foovalue', new \DateTime())))
+            ->with('fooseries')
+            ->willReturn(new PersistentToken('fooclass', 'foouser', 'fooseries', 'foovalue', new \DateTime()))
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -199,8 +199,8 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('deleteTokenBySeries')
-            ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(null))
+            ->with('fooseries')
+            ->willReturn(null)
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -276,13 +276,13 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $account
             ->expects($this->once())
             ->method('getUsername')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token
             ->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $tokenProvider = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface')->getMock();
@@ -331,7 +331,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $provider
             ->expects($this->any())
             ->method('supportsClass')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         return $provider;

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
@@ -95,9 +95,9 @@ class ResponseListenerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
-        $event->expects($this->any())->method('isMasterRequest')->will($this->returnValue(HttpKernelInterface::MASTER_REQUEST === $type));
-        $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
+        $event->expects($this->any())->method('getRequest')->willReturn($request);
+        $event->expects($this->any())->method('isMasterRequest')->willReturn(HttpKernelInterface::MASTER_REQUEST === $type);
+        $event->expects($this->any())->method('getResponse')->willReturn($response);
 
         return $event;
     }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -67,7 +67,7 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
 
         $userProvider
@@ -92,7 +92,7 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
 
         $userProvider
@@ -117,12 +117,12 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue(array('ROLE_FOO')))
+            ->willReturn(array('ROLE_FOO'))
         ;
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
 
         $userProvider = $this->getProvider();
@@ -191,7 +191,7 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
 
         $cookies = $response->headers->getCookies();
@@ -214,17 +214,17 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
         $user
             ->expects($this->once())
             ->method('getUsername')
-            ->will($this->returnValue('foouser'))
+            ->willReturn('foouser')
         ;
         $token
             ->expects($this->atLeastOnce())
             ->method('getUser')
-            ->will($this->returnValue($user))
+            ->willReturn($user)
         ;
 
         $cookies = $response->headers->getCookies();
@@ -277,7 +277,7 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $provider
             ->expects($this->any())
             ->method('supportsClass')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         return $provider;

--- a/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
@@ -41,7 +41,7 @@ class SessionAuthenticationStrategyTest extends TestCase
     public function testSessionIsMigrated()
     {
         $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
-        $session->expects($this->once())->method('migrate')->with($this->equalTo(true));
+        $session->expects($this->once())->method('migrate')->with(true);
 
         $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE);
         $strategy->onAuthentication($this->getRequest($session), $this->getToken());
@@ -61,7 +61,7 @@ class SessionAuthenticationStrategyTest extends TestCase
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
 
         if (null !== $session) {
-            $request->expects($this->any())->method('getSession')->will($this->returnValue($session));
+            $request->expects($this->any())->method('getSession')->willReturn($session);
         }
 
         return $request;

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -32,12 +32,12 @@ class ChainDecoderTest extends TestCase
 
         $this->decoder1
             ->method('supportsDecoding')
-            ->will($this->returnValueMap(array(
+            ->willReturnMap(array(
                 array(self::FORMAT_1, array(), true),
                 array(self::FORMAT_2, array(), false),
                 array(self::FORMAT_3, array(), false),
                 array(self::FORMAT_3, array('foo' => 'bar'), true),
-            )));
+            ));
 
         $this->decoder2 = $this
             ->getMockBuilder('Symfony\Component\Serializer\Encoder\DecoderInterface')
@@ -45,11 +45,11 @@ class ChainDecoderTest extends TestCase
 
         $this->decoder2
             ->method('supportsDecoding')
-            ->will($this->returnValueMap(array(
+            ->willReturnMap(array(
                 array(self::FORMAT_1, array(), false),
                 array(self::FORMAT_2, array(), true),
                 array(self::FORMAT_3, array(), false),
-            )));
+            ));
 
         $this->chainDecoder = new ChainDecoder(array($this->decoder1, $this->decoder2));
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -34,12 +34,12 @@ class ChainEncoderTest extends TestCase
 
         $this->encoder1
             ->method('supportsEncoding')
-            ->will($this->returnValueMap(array(
+            ->willReturnMap(array(
                 array(self::FORMAT_1, array(), true),
                 array(self::FORMAT_2, array(), false),
                 array(self::FORMAT_3, array(), false),
                 array(self::FORMAT_3, array('foo' => 'bar'), true),
-            )));
+            ));
 
         $this->encoder2 = $this
             ->getMockBuilder('Symfony\Component\Serializer\Encoder\EncoderInterface')
@@ -47,11 +47,11 @@ class ChainEncoderTest extends TestCase
 
         $this->encoder2
             ->method('supportsEncoding')
-            ->will($this->returnValueMap(array(
+            ->willReturnMap(array(
                 array(self::FORMAT_1, array(), false),
                 array(self::FORMAT_2, array(), true),
                 array(self::FORMAT_3, array(), false),
-            )));
+            ));
 
         $this->chainEncoder = new ChainEncoder(array($this->encoder1, $this->encoder2));
     }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
@@ -31,7 +31,7 @@ class CacheMetadataFactoryTest extends TestCase
         $decorated
             ->expects($this->once())
             ->method('getMetadataFor')
-            ->will($this->returnValue($metadata))
+            ->willReturn($metadata)
         ;
 
         $factory = new CacheClassMetadataFactory($decorated, new ArrayAdapter());
@@ -47,7 +47,7 @@ class CacheMetadataFactoryTest extends TestCase
         $decorated
             ->expects($this->once())
             ->method('hasMetadataFor')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $factory = new CacheClassMetadataFactory($decorated, new ArrayAdapter());

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryTest.php
@@ -55,7 +55,7 @@ class ClassMetadataFactoryTest extends TestCase
         $cache
             ->expects($this->once())
             ->method('fetch')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
 
         $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()), $cache);
@@ -68,7 +68,7 @@ class ClassMetadataFactoryTest extends TestCase
     public function testCacheNotExists()
     {
         $cache = $this->getMockBuilder('Doctrine\Common\Cache\Cache')->getMock();
-        $cache->method('fetch')->will($this->returnValue(false));
+        $cache->method('fetch')->willReturn(false);
         $cache->method('save');
 
         $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()), $cache);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -39,12 +39,12 @@ class ArrayDenormalizerTest extends TestCase
         $this->serializer->expects($this->at(0))
             ->method('denormalize')
             ->with(array('foo' => 'one', 'bar' => 'two'))
-            ->will($this->returnValue(new ArrayDummy('one', 'two')));
+            ->willReturn(new ArrayDummy('one', 'two'));
 
         $this->serializer->expects($this->at(1))
             ->method('denormalize')
             ->with(array('foo' => 'three', 'bar' => 'four'))
-            ->will($this->returnValue(new ArrayDummy('three', 'four')));
+            ->willReturn(new ArrayDummy('three', 'four'));
 
         $result = $this->denormalizer->denormalize(
             array(
@@ -68,7 +68,7 @@ class ArrayDenormalizerTest extends TestCase
         $this->serializer->expects($this->once())
             ->method('supportsDenormalization')
             ->with($this->anything(), __NAMESPACE__.'\ArrayDummy', $this->anything())
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->assertTrue(
             $this->denormalizer->supportsDenormalization(
@@ -85,7 +85,7 @@ class ArrayDenormalizerTest extends TestCase
     {
         $this->serializer->expects($this->any())
             ->method('supportsDenormalization')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->assertFalse(
             $this->denormalizer->supportsDenormalization(

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
@@ -50,11 +50,11 @@ class JsonSerializableNormalizerTest extends TestCase
         $this->serializer
             ->expects($this->once())
             ->method('normalize')
-            ->will($this->returnCallback(function ($data) {
+            ->willReturnCallback(function ($data) {
                 $this->assertArraySubset(array('foo' => 'a', 'bar' => 'b', 'baz' => 'c'), $data);
 
                 return 'string_object';
-            }))
+            })
         ;
 
         $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
@@ -70,11 +70,11 @@ class JsonSerializableNormalizerTest extends TestCase
         $this->serializer
             ->expects($this->once())
             ->method('normalize')
-            ->will($this->returnCallback(function ($data, $format, $context) {
+            ->willReturnCallback(function ($data, $format, $context) {
                 $this->normalizer->normalize($data['qux'], $format, $context);
 
                 return 'string_object';
-            }))
+            })
         ;
 
         $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));

--- a/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
@@ -132,7 +132,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('supports')
             ->with($template)
-            ->will($this->returnValue($supports));
+            ->willReturn($supports);
 
         return $engine;
     }
@@ -144,7 +144,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('supports')
             ->with($template)
-            ->will($this->returnValue($supports));
+            ->willReturn($supports);
 
         return $engine;
     }

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -84,10 +84,10 @@ class MessageCatalogueTest extends TestCase
     public function testAddCatalogue()
     {
         $r = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
+        $r->expects($this->any())->method('__toString')->willReturn('r');
 
         $r1 = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
+        $r1->expects($this->any())->method('__toString')->willReturn('r1');
 
         $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->addResource($r);
@@ -106,13 +106,13 @@ class MessageCatalogueTest extends TestCase
     public function testAddFallbackCatalogue()
     {
         $r = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
+        $r->expects($this->any())->method('__toString')->willReturn('r');
 
         $r1 = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
+        $r1->expects($this->any())->method('__toString')->willReturn('r1');
 
         $r2 = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r2->expects($this->any())->method('__toString')->will($this->returnValue('r2'));
+        $r2->expects($this->any())->method('__toString')->willReturn('r2');
 
         $catalogue = new MessageCatalogue('fr_FR', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->addResource($r);
@@ -171,11 +171,11 @@ class MessageCatalogueTest extends TestCase
     {
         $catalogue = new MessageCatalogue('en');
         $r = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
+        $r->expects($this->any())->method('__toString')->willReturn('r');
         $catalogue->addResource($r);
         $catalogue->addResource($r);
         $r1 = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
+        $r1->expects($this->any())->method('__toString')->willReturn('r1');
         $catalogue->addResource($r1);
 
         $this->assertEquals(array($r, $r1), $catalogue->getResources());

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -100,7 +100,7 @@ class TranslatorCacheTest extends TestCase
         $loader
             ->expects($this->exactly(2))
             ->method('load')
-            ->will($this->returnValue($catalogue))
+            ->willReturn($catalogue)
         ;
 
         // 1st pass
@@ -242,11 +242,11 @@ class TranslatorCacheTest extends TestCase
     {
         $resource = $this->getMockBuilder('Symfony\Component\Config\Resource\SelfCheckingResourceInterface')->getMock();
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')->getMock();
-        $resource->method('isFresh')->will($this->returnValue(false));
+        $resource->method('isFresh')->willReturn(false);
         $loader
             ->expects($this->exactly(2))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('fr', array(), array($resource))));
+            ->willReturn($this->getCatalogue('fr', array(), array($resource)));
 
         // prime the cache
         $translator = new Translator('fr', null, $this->tmpDir, true);

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -107,7 +107,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $validator->expects($this->any())
             ->method('inContext')
             ->with($context)
-            ->will($this->returnValue($contextualValidator));
+            ->willReturn($contextualValidator);
 
         return $context;
     }

--- a/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
@@ -54,7 +54,7 @@ class ContainerConstraintValidatorFactoryTest extends TestCase
         $constraint
             ->expects($this->once())
             ->method('validatedBy')
-            ->will($this->returnValue('Fully\\Qualified\\ConstraintValidator\\Class\\Name'));
+            ->willReturn('Fully\\Qualified\\ConstraintValidator\\Class\\Name');
 
         $factory = new ContainerConstraintValidatorFactory(new Container());
         $factory->getInstance($constraint);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
@@ -31,7 +31,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->cache->write($meta);
 
@@ -51,7 +51,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->assertFalse($this->cache->has('Foo\\Bar'), 'has() returns false when there is no entry');
 
@@ -68,7 +68,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->assertFalse($this->cache->read('Foo\\Bar'), 'read() returns false when there is no entry');
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -97,7 +97,7 @@ class LazyLoadingMetadataFactoryTest extends TestCase
                   array($this->equalTo(self::PARENT_CLASS)),
                   array($this->equalTo(self::INTERFACE_A_CLASS))
               )
-              ->will($this->returnValue(false));
+              ->willReturn(false);
         $cache->expects($this->exactly(2))
               ->method('write')
               ->withConsecutive(
@@ -172,12 +172,12 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $cache
             ->expects($this->any())
             ->method('write')
-            ->will($this->returnCallback(function ($metadata) { serialize($metadata); }))
+            ->willReturnCallback(function ($metadata) { serialize($metadata); })
         ;
 
         $cache->expects($this->any())
             ->method('read')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
         $metadata->addConstraint(new Callback(function () {}));

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/LoaderChainTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/LoaderChainTest.php
@@ -24,12 +24,12 @@ class LoaderChainTest extends TestCase
         $loader1 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader1->expects($this->once())
             ->method('loadClassMetadata')
-            ->with($this->equalTo($metadata));
+            ->with($metadata);
 
         $loader2 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader2->expects($this->once())
             ->method('loadClassMetadata')
-            ->with($this->equalTo($metadata));
+            ->with($metadata);
 
         $chain = new LoaderChain(array(
             $loader1,
@@ -46,12 +46,12 @@ class LoaderChainTest extends TestCase
         $loader1 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader1->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $loader2 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader2->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $chain = new LoaderChain(array(
             $loader1,
@@ -68,12 +68,12 @@ class LoaderChainTest extends TestCase
         $loader1 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader1->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $loader2 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader2->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $chain = new LoaderChain(array(
             $loader1,

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
@@ -610,9 +610,9 @@ abstract class AbstractTest extends AbstractValidatorTest
         $initializer1->expects($this->once())
             ->method('initialize')
             ->with($entity)
-            ->will($this->returnCallback(function ($object) {
+            ->willReturnCallback(function ($object) {
                 $object->initialized = true;
-            }));
+            });
 
         $initializer2->expects($this->once())
             ->method('initialize')

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -92,9 +92,9 @@ class RegistryTest extends TestCase
     {
         $strategy = $this->getMockBuilder(SupportStrategyInterface::class)->getMock();
         $strategy->expects($this->any())->method('supports')
-            ->will($this->returnCallback(function ($workflow, $subject) use ($supportedClassName) {
+            ->willReturnCallback(function ($workflow, $subject) use ($supportedClassName) {
                 return $subject instanceof $supportedClassName;
-            }));
+            });
 
         return $strategy;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| License       | MIT


Mirror to #29685, covering more cases, automated.


@gmponos Could you briefly review if changes are correct?

Feel free try Rector locally:

```yaml
# rector.yml
parameters:
    exclude_paths:
        - "/tests/"
        - "/Fixtures/"
        # autoload-buggy cases
        - "*TransformerTest.php"
        - "*TestRunnerForV6.php"
        - "*FactoryV1.php"
        - "*CollectorTest.php"
        - "*ValidatorTest.php"

services:
    Rector\PHPUnit\Rector\MethodCall\UseSpecificWillMethodRector: ~
```

Better separate runs over standalone dirs, since it's quite performance heavy.

```bash
vendor/bin/rector process src/Symfony/Bridge
vendor/bin/rector process src/Symfony/Bundles
vendor/bin/rector process src/Symfony/Components
```
