### PR TITLE
Improved performance of LoggerDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -66,7 +66,9 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         if (null !== $this->logger) {
             $containerDeprecationLogs = $this->getContainerDeprecationLogs();
             $this->data = $this->computeErrorsCount($containerDeprecationLogs);
-            $this->data['compiler_logs'] = $this->getContainerCompilerLogs();
+            // get compiler logs later (only when they are needed) to improve performance
+            $this->data['compiler_logs'] = array();
+            $this->data['compiler_logs_filepath'] = $this->containerPathPrefix.'Compiler.log';
             $this->data['logs'] = $this->sanitizeLogs(array_merge($this->logger->getLogs($this->currentRequest), $containerDeprecationLogs));
             $this->data = $this->cloneVar($this->data);
         }
@@ -110,7 +112,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
 
     public function getCompilerLogs()
     {
-        return isset($this->data['compiler_logs']) ? $this->data['compiler_logs'] : array();
+        return $this->cloneVar($this->getContainerCompilerLogs($this->data['compiler_logs_filepath'] ?? null));
     }
 
     /**
@@ -143,14 +145,14 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         return $logs;
     }
 
-    private function getContainerCompilerLogs()
+    private function getContainerCompilerLogs(?string $compilerLogsFilepath = null): array
     {
-        if (null === $this->containerPathPrefix || !file_exists($file = $this->containerPathPrefix.'Compiler.log')) {
+        if (!file_exists($compilerLogsFilepath)) {
             return array();
         }
 
         $logs = array();
-        foreach (file($file, FILE_IGNORE_NEW_LINES) as $log) {
+        foreach (file($compilerLogsFilepath, FILE_IGNORE_NEW_LINES) as $log) {
             $log = explode(': ', $log, 2);
             if (!isset($log[1]) || !preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $log[0])) {
                 $log = array('Unknown Compiler Pass', implode(': ', $log));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | -

My feeling is that Symfony's "dev" environment is more and more slow lately. After profiling the Symfony Demo app with Blackfire, I found that `getContainerCompilerLogs()` is one of the slowest methods.

Given that you rarely need or look at these "compiler logs", in this PR I propose to get them only when/if you really need them.

[The before/after profile comparison](https://blackfire.io/profiles/compare/4959d918-8e00-4cd7-9b0b-41919e73ae62/graph) confirms a nice performance improvement and thousands of functions no longer called.