### PR TITLE
handles double-byte characters in autocomplete

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -256,6 +256,10 @@ class QuestionHelper extends Helper
             if ("\177" === $c) {
                 if (0 === $numMatches && 0 !== $i) {
                     --$i;
+                    if (\ord($ret[$i]) > 127) {
+                        // jump back one more byte if last character was double-byte character
+                        --$i;
+                    }
                     // Move cursor backwards
                     $output->write("\033[1D");
                 }
@@ -306,6 +310,11 @@ class QuestionHelper extends Helper
 
                 continue;
             } else {
+                if (\ord($c) > 127) {
+                    // read next byte for double-byte characters
+                    $c .= fread($inputStream, 1);
+                    ++$i;
+                }
                 $output->write($c);
                 $ret .= $c;
                 ++$i;


### PR DESCRIPTION
fixes #29966

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29966 
| License       | MIT
| Doc PR        | -

The autocomplete feature of the QuestionHelper uses fread which is not multibyte safe, resulting in broken display of such characters in the autocompletion. To fix this I check the ascii code number of the entered character. If it is greater than 127 the next byte is read too. The same logic applies when deleting characters.
