### PR TITLE
[messenger] Adds a stamp to provide a routing key on message publishing

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -18,6 +18,9 @@ CHANGELOG
    changed: a required 3rd `SerializerInterface` argument was added.
  * Added a new `SyncTransport` along with `ForceCallHandlersStamp` to
    explicitly handle messages synchronously.
+ * Added `AmqpRoutingKeyStamp` allowing to provide a routing key on message publishing.
+ * Removed publishing with a `routing_key` option from queue configuration, for
+   AMQP. Use exchange `default_publish_routing_key` or `AmqpRoutingKeyStamp` instead.
  * Added optional parameter `prefetch_count` in connection configuration, 
    to setup channel prefetch count.
  * New classes: `RoutableMessageBus`, `AddBusNameStampMiddleware`
@@ -71,6 +74,8 @@ CHANGELOG
    only. Pass the `auto_setup` connection option to control this.
  * Added a `SetupTransportsCommand` command to setup the transports
  * Added a Doctrine transport. For example, use the `doctrine://default` DSN (this uses the `default` Doctrine entity manager)
+ * Added `AmqpRoutingKeyStamp` allowing to provide a routing key on message publishing.
+ * Deprecated publishing with a routing key from queue configuration, use exchange configuration instead.
 
 4.2.0
 -----

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -19,8 +19,12 @@ CHANGELOG
  * Added a new `SyncTransport` along with `ForceCallHandlersStamp` to
    explicitly handle messages synchronously.
  * Added `AmqpRoutingKeyStamp` allowing to provide a routing key on message publishing.
- * Removed publishing with a `routing_key` option from queue configuration, for
+ * [BC BREAK] Removed publishing with a `routing_key` option from queue configuration, for
    AMQP. Use exchange `default_publish_routing_key` or `AmqpRoutingKeyStamp` instead.
+ * [BC BREAK] Changed the `queue` option in the AMQP transport DSN to be `queues[name]`. You can 
+   therefore name the queue but also configure `binding_keys`, `flags` and `arguments`.
+ * [BC BREAK] The methods `get`, `ack`, `nack` and `queue` of the AMQP `Connection` 
+   have a new argument: the queue name.
  * Added optional parameter `prefetch_count` in connection configuration, 
    to setup channel prefetch count.
  * New classes: `RoutableMessageBus`, `AddBusNameStampMiddleware`
@@ -74,8 +78,7 @@ CHANGELOG
    only. Pass the `auto_setup` connection option to control this.
  * Added a `SetupTransportsCommand` command to setup the transports
  * Added a Doctrine transport. For example, use the `doctrine://default` DSN (this uses the `default` Doctrine entity manager)
- * Added `AmqpRoutingKeyStamp` allowing to provide a routing key on message publishing.
- * Deprecated publishing with a routing key from queue configuration, use exchange configuration instead.
+ * [BC BREAK] The `getConnectionConfiguration` method on Amqp's `Connection` has been removed. 
 
 4.2.0
 -----

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
@@ -49,7 +49,7 @@ class AmqpExtIntegrationTest extends TestCase
 
         $connection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'));
         $connection->setup();
-        $connection->queue()->purge();
+        $connection->purgeQueues();
 
         $sender = new AmqpSender($connection, $serializer);
         $receiver = new AmqpReceiver($connection, $serializer);
@@ -79,7 +79,7 @@ class AmqpExtIntegrationTest extends TestCase
 
         $connection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'));
         $connection->setup();
-        $connection->queue()->purge();
+        $connection->purgeQueues();
 
         $sender = new AmqpSender($connection, $serializer);
         $receiver = new AmqpReceiver($connection, $serializer);
@@ -126,7 +126,7 @@ class AmqpExtIntegrationTest extends TestCase
 
         $connection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'));
         $connection->setup();
-        $connection->queue()->purge();
+        $connection->purgeQueues();
 
         $sender = new AmqpSender($connection, $serializer);
         $sender->send(new Envelope(new DummyMessage('Hello')));
@@ -173,7 +173,7 @@ TXT
 
         $connection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'));
         $connection->setup();
-        $connection->queue()->purge();
+        $connection->purgeQueues();
 
         $sender = new AmqpSender($connection, $serializer);
 
@@ -182,7 +182,7 @@ TXT
         $sender->send(new Envelope(new DummyMessage('Third')));
 
         sleep(1); // give amqp a moment to have the messages ready
