### PR TITLE
[Debug] remove return type hint for PHP 5 compatibility

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -124,7 +124,10 @@ class DebugClassLoader
         }
     }
 
-    public function findFile($class): ?string
+    /**
+     * @return string|null
+     */
+    public function findFile($class)
     {
         return $this->isFinder ? $this->classLoader[0]->findFile($class) ?: null : null;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 