### PR TITLE
[Translation] Concatenated translation messages

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -156,9 +156,14 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
     {
         $message = '';
         $docToken = '';
+        $docPart = '';
 
         for (; $tokenIterator->valid(); $tokenIterator->next()) {
             $t = $tokenIterator->current();
+            if ('.' === $t) {
+                // Concatenate with next token
+                continue;
+            }
             if (!isset($t[1])) {
                 break;
             }
@@ -169,17 +174,22 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
                     break;
                 case T_ENCAPSED_AND_WHITESPACE:
                 case T_CONSTANT_ENCAPSED_STRING:
-                    $message .= $t[1];
+                    if ('' === $docToken) {
+                        $message .= PhpStringTokenParser::parse($t[1]);
+                    } else {
+                        $docPart = $t[1];
+                    }
                     break;
                 case T_END_HEREDOC:
-                    return PhpStringTokenParser::parseDocString($docToken, $message);
+                    $message .= PhpStringTokenParser::parseDocString($docToken, $docPart);
+                    $docToken = '';
+                    $docPart = '';
+                    break;
+                case T_WHITESPACE:
+                    break;
                 default:
                     break 2;
             }
-        }
-
-        if ($message) {
-            $message = PhpStringTokenParser::parse($message);
         }
 
         return $message;

--- a/src/Symfony/Component/Translation/Tests/Extractor/PhpExtractorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/PhpExtractorTest.php
@@ -51,6 +51,7 @@ EOF;
                 $expectedHeredoc => 'prefix'.$expectedHeredoc,
                 $expectedNowdoc => 'prefix'.$expectedNowdoc,
                 '{0} There is no apples|{1} There is one apple|]1,Inf[ There are %count% apples' => 'prefix{0} There is no apples|{1} There is one apple|]1,Inf[ There are %count% apples',
+                'concatenated message with heredoc and nowdoc' => 'prefixconcatenated message with heredoc and nowdoc',
             ],
             'not_messages' => [
                 'other-domain-test-no-params-short-array' => 'prefixother-domain-test-no-params-short-array',

--- a/src/Symfony/Component/Translation/Tests/fixtures/extractor/translation.html.php
+++ b/src/Symfony/Component/Translation/Tests/fixtures/extractor/translation.html.php
@@ -32,6 +32,14 @@ EOF
     ['%count%' => 10]
 ); ?>
 
+<?php echo $view['translator']->trans('concatenated'.' message'.<<<EOF
+ with heredoc
+EOF
+.<<<'EOF'
+ and nowdoc
+EOF
+); ?>
+
 <?php echo $view['translator']->trans('other-domain-test-no-params-short-array', [], 'not_messages'); ?>
 
 <?php echo $view['translator']->trans('other-domain-test-no-params-long-array', [], 'not_messages'); ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/29956
| License       | MIT
| Doc PR        | none

Concatenated translation messages are now treated correctly.