### PR TITLE
Fixes issues #27828 and #28326

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/BoundArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/BoundArgument.php
@@ -16,16 +16,29 @@ namespace Symfony\Component\DependencyInjection\Argument;
  */
 final class BoundArgument implements ArgumentInterface
 {
+    const SERVICE_BIND = 0;
+    const DEFAULT_BIND = 1;
+    const INSTANCE_BIND = 2;
+
+    const MESSAGES = [
+        1 => 'under "_defaults"',
+        2 => 'under "_instanceof"',
+    ];
+
     private static $sequence = 0;
 
     private $value;
     private $identifier;
     private $used;
+    private $type;
+    private $file;
 
-    public function __construct($value)
+    public function __construct($value, $type = 0, $file = null)
     {
         $this->value = $value;
         $this->identifier = ++self::$sequence;
+        $this->type = (int) $type;
+        $this->file = (string) $file;
     }
 
     /**
@@ -33,7 +46,7 @@ final class BoundArgument implements ArgumentInterface
      */
     public function getValues()
     {
-        return [$this->value, $this->identifier, $this->used];
+        return [$this->value, $this->identifier, $this->used, $this->type, $this->file];
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -123,6 +123,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
     private $removedIds = [];
 
+    /**
+     * @var bool[][][] a map of values bound to arguments in definitions
+     */
+    private $bindings = [];
+
     private static $internalTypes = [
         'int' => true,
         'float' => true,
@@ -1021,6 +1026,14 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         unset($this->aliasDefinitions[$id], $this->removedIds[$id]);
 
+        $bindings = $definition->getBindings();
+        if (!empty($bindings)) {
+            foreach ($bindings as $argument => $binding) {
+                list(, $identifier) = $binding->getValues();
+                $this->bindings[$id][$argument][$identifier] = true;
+            }
+        }
+
         return $this->definitions[$id] = $definition;
     }
 
@@ -1655,5 +1668,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         return false;
+    }
+
+    public function getBindings(): array
+    {
+        return $this->bindings;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -299,7 +299,9 @@ class YamlFileLoader extends FileLoader
                 throw new InvalidArgumentException(sprintf('Parameter "bind" in "_defaults" must be an array in %s. Check your YAML syntax.', $file));
             }
 
-            $defaults['bind'] = array_map(function ($v) { return new BoundArgument($v); }, $this->resolveServices($defaults['bind'], $file));
+            foreach ($this->resolveServices($defaults['bind'], $file) as $argument => $value) {
+                $defaults['bind'][$argument] = new BoundArgument($value, BoundArgument::DEFAULT_BIND, $file);
+            }
         }
 
         return $defaults;
@@ -558,6 +560,12 @@ class YamlFileLoader extends FileLoader
                 }
 
                 $bindings = array_merge($bindings, $this->resolveServices($service['bind'], $file));
+
+                $bindingType = $this->isLoadingInstanceof ? BoundArgument::INSTANCE_BIND : BoundArgument::SERVICE_BIND;
+
+                foreach ($bindings as $argument => $value) {
+                    $bindings[$argument] = new BoundArgument($value, $bindingType, $file);
+                }
             }
 
             $definition->setBindings($bindings);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class Foo
+{
+    public function __construct($abc)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/defaults_bindings.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/defaults_bindings.yml
@@ -1,0 +1,14 @@
+services:
+    _defaults:
+        bind:
+            $quz: quzFirstValue
+            $abc: abcFirstValue
+
+    bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
+
+    factory:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummy
+
+    foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/defaults_bindings2.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/defaults_bindings2.yml
@@ -1,0 +1,10 @@
+services:
+    _defaults:
+        bind:
+            $abc: abcSecondValue
+
+    foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Foo
+
+    factory:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummy

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/defaults_bindings3.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/defaults_bindings3.yml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        bind:
+            $abc: abcThirdValue
+
+    foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Foo
+        bind:

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\ResolveBindingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -731,5 +732,23 @@ class YamlFileLoaderTest extends TestCase
             '$quz' => 'quz',
             '$factory' => 'factory',
         ], array_map(function ($v) { return $v->getValues()[0]; }, $definition->getBindings()));
+    }
+
+    /**
+     * The pass may throw an exception, which will cause the test to fail.
+     */
+    public function testOverriddenDefaultsBindings()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('defaults_bindings.yml');
+        $loader->load('defaults_bindings2.yml');
+        $loader->load('defaults_bindings3.yml');
+
+        $pass = new ResolveBindingsPass();
+        $pass->process($container);
+
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27828, #28326 
| License       | MIT

#27828
I extended a new error message proposed by @weaverryan by adding information about the file in which the bind is located. This will require changing some tests in [ResolveBindingsPassTest](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php), which have an expectedExceptionMessageRegexp assertion. I will do it once the new error message is accepted. If I am not mistaken, the bug may also affect configurations using XML instead of YAML, but I left it for a possible separate PR.

#28326
The included test is a small modification of a test proposed by @GuilhemN. The general idea for this fix is to track all the bindings in the **ContainerBuilder**, to see, if a specific argument in a specific service has more than one bound value. If so, this means, that a default bind from one file was overwritten by a default from another file, and the overwritten may be treated as used.

