### PR TITLE
[Form] Add input_format option to DateType and DateTimeType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -32,6 +32,7 @@ CHANGELOG
        }
    }
    ```
+ * added new option `input_format` to `DateType` and `DateTimeType` to specify the date format when using the `string` input.
 
 4.2.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -176,7 +176,7 @@ class DateTimeType extends AbstractType
             $builder->addModelTransformer(new DateTimeImmutableToDateTimeTransformer());
         } elseif ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'])
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], $options['input_format'])
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
@@ -251,6 +251,7 @@ class DateTimeType extends AbstractType
             'empty_data' => function (Options $options) {
                 return $options['compound'] ? [] : '';
             },
+            'input_format' => 'Y-m-d H:i:s',
         ]);
 
         // Don't add some defaults in order to preserve the defaults
@@ -317,6 +318,8 @@ class DateTimeType extends AbstractType
 
             return '';
         });
+
+        $resolver->setAllowedTypes('input_format', 'string');
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -154,7 +154,7 @@ class DateType extends AbstractType
             $builder->addModelTransformer(new DateTimeImmutableToDateTimeTransformer());
         } elseif ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'Y-m-d')
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], $options['input_format'])
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
@@ -283,6 +283,7 @@ class DateType extends AbstractType
                 return $options['compound'] ? [] : '';
             },
             'choice_translation_domain' => false,
+            'input_format' => 'Y-m-d',
         ]);
 
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);
@@ -305,6 +306,8 @@ class DateType extends AbstractType
         $resolver->setAllowedTypes('years', 'array');
         $resolver->setAllowedTypes('months', 'array');
         $resolver->setAllowedTypes('days', 'array');
+
+        $resolver->setAllowedTypes('input_format', 'string');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -671,4 +671,19 @@ class DateTimeTypeTest extends BaseTypeTest
             'Compound choice field' => ['choice', ['date' => ['year' => '2018', 'month' => '11', 'day' => '11'], 'time' => ['hour' => '21', 'minute' => '23']], $expectedData],
         ];
     }
+
+    public function testSubmitStringWithCustomInputFormat(): void
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'input' => 'string',
+            'widget' => 'single_text',
+            'input_format' => 'd/m/Y H:i:s P',
+        ]);
+
+        $form->submit('2018-01-14T21:29:00');
+
+        $this->assertSame('14/01/2018 21:29:00 +00:00', $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -1037,4 +1037,19 @@ class DateTypeTest extends BaseTypeTest
             'Compound choice fields' => ['choice', ['year' => '2018', 'month' => '11', 'day' => '11'], $expectedData],
         ];
     }
+
+    public function testSubmitStringWithCustomInputFormat(): void
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'string',
+            'input_format' => 'd/m/Y',
+        ]);
+
+        $form->submit('2018-01-14');
+
+        $this->assertSame('14/01/2018', $form->getData());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/29883
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10882

Add a new option to specify the date format when using the `string` input type.