### PR TITLE
[Form] weaken the rejection of submitted array data

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1521,4 +1521,18 @@ class EntityTypeTest extends BaseTypeTest
         $this->assertEquals($collection, $form->getNormData());
         $this->assertEquals($collection, $form->getData());
     }
+
+    public function testSubmitArray()
+    {
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $this->persist([$entity1]);
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ]);
+        $form->submit([]);
+
+        $this->assertFalse($form->isSynchronized());
+    }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -59,6 +59,7 @@ class CheckboxType extends AbstractType
             'value' => '1',
             'empty_data' => $emptyData,
             'compound' => false,
+            'accept_multiple_values' => false,
         ]);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -328,6 +328,8 @@ class ChoiceType extends AbstractType
             'placeholder' => $placeholderDefault,
             'error_bubbling' => false,
             'compound' => $compound,
+            // submitted arrays are dealt with in data transformers
+            'accept_multiple_values' => true,
             // The view data is always a string, even if the "data" option
             // is manually set to an object.
             // See https://github.com/symfony/symfony/pull/5582

--- a/src/Symfony/Component/Form/Extension/Core/Type/ColorType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ColorType.php
@@ -12,9 +12,18 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ColorType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('accept_multiple_values', false);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
@@ -233,6 +233,9 @@ class DateIntervalType extends AbstractType
                 // this option.
                 'data_class' => null,
                 'compound' => $compound,
+                'accept_multiple_values' => function (Options $options) {
+                    return $options['compound'];
+                },
                 'empty_data' => $emptyData,
                 'labels' => [],
             ]

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -235,6 +235,9 @@ class DateTimeType extends AbstractType
             // this option.
             'data_class' => null,
             'compound' => $compound,
+            'accept_multiple_values' => function (Options $options) {
+                return $options['compound'];
+            },
             'empty_data' => function (Options $options) {
                 return $options['compound'] ? [] : '';
             },

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -276,6 +276,9 @@ class DateType extends AbstractType
             // this option.
             'data_class' => null,
             'compound' => $compound,
+            'accept_multiple_values' => function (Options $options) {
+                return $options['compound'];
+            },
             'empty_data' => function (Options $options) {
                 return $options['compound'] ? [] : '';
             },

--- a/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
@@ -12,9 +12,18 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EmailType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('accept_multiple_values', false);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -105,6 +105,8 @@ class FileType extends AbstractType
             'data_class' => $dataClass,
             'empty_data' => $emptyData,
             'multiple' => false,
+            // invalid submitted arrays will be detected when the submitted data are processed by the type
+            'accept_multiple_values' => true,
             'allow_file_upload' => true,
         ]);
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -179,10 +179,18 @@ class FormType extends BaseType
             'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
             'upload_max_size_message' => $uploadMaxSizeMessage, // internal
             'allow_file_upload' => false,
+            'accept_multiple_values' => function (Options $options) {
+                if ($options['compound']) {
+                    return true;
+                }
+
+                return null;
+            },
         ]);
 
         $resolver->setAllowedTypes('label_attr', 'array');
         $resolver->setAllowedTypes('upload_max_size_message', ['callable']);
+        $resolver->setAllowedTypes('accept_multiple_values', ['bool', 'null']);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/HiddenType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/HiddenType.php
@@ -27,6 +27,7 @@ class HiddenType extends AbstractType
             // Pass errors to the parent
             'error_bubbling' => true,
             'compound' => false,
+            'accept_multiple_values' => false,
         ]);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
@@ -43,6 +43,7 @@ class IntegerType extends AbstractType
             // Integer cast rounds towards 0, so do the same when displaying fractions
             'rounding_mode' => IntegerToLocalizedStringTransformer::ROUND_DOWN,
             'compound' => false,
+            'accept_multiple_values' => false,
         ]);
 
         $resolver->setAllowedValues('rounding_mode', [

--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -56,6 +56,7 @@ class MoneyType extends AbstractType
             'divisor' => 1,
             'currency' => 'EUR',
             'compound' => false,
+            'accept_multiple_values' => false,
         ]);
 
         $resolver->setAllowedTypes('scale', 'int');

--- a/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
@@ -41,6 +41,7 @@ class NumberType extends AbstractType
             'grouping' => false,
             'rounding_mode' => NumberToLocalizedStringTransformer::ROUND_HALF_UP,
             'compound' => false,
