### PR TITLE
[Workflow] Graphviz dumper escape not always a string

### DIFF
--- a/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
@@ -204,9 +204,9 @@ class GraphvizDumper implements DumperInterface
     /**
      * @internal
      */
-    protected function escape(string $string): string
+    protected function escape($value): string
     {
-        return addslashes($string);
+        return \is_bool($value) ? ($value ? '1' : '0') : \addslashes($value);
     }
 
     private function addAttributes(array $attributes): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The `escape` function takes a string as parameter but it can be a `bool` (see `findTransitions` method in same class). In this PR I allow any type in `escape` and does escaping only for `string`.