### PR TITLE
Drop \Serializable implementations

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * deprecated using environment variables with `cannotBeEmpty()` if the value is validated with `validate()`
+ * made `Resource\*` classes final and not implement `Serializable` anymore
 
 4.2.0
 -----

--- a/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
@@ -18,8 +18,10 @@ namespace Symfony\Component\Config\Resource;
  * The resource must be a fully-qualified class name.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.3
  */
-class ClassExistenceResource implements SelfCheckingResourceInterface, \Serializable
+class ClassExistenceResource implements SelfCheckingResourceInterface
 {
     private $resource;
     private $exists;
@@ -97,21 +99,13 @@ class ClassExistenceResource implements SelfCheckingResourceInterface, \Serializ
     /**
      * @internal
      */
-    public function serialize()
+    public function __sleep(): array
     {
         if (null === $this->exists) {
             $this->isFresh(0);
         }
 
-        return serialize([$this->resource, $this->exists]);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        list($this->resource, $this->exists) = unserialize($serialized);
+        return ['resource', 'exists'];
     }
 
     /**

--- a/src/Symfony/Component/Config/Resource/ComposerResource.php
+++ b/src/Symfony/Component/Config/Resource/ComposerResource.php
@@ -15,8 +15,10 @@ namespace Symfony\Component\Config\Resource;
  * ComposerResource tracks the PHP version and Composer dependencies.
  *
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @final since Symfony 4.3
  */
-class ComposerResource implements SelfCheckingResourceInterface, \Serializable
+class ComposerResource implements SelfCheckingResourceInterface
 {
     private $vendors;
 
@@ -49,22 +51,6 @@ class ComposerResource implements SelfCheckingResourceInterface, \Serializable
         self::refresh();
 
         return self::$runtimeVendors === $this->vendors;
-    }
-
-    /**
-     * @internal
-     */
-    public function serialize()
-    {
-        return serialize($this->vendors);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        $this->vendors = unserialize($serialized);
     }
 
     private static function refresh()

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -15,8 +15,10 @@ namespace Symfony\Component\Config\Resource;
  * DirectoryResource represents a resources stored in a subdirectory tree.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.3
  */
-class DirectoryResource implements SelfCheckingResourceInterface, \Serializable
+class DirectoryResource implements SelfCheckingResourceInterface
 {
     private $resource;
     private $pattern;
@@ -102,21 +104,5 @@ class DirectoryResource implements SelfCheckingResourceInterface, \Serializable
         }
 
         return true;
-    }
-
-    /**
-     * @internal
-     */
-    public function serialize()
-    {
-        return serialize([$this->resource, $this->pattern]);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        list($this->resource, $this->pattern) = unserialize($serialized);
     }
 }

--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -18,8 +18,10 @@ namespace Symfony\Component\Config\Resource;
  * The resource can be a file or a directory.
  *
  * @author Charles-Henri Bruyand <charleshenri.bruyand@gmail.com>
+ *
+ * @final since Symfony 4.3
  */
-class FileExistenceResource implements SelfCheckingResourceInterface, \Serializable
+class FileExistenceResource implements SelfCheckingResourceInterface
 {
     private $resource;
 
@@ -56,21 +58,5 @@ class FileExistenceResource implements SelfCheckingResourceInterface, \Serializa
     public function isFresh($timestamp)
     {
         return file_exists($this->resource) === $this->exists;
-    }
-
-    /**
-     * @internal
-     */
-    public function serialize()
-    {
-        return serialize([$this->resource, $this->exists]);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        list($this->resource, $this->exists) = unserialize($serialized);
     }
 }

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -17,8 +17,10 @@ namespace Symfony\Component\Config\Resource;
  * The resource can be a file or a directory.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.3
  */
-class FileResource implements SelfCheckingResourceInterface, \Serializable
+class FileResource implements SelfCheckingResourceInterface
 {
     /**
      * @var string|false
@@ -61,21 +63,5 @@ class FileResource implements SelfCheckingResourceInterface, \Serializable
     public function isFresh($timestamp)
     {
         return false !== ($filemtime = @filemtime($this->resource)) && $filemtime <= $timestamp;
-    }
-
-    /**
-     * @internal
-     */
-    public function serialize()
-    {
-        return serialize($this->resource);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        $this->resource = unserialize($serialized);
     }
 }

--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -20,8 +20,10 @@ use Symfony\Component\Finder\Glob;
  * Only existence/removal is tracked (not mtimes.)
  *
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @final since Symfony 4.3
  */
