### PR TITLE
[Debug] Display more details in the simple error page of Debug

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -207,7 +207,7 @@ class ExceptionHandler
                 $title = 'Sorry, the page you are looking for could not be found.';
                 break;
             default:
-                $title = 'Whoops, looks like something went wrong.';
+                $title = $this->debug ? $this->escapeHtml($exception->getMessage()) : 'Whoops, looks like something went wrong.';
         }
 
         if (!$this->debug) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29891
| License       | MIT
| Doc PR        | -

Note: this only changes the simple error page of Debug component, which is different from the full-featured error page of WebProfilerBundle.

-----

#29891 shows a confusing error page. In #29928 we improved the first error message displayed to the user. In this PR we implement @nicolas-grekas' idea to replace the generic error page title by a better error message. So, this PR + #29928 would fix #29891 to me.

### Before

![error-before](https://user-images.githubusercontent.com/73419/51920135-1519b500-23e5-11e9-99d6-e9b631b97499.png)

### After

![error-after](https://user-images.githubusercontent.com/73419/51920141-1945d280-23e5-11e9-97c3-49b2170dbd15.png)
