### PR TITLE
[FrameworkBundle] consolidate the mime types service definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -73,11 +73,6 @@ class FrameworkBundle extends Bundle
         if ($trustedHosts = $this->container->getParameter('kernel.trusted_hosts')) {
             Request::setTrustedHosts($trustedHosts);
         }
-
-        if ($this->container->has('mime_types')) {
-            $mt = $this->container->get('mime_types');
-            $mt->setDefault($mt);
-        }
     }
 
     public function build(ContainerBuilder $container)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mime_type.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mime_type.xml
@@ -7,6 +7,10 @@
     <services>
         <defaults public="false" />
 
-        <service id="mime_types" class="Symfony\Component\Mime\MimeTypes" public="true" />
+        <service id="mime_types" class="Symfony\Component\Mime\MimeTypes">
+            <call method="setDefault">
+                <argument type="service" id="mime_types" />
+            </call>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I wonder if we couldn't simplify things by just initializing the default `MimeTypes` instance once the first one is going to be created.