### PR TITLE
[Form][CallbackTransformer] Make args optional

### DIFF
--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -20,10 +20,10 @@ class CallbackTransformer implements DataTransformerInterface
     private $reverseTransform;
 
     /**
-     * @param callable $transform        The forward transform callback
-     * @param callable $reverseTransform The reverse transform callback
+     * @param callable|null $transform        The forward transform callback
+     * @param callable|null $reverseTransform The reverse transform callback
      */
-    public function __construct(callable $transform, callable $reverseTransform)
+    public function __construct(?callable $transform, ?callable $reverseTransform)
     {
         $this->transform = $transform;
         $this->reverseTransform = $reverseTransform;
@@ -41,6 +41,10 @@ class CallbackTransformer implements DataTransformerInterface
      */
     public function transform($data)
     {
+        if (null === $this->transform) {
+            return $data;
+        }
+
         return ($this->transform)($data);
     }
 
@@ -57,6 +61,10 @@ class CallbackTransformer implements DataTransformerInterface
      */
     public function reverseTransform($data)
     {
+        if (null === $this->reverseTransform) {
+            return $data;
+        }
+
         return ($this->reverseTransform)($data);
     }
 }

--- a/src/Symfony/Component/Form/Tests/CallbackTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/CallbackTransformerTest.php
@@ -16,14 +16,35 @@ use Symfony\Component\Form\CallbackTransformer;
 
 class CallbackTransformerTest extends TestCase
 {
-    public function testTransform()
+    /**
+     * @dataProvider transformProvider
+     */
+    public function testTransform($expected, ?callable $transform, $value): void
     {
-        $transformer = new CallbackTransformer(
-            function ($value) { return $value.' has been transformed'; },
-            function ($value) { return $value.' has reversely been transformed'; }
-        );
+        $this->assertSame($expected, (new CallbackTransformer($transform, null))->transform($value));
+    }
 
-        $this->assertEquals('foo has been transformed', $transformer->transform('foo'));
-        $this->assertEquals('bar has reversely been transformed', $transformer->reverseTransform('bar'));
+    public function transformProvider(): array
+    {
+        return [
+            ['foo has been transformed', function ($value) { return $value.' has been transformed'; }, 'foo'],
+            ['ccc', null, 'ccc'],
+        ];
+    }
+
+    /**
+     * @dataProvider reverseTransformProvider
+     */
+    public function testReverseTransform($expected, ?callable $reverseTransform, $value): void
+    {
+        $this->assertSame($expected, (new CallbackTransformer(null, $reverseTransform))->reverseTransform($value));
+    }
+
+    public function reverseTransformProvider(): array
+    {
+        return [
+          ['bar has reversely been transformed', function ($value) { return $value.' has reversely been transformed'; }, 'bar'],
+          ['ccc', null, 'ccc'],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I could not find a good title for this 😕 

If you only want to transform for one side and not the other, you end up passing an useless callable : 
```php
new CallbackTransformer(function ($value) {
    return $value;
}, ...)
``` 