### PR TITLE
Fix wrong value in file id attribute for Xliff 2.0

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -141,7 +141,11 @@ class XliffFileDumper extends FileDumper
         $xliff->setAttribute('trgLang', str_replace('_', '-', $messages->getLocale()));
 
         $xliffFile = $xliff->appendChild($dom->createElement('file'));
-        $xliffFile->setAttribute('id', $domain.'.'.$messages->getLocale());
+        if (MessageCatalogue::INTL_DOMAIN_SUFFIX === substr($domain, -($suffixLength = \strlen(MessageCatalogue::INTL_DOMAIN_SUFFIX)))) {
+            $xliffFile->setAttribute('id', substr($domain, 0, -$suffixLength).'.'.$messages->getLocale());
+        } else {
+            $xliffFile->setAttribute('id', $domain.'.'.$messages->getLocale());
+        }
 
         foreach ($messages->all($domain) as $source => $target) {
             $translation = $dom->createElement('unit');

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -54,6 +54,21 @@ class XliffFileDumperTest extends TestCase
         );
     }
 
+    public function testFormatIcuCatalogueXliff2()
+    {
+        $catalogue = new MessageCatalogue('en_US');
+        $catalogue->add([
+            'foo' => 'bar',
+        ], 'messages'.MessageCatalogue::INTL_DOMAIN_SUFFIX);
+
+        $dumper = new XliffFileDumper();
+
+        $this->assertStringEqualsFile(
+            __DIR__.'/../fixtures/resources-2.0+intl-icu.xlf',
+            $dumper->formatCatalogue($catalogue, 'messages'.MessageCatalogue::INTL_DOMAIN_SUFFIX, ['default_locale' => 'fr_FR', 'xliff_version' => '2.0'])
+        );
+    }
+
     public function testFormatCatalogueWithCustomToolInfo()
     {
         $options = [

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources-2.0+intl-icu.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources-2.0+intl-icu.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
+  <file id="messages.en_US">
+    <unit id="LCa0a2j" name="foo">
+      <segment>
+        <source>foo</source>
+        <target>bar</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets |
| License       | MIT
| Doc PR        |

Currently using the `XliffFileDumper` for exporting messages from catalogue with domain of the form `xxxx+intl-icu` produces an invalid Xliff version 2.0 file as the file id attribute is of type `xs:NMTOKEN` (cf. https://github.com/symfony/translation/blob/master/Resources/schemas/xliff-core-2.0.xsd#L139) which doesn't accept `+` character (cf. http://www.datypic.com/sc/xsd/t-xsd_NMTOKEN.html).
Exception is thrown when loading the content after.