-class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface, \Serializable
+class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
 {
     private $prefix;
     private $pattern;
@@ -80,21 +82,13 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface,
     /**
      * @internal
      */
-    public function serialize()
+    public function __sleep(): array
     {
         if (null === $this->hash) {
             $this->hash = $this->computeHash();
         }
 
-        return serialize([$this->prefix, $this->pattern, $this->recursive, $this->hash, $this->forExclusion, $this->excludedPrefixes]);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        list($this->prefix, $this->pattern, $this->recursive, $this->hash, $this->forExclusion, $this->excludedPrefixes) = unserialize($serialized) + [4 => false, []];
+        return ['prefix', 'pattern', 'recursive', 'hash', 'forExclusion', 'excludedPrefixes'];
     }
 
     public function getIterator()

--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -17,8 +17,10 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @final since Symfony 4.3
  */
-class ReflectionClassResource implements SelfCheckingResourceInterface, \Serializable
+class ReflectionClassResource implements SelfCheckingResourceInterface
 {
     private $files = [];
     private $className;
@@ -61,22 +63,14 @@ class ReflectionClassResource implements SelfCheckingResourceInterface, \Seriali
     /**
      * @internal
      */
-    public function serialize()
+    public function __sleep(): array
     {
         if (null === $this->hash) {
             $this->hash = $this->computeHash();
             $this->loadFiles($this->classReflector);
         }
 
-        return serialize([$this->files, $this->className, $this->hash]);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        list($this->files, $this->className, $this->hash) = unserialize($serialized);
+        return ['files', 'className', 'hash'];
     }
 
     private function loadFiles(\ReflectionClass $class)

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -158,7 +158,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
         $meta = false;
         $content = file_get_contents($file);
         $signalingException = new \UnexpectedValueException();
-        $prevUnserializeHandler = ini_set('unserialize_callback_func', '');
+        $prevUnserializeHandler = ini_set('unserialize_callback_func', self::class.'::handleUnserializeCallback');
         $prevErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler, $signalingException) {
             if (__FILE__ === $file) {
                 throw $signalingException;
@@ -179,5 +179,13 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
         }
 
         return $meta;
+    }
+
+    /**
+     * @internal
+     */
+    public static function handleUnserializeCallback($class)
+    {
+        trigger_error('Class not found: '.$class);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added `%env(default:...)%` processor to fallback to a default value
  * added `%env(nullable:...)%` processor to allow empty variables to be processed as null values
  * added support for deprecating aliases
+ * made `ContainerParametersResource` final and not implement `Serializable` anymore
 
 4.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Config/ContainerParametersResource.php
+++ b/src/Symfony/Component/DependencyInjection/Config/ContainerParametersResource.php
@@ -17,8 +17,10 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  * Tracks container parameters.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @final since Symfony 4.3
  */
-class ContainerParametersResource implements ResourceInterface, \Serializable
+class ContainerParametersResource implements ResourceInterface
 {
     private $parameters;
 
@@ -36,22 +38,6 @@ class ContainerParametersResource implements ResourceInterface, \Serializable
     public function __toString()
     {
         return 'container_parameters_'.md5(serialize($this->parameters));
-    }
-
-    /**
-     * @internal
-     */
-    public function serialize()
-    {
-        return serialize($this->parameters);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        $this->parameters = unserialize($serialized);
     }
 
     /**

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
    option is set to `single_text`
  * added `block_prefix` option to `BaseType`.
  * added `help_html` option to display the `help` text as HTML.
+ * `FormError` doesn't implement `Serializable` anymore
  * added `label_translation_parameters`, `attr_translation_parameters`, `help_translation_parameters` options 
    to `FormType` to pass translation parameters to form labels, attributes (`placeholder` and `title`) and help text respectively.
    The passed parameters will replace placeholders in translation messages.
@@ -31,7 +32,6 @@ CHANGELOG
        }
    }
    ```
-
 
 4.2.0
 -----

--- a/src/Symfony/Component/Form/FormError.php
+++ b/src/Symfony/Component/Form/FormError.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\Exception\BadMethodCallException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class FormError implements \Serializable
+class FormError
 {
     protected $messageTemplate;
     protected $messageParameters;
@@ -132,27 +132,5 @@ class FormError implements \Serializable
     public function getOrigin()
     {
         return $this->origin;
-    }
-
-    /**
-     * @internal
-     */
-    public function serialize()
-    {
-        return serialize([
-            $this->message,
-            $this->messageTemplate,
-            $this->messageParameters,
-            $this->messagePluralization,
-            $this->cause,
-        ]);
-    }
-
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        list($this->message, $this->messageTemplate, $this->messageParameters, $this->messagePluralization, $this->cause) = unserialize($serialized, ['allowed_classes' => false]);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -448,7 +448,7 @@ class FormDataCollectorTest extends TestCase
         $this->dataCollector->collectViewVariables($form2View);
         $this->dataCollector->buildFinalFormTree($form2, $form2View);
 
-        $this->dataCollector->serialize();
+        serialize($this->dataCollector);
     }
 
     public function testFinalFormReliesOnFormViewStructure()

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * increased the priority of `Symfony\Component\HttpKernel\EventListener\AddRequestFormatsListener`
  * made `Symfony\Component\HttpKernel\EventListenerLocaleListener` set the default locale early
+ * made `FileLinkFormatter` final and not implement `Serializable` anymore
 
 4.2.0
 -----

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -20,8 +20,10 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * Formats debug file links.
  *
  * @author Jérémy Romey <jeremy@free-agent.fr>
+ *
+ * @final since Symfony 4.3
  */
-class FileLinkFormatter implements \Serializable
+class FileLinkFormatter
 {
     private $fileLinkFormat;
     private $requestStack;
@@ -64,17 +66,11 @@ class FileLinkFormatter implements \Serializable
     /**
      * @internal
      */
-    public function serialize()
+    public function __sleep(): array
     {
-        return serialize($this->getFileLinkFormat());
-    }
+        $this->getFileLinkFormat();
 
-    /**
-     * @internal
-     */
-    public function unserialize($serialized)
-    {
-        $this->fileLinkFormat = unserialize($serialized, ['allowed_classes' => false]);
+        return ['fileLinkFormat'];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes, it removes `\Serializable` interface from many classes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR replaces [Serializable](https://secure.php.net/serializable) implementations with [__sleep() and __wakeup()](http://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.sleep).

Changes touch these components:

- Config
- DependencyInjection
- Form
- HttpKernel
- Validator