### PR TITLE
[Routing] Add options to debug:router command to filter by method, scheme or host

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -71,6 +71,97 @@ class RouterDebugCommandTest extends WebTestCase
         $tester->execute(['name' => 'gerard'], ['interactive' => true]);
     }
 
+    public function testFilterRouteByMethod()
+    {
+        $tester = $this->createCommandTester();
+
+        $ret = $tester->execute(['--method' => ['GET']]);
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('routerdebug_get', $tester->getDisplay());
+        $this->assertContains('/test/get', $tester->getDisplay());
+        $this->assertNotContains('routerdebug_post', $tester->getDisplay());
+        $this->assertNotContains('/test/post', $tester->getDisplay());
+
+        $ret = $tester->execute(['--method' => ['GET', 'POST']]);
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('routerdebug_get', $tester->getDisplay());
+        $this->assertContains('/test/get', $tester->getDisplay());
+        $this->assertContains('routerdebug_post', $tester->getDisplay());
+        $this->assertContains('/test/post', $tester->getDisplay());
+    }
+
+    public function testFilterRouteByScheme()
+    {
+        $tester = $this->createCommandTester();
+
+        $ret = $tester->execute(['--scheme' => 'http']);
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('routerdebug_get', $tester->getDisplay());
+        $this->assertContains('/test/get', $tester->getDisplay());
+        $this->assertNotContains('routerdebug_post', $tester->getDisplay());
+        $this->assertNotContains('/test/post', $tester->getDisplay());
+
+        $ret = $tester->execute(['--scheme' => 'https']);
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertNotContains('routerdebug_get', $tester->getDisplay());
+        $this->assertNotContains('/test/get', $tester->getDisplay());
+        $this->assertContains('routerdebug_post', $tester->getDisplay());
+        $this->assertContains('/test/post', $tester->getDisplay());
+    }
+
+    public function testFilterRouteByHost()
+    {
+        $tester = $this->createCommandTester();
+
+        $ret = $tester->execute(['--match-host' => '^test\..*\.com']);
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertNotContains('routerdebug_get', $tester->getDisplay());
+        $this->assertNotContains('/test/get', $tester->getDisplay());
+        $this->assertContains('routerdebug_post', $tester->getDisplay());
+        $this->assertContains('/test/post', $tester->getDisplay());
+        $this->assertContains('test.example.com', $tester->getDisplay());
+
+        $ret = $tester->execute(['--match-host' => '.*\.example\.(com|org)']);
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertNotContains('routerdebug_get', $tester->getDisplay());
+        $this->assertNotContains('/test/get', $tester->getDisplay());
+        $this->assertContains('routerdebug_post', $tester->getDisplay());
+        $this->assertContains('/test/post', $tester->getDisplay());
+        $this->assertContains('test.example.com', $tester->getDisplay());
+
+        $ret = $tester->execute(['--match-host' => '.*\.example\.org']);
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertNotContains('routerdebug_get', $tester->getDisplay());
+        $this->assertNotContains('/test/get', $tester->getDisplay());
+        $this->assertNotContains('routerdebug_post', $tester->getDisplay());
+        $this->assertNotContains('/test/post', $tester->getDisplay());
+        $this->assertNotContains('test.example.com', $tester->getDisplay());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage "*invalid_regex" does not seems to be a valid regex.
+     */
+    public function testFilterWithInvalidHostRegex()
+    {
+        $tester = $this->createCommandTester();
+
+        $ret = $tester->execute(['--match-host' => '*invalid_regex']);
+        $this->assertSame(1, $ret, 'Returns 0 in case of success');
+    }
+
+    public function testMultipleFilters()
+    {
+        $tester = $this->createCommandTester();
+
+        $ret = $tester->execute(['--method' => ['GET', 'POST'], '--match-host' => '.*\.com']);
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertNotContains('routerdebug_get', $tester->getDisplay());
+        $this->assertNotContains('/test/get', $tester->getDisplay());
+        $this->assertContains('routerdebug_post', $tester->getDisplay());
+        $this->assertContains('/test/post', $tester->getDisplay());
+    }
+
     private function createCommandTester(): CommandTester
     {
         $command = $this->application->get('debug:router');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RouterDebug/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RouterDebug/routing.yml
@@ -13,3 +13,17 @@ routerdebug_session_logout:
 routerdebug_test:
     path:     /test
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SessionController::welcomeAction }
+
+routerdebug_get:
+    path: /test/get
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SessionController::welcomeAction }
+    methods: [GET]
+    schemes: [http]
+    host: 'test.example.fr'
+
+routerdebug_post:
+    path: /test/post
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SessionController::welcomeAction }
+    methods: [POST]
+    schemes: [https]
+    host: 'test.example.com'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #29757 
| License       | MIT
| Doc PR        | todo

Add some options to the `bin/console debug:router` command to be able to filter by the method, the scheme and the host, allowed by a route.

- `bin/console debug:router --method=GET` to retrieve all routes that allows the GET method (also, --method=GET --method=POST to retrieve GET and POST routes at once)
- `bin/console debug:router --scheme=http`
- `bin/console debug:router --match-host=".*\.example\.com"` : the `match-host` option accept a regex