+            'accept_multiple_values' => false,
         ]);
 
         $resolver->setAllowedValues('rounding_mode', [

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -35,6 +35,7 @@ class PasswordType extends AbstractType
     {
         $resolver->setDefaults([
             'always_empty' => true,
+            'accept_multiple_values' => false,
             'trim' => false,
         ]);
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
@@ -35,6 +35,7 @@ class PercentType extends AbstractType
             'scale' => 0,
             'type' => 'fractional',
             'compound' => false,
+            'accept_multiple_values' => false,
         ]);
 
         $resolver->setAllowedValues('type', [

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -12,9 +12,18 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RangeType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('accept_multiple_values', false);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
@@ -12,9 +12,18 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SearchType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('accept_multiple_values', false);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/TelType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TelType.php
@@ -12,9 +12,18 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TelType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('accept_multiple_values', false);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -37,6 +37,7 @@ class TextType extends AbstractType implements DataTransformerInterface
     {
         $resolver->setDefaults([
             'compound' => false,
+            'accept_multiple_values' => false,
         ]);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TextareaType extends AbstractType
 {
@@ -23,6 +24,14 @@ class TextareaType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['pattern'] = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('accept_multiple_values', false);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -273,6 +273,9 @@ class TimeType extends AbstractType
                 return $options['compound'] ? [] : '';
             },
             'compound' => $compound,
+            'accept_multiple_values' => function (Options $options) {
+                return $options['compound'];
+            },
             'choice_translation_domain' => false,
         ]);
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -34,6 +34,7 @@ class UrlType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefault('default_protocol', 'http');
+        $resolver->setDefault('accept_multiple_values', false);
 
         $resolver->setAllowedTypes('default_protocol', ['null', 'string']);
     }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -535,7 +535,7 @@ class Form implements \IteratorAggregate, FormInterface
         } elseif (!$this->config->getOption('allow_file_upload') && $this->config->getRequestHandler()->isFileUpload($submittedData)) {
             $submittedData = null;
             $this->transformationFailure = new TransformationFailedException('Submitted data was expected to be text or number, file upload given.');
-        } elseif (\is_array($submittedData) && !$this->config->getCompound() && !$this->config->hasOption('multiple')) {
+        } elseif (\is_array($submittedData) && !$this->config->getCompound() && false === $this->config->getOption('accept_multiple_values', null)) {
             $submittedData = null;
             $this->transformationFailure = new TransformationFailedException('Submitted data was expected to be text or number, array given.');
         }

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -1036,20 +1036,50 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertFalse($submit->isSubmitted());
     }
 
-    public function testArrayTransformationFailureOnSubmit()
+    public function testArrayTransformationFailureOnSubmitWhenMultipleValuesNotAccepted()
     {
-        $this->form->add($this->getBuilder('foo')->setCompound(false)->getForm());
-        $this->form->add($this->getBuilder('bar', null, null, ['multiple' => false])->setCompound(false)->getForm());
-
+        $this->form->add($this->getBuilder('foo', null, null, ['accept_multiple_values' => false])->getForm());
         $this->form->submit([
-            'foo' => ['foo'],
-            'bar' => ['bar'],
+            'foo' => [
+                'foo',
+                'bar' => [
+                    'baz' => 'baz',
+                ],
+            ],
         ]);
 
         $this->assertNull($this->form->get('foo')->getData());
         $this->assertSame('Submitted data was expected to be text or number, array given.', $this->form->get('foo')->getTransformationFailure()->getMessage());
+    }
 
-        $this->assertSame(['bar'], $this->form->get('bar')->getData());
+    public function testArrayDataIsAllowedWhenFormIsCompound()
+    {
+        $this->form->add($this->getBuilder('foo', null, null, ['compound' => true])->getForm());
+        $this->form->submit([
+            'foo' => [
+                'foo',
+                'bar' => [
+                    'baz' => 'baz',
+                ],
+            ],
+        ]);
+
+        $this->assertSame(['foo', 'bar' => ['baz' => 'baz']], $this->form->get('foo')->getData());
+    }
+
+    public function testArrayDataIsAllowedWhenNotExplicitlyForbidden()
+    {
+        $this->form->add($this->getBuilder('foo')->getForm());
+        $this->form->submit([
+            'foo' => [
+                'foo',
+                'bar' => [
+                    'baz' => 'baz',
+                ],
+            ],
+        ]);
+
+        $this->assertSame(['foo', 'bar' => ['baz' => 'baz']], $this->form->get('foo')->getData());
     }
 
     public function testFileUpload()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -167,6 +167,14 @@ abstract class BaseTypeTest extends TypeTestCase
         $this->assertSame($expectedData, $form->getData());
     }
 
