### PR TITLE
[Translation] Fix dynamic translation with ICU

### DIFF
--- a/src/Symfony/Component/Translation/Formatter/IntlFormatter.php
+++ b/src/Symfony/Component/Translation/Formatter/IntlFormatter.php
@@ -28,6 +28,12 @@ class IntlFormatter implements IntlFormatterInterface
      */
     public function formatIntl(string $message, string $locale, array $parameters = array()): string
     {
+        foreach ($parameters as $key => $value) {
+            if ('{{' === substr($key, 0, 2)) {
+                $message = str_replace($key, $value, $message);
+            }
+        }
+
         if (!$formatter = $this->cache[$locale][$message] ?? null) {
             if (!($this->hasMessageFormatter ?? $this->hasMessageFormatter = class_exists(\MessageFormatter::class))) {
                 throw new LogicException('Cannot parse message translation: please install the "intl" PHP extension or the "symfony/polyfill-intl-messageformatter" package.');

--- a/src/Symfony/Component/Translation/Tests/Formatter/IntlFormatterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/IntlFormatterTest.php
@@ -93,4 +93,20 @@ _MSG_;
         $this->assertSame('Hello Fab', $formatter->formatIntl('Hello {name}', 'en', array('%name%' => 'Fab')));
         $this->assertSame('Hello Fab', $formatter->formatIntl('Hello {name}', 'en', array('{{ name }}' => 'Fab')));
     }
+
+    public function testInvalidDoubleCurlyBraces()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        (new IntlFormatter)->formatIntl('Too many tags (add {{ limit }} tags or less)', 'en');
+    }
+
+    public function testValidDoubleCurlyBraces()
+    {
+        $message = (new IntlFormatter)->formatIntl('Too {{ count }} many tags (add {{ limit }} tags or less)', 'en', array(
+            '{{ limit }}' => 4,
+            '{{ count }}' => 3,
+        ));
+
+        $this->assertEquals('Too 3 many tags (add 4 tags or less)', $message);
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/Formatter/IntlFormatterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/IntlFormatterTest.php
@@ -97,12 +97,12 @@ _MSG_;
     public function testInvalidDoubleCurlyBraces()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new IntlFormatter)->formatIntl('Too many tags (add {{ limit }} tags or less)', 'en');
+        (new IntlFormatter())->formatIntl('Too many tags (add {{ limit }} tags or less)', 'en');
     }
 
     public function testValidDoubleCurlyBraces()
     {
-        $message = (new IntlFormatter)->formatIntl('Too {{ count }} many tags (add {{ limit }} tags or less)', 'en', array(
+        $message = (new IntlFormatter())->formatIntl('Too {{ count }} many tags (add {{ limit }} tags or less)', 'en', array(
             '{{ limit }}' => 4,
             '{{ count }}' => 3,
         ));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

In symfony demo, I get a bug with ICU translation [explain here](https://github.com/symfony/demo/pull/929). I try to fix that in translation component. Globally, bug are when you ```{{ variable }}``` in [IntlFormatter](https://github.com/symfony/translation/blob/master/Formatter/IntlFormatter.php). We need to foramt variable to get value directly.
