### PR TITLE
[Profiler] Still show locale and fallback locale even if no trans used

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -56,38 +56,9 @@
 {% endblock %}
 
 {% block panel %}
-    {% if collector.messages is empty %}
-        <h2>Translations</h2>
-        <div class="empty">
-            <p>No translations have been called.</p>
-        </div>
-    {% else %}
-        {{ block('panelContent') }}
-    {% endif %}
-{% endblock %}
-
-{% block panelContent %}
-
     <h2>Translation</h2>
 
     <div class="metrics">
-        <div class="metric">
-            <span class="value">{{ collector.countDefines }}</span>
-            <span class="label">Defined messages</span>
-        </div>
-
-        <div class="metric">
-            <span class="value">{{ collector.countFallbacks }}</span>
-            <span class="label">Fallback messages</span>
-        </div>
-
-        <div class="metric">
-            <span class="value">{{ collector.countMissings }}</span>
-            <span class="label">Missing messages</span>
-        </div>
-
-        <div class="metric-divider"></div>
-
         <div class="metric">
             <span class="value">{{ collector.locale|default('-') }}</span>
             <span class="label">Locale</span>
@@ -100,88 +71,94 @@
 
     <h2>Messages</h2>
 
-    {% block messages %}
+    {% if collector.messages is empty %}
+        <div class="empty">
+            <p>No translations have been called.</p>
+        </div>
+    {% else %}
+        {% block messages %}
 
