### PR TITLE
[FrameworkBundle] deprecated the test.client service

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -29,6 +29,10 @@ Form
 FrameworkBundle
 ---------------
 
+ * Deprecated the `client.test`, `test.client.history`, and `test.client.cookiejar` services.
+   (the `test.client.parameters` parameter is also deprecated)
+ * The `Symfony\Bundle\FrameworkBundle\Test\WebTestCase` class does not use the `client.test` service anymore and
+   creates its own `Client`.
  * Not passing the project directory to the constructor of the `AssetsInstallCommand` is deprecated. This argument will
    be mandatory in 5.0.
  * Deprecated the "Psr\SimpleCache\CacheInterface" / "cache.app.simple" service, use "Symfony\Contracts\Cache\CacheInterface" / "cache.app" instead.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -134,6 +134,12 @@ Form
 FrameworkBundle
 ---------------
 
+ * The `Symfony\Bundle\FrameworkBundle\Test\WebTestCase` class does not use the `client.test` service anymore and
+   creates its own `Client`.
+
+ * The `client.test`, `test.client.history`, and `test.client.cookiejar` services were removed
+   (the `test.client.parameters` parameter was also removed).
+
  * The project dir argument of the constructor of `AssetsInstallCommand` is required.
 
  * Removed support for `bundle:controller:action` syntax to reference controllers. Use `serviceOrFqcn::method`

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 4.3.0
 -----
 
+ * Deprecated the `client.test`, `test.client.history`, and `test.client.cookiejar` services.
+   (the `test.client.parameters` parameter is also deprecated)
+ * The `Symfony\Bundle\FrameworkBundle\Test\WebTestCase` class does not use the `client.test` service anymore and
+   creates its own `Client`.
  * Not passing the project directory to the constructor of the `AssetsInstallCommand` is deprecated. This argument will
    be mandatory in 5.0.
  * Deprecated the "Psr\SimpleCache\CacheInterface" / "cache.app.simple" service, use "Symfony\Contracts\Cache\CacheInterface" / "cache.app" instead

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -12,15 +12,20 @@
         <defaults public="false" />
 
         <service id="test.client" class="Symfony\Bundle\FrameworkBundle\Client" shared="false" public="true">
+            <deprecated />
             <argument type="service" id="kernel" />
             <argument>%test.client.parameters%</argument>
             <argument type="service" id="test.client.history" />
             <argument type="service" id="test.client.cookiejar" />
         </service>
 
-        <service id="test.client.history" class="Symfony\Component\BrowserKit\History" shared="false" />
+        <service id="test.client.history" class="Symfony\Component\BrowserKit\History" shared="false">
+            <deprecated />
+        </service>
 
-        <service id="test.client.cookiejar" class="Symfony\Component\BrowserKit\CookieJar" shared="false" />
+        <service id="test.client.cookiejar" class="Symfony\Component\BrowserKit\CookieJar" shared="false">
+            <deprecated />
+        </service>
 
         <service id="test.session.listener" class="Symfony\Component\HttpKernel\EventListener\TestSessionListener">
             <tag name="kernel.event_subscriber" />

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
@@ -33,14 +34,10 @@ abstract class WebTestCase extends KernelTestCase
     {
         $kernel = static::bootKernel($options);
 
-        try {
-            $client = $kernel->getContainer()->get('test.client');
-        } catch (ServiceNotFoundException $e) {
+        if (!class_exists(CookieJar::class)) {
             throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit component is not available. Try running "composer require symfony/browser-kit".');
         }
 
-        $client->setServerParameters($server);
-
-        return $client;
+        return new Client($kernel, $server);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | symfony/symfony-docs#10958

As `test.client` is not shared anyway, I think it would be better to create a new client directly instead of having it in the container.

The only use cases for having a service in the container are:

 * If you want to override some class names, but you can then be more explicit and override the `WebTestCase::createClient()` method

 * If you want to inject some specific server parameters (but you can already do that when calling `createClient()`)

WDYT?
