### PR TITLE
[Security] Declare exceptions that are already thrown by implementations

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+
 /**
  * PasswordEncoderInterface is the interface for all encoders.
  *
@@ -25,6 +27,9 @@ interface PasswordEncoderInterface
      * @param string $salt The salt
      *
      * @return string The encoded password
+     *
+     * @throws BadCredentialsException   If the raw password is invalid, e.g. excessively long
+     * @throws \InvalidArgumentException If the salt is invalid
      */
     public function encodePassword($raw, $salt);
 
@@ -36,6 +41,8 @@ interface PasswordEncoderInterface
      * @param string $salt    The salt
      *
      * @return bool true if the password is valid, false otherwise
+     *
+     * @throws \InvalidArgumentException If the salt is invalid
      */
     public function isPasswordValid($encoded, $raw, $salt);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29650
| License       | MIT
| Doc PR        | 

Adding exception declarations for PasswordEncoderInterface. I think it's a matter of opinion whether this change is a BC break. The BC promise doesn't cover such a case; I'd see it as a BC break to add exceptions in general, but in this case it's more of a "documentation" issue, as most implementations of the interface have been throwing those exceptions for years.