### PR TITLE
[Cache] PDO-based cache pool table autocreation does not work

### DIFF
--- a/src/Symfony/Component/Cache/Traits/PdoTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PdoTrait.php
@@ -306,7 +306,14 @@ trait PdoTrait
 
         $now = time();
         $lifetime = $lifetime ?: null;
-        $stmt = $conn->prepare($sql);
+        try {
+            $stmt = $conn->prepare($sql);
+        } catch (TableNotFoundException $e) {
+            if (!$conn->isTransactionActive() || \in_array($this->driver, ['pgsql', 'sqlite', 'sqlsrv'], true)) {
+                $this->createTable();
+            }
+            $stmt = $conn->prepare($sql);
+        }
 
         if ('sqlsrv' === $driver || 'oci' === $driver) {
             $stmt->bindParam(1, $id);


### PR DESCRIPTION
This is continue for https://github.com/symfony/symfony/pull/29900
I have fixed what @nicolas-grekas found https://github.com/symfony/symfony/pull/29900#issuecomment-457598072

look at https://github.com/symfony/symfony/issues/29898
I believe that it is not good fix... But pgsq table not foutd throwed right there, in execute(). Dont know about another DB drivers, and i dont know will execute() again work or not, please if some one know more about PDO than me, check it!

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29898 
| License       | MIT
