### PR TITLE
Grammar fix in exception message

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -161,7 +161,7 @@ final class Dotenv
         }
 
         if (' ' === $this->data[$this->cursor] || "\t" === $this->data[$this->cursor]) {
-            throw $this->createFormatException('Whitespace are not supported after the variable name');
+            throw $this->createFormatException('Whitespace characters are not supported after the variable name');
         }
 
         if ('=' !== $this->data[$this->cursor]) {

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -36,7 +36,7 @@ class DotenvTest extends TestCase
     {
         $tests = [
             ['FOO=BAR BAZ', "A value containing spaces must be surrounded by quotes in \".env\" at line 1.\n...FOO=BAR BAZ...\n             ^ line 1 offset 11"],
-            ['FOO BAR=BAR', "Whitespace are not supported after the variable name in \".env\" at line 1.\n...FOO BAR=BAR...\n     ^ line 1 offset 3"],
+            ['FOO BAR=BAR', "Whitespace characters are not supported after the variable name in \".env\" at line 1.\n...FOO BAR=BAR...\n     ^ line 1 offset 3"],
             ['FOO', "Missing = in the environment variable declaration in \".env\" at line 1.\n...FOO...\n     ^ line 1 offset 3"],
             ['FOO="foo', "Missing quote to end the value in \".env\" at line 1.\n...FOO=\"foo...\n          ^ line 1 offset 8"],
             ['FOO=\'foo', "Missing quote to end the value in \".env\" at line 1.\n...FOO='foo...\n          ^ line 1 offset 8"],


### PR DESCRIPTION
According to https://en.wiktionary.org/wiki/whitespace and https://english.stackexchange.com/questions/25368/what-is-the-plural-form-of-whitespace valid sentences would be:
- Whitespace is ...
- Whitespaces are ...
- Whitespace characters are ...

But this is not correct:
- Whitespace are ...

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
