### PR TITLE
[Form] Fix FormDefaultChoiceListFactory test

### DIFF
--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -443,7 +443,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             array($this->obj2, $this->obj3),
             null, // label
             null, // index
-            array() // ignored
+            null  // group
         );
 
         $this->assertFlatView($view);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/29731#pullrequestreview-189023682
| License       | MIT
| Doc PR        | n/a

`$groupBy` is either `null` or `callable`. Passing `array()` is wrong.