### PR TITLE
[Form] Support dynamic error_mapping rules

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/AbstractMappingRule.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/AbstractMappingRule.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Validator\ViolationMapper;
+
+use Symfony\Component\Form\Exception\ErrorMappingException;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * @internal
+ */
+abstract class AbstractMappingRule
+{
+    protected $origin;
+
+    protected $targetPath;
+
+    public function __construct(FormInterface $origin, string $targetPath)
+    {
+        $this->origin = $origin;
+        $this->targetPath = $targetPath;
+    }
+
+    protected function doGetTarget(string $targetPath): FormInterface
+    {
+        $childNames = explode('.', $targetPath);
+        $target = $this->origin;
+
+        foreach ($childNames as $childName) {
+            if (!$target->has($childName)) {
+                throw new ErrorMappingException(sprintf('The child "%s" of "%s" mapped by the rule "%s" in "%s" does not exist.', $childName, $target->getName(), $this->targetPath, $this->origin->getName()));
+            }
+
+            $target = $target->get($childName);
+        }
+
+        return $target;
+    }
+
+    /**
+     * Matches a property path against the rule path.
+     *
+     * If the rule matches, the form mapped by the rule is returned.
+     * Otherwise this method returns null.
+     *
+     * @param string $propertyPath The property path to match against the rule
+     *
+     * @return FormInterface|null The mapped form or null
+     */
+    abstract public function match($propertyPath);
+
+    /**
+     * Matches a property path against a prefix of the rule path.
+     *
+     * @param string $propertyPath The property path to match against the rule
+     *
+     * @return bool Whether the property path is a prefix of the rule or not
+     */
+    abstract public function isPrefix($propertyPath);
+}

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/DynamicMappingRule.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/DynamicMappingRule.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Validator\ViolationMapper;
+
+use Symfony\Component\Form\Exception\ErrorMappingException;
+use Symfony\Component\Form\FormConfigBuilder;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+/**
+ * @internal
+ */
+class DynamicMappingRule extends AbstractMappingRule
+{
+    private $propertyPathLength;
+
+    private $matchRules;
+
+    private $isPrefixRules;
+
+    public function __construct(FormInterface $origin, string $propertyPath, string $targetPath)
+    {
+        if (substr_count($propertyPath, '*') !== substr_count($targetPath, '*')) {
+            throw new ErrorMappingException(sprintf('The number of "*" must be equals on both sides for the dynamic mapping rule "%s => %s" in "%s".', $propertyPath, $targetPath, $origin->getName()));
+        }
+
+        parent::__construct($origin, $targetPath);
+
+        $propertyPath = new PropertyPath($propertyPath);
+
+        $this->propertyPathLength = $propertyPath->getLength();
+
+        foreach ($propertyPath->getElements() as $ruleElement) {
+            if ('*' === $ruleElement) {
+                $this->matchRules[] = function (string $element, &$dynamicValues): bool {
+                    $dynamicValues[] = $element;
+
+                    return true;
+                };
+
+                $this->isPrefixRules[] =  function (): bool {
+                    return true;
+                };
+            } elseif (false === strpos($ruleElement, '*')) {
+                $this->matchRules[] = $this->isPrefixRules[] = function (string $element) use ($ruleElement): bool {
+                    return $element === $ruleElement;
+                };
+            } else {
+                $ruleElementPattern = preg_quote($ruleElement, '/');
+
+                $matchPattern = '/'.str_replace('\\*', '('.FormConfigBuilder::VALID_NAME_PATTERN.')', $ruleElementPattern).'/';
+                $this->matchRules[] = function (string $element, array &$dynamicValues) use ($matchPattern): bool {
+                    if (1 === preg_match($matchPattern, $element, $matches)) {
+                        array_push($dynamicValues, ...array_slice($matches, 1));
+
+                        return true;
+                    }
+
+                    return false;
+                };
+
+                $isPrefixPattern = '/'.str_replace('\\*', FormConfigBuilder::VALID_NAME_PATTERN, $ruleElementPattern).'/';
+                $this->isPrefixRules[] = function (string $element) use ($isPrefixPattern): bool {
+                    return 1 === preg_match($isPrefixPattern, $element);
+                };
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function match($propertyPath)
+    {
+        $propertyPath = new PropertyPath($propertyPath);
+
+        if ($propertyPath->getLength() !== $this->propertyPathLength) {
+            return null;
+        }
+
+        $dynamicValues = [];
+        foreach ($this->matchRules as $index => $matchingRule) {
+            if (!$matchingRule($propertyPath->getElement($index), $dynamicValues)) {
+                return null;
+            }
+        }
+
+        $realTargetPath = $this->targetPath;
+        while (false !== $pos = strpos($realTargetPath, '*')) {
+            $realTargetPath = substr_replace($realTargetPath, array_shift($dynamicValues), $pos, 1);
+        }
+
+        return $this->doGetTarget($realTargetPath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPrefix($propertyPath)
+    {
+        $propertyPath = new PropertyPath($propertyPath);
+
+        if ($propertyPath->getLength() >= $this->propertyPathLength) {
+            return false;
+        }
+
+        foreach ($propertyPath->getElements() as $index => $element) {
+            if (!$this->isPrefixRules[$index]($element)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
@@ -17,17 +17,15 @@ use Symfony\Component\Form\FormInterface;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class MappingRule
+class MappingRule extends AbstractMappingRule
 {
-    private $origin;
     private $propertyPath;
-    private $targetPath;
 
     public function __construct(FormInterface $origin, string $propertyPath, string $targetPath)
     {
-        $this->origin = $origin;
+        parent::__construct($origin, $targetPath);
+
         $this->propertyPath = $propertyPath;
-        $this->targetPath = $targetPath;
     }
 
     /**
@@ -39,28 +37,17 @@ class MappingRule
     }
 
     /**
-     * Matches a property path against the rule path.
-     *
-     * If the rule matches, the form mapped by the rule is returned.
-     * Otherwise this method returns false.
-     *
-     * @param string $propertyPath The property path to match against the rule
-     *
-     * @return FormInterface|null The mapped form or null
+     * {@inheritdoc}
      */
     public function match($propertyPath)
     {
-        if ($propertyPath === (string) $this->propertyPath) {
+        if ($propertyPath === $this->propertyPath) {
             return $this->getTarget();
         }
     }
 
     /**
-     * Matches a property path against a prefix of the rule path.
-     *
-     * @param string $propertyPath The property path to match against the rule
-     *
-     * @return bool Whether the property path is a prefix of the rule or not
+     * {@inheritdoc}
      */
     public function isPrefix($propertyPath)
     {
@@ -78,16 +65,6 @@ class MappingRule
      */
     public function getTarget()
     {
-        $childNames = explode('.', $this->targetPath);
-        $target = $this->origin;
-
-        foreach ($childNames as $childName) {
-            if (!$target->has($childName)) {
-                throw new ErrorMappingException(sprintf('The child "%s" of "%s" mapped by the rule "%s" in "%s" does not exist.', $childName, $target->getName(), $this->targetPath, $this->origin->getName()));
-            }
-            $target = $target->get($childName);
-        }
-
-        return $target;
+        return $this->doGetTarget($this->targetPath);
     }
 }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -28,6 +28,11 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
 class FormConfigBuilder implements FormConfigBuilderInterface
 {
     /**
+     * @internal
+     */
+    public const VALID_NAME_PATTERN = '[a-zA-Z0-9_][a-zA-Z0-9_\-:]*';
+
+    /**
      * Caches a globally unique {@link NativeRequestHandler} instance.
      *
      * @var NativeRequestHandler
@@ -859,6 +864,6 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public static function isValidName($name)
     {
-        return '' === $name || null === $name || preg_match('/^[a-zA-Z0-9_][a-zA-Z0-9_\-:]*$/D', $name);
+        return '' === $name || null === $name || preg_match('/^'.self::VALID_NAME_PATTERN.'$/D', $name);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | TODO

When you build a form with a dynamic structure (unknown number of fields) or when you use a custom data mapper, or both, `error_mapping` can be hard to use depending of how your data end up in being mapped in yout model. I thought it would be nice to be able to define dynamic rules.

Example with a model that would put everything in a `$stack` property, indexed by a type.

Current : 
```php
<?php

class ParentType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        foreach ($options['types'] as $type) {
            $builder->add(sprintf('sub_%s', $type), SubType::class);
        }
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => Parent::class,
            'error_mapping' => function (Options $options): array {
            	return array_combine(array_map(function (string $type): string {
                    return sprintf('stack[%s]', $type);
                }, $options['types']), array_map(function (string $type): string {
                    return sprintf('sub_%s', $type);
                }, $options['types']));
            },
        ]);
        $resolver->setRequired('types');
        $resolver->setAllowedTypes('types', 'array');
    }
}
```

After : 
```php
<?php

class ParentType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        foreach ($options['types'] as $type) {
            $builder->add(sprintf('sub_%s', $type), SubType::class);
        }
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => Parent::class,
            'error_mapping' => [
            	'stack[*]' => 'sub_*',
            ],
        ]);
        $resolver->setRequired('types');
        $resolver->setAllowedTypes('types', 'array');
    }
}
```

TODO : 
- [ ] Add more tests
- [ ] Update CHANGELOG
- [ ] Update doc

One more thing that I would like to do (in a separate PR) whether this feature end up being merged or not would be to validate the right side (that contains the names of fields in the form) of error mappings whether there is match or no. For a better DX, I think we should throw an useful exception if the path is not a simple property path (ie with no index) effectively corresponding to the target form child. Currently, there is an exception only if there is a match.

The proposed implementation is backward compatible since a `*` cannot be in a valid form name.