### PR TITLE
Always pass $key to NullAdapter->createCacheItem

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -42,7 +42,7 @@ class NullAdapter implements AdapterInterface, CacheInterface
      */
     public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
     {
-        return $callback(($this->createCacheItem)());
+        return $callback(($this->createCacheItem)($key));
     }
 
     /**

--- a/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
@@ -34,6 +34,19 @@ class NullAdapterTest extends TestCase
         $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
     }
 
+    public function testGet()
+    {
+        $adapter = $this->createCachePool();
+
+        $fetched = [];
+        $item = $adapter->get('myKey', function ($item) use (&$fetched) { $fetched[] = $item; });
+        $this->assertCount(1, $fetched);
+        $item = $fetched[0];
+        $this->assertFalse($item->isHit());
+        $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
+        $this->assertSame('myKey', $item->getKey());
+    }
+
     public function testHasItem()
     {
         $this->assertFalse($this->createCachePool()->hasItem('key'));


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (build failure seems unrelated)
| Fixed tickets | 
| License       | MIT
| Doc PR        |

Previously, if this were called, it would throw an ArgumentCountError.
I'm assuming existing code always checks hasItem, so this bug hasn't impacted many people.
This was noticed via static analysis.

The get() method was added to NullAdapter in symfony 4.2