### PR TITLE
Revert "bug #29597 [DI] fix reporting bindings on overriden services as unused"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -34,8 +34,6 @@ class ResolveBindingsPass extends AbstractRecursivePass
      */
     public function process(ContainerBuilder $container)
     {
-        $this->usedBindings = $container->getRemovedBindingIds();
-
         try {
             parent::process($container);
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -123,8 +123,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
     private $removedIds = array();
 
-    private $removedBindingIds = array();
-
     private static $internalTypes = array(
         'int' => true,
         'float' => true,
@@ -533,8 +531,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             throw new BadMethodCallException(sprintf('Setting service "%s" for an unknown or non-synthetic service definition on a compiled container is not allowed.', $id));
         }
 
-        $this->removeId($id);
-        unset($this->removedIds[$id]);
+        unset($this->definitions[$id], $this->aliasDefinitions[$id], $this->removedIds[$id]);
 
         parent::set($id, $service);
     }
@@ -547,7 +544,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     public function removeDefinition($id)
     {
         if (isset($this->definitions[$id = $this->normalizeId($id)])) {
-            $this->removeId($id);
+            unset($this->definitions[$id]);
+            $this->removedIds[$id] = true;
         }
     }
 
@@ -878,8 +876,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             throw new InvalidArgumentException(sprintf('An alias can not reference itself, got a circular reference on "%s".', $alias));
         }
 
-        $this->removeId($alias);
-        unset($this->removedIds[$alias]);
+        unset($this->definitions[$alias], $this->removedIds[$alias]);
 
         return $this->aliasDefinitions[$alias] = $id;
     }
@@ -892,7 +889,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     public function removeAlias($alias)
     {
         if (isset($this->aliasDefinitions[$alias = $this->normalizeId($alias)])) {
-            $this->removeId($alias);
+            unset($this->aliasDefinitions[$alias]);
+            $this->removedIds[$alias] = true;
         }
     }
 
@@ -1021,8 +1019,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         $id = $this->normalizeId($id);
 
-        $this->removeId($id);
-        unset($this->removedIds[$id]);
+        unset($this->aliasDefinitions[$id], $this->removedIds[$id]);
 
         return $this->definitions[$id] = $definition;
     }
@@ -1556,18 +1553,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
-     * Gets removed binding ids.
-     *
-     * @return array
-     *
-     * @internal
-     */
-    public function getRemovedBindingIds()
-    {
-        return $this->removedBindingIds;
-    }
-
-    /**
      * Computes a reasonably unique hash of a value.
      *
      * @param mixed $value A serializable value
@@ -1670,22 +1655,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         return false;
-    }
-
-    private function removeId($id)
-    {
-        $this->removedIds[$id] = true;
-        unset($this->aliasDefinitions[$id]);
-
-        if (!isset($this->definitions[$id])) {
-            return;
-        }
-
-        foreach ($this->definitions[$id]->getBindings() as $binding) {
-            list(, $identifier) = $binding->getValues();
-            $this->removedBindingIds[$identifier] = true;
-        }
-
-        unset($this->definitions[$id]);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -111,22 +111,4 @@ class ResolveBindingsPassTest extends TestCase
 
         $this->assertEquals(array(array('setDefaultLocale', array('fr'))), $definition->getMethodCalls());
     }
-
-    public function testOverriddenBindings()
-    {
-        $container = new ContainerBuilder();
-
-        $binding = new BoundArgument('bar');
-
-        $container->register('foo', 'stdClass')
-            ->setBindings(array('$foo' => clone $binding));
-        $container->register('bar', 'stdClass')
-            ->setBindings(array('$foo' => clone $binding));
-
-        $container->register('foo', 'stdClass');
-
-        (new ResolveBindingsPass())->process($container);
-
-        $this->assertInstanceOf('stdClass', $container->get('foo'));
-    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -434,7 +434,7 @@ class ResolveChildDefinitionsPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     * @expectedExceptionMessageRegExp /^Circular reference detected for service "a", path: "a -> c -> b -> a"./
+     * @expectedExceptionMessageRegExp /^Circular reference detected for service "c", path: "c -> b -> a -> c"./
      */
     public function testProcessDetectsChildDefinitionIndirectCircularReference()
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -559,7 +559,7 @@ class ContainerBuilderTest extends TestCase
         $config->setDefinition('baz', new Definition('BazClass'));
         $config->setAlias('alias_for_foo', 'foo');
         $container->merge($config);
-        $this->assertEquals(array('foo', 'bar', 'service_container', 'baz'), array_keys($container->getDefinitions()), '->merge() merges definitions already defined ones');
+        $this->assertEquals(array('service_container', 'foo', 'bar', 'baz'), array_keys($container->getDefinitions()), '->merge() merges definitions already defined ones');
 
         $aliases = $container->getAliases();
         $this->assertArrayHasKey('alias_for_foo', $aliases);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.expected.yml
@@ -4,9 +4,6 @@ services:
         class: Symfony\Component\DependencyInjection\ContainerInterface
         public: true
         synthetic: true
-    foo:
-        class: App\FooService
-        public: true
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
         public: true
@@ -19,3 +16,6 @@ services:
 
         shared: false
         configurator: c
+    foo:
+        class: App\FooService
+        public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.expected.yml
@@ -4,6 +4,15 @@ services:
         class: Symfony\Component\DependencyInjection\ContainerInterface
         public: true
         synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
+        public: true
+        tags:
+            - { name: foo }
+            - { name: baz }
+        deprecated: '%service_id%'
+        arguments: [1]
+        factory: f
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
         public: true
@@ -12,14 +21,5 @@ services:
             - { name: baz }
         deprecated: '%service_id%'
         lazy: true
-        arguments: [1]
-        factory: f
-    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
-        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
-        public: true
-        tags:
-            - { name: foo }
-            - { name: baz }
-        deprecated: '%service_id%'
         arguments: [1]
         factory: f


### PR DESCRIPTION
This reverts commit 44e9a91f306169aff0573bcb8380e3d5f9c912d0, reversing
changes made to 91b28ff0817e33f7430084ef4e4b431c6648989d.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29836
| License       | MIT
| Doc PR        | 

4.2.2 release changed the way tagged service are injected

As asked by @nicolas-grekas https://github.com/symfony/symfony/issues/29836#issuecomment-453464500