### PR TITLE
[Security] don't do nested calls to serialize()

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -134,10 +134,6 @@ abstract class AbstractToken implements TokenInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param bool $isCalledFromOverridingMethod Must be set to true when called from an overriding method
-     *
-     * @return string|array Returns an array when $isCalledFromOverridingMethod is set to true
      */
     public function serialize()
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -67,7 +67,7 @@ class AnonymousToken extends AbstractToken
      */
     public function unserialize($serialized)
     {
-        list($this->secret, $parentStr) = unserialize($serialized);
+        list($this->secret, $parentStr) = \is_array($serialized) ? $serialized : unserialize($serialized);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -59,7 +59,9 @@ class AnonymousToken extends AbstractToken
      */
     public function serialize()
     {
-        return serialize([$this->secret, parent::serialize()]);
+        $serialized = [$this->secret, parent::serialize(true)];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -76,10 +76,14 @@ class PreAuthenticatedToken extends AbstractToken
 
     /**
      * {@inheritdoc}
+     *
+     * @param bool $isCalledFromOverridingMethod Must be set to true when called from an overriding method
      */
     public function serialize()
     {
-        return serialize([$this->credentials, $this->providerKey, parent::serialize()]);
+        $serialized = [$this->credentials, $this->providerKey, parent::serialize(true)];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     /**
@@ -87,7 +91,7 @@ class PreAuthenticatedToken extends AbstractToken
      */
     public function unserialize($str)
     {
-        list($this->credentials, $this->providerKey, $parentStr) = unserialize($str);
+        list($this->credentials, $this->providerKey, $parentStr) = \is_array($str) ? $str : unserialize($str);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -76,8 +76,6 @@ class PreAuthenticatedToken extends AbstractToken
 
     /**
      * {@inheritdoc}
-     *
-     * @param bool $isCalledFromOverridingMethod Must be set to true when called from an overriding method
      */
     public function serialize()
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -106,7 +106,7 @@ class RememberMeToken extends AbstractToken
      */
     public function unserialize($serialized)
     {
-        list($this->secret, $this->providerKey, $parentStr) = unserialize($serialized);
+        list($this->secret, $this->providerKey, $parentStr) = \is_array($serialized) ? $serialized : unserialize($serialized);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -94,11 +94,9 @@ class RememberMeToken extends AbstractToken
      */
     public function serialize()
     {
-        return serialize([
-            $this->secret,
-            $this->providerKey,
-            parent::serialize(),
-        ]);
+        $serialized = [$this->secret, $this->providerKey, parent::serialize(true)];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -99,7 +99,7 @@ class UsernamePasswordToken extends AbstractToken
      */
     public function unserialize($serialized)
     {
-        list($this->credentials, $this->providerKey, $parentStr) = unserialize($serialized);
+        list($this->credentials, $this->providerKey, $parentStr) = \is_array($serialized) ? $serialized : unserialize($serialized);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -91,7 +91,9 @@ class UsernamePasswordToken extends AbstractToken
      */
     public function serialize()
     {
-        return serialize([$this->credentials, $this->providerKey, parent::serialize()]);
+        $serialized = [$this->credentials, $this->providerKey, parent::serialize(true)];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -44,10 +44,9 @@ abstract class AccountStatusException extends AuthenticationException
      */
     public function serialize()
     {
-        return serialize([
-            $this->user,
-            parent::serialize(),
-        ]);
+        $serialized = [$this->user, parent::serialize(true)];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -55,7 +55,7 @@ abstract class AccountStatusException extends AuthenticationException
      */
     public function unserialize($str)
     {
-        list($this->user, $parentData) = unserialize($str);
+        list($this->user, $parentData) = \is_array($str) ? $str : unserialize($str);
 
         parent::unserialize($parentData);
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -38,15 +38,33 @@ class AuthenticationException extends \RuntimeException implements \Serializable
         $this->token = $token;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function serialize()
     {
-        return serialize([
+        $serialized = [
             $this->token,
             $this->code,
             $this->message,
             $this->file,
             $this->line,
-        ]);
+        ];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
+    }
+
+    /**
+     * @internal
+     */
+    protected function doSerialize($serialized, $isCalledFromOverridingMethod)
+    {
+        if (null === $isCalledFromOverridingMethod) {
+            $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 3);
+            $isCalledFromOverridingMethod = isset($trace[2]['function'], $trace[2]['object']) && 'serialize' === $trace[2]['function'] && $this === $trace[2]['object'];
+        }
+
+        return $isCalledFromOverridingMethod ? $serialized : serialize($serialized);
     }
 
     public function unserialize($str)
@@ -57,7 +75,7 @@ class AuthenticationException extends \RuntimeException implements \Serializable
             $this->message,
             $this->file,
             $this->line
-        ) = unserialize($str);
+        ) = \is_array($str) ? $str : unserialize($str);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
@@ -60,11 +60,9 @@ class CustomUserMessageAuthenticationException extends AuthenticationException
      */
     public function serialize()
     {
-        return serialize([
-            parent::serialize(),
-            $this->messageKey,
-            $this->messageData,
-        ]);
+        return serialize([parent::serialize(true), $this->messageKey, $this->messageData]);
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
@@ -72,7 +72,7 @@ class CustomUserMessageAuthenticationException extends AuthenticationException
      */
     public function unserialize($str)
     {
-        list($parentData, $this->messageKey, $this->messageData) = unserialize($str);
+        list($parentData, $this->messageKey, $this->messageData) = \is_array($str) ? $str : unserialize($str);
 
         parent::unserialize($parentData);
     }

--- a/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
@@ -54,10 +54,9 @@ class UsernameNotFoundException extends AuthenticationException
      */
     public function serialize()
     {
-        return serialize([
-            $this->username,
-            parent::serialize(),
-        ]);
+        $serialized = [$this->username, parent::serialize(true)];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
@@ -65,7 +65,7 @@ class UsernameNotFoundException extends AuthenticationException
      */
     public function unserialize($str)
     {
-        list($this->username, $parentData) = unserialize($str);
+        list($this->username, $parentData) = \is_array($str) ? $str : unserialize($str);
 
         parent::unserialize($parentData);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -44,11 +44,13 @@ class ConcreteToken extends AbstractToken
     }
 
     /**
-     * @param bool $isCalledFromOverridingMethod Must be set to true when called from an overriding method
+     * {@inheritdoc}
      */
     public function serialize()
     {
-        return serialize([$this->credentials, parent::serialize()]);
+        $serialized = [$this->credentials, parent::serialize(true)];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     public function unserialize($serialized)

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -43,6 +43,9 @@ class ConcreteToken extends AbstractToken
         $this->setUser($user);
     }
 
+    /**
+     * @param bool $isCalledFromOverridingMethod Must be set to true when called from an overriding method
+     */
     public function serialize()
     {
         return serialize([$this->credentials, parent::serialize()]);

--- a/src/Symfony/Component/Security/Core/Tests/Exception/CustomUserMessageAuthenticationExceptionTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Exception/CustomUserMessageAuthenticationExceptionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Exception;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 
 class CustomUserMessageAuthenticationExceptionTest extends TestCase
@@ -23,5 +24,19 @@ class CustomUserMessageAuthenticationExceptionTest extends TestCase
         $this->assertEquals('SAFE MESSAGE', $e->getMessageKey());
         $this->assertEquals(['foo' => true], $e->getMessageData());
         $this->assertEquals('SAFE MESSAGE', $e->getMessage());
+    }
+
+    public function testSharedSerializedData()
+    {
+        $token = new AnonymousToken('foo', 'bar');
+
+        $exception = new CustomUserMessageAuthenticationException();
+        $exception->setToken($token);
+        $exception->setSafeMessage('message', ['token' => $token]);
+
+        $processed = unserialize(serialize($exception));
+        $this->assertEquals($token, $processed->getToken());
+        $this->assertEquals($token, $processed->getMessageData()['token']);
+        $this->assertSame($processed->getToken(), $processed->getMessageData()['token']);
     }
 }

--- a/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
@@ -76,7 +76,7 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
      */
     public function serialize()
     {
-        return serialize([$this->providerKey, parent::serialize()]);
+        return serialize([$this->providerKey, parent::serialize(true)]);
     }
 
     /**
@@ -84,7 +84,7 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
      */
     public function unserialize($serialized)
     {
-        list($this->providerKey, $parentStr) = unserialize($serialized);
+        list($this->providerKey, $parentStr) = \is_array($serialized) ? $serialized : unserialize($serialized);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
@@ -76,7 +76,9 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
      */
     public function serialize()
     {
-        return serialize([$this->providerKey, parent::serialize(true)]);
+        $serialized = [$this->providerKey, parent::serialize(true)];
+
+        return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29951
| License       | MIT
| Doc PR        | n/a

The problem (originally reported as `Symfony\Component\Security\Core\Authentication\Token\AbstractToken` issue), may occur also in classes extending `Symfony\Component\Security\Core\Exception\AuthenticationException` 

Tasks:

- [x] Skip native serializer (workaround itself)
- [x] Token test
- [x] Exception test
