### PR TITLE
[fabbot] enable short arrays

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,7 +10,6 @@ return PhpCsFixer\Config::create()
         '@Symfony:risky' => true,
         '@PHPUnit48Migration:risky' => true,
         'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
-        'array_syntax' => array('syntax' => 'long'),
         'fopen_flags' => false,
         'ordered_imports' => true,
         'protected_to_private' => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Let's move to short arrays, but let's do it in a smooth way.
This PR enables short arrays for php-cs-fixer, making PRs red when they don't follow the CS.
We should then ask all authors of pending PRs to rebase their PR and apply the CS patch.
This will need some time.
Then, in 1-2 months, we'll be able to move all the code base to short arrays without creating hundred merge conflicts with all pending PRs, hopefully.