### PR TITLE
[Cache] fix pruning pdo cache for vendors that throw on execute

### DIFF
--- a/src/Symfony/Component/Cache/Traits/PdoTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PdoTrait.php
@@ -165,8 +165,11 @@ trait PdoTrait
         if ('' !== $this->namespace) {
             $delete->bindValue(':namespace', sprintf('%s%%', $this->namespace), \PDO::PARAM_STR);
         }
-
-        return $delete->execute();
+        try {
+            return $delete->execute();
+        } catch (TableNotFoundException $e) {
+            return true;
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no >
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This additionally fixes pruning of the PdoAdapter when the table does not exist.
Similar to https://github.com/symfony/symfony/pull/29900 https://github.com/symfony/symfony/pull/30005 and https://github.com/symfony/symfony/commit/f419851eb1d63a9c4d1c0c77c1a19486ba4cff81 
