### PR TITLE
[DebugClassLoader] expose proxyfied findFile() method

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -124,6 +124,11 @@ class DebugClassLoader
         }
     }
 
+    public function findFile($class): ?string
+    {
+        return $this->isFinder ? $this->classLoader[0]->findFile($class) ?: null : null;
+    }
+
     /**
      * Loads the given class or interface.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As bad as it is, some third party libraries expect that at least one autoload function will be the Composer one and have behaviors that relies on the public `findFile` method.

When the `DebugClassLoader` wraps the Composer `ClassLoader`, the function `findFile` is currently lost. So it becomes impossible to use the `DebugClassLoader` with these libraries.

This is for example the case in Drupal 😢 (cf https://github.com/drupal/core/blob/83bc30ac4030ed163e1919ca5e12b338a22c87dd/lib/Drupal/Component/ClassFinder/ClassFinder.php).

Fixing these bad implementations in third party libraries can take forever as things move way slower than in Symfony. This is why I think supporting this case directly in Symfony is better. It's easy and will make the `DebugClassLoader` compatible with more cases.

What could be done to go further in this direction would be to proxify any method implementend by wrapped class loaders.