### PR TITLE
[Security] Fix serialization workaround in CustomUserMessageAuthenticationException

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
@@ -60,7 +60,7 @@ class CustomUserMessageAuthenticationException extends AuthenticationException
      */
     public function serialize()
     {
-        return serialize([parent::serialize(true), $this->messageKey, $this->messageData]);
+        $serialized = [parent::serialize(true), $this->messageKey, $this->messageData];
 
         return $this->doSerialize($serialized, \func_num_args() ? \func_get_arg(0) : null);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | m/a
