### PR TITLE
[Cache] Add __destruct() on TraceableAdapter to fix fatal error

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -220,6 +220,11 @@ class TraceableAdapter implements AdapterInterface, PruneableInterface, Resettab
 
         return $event;
     }
+    
+    public function __destruct()
+    {
+        unset($this->pool, $this->calls);
+    }
 }
 
 class TraceableAdapterEvent

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -223,7 +223,7 @@ class TraceableAdapter implements AdapterInterface, PruneableInterface, Resettab
 
     public function __destruct()
     {
-        unset($this->pool, $this->calls);
+        // no-op
     }
 }
 

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -220,7 +220,7 @@ class TraceableAdapter implements AdapterInterface, PruneableInterface, Resettab
 
         return $event;
     }
-    
+
     public function __destruct()
     {
         unset($this->pool, $this->calls);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | N/A?
| License       | MIT

Fixes:
```
PHP Fatal error:  Uncaught Error: Call to undefined method Symfony\Component\Cache\Adapter\TraceableTagAwareAdapter::__destruct() in /usr/sf/var/cache/dev/ContainerOjtvevg/TagAwareAdapter_5b4740c.php:128
Stack trace:
#0 [internal function]: TagAwareAdapter_5b4740c->__destruct()
```

When setting a TagAwareAdapter as cache service.
In my case it was a custom TagAwareAdapter _(which does not decorate other cache services)_, but I think the issue is probably also there if you use the default TagAwareAdapter and set it as cache service.
