### PR TITLE
[Debug][ErrorHandler] Preserve our error handler when a logger sets another one

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -523,6 +523,10 @@ class ErrorHandler
                 $this->loggers[$type][0]->log($level, $logMessage, $errorAsException ? ['exception' => $errorAsException] : []);
             } finally {
                 $this->isRecursive = false;
+
+                if (!\defined('HHVM_VERSION')) {
+                    set_error_handler([$this, __FUNCTION__]);
+                }
             }
         }
 

--- a/src/Symfony/Component/Debug/Tests/Fixtures/LoggerThatSetAnErrorHandler.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/LoggerThatSetAnErrorHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+use Psr\Log\AbstractLogger;
+
+class LoggerThatSetAnErrorHandler extends AbstractLogger
+{
+    public function log($level, $message, array $context = [])
+    {
+        set_error_handler('is_string');
+        restore_error_handler();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When logging errors handled by the `ErrorHandler::handleError()` method, the logger can temporarily set its own custom error handler. This is for example the case of `Monolog` in the `StreamHandler` class (cf https://github.com/Seldaek/monolog/blob/ebb804e432e8fe0fe96828f30d89c45581d36d07/src/Monolog/Handler/StreamHandler.php#L101).

However, when the previous error handler is restored by the logger, it "skips" the real previous handler (the `ErrorHandler::handleError()` one) in the pile and goes back directly to the one before. I guess this is because the `restore_error_handler()` call is technically done in the error handler itself, so it logically restore it to the one before and not to itself.

Here is an easy small example that shows the PHP behavior : https://3v4l.org/4OZNZ

The only solution I have found to fix it is to set our error handler everytime an error is logged.

Here are the things I discovered while trying to find a cleaner fix : 
- Setting the same error handler in the error handler itself doesn't actually add it to the pile. This is why adding a check is useless. 
- Checking if the logger modified the error handler is impossible anyway : to get the current error handler, you need to set a new one temporarirly and then revert it. However, when you revert it by calling `restore_error_handler()` you end up having the same problem you are trying to fix...
- Also trying to get the current error handler in the error handler itself will return NULL if it is itself.