### PR TITLE
Ensure final input of CommandTester works with default

### DIFF
--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -148,7 +148,10 @@ class CommandTester
     {
         $stream = fopen('php://memory', 'r+', false);
 
-        fwrite($stream, implode(PHP_EOL, $inputs));
+        foreach ($inputs as $input) {
+            fwrite($stream, $input.PHP_EOL);
+        }
+
         rewind($stream);
 
         return $stream;

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -112,6 +112,31 @@ class CommandTesterTest extends TestCase
         $this->assertEquals(implode('', $questions), $tester->getDisplay(true));
     }
 
+    public function testCommandWithDefaultInputs()
+    {
+        $questions = array(
+            'What\'s your name?',
+            'How are you?',
+            'Where do you come from?',
+        );
+
+        $command = new Command('foo');
+        $command->setHelperSet(new HelperSet(array(new QuestionHelper())));
+        $command->setCode(function ($input, $output) use ($questions, $command) {
+            $helper = $command->getHelper('question');
+            $helper->ask($input, $output, new Question($questions[0], 'Bobby'));
+            $helper->ask($input, $output, new Question($questions[1], 'Fine'));
+            $helper->ask($input, $output, new Question($questions[2], 'France'));
+        });
+
+        $tester = new CommandTester($command);
+        $tester->setInputs(array('', '', ''));
+        $tester->execute(array());
+
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertEquals(implode('', $questions), $tester->getDisplay(true));
+    }
+
     /**
      * @expectedException \RuntimeException
      * @expectedMessage   Aborted


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

If the final element of `CommandTester::setInputs()` is an empty string (to send the default value), the internal stream the tester uses hits EOF and triggers the `Aborted` exception. This appends an additional EOL to the stream after the `implode` to simulate one final return key, allowing the final input to use the default value when used in the tester's documented style.

A test has been added to cover the new behavior, which failed before this change.