### PR TITLE
Avoid target directories within the source directory

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -569,6 +569,10 @@ class Filesystem
         }
 
         foreach ($iterator as $file) {
+            if ($file->getPathName() === $targetDir) {
+                continue;
+            }
+
             if (false === strpos($file->getPath(), $originDir)) {
                 throw new IOException(sprintf('Unable to mirror "%s" directory. If the origin directory is relative, try using "realpath" before calling the mirror method.', $originDir), 0, null, $originDir);
             }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1372,6 +1372,31 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->mirror($sourcePath, $targetPath, $iterator);
     }
 
+    public function testMirrorAvoidCopyingTargetDirectoryIfInSourceDirectory()
+    {
+        $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;
+        $directory = $sourcePath.'directory'.\DIRECTORY_SEPARATOR;
+        $file1 = $directory.'file1';
+        $file2 = $sourcePath.'file2';
+
+        mkdir($sourcePath);
+        mkdir($directory);
+        file_put_contents($file1, 'FILE1');
+        file_put_contents($file2, 'FILE2');
+
+        $targetPath = $sourcePath . 'target' . \DIRECTORY_SEPARATOR;
+
+        $this->filesystem->mirror($sourcePath, $targetPath);
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertTrue(is_dir($targetPath.'directory'));
+
+        $this->assertFileEquals($file1, $targetPath.'directory'.\DIRECTORY_SEPARATOR.'file1');
+        $this->assertFileEquals($file2, $targetPath.'file2');
+
+        $this->assertFalse(file_exists($targetPath.'target'));
+    }
+
     /**
      * @dataProvider providePathsForIsAbsolutePath
      */

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1384,7 +1384,7 @@ class FilesystemTest extends FilesystemTestCase
         file_put_contents($file1, 'FILE1');
         file_put_contents($file2, 'FILE2');
 
-        $targetPath = $sourcePath . 'target' . \DIRECTORY_SEPARATOR;
+        $targetPath = $sourcePath.'target'.\DIRECTORY_SEPARATOR;
 
         $this->filesystem->mirror($sourcePath, $targetPath);
 
@@ -1394,7 +1394,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileEquals($file1, $targetPath.'directory'.\DIRECTORY_SEPARATOR.'file1');
         $this->assertFileEquals($file2, $targetPath.'file2');
 
-        $this->assertFalse(file_exists($targetPath.'target'));
+        $this->assertFileNotExists($targetPath.'target');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no, but kind of yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Currently when you run:
```
$filesystem->mirror('/foo', '/foo/bar');
```
The method will get caught in a recursive loop of creating "bar" sub directories in the target directory.

This will happen:
```
/foo/bar/bar/
/foo/bar/bar/bar/
/foo/bar/bar/bar/bar/
...
```
Until the path is so long that is validated as an invalid path string and thus mkdir() crashes.

In this pull request I implemented an if statement at the beginning of the foreach in the mirror() method. This if statement ensures that the target directory in the mirror process is skipped.
