### PR TITLE
[Console] Add an iterate method to the ProgressBar class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/polyfill-php72": "~1.5"
+        "symfony/polyfill-php72": "~1.5",
+        "symfony/polyfill-php73": "^1.8"
     },
     "replace": {
         "symfony/asset": "self.version",

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added support for hyperlinks
+ * added `ProgressBar::iterate()` method that simplify updating the progress bar when iterating
 
 4.2.0
 -----

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -244,6 +244,24 @@ final class ProgressBar
     }
 
     /**
+     * Returns an iterator that will automatically update the progress bar when iterated.
+     *
+     * @param int|null $max Number of steps to complete the bar (0 if indeterminate), if null it will be inferred from $iterable
+     */
+    public function iterate(iterable $iterable, ?int $max = null): iterable
+    {
+        $this->start($max ?? (\is_countable($iterable) ? \count($iterable) : 0));
+
+        foreach ($iterable as $key => $value) {
+            yield $key => $value;
+
+            $this->advance();
+        }
+
+        $this->finish();
+    }
+
+    /**
      * Starts the progress output.
      *
      * @param int|null $max Number of steps to complete the bar (0 if indeterminate), null to leave unchanged

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -867,6 +867,41 @@ class ProgressBarTest extends TestCase
         ];
     }
 
+    public function testIterate(): void
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream());
+
+        $this->assertEquals([1, 2], \iterator_to_array($bar->iterate([1, 2])));
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            ' 0/2 [>---------------------------]   0%'.
+            $this->generateOutput(' 1/2 [==============>-------------]  50%').
+            $this->generateOutput(' 2/2 [============================] 100%').
+            $this->generateOutput(' 2/2 [============================] 100%'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testIterateUncountable(): void
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream());
+
+        $this->assertEquals([1, 2], \iterator_to_array($bar->iterate((function () {
+            yield 1;
+            yield 2;
+        })())));
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            '    0 [>---------------------------]'.
+            $this->generateOutput('    1 [->--------------------------]').
+            $this->generateOutput('    2 [-->-------------------------]').
+            $this->generateOutput('    2 [============================]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
     protected function getOutputStream($decorated = true, $verbosity = StreamOutput::VERBOSITY_NORMAL)
     {
         return new StreamOutput(fopen('php://memory', 'r+', false), $verbosity, $decorated);

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": "^7.1.3",
         "symfony/contracts": "^1.0",
-        "symfony/polyfill-mbstring": "~1.0"
+        "symfony/polyfill-mbstring": "~1.0",
+        "symfony/polyfill-php73": "^1.8"
     },
     "require-dev": {
         "symfony/config": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10949

Add an iterate method to the `ProgressBar` class that simplify updating the progress bar when iterating over an `iterable`.

Before:
```php
$bar->start();
foreach ($iterable as $value) {
    // Process $value

    $bar->advance();
}
$bar->finish();
```

After:
```php
foreach ($bar->iterate($iterable) as $value) {
    // Process $value
}
```

Additionally if `$iterable` is countable, the progress bar max step will automatically set to its count. If it isn't countable, nothing is done (instead of setting it to 0) to allow passing a max independently before calling `iterate`.

I will try to do the doc PR soon.