-        $this->assertSame(3, $connection->countMessagesInQueue());
+        $this->assertSame(3, $connection->countMessagesInQueues());
     }
 
     private function waitForOutput(Process $process, string $output, $timeoutInSeconds = 10)

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpReceivedStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpReceivedStampTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\AmqpExt;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceivedStamp;
+
+/**
+ * @requires extension amqp
+ */
+class AmqpReceivedStampTest extends TestCase
+{
+    public function testStamp()
+    {
+        $amqpEnvelope = $this->createMock(\AMQPEnvelope::class);
+
+        $stamp = new AmqpReceivedStamp($amqpEnvelope, 'queueName');
+
+        $this->assertSame($amqpEnvelope, $stamp->getAmqpEnvelope());
+        $this->assertSame('queueName', $stamp->getQueueName());
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpReceiverTest.php
@@ -36,7 +36,8 @@ class AmqpReceiverTest extends TestCase
 
         $amqpEnvelope = $this->createAMQPEnvelope();
         $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
-        $connection->method('get')->willReturn($amqpEnvelope);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
 
         $receiver = new AmqpReceiver($connection, $serializer);
         $actualEnvelopes = iterator_to_array($receiver->get());
@@ -52,11 +53,12 @@ class AmqpReceiverTest extends TestCase
         $serializer = $this->createMock(SerializerInterface::class);
         $amqpEnvelope = $this->createAMQPEnvelope();
         $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
-        $connection->method('get')->willReturn($amqpEnvelope);
-        $connection->method('ack')->with($amqpEnvelope)->willThrowException(new \AMQPException());
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
+        $connection->method('ack')->with($amqpEnvelope, 'queueName')->willThrowException(new \AMQPException());
 
         $receiver = new AmqpReceiver($connection, $serializer);
-        $receiver->ack(new Envelope(new \stdClass(), [new AmqpReceivedStamp($amqpEnvelope)]));
+        $receiver->ack(new Envelope(new \stdClass(), [new AmqpReceivedStamp($amqpEnvelope, 'queueName')]));
     }
 
     /**
@@ -67,11 +69,12 @@ class AmqpReceiverTest extends TestCase
         $serializer = $this->createMock(SerializerInterface::class);
         $amqpEnvelope = $this->createAMQPEnvelope();
         $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
-        $connection->method('get')->willReturn($amqpEnvelope);
-        $connection->method('nack')->with($amqpEnvelope, AMQP_NOPARAM)->willThrowException(new \AMQPException());
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
+        $connection->method('nack')->with($amqpEnvelope, 'queueName', AMQP_NOPARAM)->willThrowException(new \AMQPException());
 
         $receiver = new AmqpReceiver($connection, $serializer);
-        $receiver->reject(new Envelope(new \stdClass(), [new AmqpReceivedStamp($amqpEnvelope)]));
+        $receiver->reject(new Envelope(new \stdClass(), [new AmqpReceivedStamp($amqpEnvelope, 'queueName')]));
     }
 
     private function createAMQPEnvelope()

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpRoutingKeyStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpRoutingKeyStampTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\AmqpExt;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Transport\AmqpExt\AmqpRoutingKeyStamp;
+
+class AmqpRoutingKeyStampTest extends TestCase
+{
+    public function testStamp()
+    {
+        $stamp = new AmqpRoutingKeyStamp('routing_key');
+        $this->assertSame('routing_key', $stamp->getRoutingKey());
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportTest.php
@@ -45,7 +45,8 @@ class AmqpTransportTest extends TestCase
         $amqpEnvelope->method('getHeaders')->willReturn(['my' => 'header']);
 
         $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
-        $connection->method('get')->willReturn($amqpEnvelope);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
 
         $envelopes = iterator_to_array($transport->get());
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceivedStamp.php
@@ -21,14 +21,21 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 class AmqpReceivedStamp implements StampInterface
 {
     private $amqpEnvelope;
+    private $queueName;
 
-    public function __construct(\AMQPEnvelope $amqpEnvelope)
+    public function __construct(\AMQPEnvelope $amqpEnvelope, string $queueName)
     {
         $this->amqpEnvelope = $amqpEnvelope;
+        $this->queueName = $queueName;
     }
 
     public function getAmqpEnvelope(): \AMQPEnvelope
     {
         return $this->amqpEnvelope;
+    }
+
+    public function getQueueName(): string
+    {
+        return $this->queueName;
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -43,8 +43,15 @@ class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
      */
     public function get(): iterable
     {
+        foreach ($this->connection->getQueueNames() as $queueName) {
+            yield from $this->getEnvelope($queueName);
+        }
+    }
+
+    private function getEnvelope(string $queueName): iterable
+    {
         try {
-            $amqpEnvelope = $this->connection->get();
+            $amqpEnvelope = $this->connection->get($queueName);
         } catch (\AMQPException $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
         }
@@ -60,12 +67,12 @@ class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
             ]);
         } catch (MessageDecodingFailedException $exception) {
             // invalid message of some type
-            $this->rejectAmqpEnvelope($amqpEnvelope);
+            $this->rejectAmqpEnvelope($amqpEnvelope, $queueName);
 
             throw $exception;
         }
 
