### PR TITLE
[Form] Add `LocaleTypeTest::testInvalidLocaleMessage()`

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Extension\Core\Type\LocaleType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
+use Symfony\Component\Validator\Constraints\Locale;
 
 class LocaleTypeTest extends BaseTypeTest
 {
@@ -51,5 +52,16 @@ class LocaleTypeTest extends BaseTypeTest
         $type = new LocaleType();
 
         $this->assertSame([], $type->loadChoicesForValues(['foo']));
+    }
+
+    public function testInvalidLocaleMessage()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+
+        $form->submit('nonexistent-locale');
+
+        $localeConstraint = new Locale();
+
+        $this->assertSame($localeConstraint->message, $form->getErrors()->current()->getMessage());
     }
 }


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Branch       |3.4|
|Bug fix?     |no |
|New feature? |no |
|BC breaks?   |no |
|Deprecations?|no |
|Tests pass?  |yes|
|Fixed tickets|n/a|
|License      |MIT|
|Doc PR       |n/a|

Since passing a invalid locale causes the form to be not synchronized, the validation fails because this reason instead of the locale validation.
Since I don't know if this is the expected result, this PR provides a test covering the described behavior in order to clarify the situation.