### PR TITLE
[HttpFoundation] MemcachedSessionHandler::close() must close connection

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -62,7 +62,7 @@ class MemcachedSessionHandler extends AbstractSessionHandler
      */
     public function close()
     {
-        return true;
+        return $this->memcached->quit();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -63,6 +63,12 @@ class MemcachedSessionHandlerTest extends TestCase
 
     public function testCloseSession()
     {
+        $this->memcached
+            ->expects($this->once())
+            ->method('quit')
+            ->will($this->returnValue(true))
+        ;
+
         $this->assertTrue($this->storage->close());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Intoduced here https://github.com/symfony/symfony/pull/3333