### PR TITLE
[Serializer] Docblock about throwing exceptions on serializer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\Serializer\Exception\BadMethodCallException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -41,8 +42,9 @@ interface DenormalizerInterface
      * @throws ExtraAttributesException Occurs when the item doesn't have attribute to receive given data
      * @throws LogicException           Occurs when the normalizer is not supposed to denormalize
      * @throws RuntimeException         Occurs if the class cannot be instantiated
+     * @throws ExceptionInterface       Occurs for all the other cases of errors
      */
-    public function denormalize($data, $class, $format = null, array $context = array());
+    public function denormalize($data, $class, $format = null, array $context = []);
 
     /**
      * Checks whether the given class is supported for denormalization by this normalizer.

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
 
@@ -35,8 +36,9 @@ interface NormalizerInterface
      * @throws CircularReferenceException Occurs when the normalizer detects a circular reference when no circular
      *                                    reference handler can fix it
      * @throws LogicException             Occurs when the normalizer is not called in an expected context
+     * @throws ExceptionInterface         Occurs for all the other cases of errors
      */
-    public function normalize($object, $format = null, array $context = array());
+    public function normalize($object, $format = null, array $context = []);
 
     /**
      * Checks whether the given class is supported for normalization by this normalizer.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes 
| License       | MIT

Most of the serializers can throw a `\Symfony\Component\Serializer\ExceptionInterface`. This makes the docblock in line with that.

Similar to this https://github.com/symfony/symfony/pull/29832