+    public function testSubmitArray()
+    {
+        $form = $this->factory->create($this->getTestedType());
+        $form->submit([]);
+
+        $this->assertSame($form->getConfig()->getOption('accept_multiple_values'), $form->isSynchronized());
+    }
+
     protected function getTestedType()
     {
         return static::TESTED_TYPE;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -34,4 +34,9 @@ class ButtonTypeTest extends BaseTypeTest
     {
         parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
     }
+
+    public function testSubmitArray()
+    {
+        $this->markTestSkipped();
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -190,4 +190,9 @@ class CheckboxTypeTest extends BaseTypeTest
         $this->assertSame($expectedData, $form->getNormData());
         $this->assertSame($expectedData, $form->getData());
     }
+
+    protected function supportsMultipleValues()
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2053,4 +2053,12 @@ class ChoiceTypeTest extends BaseTypeTest
             'Multiple expanded' => [true, true],
         ];
     }
+
+    public function testSubmitArray()
+    {
+        $form = $this->factory->create($this->getTestedType());
+        $form->submit([]);
+
+        $this->assertFalse($form->isSynchronized());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -69,4 +69,12 @@ class CountryTypeTest extends BaseTypeTest
 
         $this->assertSame([], $type->loadChoicesForValues(['foo']));
     }
+
+    public function testSubmitArray()
+    {
+        $form = $this->factory->create($this->getTestedType());
+        $form->submit([]);
+
+        $this->assertFalse($form->isSynchronized());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -52,4 +52,12 @@ class CurrencyTypeTest extends BaseTypeTest
 
         $this->assertSame([], $type->loadChoicesForValues(['foo']));
     }
+
+    public function testSubmitArray()
+    {
+        $form = $this->factory->create($this->getTestedType());
+        $form->submit([]);
+
+        $this->assertFalse($form->isSynchronized());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -50,4 +50,9 @@ class IntegerTypeTest extends BaseTypeTest
         $this->assertSame($expectedData, $form->getNormData());
         $this->assertSame($expectedData, $form->getData());
     }
+
+    protected function supportsMultipleValues()
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -62,4 +62,12 @@ class LanguageTypeTest extends BaseTypeTest
 
         $this->assertSame([], $type->loadChoicesForValues(['foo']));
     }
+
+    public function testSubmitArray()
+    {
+        $form = $this->factory->create($this->getTestedType());
+        $form->submit([]);
+
+        $this->assertFalse($form->isSynchronized());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -52,4 +52,12 @@ class LocaleTypeTest extends BaseTypeTest
 
         $this->assertSame([], $type->loadChoicesForValues(['foo']));
     }
+
+    public function testSubmitArray()
+    {
+        $form = $this->factory->create($this->getTestedType());
+        $form->submit([]);
+
+        $this->assertFalse($form->isSynchronized());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -82,4 +82,9 @@ class MoneyTypeTest extends BaseTypeTest
         $this->assertSame($expectedData, $form->getNormData());
         $this->assertSame($expectedData, $form->getData());
     }
+
+    protected function supportsMultipleValues()
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -75,4 +75,9 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame($expectedData, $form->getNormData());
         $this->assertSame($expectedData, $form->getData());
     }
+
+    protected function supportsMultipleValues()
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -51,4 +51,9 @@ class PasswordTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull($expected, $norm, '');
     }
+
+    protected function supportsMultipleValues()
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
@@ -62,4 +62,9 @@ class SubmitTypeTest extends ButtonTypeTest
 
         $this->assertSame($form, $form->add('send', static::TESTED_TYPE));
     }
+
+    public function testSubmitArray()
+    {
+        $this->markTestSkipped();
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -58,4 +58,9 @@ class TextTypeTest extends BaseTypeTest
         $this->assertSame($dataAsString, $view->vars['value']);
         $this->assertSame($dataAsString, $form->getData());
     }
+
+    protected function supportsMultipleValues()
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -72,4 +72,12 @@ class TimezoneTypeTest extends BaseTypeTest
 
         $this->assertContains(new ChoiceView('Europe/Amsterdam', 'Europe/Amsterdam', 'Amsterdam'), $choices, '', false, false);
     }
