### PR TITLE
[Form] don't lose int precision with not needed type casts

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
@@ -44,4 +44,12 @@ class IntegerToLocalizedStringTransformer extends NumberToLocalizedStringTransfo
 
         return null !== $result ? (int) $result : null;
     }
+
+    /**
+     * @internal
+     */
+    protected function castParsedValue($value)
+    {
+        return $value;
+    }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -181,9 +181,7 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
             throw new TransformationFailedException('I don\'t have a clear idea what infinity looks like');
         }
 
-        if (\is_int($result) && $result === (int) $float = (float) $result) {
-            $result = $float;
-        }
+        $result = $this->castParsedValue($result);
 
         if (false !== $encoding = mb_detect_encoding($value, null, true)) {
             $length = mb_strlen($value, $encoding);
@@ -226,6 +224,18 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
         $formatter->setAttribute(\NumberFormatter::GROUPING_USED, $this->grouping);
 
         return $formatter;
+    }
+
+    /**
+     * @internal
+     */
+    protected function castParsedValue($value)
+    {
+        if (\is_int($value) && $value === (int) $float = (float) $value) {
+            return $float;
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -50,4 +50,45 @@ class IntegerTypeTest extends BaseTypeTest
         $this->assertSame($expectedData, $form->getNormData());
         $this->assertSame($expectedData, $form->getData());
     }
+
+    public function testSubmittedLargeIntegersAreNotCastToFloat()
+    {
+        if (4 === \PHP_INT_SIZE) {
+            $this->markTestSkipped('This test requires a 64bit PHP.');
+        }
+
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit('201803221011791');
+
+        $this->assertSame(201803221011791, $form->getData());
+        $this->assertSame('201803221011791', $form->getViewData());
+    }
+
+    public function testTooSmallIntegersAreNotValid()
+    {
+        if (4 === \PHP_INT_SIZE) {
+            $min = '-2147483649';
+        } else {
+            $min = '-9223372036854775808';
+        }
+
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit($min);
+
+        $this->assertFalse($form->isSynchronized());
+    }
+
+    public function testTooGreatIntegersAreNotValid()
+    {
+        if (4 === \PHP_INT_SIZE) {
+            $max = '2147483648';
+        } else {
+            $max = '9223372036854775808';
+        }
+
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit($max);
+
+        $this->assertFalse($form->isSynchronized());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26795
| License       | MIT
| Doc PR        | 