### PR TITLE
[Process] disable transient test on Windows

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -135,6 +135,10 @@ class ProcessTest extends TestCase
 
     public function testWaitUntilSpecificOutput()
     {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestIncomplete('This test is too transient on Windows, help wanted to improve it');
+        }
+
         $p = $this->getProcess([self::$phpBin, __DIR__.'/KillableProcessWithOutput.php']);
         $p->start();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This test makes our Windows CI red 80% of the time, let's disable it until someone can have a deeper look.
PIng @Nek- , help wanted.