### PR TITLE
Fix KernelTestCase compatibility for PhpUnit 8

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -208,6 +208,8 @@ abstract class KernelTestCase extends TestCase
     }
 
     /**
+     * @after
+     *
      * Shuts the kernel down if it was used in the test.
      */
     protected static function ensureKernelShutdown()
@@ -219,13 +221,5 @@ abstract class KernelTestCase extends TestCase
                 $container->reset();
             }
         }
-    }
-
-    /**
-     * Clean up Kernel usage in this test.
-     */
-    protected function tearDown()
-    {
-        static::ensureKernelShutdown();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30071
| License       | MIT
| Doc PR        | 

As the PhpUnit 8 Testcase has different return types as PhpUnit 7 there need to be 2 different classes to support both PhpUnit 8 and PhpUnit 7. With a class alias we can then change which version is used based on the PhpUnit Version constant. The fix is a little bit hacky but to support different major versions I see no other way.

Not sure as we can't upgrade symfony/symfony to PhpUnit 8 how we can create a TestCase for this change.