-        yield $envelope->with(new AmqpReceivedStamp($amqpEnvelope));
+        yield $envelope->with(new AmqpReceivedStamp($amqpEnvelope, $queueName));
     }
 
     /**
@@ -74,7 +81,11 @@ class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
     public function ack(Envelope $envelope): void
     {
         try {
-            $this->connection->ack($this->findAmqpEnvelope($envelope));
+            /* @var AmqpReceivedStamp $amqpReceivedStamp */
+            $this->connection->ack(
+                $this->findAmqpEnvelope($envelope, $amqpReceivedStamp),
+                $amqpReceivedStamp->getQueueName()
+            );
         } catch (\AMQPException $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
         }
@@ -85,7 +96,11 @@ class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
      */
     public function reject(Envelope $envelope): void
     {
-        $this->rejectAmqpEnvelope($this->findAmqpEnvelope($envelope));
+        /* @var AmqpReceivedStamp $amqpReceivedStamp */
+        $this->rejectAmqpEnvelope(
+            $this->findAmqpEnvelope($envelope, $amqpReceivedStamp),
+            $amqpReceivedStamp->getQueueName()
+        );
     }
 
     /**
@@ -93,21 +108,20 @@ class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
      */
     public function getMessageCount(): int
     {
-        return $this->connection->countMessagesInQueue();
+        return $this->connection->countMessagesInQueues();
     }
 
-    private function rejectAmqpEnvelope(\AMQPEnvelope $amqpEnvelope): void
+    private function rejectAmqpEnvelope(\AMQPEnvelope $amqpEnvelope, string $queueName): void
     {
         try {
-            $this->connection->nack($amqpEnvelope, AMQP_NOPARAM);
+            $this->connection->nack($amqpEnvelope, $queueName, AMQP_NOPARAM);
         } catch (\AMQPException $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
         }
     }
 
-    private function findAmqpEnvelope(Envelope $envelope): \AMQPEnvelope
+    private function findAmqpEnvelope(Envelope $envelope, AmqpReceivedStamp &$amqpReceivedStamp = null): \AMQPEnvelope
     {
-        /** @var AmqpReceivedStamp|null $amqpReceivedStamp */
         $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
 
         if (null === $amqpReceivedStamp) {

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpRoutingKeyStamp.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpRoutingKeyStamp.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\AmqpExt;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * @author Guillaume Gammelin <ggammelin@gmail.com>
+ *
+ * @experimental in 4.3
+ */
+final class AmqpRoutingKeyStamp implements StampInterface
+{
+    private $routingKey;
+
+    public function __construct(string $routingKey)
+    {
+        $this->routingKey = $routingKey;
+    }
+
+    public function getRoutingKey(): string
+    {
+        return $this->routingKey;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -51,7 +51,11 @@ class AmqpSender implements SenderInterface
         }
 
         try {
-            $this->connection->publish($encodedMessage['body'], $encodedMessage['headers'] ?? [], $delay);
+            /** @var $routingKeyStamp AmqpRoutingKeyStamp */
+            $routingKeyStamp = $envelope->last(AmqpRoutingKeyStamp::class);
+            $routingKey = $routingKeyStamp ? $routingKeyStamp->getRoutingKey() : null;
+
+            $this->connection->publish($encodedMessage['body'], $encodedMessage['headers'] ?? [], $delay, $routingKey);
         } catch (\AMQPException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29950
| License       | MIT
| Doc PR        | symfony/symfony-docs#11236

Adds a stamp allowing to set a `routing_key` at `MessageBus::dispatch()` level.

```php
$message = (new Envelope('message'))->with(new RoutingKeyStamp('routing_key'));
$bus->dispatch($message);
```
