### PR TITLE
[Intl] fixed tests by providing nullable type hints instead of strict ones

### DIFF
--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -132,7 +132,7 @@ class IntlDateFormatter
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
-    public function __construct(?string $locale, int $datetype, int $timetype, $timezone = null, ?int $calendar = self::GREGORIAN, string $pattern = null)
+    public function __construct(?string $locale, ?int $datetype, ?int $timetype, $timezone = null, ?int $calendar = self::GREGORIAN, string $pattern = null)
     {
         if ('en' !== $locale && null !== $locale) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no (test fix)
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... 
| License       | MIT

Currently tests `IntlDateFormatterTest::testConstructorWithoutDateType` and  `IntlDateFormatterTest::testConstructorWithoutTimeType` are not passing because of strict type hints for `datetype` and `timetpye` parameters in IntlDateFormatter class contructor, whereas PHPDoc hints that these parameters are nullable. This PR resolves it, and makes all tests in the Intl test suite pass.
