### PR TITLE
Remove a harmless duplicate array key from VarDumper

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/IntlCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/IntlCaster.php
@@ -132,7 +132,6 @@ class IntlCaster
             Caster::PREFIX_VIRTUAL.'repeated_wall_time_option' => $c->getRepeatedWallTimeOption(),
             Caster::PREFIX_VIRTUAL.'skipped_wall_time_option' => $c->getSkippedWallTimeOption(),
             Caster::PREFIX_VIRTUAL.'time' => $c->getTime(),
-            Caster::PREFIX_VIRTUAL.'type' => $c->getType(),
             Caster::PREFIX_VIRTUAL.'in_daylight_time' => $c->inDaylightTime(),
             Caster::PREFIX_VIRTUAL.'is_lenient' => $c->isLenient(),
             Caster::PREFIX_VIRTUAL.'time_zone' => ($filter & Caster::EXCLUDE_VERBOSE) ? new CutStub($c->getTimeZone()) : $c->getTimeZone(),


### PR DESCRIPTION
This has the same field order as the original code.

Detected via static analysis - The `type` is also the first element of the array. This change preserves the key order of the resulting array.

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes (harmless)
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | N/A
| Fixed tickets |
| License       | MIT
| Doc PR        | 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
