### PR TITLE
[Console] ArrayInput: ensure option accept value

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -225,7 +225,7 @@ class ArgvInput extends Input
 
         $option = $this->definition->getOption($name);
 
-        if (null !== $value && !$option->acceptValue()) {
+        if (null !== $value && !$option->acceptValue() && 'verbose' !== $name) {
             throw new RuntimeException(sprintf('The "--%s" option does not accept a value.', $name));
         }
 

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -176,6 +176,10 @@ class ArrayInput extends Input
 
         $option = $this->definition->getOption($name);
 
+        if (!\in_array($value, [null, true], true) && !$option->acceptValue() && 'verbose' !== $name) {
+            throw new InvalidOptionException(sprintf('The "--%s" option does not accept a value.', $name));
+        }
+
         if (null === $value) {
             if ($option->isValueRequired()) {
                 throw new InvalidOptionException(sprintf('The "--%s" option requires a value.', $name));

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -890,10 +890,10 @@ class ApplicationTest extends TestCase
         $this->assertSame(Output::VERBOSITY_VERBOSE, $tester->getOutput()->getVerbosity(), '->run() sets the output to verbose if -v is passed');
 
         $tester->run(['command' => 'list', '-vv' => true]);
-        $this->assertSame(Output::VERBOSITY_VERY_VERBOSE, $tester->getOutput()->getVerbosity(), '->run() sets the output to verbose if -v is passed');
+        $this->assertSame(Output::VERBOSITY_VERY_VERBOSE, $tester->getOutput()->getVerbosity(), '->run() sets the output to very verbose if -vv is passed');
 
         $tester->run(['command' => 'list', '-vvv' => true]);
-        $this->assertSame(Output::VERBOSITY_DEBUG, $tester->getOutput()->getVerbosity(), '->run() sets the output to verbose if -v is passed');
+        $this->assertSame(Output::VERBOSITY_DEBUG, $tester->getOutput()->getVerbosity(), '->run() sets the output to debug if -vvv is passed');
 
         $application = new Application();
         $application->setAutoExit(false);
@@ -943,6 +943,27 @@ class ApplicationTest extends TestCase
         $this->addToAssertionCount(1);
 
         $input = new ArgvInput(['cli.php', '--verbose', 'foo:bar']);
+        $application->run($input, $output);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testVerboseOptionInFrontOfArguments()
+    {
+        require_once realpath(__DIR__.'/Fixtures/Foo7Command.php');
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->add(new \Foo7Command());
+
+        $output = new StreamOutput(fopen('php://memory', 'w', false));
+
+        $input = new ArgvInput(['cli.php', 'foo7:bar', '-v', 'bar']);
+        $application->run($input, $output);
+
+        $this->addToAssertionCount(1);
+
+        $input = new ArgvInput(['cli.php', 'foo7:bar', '--verbose=2', 'bar']);
         $application->run($input, $output);
 
         $this->addToAssertionCount(1);

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo7Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo7Command.php
@@ -1,0 +1,22 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Foo7Command extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('foo7:bar')
+            ->addArgument('foo', InputArgument::REQUIRED)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('foo argument: '.$input->getArgument('foo'));
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -79,7 +79,7 @@ class ArrayInputTest extends TestCase
         return [
             [
                 ['--foo' => 'bar'],
-                [new InputOption('foo')],
+                [new InputOption('foo', '', InputOption::VALUE_OPTIONAL)],
                 ['foo' => 'bar'],
                 '->parse() parses long options',
             ],
@@ -103,9 +103,15 @@ class ArrayInputTest extends TestCase
             ],
             [
                 ['-f' => 'bar'],
-                [new InputOption('foo', 'f')],
+                [new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL)],
                 ['foo' => 'bar'],
                 '->parse() parses short options',
+            ],
+            [
+                ['--verbose' => '2'],
+                [new InputOption('verbose', 'v', InputOption::VALUE_NONE)],
+                ['verbose' => '2'],
+                '->parse() allows verbose long option to have values',
             ],
             [
                 ['--' => null, '-f' => 'bar'],
@@ -145,6 +151,21 @@ class ArrayInputTest extends TestCase
                 ['--foo' => null],
                 new InputDefinition([new InputOption('foo', 'f', InputOption::VALUE_REQUIRED)]),
                 'The "--foo" option requires a value.',
+            ],
+            [
+                ['--foo' => 'bar'],
+                new InputDefinition([new InputOption('foo')]),
+                'The "--foo" option does not accept a value.',
+            ],
+            [
+                ['-f' => 'bar'],
+                new InputDefinition([new InputOption('foo', 'f')]),
+                'The "--foo" option does not accept a value.',
+            ],
+            [
+                ['--foo' => 'bar'],
+                new InputDefinition([new InputOption('foo', 'f', InputOption::VALUE_NONE)]),
+                'The "--foo" option does not accept a value.',
             ],
             [
                 ['--foo' => 'foo'],

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -27,22 +27,22 @@ class InputTest extends TestCase
 
     public function testOptions()
     {
-        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name')]));
+        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name', null, InputOption::VALUE_OPTIONAL)]));
         $this->assertEquals('foo', $input->getOption('name'), '->getOption() returns the value for the given option');
 
         $input->setOption('name', 'bar');
         $this->assertEquals('bar', $input->getOption('name'), '->setOption() sets the value for a given option');
         $this->assertEquals(['name' => 'bar'], $input->getOptions(), '->getOptions() returns all option values');
 
-        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name', '', InputOption::VALUE_OPTIONAL), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $this->assertEquals('default', $input->getOption('bar'), '->getOption() returns the default value for optional options');
         $this->assertEquals(['name' => 'foo', 'bar' => 'default'], $input->getOptions(), '->getOptions() returns all option values, even optional ones');
 
-        $input = new ArrayInput(['--name' => 'foo', '--bar' => ''], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+        $input = new ArrayInput(['--name' => 'foo', '--bar' => ''], new InputDefinition([new InputOption('name', '', InputOption::VALUE_OPTIONAL), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $this->assertEquals('', $input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
         $this->assertEquals(['name' => 'foo', 'bar' => ''], $input->getOptions(), '->getOptions() returns all option values.');
 
-        $input = new ArrayInput(['--name' => 'foo', '--bar' => null], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+        $input = new ArrayInput(['--name' => 'foo', '--bar' => null], new InputDefinition([new InputOption('name', '', InputOption::VALUE_OPTIONAL), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $this->assertNull($input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
         $this->assertEquals(['name' => 'foo', 'bar' => null], $input->getOptions(), '->getOptions() returns all option values');
     }
@@ -51,7 +51,7 @@ class InputTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('The "foo" option does not exist.');
-        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name', '', InputOption::VALUE_OPTIONAL), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $input->setOption('foo', 'bar');
     }
 
@@ -59,7 +59,7 @@ class InputTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('The "foo" option does not exist.');
-        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
+        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name', '', InputOption::VALUE_OPTIONAL), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $input->getOption('foo');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  3.4 up to 4.2 for bug fixes 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | I dont think so
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | https://github.com/symfony/symfony/issues/29967
| License       | MIT
| Doc PR        | 

**edit**: Definition & reproduction [here](https://github.com/symfony/symfony/issues/29967).

In short: the CommandTester does not validate options set to mode `InputOption::VALUE_NONE`.

- When using the CLI, an `ArgvInput` holds and validates arguments to pass to the command.
- When using the `CommandTester`, an `ArrayInput` is used to hold and validate the parameters.
`ArrayInput` does not perform the check regarding if the long options accept values or not. (unlike ArgvInput [here](https://github.com/symfony/symfony/blob/ee520ed90b9393ebb46f4e9d5b003df2b63c7bf2/src/Symfony/Component/Console/Input/ArgvInput.php#L228))
 
Adding this validation like the `ArgvInput` handles it will lead to BC breaks because, as the testsuite is showing, a lot of people are testing commands with inputs containing things like `"--no-interaction" => true` (though options like `no-interaction` are set to mode `InputOption::VALUE_NONE`..)


To solve this & avoid bc breaks I propose to allow `true` (with `null`) as the only valid values for options set to `InputOption::VALUE_NONE`.
It implies to handle `verbose` option as an exception, since it's defined with mode `VALUE_NONE` to allow commands like `bin/console -vv bar` or `bin/console --verbose=2 bar`.