### PR TITLE
introducing native php serialize() support for Messenger transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,12 @@ CHANGELOG
  * Not passing the project directory to the constructor of the `AssetsInstallCommand` is deprecated. This argument will
    be mandatory in 5.0.
 
+ * [BC Break] When using Messenger, the default transport changed from
+   using Symfony's serializer service to use `PhpSerializer`, which uses
+   PHP's native `serialize()` and `unserialize()` functions. To use the
+   original serialization method, set the `framework.messenger.serializer.id`
+   config option to `messenger.transport.symfony_serializer`.
+
 4.2.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1060,7 +1060,7 @@ class Configuration implements ConfigurationInterface
                                 })
                             ->end()
                             ->children()
-                                ->scalarNode('id')->defaultValue(!class_exists(FullStack::class) && class_exists(Serializer::class) ? 'messenger.transport.symfony_serializer' : null)->end()
+                                ->scalarNode('id')->defaultValue('messenger.transport.native_php_serializer')->end()
                                 ->scalarNode('format')->defaultValue('json')->end()
                                 ->arrayNode('context')
                                     ->normalizeKeys(false)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1529,7 +1529,7 @@ class FrameworkExtension extends Extension
         } else {
             if ('messenger.transport.symfony_serializer' === $config['serializer']['id']) {
                 if (!$this->isConfigEnabled($container, $serializerConfig)) {
-                    throw new LogicException('The default Messenger serializer cannot be enabled as the Serializer support is not available. Try enabling it or running "composer require symfony/serializer-pack".');
+                    throw new LogicException('The Messenger serializer cannot be enabled as the Serializer support is not available. Try enabling it or running "composer require symfony/serializer-pack".');
                 }
 
                 $container->getDefinition('messenger.transport.symfony_serializer')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -24,7 +24,7 @@
         </service>
         <service id="Symfony\Component\Messenger\Transport\Serialization\SerializerInterface" alias="messenger.transport.serializer" />
 
-        <service id="messenger.transport.native_php_serializer" class="Symfony\Component\Messenger\Transport\Serialization\Serializer" />
+        <service id="messenger.transport.native_php_serializer" class="Symfony\Component\Messenger\Transport\Serialization\PhpSerializer" />
 
         <!-- Middleware -->
         <service id="messenger.middleware.handle_message" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -24,6 +24,8 @@
         </service>
         <service id="Symfony\Component\Messenger\Transport\Serialization\SerializerInterface" alias="messenger.transport.serializer" />
 
+        <service id="messenger.transport.native_php_serializer"  class="Symfony\Component\Messenger\Transport\Serialization\Serializer" />
+
         <!-- Middleware -->
         <service id="messenger.middleware.handle_message" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">
             <argument /> <!-- Bus handler resolver -->

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -24,7 +24,7 @@
         </service>
         <service id="Symfony\Component\Messenger\Transport\Serialization\SerializerInterface" alias="messenger.transport.serializer" />
 
-        <service id="messenger.transport.native_php_serializer"  class="Symfony\Component\Messenger\Transport\Serialization\Serializer" />
+        <service id="messenger.transport.native_php_serializer" class="Symfony\Component\Messenger\Transport\Serialization\Serializer" />
 
         <!-- Middleware -->
         <service id="messenger.middleware.handle_message" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Serializer\Serializer;
 
 class ConfigurationTest extends TestCase
 {
@@ -295,7 +294,7 @@ class ConfigurationTest extends TestCase
                 'routing' => [],
                 'transports' => [],
                 'serializer' => [
-                    'id' => !class_exists(FullStack::class) && class_exists(Serializer::class) ? 'messenger.transport.symfony_serializer' : null,
+                    'id' => 'messenger.transport.native_php_serializer',
                     'format' => 'json',
                     'context' => [],
                 ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -660,7 +660,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
-     * @expectedExceptionMessage The default Messenger serializer cannot be enabled as the Serializer support is not available. Try enabling it or running "composer require symfony/serializer-pack".
+     * @expectedExceptionMessage The Messenger serializer cannot be enabled as the Serializer support is not available. Try enabling it or running "composer require symfony/serializer-pack".
      */
     public function testMessengerTransportConfigurationWithoutSerializer()
     {

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,6 +7,10 @@ CHANGELOG
  * Added `PhpSerializer` which uses PHP's native `serialize()` and
    `unserialize()` to serialize messages to a transport
 
+ * [BC BREAK] If no serializer were passed, the default serializer
+   changed from `Serializer` to `PhpSerializer` inside `AmqpReceiver`,
+   `AmqpSender`, `AmqpTransport` and `AmqpTransportFactory`.
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * Added `PhpSerializer` which uses PHP's native `serialize()` and
+   `unserialize()` to serialize messages to a transport
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+
+class PhpSerializerTest extends TestCase
+{
+    public function testEncodedIsDecodable()
+    {
+        $serializer = new PhpSerializer();
+
+        $envelope = new Envelope(new DummyMessage('Hello'));
+
+        $this->assertEquals($envelope, $serializer->decode($serializer->encode($envelope)));
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Transport\AmqpExt\Exception\RejectMessageExceptionInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
-use Symfony\Component\Messenger\Transport\Serialization\Serializer;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
@@ -32,7 +32,7 @@ class AmqpReceiver implements ReceiverInterface
     public function __construct(Connection $connection, SerializerInterface $serializer = null)
     {
         $this->connection = $connection;
-        $this->serializer = $serializer ?? Serializer::create();
+        $this->serializer = $serializer ?? new PhpSerializer();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
-use Symfony\Component\Messenger\Transport\Serialization\Serializer;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
@@ -31,7 +31,7 @@ class AmqpSender implements SenderInterface
     public function __construct(Connection $connection, SerializerInterface $serializer = null)
     {
         $this->connection = $connection;
-        $this->serializer = $serializer ?? Serializer::create();
+        $this->serializer = $serializer ?? new PhpSerializer();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\Serialization\Serializer;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
@@ -31,7 +31,7 @@ class AmqpTransport implements TransportInterface
     public function __construct(Connection $connection, SerializerInterface $serializer = null)
     {
         $this->connection = $connection;
-        $this->serializer = $serializer ?? Serializer::create();
+        $this->serializer = $serializer ?? new PhpSerializer();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
-use Symfony\Component\Messenger\Transport\Serialization\Serializer;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -28,7 +28,7 @@ class AmqpTransportFactory implements TransportFactoryInterface
 
     public function __construct(SerializerInterface $serializer = null, bool $debug = false)
     {
-        $this->serializer = $serializer ?? Serializer::create();
+        $this->serializer = $serializer ?? new PhpSerializer();
         $this->debug = $debug;
     }
 

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 
 /**
- * @author Ruyan Weaver<ryan@symfonycasts.com>
+ * @author Ryan Weaver<ryan@symfonycasts.com>
  *
  * @experimental in 4.2
  */

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Serialization;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+
+/**
+ * @author Ruyan Weaver<ryan@symfonycasts.com>
+ *
+ * @experimental in 4.2
+ */
+class PhpSerializer implements SerializerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function decode(array $encodedEnvelope): Envelope
+    {
+        if (empty($encodedEnvelope['body'])) {
+            throw new InvalidArgumentException('Encoded envelope should have at least a "body".');
+        }
+
+        return unserialize($encodedEnvelope['body']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode(Envelope $envelope): array
+    {
+        return [
+            'body' => serialize($envelope),
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes and no
| New feature?  | yes and no
| BC breaks?    | maybe (yes if we change the default)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29163
| License       | MIT
| Doc PR        | TODO!

Messenger currently uses the Serialize to serialize to JSON and then unserialize. This creates a lot of issues:

1) The default serializer requires you to have getter & setter method (or public properties) for them to be serialized. This makes it easy for data to disappear. I've seen several really smart people have this problem.

2) Related to the above, the forced getters/setters (and no required constructor args) force you to design your message classes around this.

It's not that the serializer is doing a bad job - it's just not the right use-case for it.

This PR proposes simply using `serialize()` and `unserialize()`. This is the behavior we want: we want to put objects to sleep and wake them back up.

I believe the original reason we did not do this was so that we could export "generic JSON", in case we wanted other workers (not our Symfony app) to consume the messages. But, that's an edge case, and could still be accomplished by creating your own serializer.

Btw, Laravel uses `serialize()` as does Enqueue for (un)serializing Event objects. We're making our life more difficult for no benefit.

Cheers!