+
+    public function testSubmitArray()
+    {
+        $form = $this->factory->create($this->getTestedType());
+        $form->submit([]);
+
+        $this->assertFalse($form->isSynchronized());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -95,4 +95,9 @@ class UrlTypeTest extends TextTypeTest
         $this->assertSame($expectedData, $form->getNormData());
         $this->assertSame($expectedData, $form->getData());
     }
+
+    protected function supportsMultipleValues()
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -19,6 +19,7 @@
         ],
         "overridden": {
             "Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType": [
+                "accept_multiple_values",
                 "compound",
                 "data_class",
                 "empty_data",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -2,31 +2,31 @@
 Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
 ==============================================================================
 
- --------------------------- -------------------- ------------------------- ----------------------- 
-  Options                     Overridden options   Parent options            Extension options      
- --------------------------- -------------------- ------------------------- ----------------------- 
-  choice_attr                 FormType             FormType                  FormTypeCsrfExtension  
-  choice_label               -------------------- ------------------------- ----------------------- 
-  choice_loader               compound             action                    csrf_field_name        
-  choice_name                 data_class           allow_file_upload         csrf_message           
-  choice_translation_domain   empty_data           attr                      csrf_protection        
-  choice_value                error_bubbling       auto_initialize           csrf_token_id          
-  choices                     trim                 block_name                csrf_token_manager     
-  choices_as_values                                by_reference                                     
-  expanded                                         data                                             
-  group_by                                         disabled                                         
-  multiple                                         inherit_data                                     
-  placeholder                                      label                                            
-  preferred_choices                                label_attr                                       
-                                                   label_format                                     
-                                                   mapped                                           
-                                                   method                                           
-                                                   post_max_size_message                            
-                                                   property_path                                    
-                                                   required                                         
-                                                   translation_domain                               
-                                                   upload_max_size_message                          
- --------------------------- -------------------- ------------------------- ----------------------- 
+ --------------------------- ------------------------ ------------------------- ----------------------- 
+  Options                     Overridden options       Parent options            Extension options      
+ --------------------------- ------------------------ ------------------------- ----------------------- 
+  choice_attr                 FormType                 FormType                  FormTypeCsrfExtension  
+  choice_label               ------------------------ ------------------------- ----------------------- 
+  choice_loader               accept_multiple_values   action                    csrf_field_name        
+  choice_name                 compound                 allow_file_upload         csrf_message           
+  choice_translation_domain   data_class               attr                      csrf_protection        
+  choice_value                empty_data               auto_initialize           csrf_token_id          
+  choices                     error_bubbling           block_name                csrf_token_manager     
+  choices_as_values           trim                     by_reference                                     
+  expanded                                             data                                             
+  group_by                                             disabled                                         
+  multiple                                             inherit_data                                     
+  placeholder                                          label                                            
+  preferred_choices                                    label_attr                                       
+                                                       label_format                                     
+                                                       mapped                                           
+                                                       method                                           
+                                                       post_max_size_message                            
+                                                       property_path                                    
+                                                       required                                         
+                                                       translation_domain                               
+                                                       upload_max_size_message                          
+ --------------------------- ------------------------ ------------------------- ----------------------- 
 
 Parent types
 ------------

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
@@ -3,6 +3,7 @@
     "block_prefix": "form",
     "options": {
         "own": [
+            "accept_multiple_values",
             "action",
             "allow_file_upload",
             "attr",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
@@ -5,6 +5,7 @@ Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")
  ------------------------- 
   Options                  
  ------------------------- 
+  accept_multiple_values   
   action                   
   allow_file_upload        
   attr                     


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29809, #29841, #29905
| License       | MIT
| Doc PR        | 

It seems that the bugfix made in #29307 seems to break quite some applications. I therefore suggest that we solve the issue a bit different by introducing a new `accept_multiple_values` option. This value will be `null` by default which means no checks will be performed for backwards compatibility. The core form types do explicitly set this value to `false` if they expect the submitted data to be strings. If a form is compound, the option value will automatically default to `true`.

Since from my experience most custom form types have child forms, they are already compound and so do accept arrays. Nothing will change for them. Other custom types will not have the check as long as they do not extend one of the built-in types that have this check enabled.

In Symfony 4.3 we can then deprecate the `null` default value so that each type must opt for either `true` or `false` as the value in 5.0.