### PR TITLE
Fix format strings for deprecation notices

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/TranslatorHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/TranslatorHelper.php
@@ -58,7 +58,7 @@ class TranslatorHelper extends Helper
      */
     public function transChoice($id, $number, array $parameters = [], $domain = 'messages', $locale = null)
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the trans() one instead with a "%count%" parameter.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the trans() one instead with a "%%count%%" parameter.', __METHOD__), E_USER_DEPRECATED);
 
         if (null === $this->translator) {
             return $this->doTrans($id, ['%count%' => $number] + $parameters, $domain, $locale);

--- a/src/Symfony/Component/Translation/IdentityTranslator.php
+++ b/src/Symfony/Component/Translation/IdentityTranslator.php
@@ -34,7 +34,7 @@ class IdentityTranslator implements LegacyTranslatorInterface, TranslatorInterfa
         $this->selector = $selector;
 
         if (__CLASS__ !== \get_class($this)) {
-            @trigger_error(sprintf('Calling "%s()" is deprecated since Symfony 4.2.'), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling "%s()" is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
         }
     }
 
@@ -45,7 +45,7 @@ class IdentityTranslator implements LegacyTranslatorInterface, TranslatorInterfa
      */
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the trans() one instead with a "%count%" parameter.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the trans() one instead with a "%%count%%" parameter.', __METHOD__), E_USER_DEPRECATED);
 
         if ($this->selector) {
             return strtr($this->selector->choose((string) $id, $number, $locale ?: $this->getLocale()), $parameters);

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -64,7 +64,7 @@ class LoggingTranslator implements TranslatorInterface, LegacyTranslatorInterfac
      */
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the trans() one instead with a "%count%" parameter.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the trans() one instead with a "%%count%%" parameter.', __METHOD__), E_USER_DEPRECATED);
 
         if ($this->translator instanceof TranslatorInterface) {
             $trans = $this->translator->trans($id, ['%count%' => $number] + $parameters, $domain, $locale);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4 up to 4.2 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   |
| Fixed tickets |
| License       | MIT
| Doc PR        |

The `%c` conversion specifier expects an integer
(the value of the byte to print). To produce a literal `%`, `%%` should be used.

Detected via static analysis