### PR TITLE
[FrameworkBundle] Support use of hyphen in asset package name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -642,6 +642,7 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('package')
                     ->children()
                         ->arrayNode('packages')
+                            ->normalizeKeys(false)
                             ->useAttributeAsKey('name')
                             ->prototype('array')
                                 ->fixXmlConfig('base_url')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -212,6 +212,35 @@ class ConfigurationTest extends TestCase
     }
 
     /**
+     * @dataProvider provideValidAssetsPackageNameConfigurationTests
+     */
+    public function testValidAssetsPackageNameConfiguration($packageName)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $config = $processor->processConfiguration($configuration, [
+            [
+                'assets' => [
+                    'packages' => [
+                        $packageName => [],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertArrayHasKey($packageName, $config['assets']['packages']);
+    }
+
+    public function provideValidAssetsPackageNameConfigurationTests()
+    {
+        return [
+            ['foobar'],
+            ['foo-bar'],
+            ['foo_bar'],
+        ];
+    }
+
+    /**
      * @dataProvider provideInvalidAssetConfigurationTests
      */
     public function testInvalidAssetsConfiguration(array $assetConfig, $expectedMessage)


### PR DESCRIPTION
This PR is a continuity of #28128

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29122
| License       | MIT
| Doc PR        | n/a

According to issue https://github.com/symfony/symfony-docs/pull/10442, we tested in a demo bundle, for example in src/AppBundle/Resources/config/config.yml a package using hyphens: app-client-frontend, and withouth the patch it fails because the package is not recognized. With the patch, it works as expected.
```yaml
framework:
    assets:
        packages:
            app-client-frontend:
                version: "%env(FRONTEND_VERSION)%"
                version_format: '%%2$s/dist/%%1$s'
                base_urls:
                  - "%env(FRONTEND_URL)%"
```