### PR TITLE
Add block prefix to csrf token field

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -90,9 +90,10 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             $tokenId = $options['csrf_token_id'] ?: ($form->getName() ?: \get_class($form->getConfig()->getType()->getInnerType()));
             $data = (string) $options['csrf_token_manager']->getToken($tokenId);
 
-            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'Symfony\Component\Form\Extension\Core\Type\HiddenType', $data, array(
+            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'Symfony\Component\Form\Extension\Core\Type\HiddenType', $data, [
+                'block_prefix' => 'csrf_token',
                 'mapped' => false,
-            ));
+            ]);
 
             $view->children[$options['csrf_field_name']] = $csrfForm->createView($view);
         }
@@ -103,13 +104,13 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'csrf_protection' => $this->defaultEnabled,
             'csrf_field_name' => $this->defaultFieldName,
             'csrf_message' => 'The CSRF token is invalid. Please try to resubmit the form.',
             'csrf_token_manager' => $this->defaultTokenManager,
             'csrf_token_id' => null,
-        ));
+        ]);
     }
 
     /**
@@ -117,6 +118,6 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
      */
     public static function getExtendedTypes(): iterable
     {
-        return array(FormType::class);
+        return [FormType::class];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10867

Currently I use the following code snippet to overwrite the token rendering:

```twig
{%- block hidden_widget -%}
    {%- if form.vars.name == '_token' -%}
        {{ block('app__token_widget') }}
    {%- else -%}
        {{ block('hidden_widget', 'form_div_layout.html.twig') }}
    {%- endif -%}
{%- endblock hidden_widget -%}

{%- block app__token_widget %}
    {{ render_esi(controller('SuluFormBundle:FormWebsite:token', { 'form': form.parent.vars.name })) }}
{%- endblock app__token_widget -%}
```

With the change of https://symfony.com/blog/new-in-symfony-4-3-simpler-form-theming this workaround can now be removed and the following can be used:

```twig
{%- block token_widget %}
    {{ render_esi(controller('SuluFormBundle:FormWebsite:token', { 'form': form.parent.vars.name })) }}
{%- endblock token_widget -%}
```