### PR TITLE
[HttpKernel] Fix HttpKernel Debug requirement

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5.9|>=7.0.8",
         "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
         "symfony/http-foundation": "~3.4.12|~4.0.12|^4.1.1",
-        "symfony/debug": "~2.8|~3.0|~4.0",
+        "symfony/debug": "^3.3.3|~4.0",
         "symfony/polyfill-ctype": "~1.8",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

The `LoggerDataCollector` is using the `SilencedErrorContext` class that doesn't exists before Symfony 3.2