-    {# sort translation messages in groups #}
-    {% set messages_defined, messages_missing, messages_fallback = [], [], [] %}
-    {% for message in collector.messages %}
-        {% if message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_DEFINED') %}
-            {% set messages_defined = messages_defined|merge([message]) %}
-        {% elseif message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_MISSING') %}
-            {% set messages_missing = messages_missing|merge([message]) %}
-        {% elseif message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK') %}
-            {% set messages_fallback = messages_fallback|merge([message]) %}
-        {% endif %}
-    {% endfor %}
+        {# sort translation messages in groups #}
+        {% set messages_defined, messages_missing, messages_fallback = [], [], [] %}
+        {% for message in collector.messages %}
+            {% if message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_DEFINED') %}
+                {% set messages_defined = messages_defined|merge([message]) %}
+            {% elseif message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_MISSING') %}
+                {% set messages_missing = messages_missing|merge([message]) %}
+            {% elseif message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK') %}
+                {% set messages_fallback = messages_fallback|merge([message]) %}
+            {% endif %}
+        {% endfor %}
 
-    <div class="sf-tabs">
-        <div class="tab {{ collector.countMissings == 0 ? 'active' }}">
-            <h3 class="tab-title">Defined <span class="badge">{{ collector.countDefines }}</span></h3>
+        <div class="sf-tabs">
+            <div class="tab {{ collector.countMissings == 0 ? 'active' }}">
+                <h3 class="tab-title">Defined <span class="badge">{{ collector.countDefines }}</span></h3>
 
-            <div class="tab-content">
-                <p class="help">
-                    These messages are correctly translated into the given locale.
-                </p>
+                <div class="tab-content">
+                    <p class="help">
+                        These messages are correctly translated into the given locale.
+                    </p>
 
-                {% if messages_defined is empty %}
-                    <div class="empty">
-                        <p>None of the used translation messages are defined for the given locale.</p>
-                    </div>
-                {% else %}
-                    {% block defined_messages %}
-                        {{ helper.render_table(messages_defined) }}
-                    {% endblock %}
-                {% endif %}
+                    {% if messages_defined is empty %}
+                        <div class="empty">
+                            <p>None of the used translation messages are defined for the given locale.</p>
+                        </div>
+                    {% else %}
+                        {% block defined_messages %}
+                            {{ helper.render_table(messages_defined) }}
+                        {% endblock %}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab">
+                <h3 class="tab-title">Fallback <span class="badge {{ collector.countFallbacks ? 'status-warning' }}">{{ collector.countFallbacks }}</span></h3>
+
+                <div class="tab-content">
+                    <p class="help">
+                        These messages are not available for the given locale
+                        but Symfony found them in the fallback locale catalog.
+                    </p>
+
+                    {% if messages_fallback is empty %}
+                        <div class="empty">
+                            <p>No fallback translation messages were used.</p>
+                        </div>
+                    {% else %}
+                        {% block fallback_messages %}
+                            {{ helper.render_table(messages_fallback) }}
+                        {% endblock %}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab {{ collector.countMissings > 0 ? 'active' }}">
+                <h3 class="tab-title">Missing <span class="badge {{ collector.countMissings ? 'status-error' }}">{{ collector.countMissings }}</span></h3>
+
+                <div class="tab-content">
+                    <p class="help">
+                        These messages are not available for the given locale and cannot
+                        be found in the fallback locales. Add them to the translation
+                        catalogue to avoid Symfony outputting untranslated contents.
+                    </p>
+
+                    {% if messages_missing is empty %}
+                        <div class="empty">
+                            <p>There are no messages of this category.</p>
+                        </div>
+                    {% else %}
+                        {% block missing_messages %}
+                            {{ helper.render_table(messages_missing) }}
+                        {% endblock %}
+                    {% endif %}
+                </div>
             </div>
         </div>
 
-        <div class="tab">
-            <h3 class="tab-title">Fallback <span class="badge {{ collector.countFallbacks ? 'status-warning' }}">{{ collector.countFallbacks }}</span></h3>
+        <script>Sfjs.createFilters();</script>
 
-            <div class="tab-content">
-                <p class="help">
-                    These messages are not available for the given locale
-                    but Symfony found them in the fallback locale catalog.
-                </p>
-
-                {% if messages_fallback is empty %}
-                    <div class="empty">
-                        <p>No fallback translation messages were used.</p>
-                    </div>
-                {% else %}
-                    {% block fallback_messages %}
-                        {{ helper.render_table(messages_fallback) }}
-                    {% endblock %}
-                {% endif %}
-            </div>
-        </div>
-
-        <div class="tab {{ collector.countMissings > 0 ? 'active' }}">
-            <h3 class="tab-title">Missing <span class="badge {{ collector.countMissings ? 'status-error' }}">{{ collector.countMissings }}</span></h3>
-
-            <div class="tab-content">
-                <p class="help">
-                    These messages are not available for the given locale and cannot
-                    be found in the fallback locales. Add them to the translation
-                    catalogue to avoid Symfony outputting untranslated contents.
-                </p>
-
-                {% if messages_missing is empty %}
-                    <div class="empty">
-                        <p>There are no messages of this category.</p>
-                    </div>
-                {% else %}
-                    {% block missing_messages %}
-                        {{ helper.render_table(messages_missing) }}
-                    {% endblock %}
-                {% endif %}
-            </div>
-        </div>
-    </div>
-
-    <script>Sfjs.createFilters();</script>
-
-    {% endblock messages %}
+        {% endblock messages %}
+    {% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Even if no translation is used for the current request, this information can still be valuable and displayed in the panel.

### Before

![capture d ecran 2019-01-04 a 18 03 03](https://user-images.githubusercontent.com/2211145/50701531-6933b280-104e-11e9-87a9-1f22ddfd7dc5.png)

### After

![capture d ecran 2019-01-04 a 18 01 06](https://user-images.githubusercontent.com/2211145/50701539-718bed80-104e-11e9-8293-388e9c6ee240.png)

and with messages, move locales info first:

![capture d ecran 2019-01-04 a 18 01 18](https://user-images.githubusercontent.com/2211145/50701593-96806080-104e-11e9-835e-1f207f720616.png)

Actually, following metrics are redundant with the tabs count. Not convinced we should duplicate it.

Edit: removed

---

Note we also collect the locale set into the request from the `RequestDataCollector`, but we never use it. Should we display it somewhere in the request panel?