### PR TITLE
Fix SwiftMailerHandler to support Monolog's latest reset functionality

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
@@ -60,6 +60,14 @@ class SwiftMailerHandler extends BaseSwiftMailerHandler
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->flushMemorySpool();
+    }
+
+    /**
      * Flushes the mail queue if a memory spool is used.
      */
     private function flushMemorySpool()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Monolog 1.24 added the ResettableInterface which is meant to support resetting handlers. Reset should also flush as if the request was ending, and it can be used for long running workers for example in between each job that is processed. Due to SwiftMailer's spool however the emails in case of errors are right now only sent at the very end of the worker's lifetime.

For older Monolog versions, this will be ignored, and is thus harmless.