### PR TITLE
[DependencyInjection] fix test after revert of bugfix

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
@@ -4,6 +4,15 @@ services:
         class: Symfony\Component\DependencyInjection\ContainerInterface
         public: true
         synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
+        public: true
+        tags:
+            - { name: foo }
+            - { name: baz }
+        deprecated: '%service_id%'
+        arguments: [1]
+        factory: f
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
         public: true
@@ -12,14 +21,5 @@ services:
             - { name: baz }
         deprecated: '%service_id%'
         lazy: true
-        arguments: [1]
-        factory: f
-    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
-        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
-        public: true
-        tags:
-            - { name: foo }
-            - { name: baz }
-        deprecated: '%service_id%'
         arguments: [1]
         factory: f


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In #29853 the bugfix made in #29597 was reverted as it did not work as
expected. This fixture file has been modified after the 3.4 branch was
merged up to account for the changes made in #2957 and must now be
reverted to the former state too.
