### PR TITLE
Allow exchange type headers binding

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -160,7 +160,7 @@ class Connection
         $this->exchange()->declareExchange();
 
         $this->queue()->declareQueue();
-        $this->queue()->bind($this->exchange()->getName(), $this->queueConfiguration['routing_key'] ?? null);
+        $this->queue()->bind($this->exchange()->getName(), $this->queueConfiguration['routing_key'] ?? null, $this->queueConfiguration['arguments'] ?? null);
     }
 
     public function channel(): \AMQPChannel

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -160,7 +160,7 @@ class Connection
         $this->exchange()->declareExchange();
 
         $this->queue()->declareQueue();
-        $this->queue()->bind($this->exchange()->getName(), $this->queueConfiguration['routing_key'] ?? null, $this->queueConfiguration['bind_arguments'] ?? null);
+        $this->queue()->bind($this->exchange()->getName(), $this->queueConfiguration['routing_key'] ?? null, $this->queueConfiguration['bind_arguments'] ?? []);
     }
 
     public function channel(): \AMQPChannel

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -160,7 +160,7 @@ class Connection
         $this->exchange()->declareExchange();
 
         $this->queue()->declareQueue();
-        $this->queue()->bind($this->exchange()->getName(), $this->queueConfiguration['routing_key'] ?? null, $this->queueConfiguration['arguments'] ?? null);
+        $this->queue()->bind($this->exchange()->getName(), $this->queueConfiguration['routing_key'] ?? null, $this->queueConfiguration['bind_arguments'] ?? null);
     }
 
     public function channel(): \AMQPChannel


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allows the use of headers exchange to deliver messages by defining the headers to bind.
When binding a exchange of type headers to a queue, adding the arguments allows you to define the message routing correctly.
