### PR TITLE
[Console] Fixed #29835: ConfirmationQuestion with default true for answer '0'

### DIFF
--- a/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
+++ b/src/Symfony/Component/Console/Question/ConfirmationQuestion.php
@@ -53,7 +53,7 @@ class ConfirmationQuestion extends Question
                 return $answer && $answerIsTrue;
             }
 
-            return !$answer || $answerIsTrue;
+            return '' === $answer || $answerIsTrue;
         };
     }
 }

--- a/src/Symfony/Component/Console/Tests/Question/ConfirmationQuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/ConfirmationQuestionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Question;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class ConfirmationQuestionTest extends TestCase
+{
+    /**
+     * @dataProvider normalizerUsecases
+     */
+    public function testDefaultRegexUsecases($default, $answers, $expected, $message)
+    {
+        $sut = new ConfirmationQuestion('A question', $default);
+
+        foreach ($answers as $answer) {
+            $normalizer = $sut->getNormalizer();
+            $actual = $normalizer($answer);
+            $this->assertEquals($expected, $actual, sprintf($message, $answer));
+        }
+    }
+
+    public function normalizerUsecases()
+    {
+        return [
+            [
+                true,
+                ['y', 'Y', 'yes', 'YES', 'yEs', ''],
+                true,
+                'When default is true, the normalizer must return true for "%s"',
+            ],
+            [
+                true,
+                ['n', 'N', 'no', 'NO', 'nO', 'foo', '1', '0'],
+                false,
+                'When default is true, the normalizer must return false for "%s"',
+            ],
+            [
+                false,
+                ['y', 'Y', 'yes', 'YES', 'yEs'],
+                true,
+                'When default is false, the normalizer must return true for "%s"',
+            ],
+            [
+                false,
+                ['n', 'N', 'no', 'NO', 'nO', 'foo', '1', '0', ''],
+                false,
+                'When default is false, the normalizer must return false for "%s"',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | Almost all, one failure on appveyor?
| Fixed tickets | #29835 
| License       | MIT
| Doc PR        | n/a

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

When using the ConfirmationQuestion class to ask a yes / no question,
if the default is true, and the answer regex is '/^y/i', then any
value not starting with [yY] is considered false.

This must include "0", which previously would return true, producing results such as:
```
$ php bin/console do:stuff
$ Do you want to continue? 0 <enter>
$ Ok, continuing!
```

