### PR TITLE
[DI] Fix FactoryReturnTypePassTest on PHP 5

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/FactoryReturnTypePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/FactoryReturnTypePassTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryParent;
  * @author Guilhem N. <egetick@gmail.com>
  *
  * @group legacy
+ * @requires function ReflectionMethod::getReturnType
  */
 class FactoryReturnTypePassTest extends TestCase
 {
@@ -44,13 +45,8 @@ class FactoryReturnTypePassTest extends TestCase
         $pass = new FactoryReturnTypePass();
         $pass->process($container);
 
-        if (method_exists(\ReflectionMethod::class, 'getReturnType')) {
-            $this->assertEquals(FactoryDummy::class, $factory->getClass());
-            $this->assertEquals(\stdClass::class, $foo->getClass());
-        } else {
-            $this->assertNull($factory->getClass());
-            $this->assertNull($foo->getClass());
-        }
+        $this->assertEquals(FactoryDummy::class, $factory->getClass());
+        $this->assertEquals(\stdClass::class, $foo->getClass());
         $this->assertEquals(__CLASS__, $bar->getClass());
     }
 
@@ -71,11 +67,7 @@ class FactoryReturnTypePassTest extends TestCase
         $pass = new FactoryReturnTypePass();
         $pass->process($container);
 
-        if (method_exists(\ReflectionMethod::class, 'getReturnType')) {
-            $this->assertEquals($returnType, $service->getClass());
-        } else {
-            $this->assertNull($service->getClass());
-        }
+        $this->assertEquals($returnType, $service->getClass());
     }
 
     public function returnTypesProvider()
@@ -107,7 +99,6 @@ class FactoryReturnTypePassTest extends TestCase
     }
 
     /**
-     * @requires function ReflectionMethod::getReturnType
      * @expectedDeprecation Relying on its factory's return-type to define the class of service "factory" is deprecated since Symfony 3.3 and won't work in 4.0. Set the "class" attribute to "Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummy" on the service definition instead.
      */
     public function testCompile()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

One of my PRs failed a Travis CI test on PHP 5 due to a syntax error resulting from loading a class with return type declarations:
https://travis-ci.org/symfony/symfony/jobs/482202091#L2865-L2867

Since **FactoryReturnTypePass** works only PHP 7
https://github.com/symfony/symfony/blob/aca3d2c90d3ad01687771ce75602fed5b12bcf2b/src/Symfony/Component/DependencyInjection/Compiler/FactoryReturnTypePass.php#L38-L43
I modified **FactoryReturnTypePassTest** accordingly.

