### PR TITLE
[Fix Bug]SplFileInfo::getSize(): stat failed

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -197,7 +197,7 @@ class BinaryFileResponse extends Response
         $this->offset = 0;
         $this->maxlen = -1;
 
-        if (false === $fileSize = $this->file->getSize()) {
+        if (!$this->file->isFile() || false === $fileSize = $this->file->getSize()) {
             return $this;
         }
         $this->headers->set('Content-Length', $fileSize);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

RuntimeException: SplFileInfo::getSize(): stat failed for symfony/http-foundation/BinaryFileResponse.php:200
