### PR TITLE
Mark some/most implementations of Serializable as `@internal`

### DIFF
--- a/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
@@ -97,7 +97,7 @@ class ClassExistenceResource implements SelfCheckingResourceInterface, \Serializ
     }
 
     /**
-     * {@inheritdoc}
+     * @internal
      */
     public function serialize()
     {
@@ -109,7 +109,7 @@ class ClassExistenceResource implements SelfCheckingResourceInterface, \Serializ
     }
 
     /**
-     * {@inheritdoc}
+     * @internal
      */
     public function unserialize($serialized)
     {

--- a/src/Symfony/Component/Config/Resource/ComposerResource.php
+++ b/src/Symfony/Component/Config/Resource/ComposerResource.php
@@ -51,11 +51,17 @@ class ComposerResource implements SelfCheckingResourceInterface, \Serializable
         return self::$runtimeVendors === $this->vendors;
     }
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         return serialize($this->vendors);
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($serialized)
     {
         $this->vendors = unserialize($serialized);

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -104,11 +104,17 @@ class DirectoryResource implements SelfCheckingResourceInterface, \Serializable
         return true;
     }
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         return serialize([$this->resource, $this->pattern]);
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($serialized)
     {
         list($this->resource, $this->pattern) = unserialize($serialized);

--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -59,7 +59,7 @@ class FileExistenceResource implements SelfCheckingResourceInterface, \Serializa
     }
 
     /**
-     * {@inheritdoc}
+     * @internal
      */
     public function serialize()
     {
@@ -67,7 +67,7 @@ class FileExistenceResource implements SelfCheckingResourceInterface, \Serializa
     }
 
     /**
-     * {@inheritdoc}
+     * @internal
      */
     public function unserialize($serialized)
     {

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -63,11 +63,17 @@ class FileResource implements SelfCheckingResourceInterface, \Serializable
         return false !== ($filemtime = @filemtime($this->resource)) && $filemtime <= $timestamp;
     }
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         return serialize($this->resource);
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($serialized)
     {
         $this->resource = unserialize($serialized);

--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -73,6 +73,9 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface,
         return $this->hash === $hash;
     }
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         if (null === $this->hash) {
@@ -82,6 +85,9 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface,
         return serialize([$this->prefix, $this->pattern, $this->recursive, $this->hash]);
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($serialized)
     {
         list($this->prefix, $this->pattern, $this->recursive, $this->hash) = unserialize($serialized);

--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -57,6 +57,9 @@ class ReflectionClassResource implements SelfCheckingResourceInterface, \Seriali
         return 'reflection.'.$this->className;
     }
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         if (null === $this->hash) {
@@ -67,6 +70,9 @@ class ReflectionClassResource implements SelfCheckingResourceInterface, \Seriali
         return serialize([$this->files, $this->className, $this->hash]);
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($serialized)
     {
         list($this->files, $this->className, $this->hash) = unserialize($serialized);

--- a/src/Symfony/Component/DependencyInjection/Config/AutowireServiceResource.php
+++ b/src/Symfony/Component/DependencyInjection/Config/AutowireServiceResource.php
@@ -58,11 +58,17 @@ class AutowireServiceResource implements SelfCheckingResourceInterface, \Seriali
         return 'service.autowire.'.$this->class;
     }
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         return serialize([$this->class, $this->filePath, $this->autowiringMetadata]);
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($serialized)
     {
         if (\PHP_VERSION_ID >= 70000) {

--- a/src/Symfony/Component/DependencyInjection/Config/ContainerParametersResource.php
+++ b/src/Symfony/Component/DependencyInjection/Config/ContainerParametersResource.php
@@ -39,7 +39,7 @@ class ContainerParametersResource implements ResourceInterface, \Serializable
     }
 
     /**
-     * {@inheritdoc}
+     * @internal
      */
     public function serialize()
     {
@@ -47,7 +47,7 @@ class ContainerParametersResource implements ResourceInterface, \Serializable
     }
 
     /**
-     * {@inheritdoc}
+     * @internal
      */
     public function unserialize($serialized)
     {

--- a/src/Symfony/Component/Form/FormError.php
+++ b/src/Symfony/Component/Form/FormError.php
@@ -135,9 +135,7 @@ class FormError implements \Serializable
     }
 
     /**
-     * Serializes this error.
-     *
-     * @return string The serialized error
+     * @internal
      */
     public function serialize()
     {
@@ -151,9 +149,7 @@ class FormError implements \Serializable
     }
 
     /**
-     * Unserializes a serialized error.
-     *
-     * @param string $serialized The serialized error
+     * @internal
      */
     public function unserialize($serialized)
     {

--- a/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
+++ b/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
@@ -65,11 +65,17 @@ class EnvParametersResource implements SelfCheckingResourceInterface, \Serializa
         return $this->findVariables() === $this->variables;
     }
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         return serialize(['prefix' => $this->prefix, 'variables' => $this->variables]);
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($serialized)
     {
         if (\PHP_VERSION_ID >= 70000) {

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -40,6 +40,9 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
      */
     private $cloner;
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
@@ -48,6 +51,9 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
         return $isCalledFromOverridingMethod ? $this->data : serialize($this->data);
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($data)
     {
         $this->data = \is_array($data) ? $data : unserialize($data);

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -61,11 +61,17 @@ class FileLinkFormatter implements \Serializable
         return false;
     }
 
+    /**
+     * @internal
+     */
     public function serialize()
     {
         return serialize($this->getFileLinkFormat());
     }
 
+    /**
+     * @internal
+     */
     public function unserialize($serialized)
     {
         if (\PHP_VERSION_ID >= 70000) {

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -284,9 +284,7 @@ abstract class Constraint
      *
      * @return array The properties to serialize
      *
-     * @internal This method may be replaced by an implementation of
-     *           {@link \Serializable} in the future. Please don't use or
-     *           overwrite it.
+     * @internal
      */
     public function __sleep()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

There are more usages of `Serializable` in the code base, but the remaining are unfortunately exposed as part of interfaces.

All these places are IMHO already considered internal, this just makes it explicit.

Will ease moving away from `Serializable`.