### PR TITLE
PHPUnit Bridge: Rollback to traditional array syntax.

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -73,7 +73,7 @@ class ClockMock
     {
         $self = \get_called_class();
 
-        $mockedNs = [substr($class, 0, strrpos($class, '\\'))];
+        $mockedNs = array(substr($class, 0, strrpos($class, '\\')));
         if (0 < strpos($class, '\\Tests\\')) {
             $ns = str_replace('\\Tests\\', '\\', $class);
             $mockedNs[] = substr($ns, 0, strrpos($ns, '\\'));

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -92,19 +92,19 @@ class DeprecationErrorHandler
             return false;
         };
 
-        $deprecations = [
+        $deprecations = array(
             'unsilencedCount' => 0,
             'remainingCount' => 0,
             'legacyCount' => 0,
             'otherCount' => 0,
             'remaining vendorCount' => 0,
-            'unsilenced' => [],
-            'remaining' => [],
-            'legacy' => [],
-            'other' => [],
-            'remaining vendor' => [],
-        ];
-        $deprecationHandler = function ($type, $msg, $file, $line, $context = []) use (&$deprecations, $getMode, $UtilPrefix, $inVendors) {
+            'unsilenced' => array(),
+            'remaining' => array(),
+            'legacy' => array(),
+            'other' => array(),
+            'remaining vendor' => array(),
+        );
+        $deprecationHandler = function ($type, $msg, $file, $line, $context = array()) use (&$deprecations, $getMode, $UtilPrefix, $inVendors) {
             $mode = $getMode();
             if ((E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) || self::MODE_DISABLED === $mode) {
                 $ErrorHandler = $UtilPrefix.'ErrorHandler';
@@ -184,7 +184,7 @@ class DeprecationErrorHandler
 
         if (null !== $oldErrorHandler) {
             restore_error_handler();
-            if ([$UtilPrefix.'ErrorHandler', 'handleError'] === $oldErrorHandler) {
+            if (array($UtilPrefix.'ErrorHandler', 'handleError') === $oldErrorHandler) {
                 restore_error_handler();
                 self::register($mode);
             }
@@ -218,7 +218,7 @@ class DeprecationErrorHandler
                     return $b['count'] - $a['count'];
                 };
 
-                $groups = ['unsilenced', 'remaining'];
+                $groups = array('unsilenced', 'remaining');
                 if (self::MODE_WEAK_VENDORS === $mode) {
                     $groups[] = 'remaining vendor';
                 }
@@ -259,7 +259,7 @@ class DeprecationErrorHandler
 
                 // reset deprecations array
                 foreach ($deprecations as $group => $arrayOrInt) {
-                    $deprecations[$group] = \is_int($arrayOrInt) ? 0 : [];
+                    $deprecations[$group] = \is_int($arrayOrInt) ? 0 : array();
                 }
 
                 register_shutdown_function(function () use (&$deprecations, $isFailing, $displayDeprecations, $mode) {
@@ -280,8 +280,8 @@ class DeprecationErrorHandler
 
     public static function collectDeprecations($outputFile)
     {
-        $deprecations = [];
-        $previousErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$deprecations, &$previousErrorHandler) {
+        $deprecations = array();
+        $previousErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = array()) use (&$deprecations, &$previousErrorHandler) {
             if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
                 if ($previousErrorHandler) {
                     return $previousErrorHandler($type, $msg, $file, $line, $context);
@@ -293,7 +293,7 @@ class DeprecationErrorHandler
 
                 return $ErrorHandler::handleError($type, $msg, $file, $line, $context);
             }
-            $deprecations[] = [error_reporting(), $msg, $file];
+            $deprecations[] = array(error_reporting(), $msg, $file);
         });
 
         register_shutdown_function(function () use ($outputFile, &$deprecations) {

--- a/src/Symfony/Bridge/PhpUnit/DnsMock.php
+++ b/src/Symfony/Bridge/PhpUnit/DnsMock.php
@@ -16,8 +16,8 @@ namespace Symfony\Bridge\PhpUnit;
  */
 class DnsMock
 {
-    private static $hosts = [];
-    private static $dnsTypes = [
+    private static $hosts = array();
+    private static $dnsTypes = array(
         'A' => DNS_A,
         'MX' => DNS_MX,
         'NS' => DNS_NS,
@@ -30,7 +30,7 @@ class DnsMock
         'NAPTR' => DNS_NAPTR,
         'TXT' => DNS_TXT,
         'HINFO' => DNS_HINFO,
-    ];
+    );
 
     /**
      * Configures the mock values for DNS queries.
@@ -68,7 +68,7 @@ class DnsMock
         if (!self::$hosts) {
             return \getmxrr($hostname, $mxhosts, $weight);
         }
-        $mxhosts = $weight = [];
+        $mxhosts = $weight = array();
 
         if (isset(self::$hosts[$hostname])) {
             foreach (self::$hosts[$hostname] as $record) {
@@ -125,7 +125,7 @@ class DnsMock
         $ips = false;
 
         if (isset(self::$hosts[$hostname])) {
-            $ips = [];
+            $ips = array();
 
             foreach (self::$hosts[$hostname] as $record) {
                 if ('A' === $record['type']) {
@@ -149,11 +149,11 @@ class DnsMock
             if (DNS_ANY === $type) {
                 $type = DNS_ALL;
             }
-            $records = [];
+            $records = array();
 
             foreach (self::$hosts[$hostname] as $record) {
                 if (isset(self::$dnsTypes[$record['type']]) && (self::$dnsTypes[$record['type']] & $type)) {
-                    $records[] = array_merge(['host' => $hostname, 'class' => 'IN', 'ttl' => 1, 'type' => $record['type']], $record);
+                    $records[] = array_merge(array('host' => $hostname, 'class' => 'IN', 'ttl' => 1, 'type' => $record['type']), $record);
                 }
             }
         }
@@ -165,7 +165,7 @@ class DnsMock
     {
         $self = \get_called_class();
 
-        $mockedNs = [substr($class, 0, strrpos($class, '\\'))];
+        $mockedNs = array(substr($class, 0, strrpos($class, '\\')));
         if (0 < strpos($class, '\\Tests\\')) {
             $ns = str_replace('\\Tests\\', '\\', $class);
             $mockedNs[] = substr($ns, 0, strrpos($ns, '\\'));

--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
@@ -31,7 +31,7 @@ class CoverageListenerTrait
     {
         $this->sutFqcnResolver = $sutFqcnResolver;
         $this->warningOnSutNotFound = $warningOnSutNotFound;
-        $this->warnings = [];
+        $this->warnings = array();
     }
 
     public function startTest($test)
@@ -42,7 +42,7 @@ class CoverageListenerTrait
 
         $annotations = $test->getAnnotations();
 
-        $ignoredAnnotations = ['covers', 'coversDefaultClass', 'coversNothing'];
+        $ignoredAnnotations = array('covers', 'coversDefaultClass', 'coversNothing');
 
         foreach ($ignoredAnnotations as $annotation) {
             if (isset($annotations['class'][$annotation]) || isset($annotations['method'][$annotation])) {
@@ -74,11 +74,11 @@ class CoverageListenerTrait
         $r->setAccessible(true);
 
         $cache = $r->getValue();
-        $cache = array_replace_recursive($cache, [
-            \get_class($test) => [
-                'covers' => [$sutFqcn],
-            ],
-        ]);
+        $cache = array_replace_recursive($cache, array(
+            \get_class($test) => array(
+                'covers' => array($sutFqcn),
+            ),
+        ));
         $r->setValue($testClass, $cache);
     }
 

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV5.php
@@ -22,7 +22,7 @@ class SymfonyTestsListenerForV5 extends \PHPUnit_Framework_BaseTestListener
 {
     private $trait;
 
-    public function __construct(array $mockedNamespaces = [])
+    public function __construct(array $mockedNamespaces = array())
     {
         $this->trait = new SymfonyTestsListenerTrait($mockedNamespaces);
     }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV6.php
@@ -27,7 +27,7 @@ class SymfonyTestsListenerForV6 extends BaseTestListener
 {
     private $trait;
 
-    public function __construct(array $mockedNamespaces = [])
+    public function __construct(array $mockedNamespaces = array())
     {
         $this->trait = new SymfonyTestsListenerTrait($mockedNamespaces);
     }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV7.php
@@ -30,7 +30,7 @@ class SymfonyTestsListenerForV7 implements TestListener
 
     private $trait;
 
-    public function __construct(array $mockedNamespaces = [])
+    public function __construct(array $mockedNamespaces = array())
     {
         $this->trait = new SymfonyTestsListenerTrait($mockedNamespaces);
     }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -31,10 +31,10 @@ class SymfonyTestsListenerTrait
     private static $globallyEnabled = false;
     private $state = -1;
     private $skippedFile = false;
-    private $wasSkipped = [];
-    private $isSkipped = [];
-    private $expectedDeprecations = [];
-    private $gatheredDeprecations = [];
+    private $wasSkipped = array();
+    private $isSkipped = array();
+    private $expectedDeprecations = array();
+    private $gatheredDeprecations = array();
     private $previousErrorHandler;
     private $testsWithWarnings;
     private $reportUselessTests;
@@ -44,7 +44,7 @@ class SymfonyTestsListenerTrait
     /**
      * @param array $mockedNamespaces List of namespaces, indexed by mocked features (time-sensitive or dns-sensitive)
      */
-    public function __construct(array $mockedNamespaces = [])
+    public function __construct(array $mockedNamespaces = array())
     {
         if (class_exists('PHPUnit_Util_Blacklist')) {
             \PHPUnit_Util_Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerTrait'] = 2;
@@ -55,7 +55,7 @@ class SymfonyTestsListenerTrait
         $warn = false;
         foreach ($mockedNamespaces as $type => $namespaces) {
             if (!\is_array($namespaces)) {
-                $namespaces = [$namespaces];
+                $namespaces = array($namespaces);
             }
             if (\is_int($type)) {
                 // @deprecated BC with v2.8 to v3.0
@@ -104,7 +104,7 @@ class SymfonyTestsListenerTrait
             $Test = 'PHPUnit\Util\Test';
         }
         $suiteName = $suite->getName();
-        $this->testsWithWarnings = [];
+        $this->testsWithWarnings = array();
 
         foreach ($suite->tests() as $test) {
             if (!($test instanceof \PHPUnit\Framework\TestCase || $test instanceof TestCase)) {
@@ -135,11 +135,11 @@ class SymfonyTestsListenerTrait
 
                     if (!$this->wasSkipped = require $this->skippedFile) {
                         echo "All tests already ran successfully.\n";
-                        $suite->setTests([]);
+                        $suite->setTests(array());
                     }
                 }
             }
-            $testSuites = [$suite];
+            $testSuites = array($suite);
             for ($i = 0; isset($testSuites[$i]); ++$i) {
                 foreach ($testSuites[$i]->tests() as $test) {
                     if ($test instanceof \PHPUnit_Framework_TestSuite || $test instanceof TestSuite) {
@@ -158,7 +158,7 @@ class SymfonyTestsListenerTrait
                 }
             }
         } elseif (2 === $this->state) {
-            $skipped = [];
+            $skipped = array();
             foreach ($suite->tests() as $test) {
                 if (!($test instanceof \PHPUnit\Framework\TestCase || $test instanceof TestCase)
                     || isset($this->wasSkipped[$suiteName]['*'])
@@ -230,7 +230,7 @@ class SymfonyTestsListenerTrait
                 $test->getTestResultObject()->beStrictAboutTestsThatDoNotTestAnything(false);
 
                 $this->expectedDeprecations = $annotations['method']['expectedDeprecation'];
-                $this->previousErrorHandler = set_error_handler([$this, 'handleError']);
+                $this->previousErrorHandler = set_error_handler(array($this, 'handleError'));
             }
         }
     }
@@ -271,8 +271,8 @@ class SymfonyTestsListenerTrait
             $deprecations = file_get_contents($this->runsInSeparateProcess);
             unlink($this->runsInSeparateProcess);
             putenv('SYMFONY_DEPRECATIONS_SERIALIZE');
-            foreach ($deprecations ? unserialize($deprecations) : [] as $deprecation) {
-                $error = serialize(['deprecation' => $deprecation[1], 'class' => $className, 'method' => $test->getName(false), 'triggering_file' => isset($deprecation[2]) ? $deprecation[2] : null]);
+            foreach ($deprecations ? unserialize($deprecations) : array() as $deprecation) {
+                $error = serialize(array('deprecation' => $deprecation[1], 'class' => $className, 'method' => $test->getName(false), 'triggering_file' => isset($deprecation[2]) ? $deprecation[2] : null));
                 if ($deprecation[0]) {
                     @trigger_error($error, E_USER_DEPRECATED);
                 } else {
@@ -283,13 +283,13 @@ class SymfonyTestsListenerTrait
         }
 
         if ($this->expectedDeprecations) {
-            if (!\in_array($test->getStatus(), [$BaseTestRunner::STATUS_SKIPPED, $BaseTestRunner::STATUS_INCOMPLETE], true)) {
+            if (!\in_array($test->getStatus(), array($BaseTestRunner::STATUS_SKIPPED, $BaseTestRunner::STATUS_INCOMPLETE), true)) {
                 $test->addToAssertionCount(\count($this->expectedDeprecations));
             }
 
             restore_error_handler();
 
-            if (!$errored && !\in_array($test->getStatus(), [$BaseTestRunner::STATUS_SKIPPED, $BaseTestRunner::STATUS_INCOMPLETE, $BaseTestRunner::STATUS_FAILURE, $BaseTestRunner::STATUS_ERROR], true)) {
+            if (!$errored && !\in_array($test->getStatus(), array($BaseTestRunner::STATUS_SKIPPED, $BaseTestRunner::STATUS_INCOMPLETE, $BaseTestRunner::STATUS_FAILURE, $BaseTestRunner::STATUS_ERROR), true)) {
                 try {
                     $prefix = "@expectedDeprecation:\n";
                     $test->assertStringMatchesFormat($prefix.'%A  '.implode("\n%A  ", $this->expectedDeprecations)."\n%A", $prefix.'  '.implode("\n  ", $this->gatheredDeprecations)."\n");
@@ -300,7 +300,7 @@ class SymfonyTestsListenerTrait
                 }
             }
 
-            $this->expectedDeprecations = $this->gatheredDeprecations = [];
+            $this->expectedDeprecations = $this->gatheredDeprecations = array();
             $this->previousErrorHandler = null;
         }
         if (!$this->runsInSeparateProcess && -2 < $this->state && ($test instanceof \PHPUnit\Framework\TestCase || $test instanceof TestCase)) {
@@ -308,7 +308,7 @@ class SymfonyTestsListenerTrait
                 ClockMock::withClockMock(false);
             }
             if (\in_array('dns-sensitive', $groups, true)) {
-                DnsMock::withMockedHosts([]);
+                DnsMock::withMockedHosts(array());
             }
         }
 
@@ -329,7 +329,7 @@ class SymfonyTestsListenerTrait
         }
     }
 
-    public function handleError($type, $msg, $file, $line, $context = [])
+    public function handleError($type, $msg, $file, $line, $context = array())
     {
         if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
             $h = $this->previousErrorHandler;

--- a/src/Symfony/Bridge/PhpUnit/Legacy/TestRunnerForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/TestRunnerForV5.php
@@ -27,7 +27,7 @@ class TestRunnerForV5 extends \PHPUnit_TextUI_TestRunner
 
         $result = parent::handleConfiguration($arguments);
 
-        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : [];
+        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
         $registeredLocally = false;
 

--- a/src/Symfony/Bridge/PhpUnit/Legacy/TestRunnerForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/TestRunnerForV6.php
@@ -30,7 +30,7 @@ class TestRunnerForV6 extends BaseRunner
 
         parent::handleConfiguration($arguments);
 
-        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : [];
+        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
         $registeredLocally = false;
 

--- a/src/Symfony/Bridge/PhpUnit/Legacy/TestRunnerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/TestRunnerForV7.php
@@ -30,7 +30,7 @@ class TestRunnerForV7 extends BaseRunner
 
         parent::handleConfiguration($arguments);
 
-        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : [];
+        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
         $registeredLocally = false;
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt
@@ -35,7 +35,7 @@ class PHPUnit_Util_Test
 {
     public static function getGroups()
     {
-        return [];
+        return array();
     }
 }
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/shutdown_deprecations.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/shutdown_deprecations.phpt
@@ -35,7 +35,7 @@ class PHPUnit_Util_Test
 {
     public static function getGroups()
     {
-        return [];
+        return array();
     }
 }
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
@@ -18,15 +18,15 @@ class DnsMockTest extends TestCase
 {
     protected function tearDown()
     {
-        DnsMock::withMockedHosts([]);
+        DnsMock::withMockedHosts(array());
     }
 
     public function testCheckdnsrr()
     {
-        DnsMock::withMockedHosts(['example.com' => [['type' => 'MX']]]);
+        DnsMock::withMockedHosts(array('example.com' => array(array('type' => 'MX'))));
         $this->assertTrue(DnsMock::checkdnsrr('example.com'));
 
-        DnsMock::withMockedHosts(['example.com' => [['type' => 'A']]]);
+        DnsMock::withMockedHosts(array('example.com' => array(array('type' => 'A'))));
         $this->assertFalse(DnsMock::checkdnsrr('example.com'));
         $this->assertTrue(DnsMock::checkdnsrr('example.com', 'a'));
         $this->assertTrue(DnsMock::checkdnsrr('example.com', 'any'));
@@ -35,34 +35,34 @@ class DnsMockTest extends TestCase
 
     public function testGetmxrr()
     {
-        DnsMock::withMockedHosts([
-            'example.com' => [[
+        DnsMock::withMockedHosts(array(
+            'example.com' => array(array(
                 'type' => 'MX',
                 'host' => 'mx.example.com',
                 'pri' => 10,
-            ]],
-        ]);
+            )),
+        ));
 
         $this->assertFalse(DnsMock::getmxrr('foobar.com', $mxhosts, $weight));
         $this->assertTrue(DnsMock::getmxrr('example.com', $mxhosts, $weight));
-        $this->assertSame(['mx.example.com'], $mxhosts);
-        $this->assertSame([10], $weight);
+        $this->assertSame(array('mx.example.com'), $mxhosts);
+        $this->assertSame(array(10), $weight);
     }
 
     public function testGethostbyaddr()
     {
-        DnsMock::withMockedHosts([
-            'example.com' => [
-                [
+        DnsMock::withMockedHosts(array(
+            'example.com' => array(
+                array(
                     'type' => 'A',
                     'ip' => '1.2.3.4',
-                ],
-                [
+                ),
+                array(
                     'type' => 'AAAA',
                     'ipv6' => '::12',
-                ],
-            ],
-        ]);
+                ),
+            ),
+        ));
 
         $this->assertSame('::21', DnsMock::gethostbyaddr('::21'));
         $this->assertSame('example.com', DnsMock::gethostbyaddr('::12'));
@@ -71,18 +71,18 @@ class DnsMockTest extends TestCase
 
     public function testGethostbyname()
     {
-        DnsMock::withMockedHosts([
-            'example.com' => [
-                [
+        DnsMock::withMockedHosts(array(
+            'example.com' => array(
+                array(
                     'type' => 'AAAA',
                     'ipv6' => '::12',
-                ],
-                [
+                ),
+                array(
                     'type' => 'A',
                     'ip' => '1.2.3.4',
-                ],
-            ],
-        ]);
+                ),
+            ),
+        ));
 
         $this->assertSame('foobar.com', DnsMock::gethostbyname('foobar.com'));
         $this->assertSame('1.2.3.4', DnsMock::gethostbyname('example.com'));
@@ -90,59 +90,59 @@ class DnsMockTest extends TestCase
 
     public function testGethostbynamel()
     {
-        DnsMock::withMockedHosts([
-            'example.com' => [
-                [
+        DnsMock::withMockedHosts(array(
+            'example.com' => array(
+                array(
                     'type' => 'A',
                     'ip' => '1.2.3.4',
-                ],
-                [
+                ),
+                array(
                     'type' => 'A',
                     'ip' => '2.3.4.5',
-                ],
-            ],
-        ]);
+                ),
+            ),
+        ));
 
         $this->assertFalse(DnsMock::gethostbynamel('foobar.com'));
-        $this->assertSame(['1.2.3.4', '2.3.4.5'], DnsMock::gethostbynamel('example.com'));
+        $this->assertSame(array('1.2.3.4', '2.3.4.5'), DnsMock::gethostbynamel('example.com'));
     }
 
     public function testDnsGetRecord()
     {
-        DnsMock::withMockedHosts([
-            'example.com' => [
-                [
+        DnsMock::withMockedHosts(array(
+            'example.com' => array(
+                array(
                     'type' => 'A',
                     'ip' => '1.2.3.4',
-                ],
-                [
+                ),
+                array(
                     'type' => 'PTR',
                     'ip' => '2.3.4.5',
-                ],
-            ],
-        ]);
+                ),
+            ),
+        ));
 
-        $records = [
-            [
+        $records = array(
+            array(
                 'host' => 'example.com',
                 'class' => 'IN',
                 'ttl' => 1,
                 'type' => 'A',
                 'ip' => '1.2.3.4',
-            ],
-            $ptr = [
+            ),
+            $ptr = array(
                 'host' => 'example.com',
                 'class' => 'IN',
                 'ttl' => 1,
                 'type' => 'PTR',
                 'ip' => '2.3.4.5',
-            ],
-        ];
+            ),
+        );
 
         $this->assertFalse(DnsMock::dns_get_record('foobar.com'));
         $this->assertSame($records, DnsMock::dns_get_record('example.com'));
         $this->assertSame($records, DnsMock::dns_get_record('example.com', DNS_ALL));
         $this->assertSame($records, DnsMock::dns_get_record('example.com', DNS_A | DNS_PTR));
-        $this->assertSame([$ptr], DnsMock::dns_get_record('example.com', DNS_PTR));
+        $this->assertSame(array($ptr), DnsMock::dns_get_record('example.com', DNS_PTR));
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -85,7 +85,7 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
     $prevRoot = getenv('COMPOSER_ROOT_VERSION');
     putenv("COMPOSER_ROOT_VERSION=$PHPUNIT_VERSION.99");
     // --no-suggest is not in the list to keep compat with composer 1.0, which is shipped with Ubuntu 16.04LTS
-    $exit = proc_close(proc_open("$COMPOSER install --no-dev --prefer-dist --no-progress --ansi", [], $p, getcwd(), null, ['bypass_shell' => true]));
+    $exit = proc_close(proc_open("$COMPOSER install --no-dev --prefer-dist --no-progress --ansi", array(), $p, getcwd(), null, array('bypass_shell' => true)));
     putenv('COMPOSER_ROOT_VERSION'.(false !== $prevRoot ? '='.$prevRoot : ''));
     if ($exit) {
         exit($exit);
@@ -118,9 +118,9 @@ EOPHP
 }
 
 global $argv, $argc;
-$argv = isset($_SERVER['argv']) ? $_SERVER['argv'] : [];
+$argv = isset($_SERVER['argv']) ? $_SERVER['argv'] : array();
 $argc = isset($_SERVER['argc']) ? $_SERVER['argc'] : 0;
-$components = [];
+$components = array();
 $cmd = array_map('escapeshellarg', $argv);
 $exit = 0;
 
@@ -155,7 +155,7 @@ if ('\\' === DIRECTORY_SEPARATOR) {
 
 if ($components) {
     $skippedTests = isset($_SERVER['SYMFONY_PHPUNIT_SKIPPED_TESTS']) ? $_SERVER['SYMFONY_PHPUNIT_SKIPPED_TESTS'] : false;
-    $runningProcs = [];
+    $runningProcs = array();
 
     foreach ($components as $component) {
         // Run phpunit tests in parallel
@@ -166,7 +166,7 @@ if ($components) {
 
         $c = escapeshellarg($component);
 
-        if ($proc = proc_open(sprintf($cmd, $c, " > $c/phpunit.stdout 2> $c/phpunit.stderr"), [], $pipes)) {
+        if ($proc = proc_open(sprintf($cmd, $c, " > $c/phpunit.stdout 2> $c/phpunit.stderr"), array(), $pipes)) {
             $runningProcs[$component] = $proc;
         } else {
             $exit = 1;
@@ -176,7 +176,7 @@ if ($components) {
 
     while ($runningProcs) {
         usleep(300000);
-        $terminatedProcs = [];
+        $terminatedProcs = array();
         foreach ($runningProcs as $component => $proc) {
             $procStatus = proc_get_status($proc);
             if (!$procStatus['running']) {
@@ -187,7 +187,7 @@ if ($components) {
         }
 
         foreach ($terminatedProcs as $component => $procStatus) {
-            foreach (['out', 'err'] as $file) {
+            foreach (array('out', 'err') as $file) {
                 $file = "$component/phpunit.std$file";
                 readfile($file);
                 unlink($file);
@@ -197,7 +197,7 @@ if ($components) {
             // STATUS_STACK_BUFFER_OVERRUN (-1073740791/0xC0000409)
             // STATUS_ACCESS_VIOLATION (-1073741819/0xC0000005)
             // STATUS_HEAP_CORRUPTION (-1073740940/0xC0000374)
-            if ($procStatus && ('\\' !== DIRECTORY_SEPARATOR || !extension_loaded('apcu') || !filter_var(ini_get('apc.enable_cli'), FILTER_VALIDATE_BOOLEAN) || !in_array($procStatus, [-1073740791, -1073741819, -1073740940]))) {
+            if ($procStatus && ('\\' !== DIRECTORY_SEPARATOR || !extension_loaded('apcu') || !filter_var(ini_get('apc.enable_cli'), FILTER_VALIDATE_BOOLEAN) || !in_array($procStatus, array(-1073740791, -1073741819, -1073740940)))) {
                 $exit = $procStatus;
                 echo "\033[41mKO\033[0m $component\n\n";
             } else {
@@ -209,7 +209,7 @@ if ($components) {
     if (!class_exists('SymfonyBlacklistSimplePhpunit', false)) {
         class SymfonyBlacklistSimplePhpunit {}
     }
-    array_splice($argv, 1, 0, ['--colors=always']);
+    array_splice($argv, 1, 0, array('--colors=always'));
     $_SERVER['argv'] = $argv;
     $_SERVER['argc'] = ++$argc;
     include "$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30039
| License       | MIT
| Doc PR        | N/A

I've used PHP CS Fixer to convert all short array expressions back to the traditional syntax understood by php 5.3. Unfortunately, I don't have a local php 5.3 setup anymore, so I hope I've caught all occurrences.