### PR TITLE
[DependencyInjection] Fix serialization of \Closure in RemoveUnusedDefinitionsPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
@@ -70,7 +70,7 @@ class RemoveUnusedDefinitionsPass extends AbstractRecursivePass implements Repea
             foreach ($container->getDefinitions() as $id => $definition) {
                 if (!isset($connectedIds[$id])) {
                     $container->removeDefinition($id);
-                    $container->resolveEnvPlaceholders(serialize($definition));
+                    $container->resolveEnvPlaceholders(!$definition->hasErrors() ? serialize($definition) : $definition);
                     $container->log($this, sprintf('Removed service "%s"; reason: unused.', $id));
                 }
             }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1394,6 +1394,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             $value = $bag->resolveValue($value);
         }
 
+        if ($value instanceof Definition) {
+            $value = (array) $value;
+        }
+
         if (\is_array($value)) {
             $result = [];
             foreach ($value as $k => $v) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveUnusedDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveUnusedDefinitionsPassTest.php
@@ -142,6 +142,24 @@ class RemoveUnusedDefinitionsPassTest extends TestCase
         $this->assertFalse($container->hasDefinition('not.defined'));
     }
 
+    public function testProcessWorksWithClosureErrorsInDefinitions()
+    {
+        $definition = new Definition();
+        $definition->addError(function () {
+            return 'foo bar';
+        });
+
+        $container = new ContainerBuilder();
+        $container
+            ->setDefinition('foo', $definition)
+            ->setPublic(false)
+        ;
+
+        $this->process($container);
+
+        $this->assertFalse($container->hasDefinition('foo'));
+    }
+
     protected function process(ContainerBuilder $container)
     {
         (new RemoveUnusedDefinitionsPass())->process($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29694 
| License       | MIT
| Doc PR        | n/a

Fix the issue #29694