### PR TITLE
Revert "bug #29597 [DI] fix reporting bindings on overriden services as unused"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -34,8 +34,6 @@ class ResolveBindingsPass extends AbstractRecursivePass
      */
     public function process(ContainerBuilder $container)
     {
-        $this->usedBindings = $container->getRemovedBindingIds();
-
         try {
             parent::process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -112,24 +112,6 @@ class ResolveBindingsPassTest extends TestCase
         $this->assertEquals(array(array('setDefaultLocale', array('fr'))), $definition->getMethodCalls());
     }
 
-    public function testOverriddenBindings()
-    {
-        $container = new ContainerBuilder();
-
-        $binding = new BoundArgument('bar');
-
-        $container->register('foo', 'stdClass')
-            ->setBindings(array('$foo' => clone $binding));
-        $container->register('bar', 'stdClass')
-            ->setBindings(array('$foo' => clone $binding));
-
-        $container->register('foo', 'stdClass');
-
-        (new ResolveBindingsPass())->process($container);
-
-        $this->assertInstanceOf('stdClass', $container->get('foo'));
-    }
-
     public function testTupleBinding()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -399,7 +399,7 @@ class ResolveChildDefinitionsPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     * @expectedExceptionMessageRegExp /^Circular reference detected for service "a", path: "a -> c -> b -> a"./
+     * @expectedExceptionMessageRegExp /^Circular reference detected for service "c", path: "c -> b -> a -> c"./
      */
     public function testProcessDetectsChildDefinitionIndirectCircularReference()
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -559,7 +559,7 @@ class ContainerBuilderTest extends TestCase
         $config->setDefinition('baz', new Definition('BazClass'));
         $config->setAlias('alias_for_foo', 'foo');
         $container->merge($config);
-        $this->assertEquals(array('foo', 'bar', 'service_container', 'baz'), array_keys($container->getDefinitions()), '->merge() merges definitions already defined ones');
+        $this->assertEquals(array('service_container', 'foo', 'bar', 'baz'), array_keys($container->getDefinitions()), '->merge() merges definitions already defined ones');
 
         $aliases = $container->getAliases();
         $this->assertArrayHasKey('alias_for_foo', $aliases);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
@@ -4,9 +4,6 @@ services:
         class: Symfony\Component\DependencyInjection\ContainerInterface
         public: true
         synthetic: true
-    foo:
-        class: App\FooService
-        public: true
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
         public: true
@@ -19,3 +16,6 @@ services:
 
         shared: false
         configurator: c
+    foo:
+        class: App\FooService
+        public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.expected.yml
@@ -4,6 +4,15 @@ services:
         class: Symfony\Component\DependencyInjection\ContainerInterface
         public: true
         synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
+        public: true
+        tags:
+            - { name: foo }
+            - { name: baz }
+        deprecated: '%service_id%'
+        arguments: [1]
+        factory: f
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
         public: true
@@ -12,14 +21,5 @@ services:
             - { name: baz }
         deprecated: '%service_id%'
         lazy: true
-        arguments: [1]
-        factory: f
-    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
-        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
-        public: true
-        tags:
-            - { name: foo }
-            - { name: baz }
-        deprecated: '%service_id%'
         arguments: [1]
         factory: f

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
@@ -4,6 +4,15 @@ services:
         class: Symfony\Component\DependencyInjection\ContainerInterface
         public: true
         synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
+        public: true
+        tags:
+            - { name: foo }
+            - { name: baz }
+        deprecated: '%service_id%'
+        arguments: [1]
+        factory: f
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
         public: true
@@ -12,14 +21,5 @@ services:
             - { name: baz }
         deprecated: '%service_id%'
         lazy: true
-        arguments: [1]
-        factory: f
-    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
-        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
-        public: true
-        tags:
-            - { name: foo }
-            - { name: baz }
-        deprecated: '%service_id%'
         arguments: [1]
         factory: f


### PR DESCRIPTION
This reverts commit e07ad2b4

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29836
| License       | MIT
| Doc PR        | 

4.2.2 release changed the way tagged service are injected

As asked by @nicolas-grekas https://github.com/symfony/symfony/issues/29836#issuecomment-453464500

