### PR TITLE
[Config] ensure moving away from Serializable wont break cache:clear

### DIFF
--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -156,10 +156,11 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
     {
         $e = null;
         $meta = false;
+        $content = file_get_contents($file);
         $signalingException = new \UnexpectedValueException();
         $prevUnserializeHandler = ini_set('unserialize_callback_func', '');
         $prevErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler, $signalingException) {
-            if (E_WARNING === $type && 'Class __PHP_Incomplete_Class has no unserializer' === $msg) {
+            if (__FILE__ === $file) {
                 throw $signalingException;
             }
 
@@ -167,7 +168,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
         });
 
         try {
-            $meta = unserialize(file_get_contents($file));
+            $meta = unserialize($content);
         } catch (\Error $e) {
         } catch (\Exception $e) {
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When a resource implementation moves away from `Serializable`, the `cache:clear` command currently fails with `Warning: Class Symfony\Component\Config\Resource\ClassExistenceResource has no unserializer`. This change makes it ignore the failure, which is fine.