### PR TITLE
[WIP][Console] Fix escaping

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -140,6 +140,7 @@ class OutputFormatter implements OutputFormatterInterface
             $text = $match[0];
 
             if (0 != $pos && '\\' == $message[$pos - 1]) {
+                // @fixme ignore if slash itself is escaped
                 continue;
             }
 
@@ -172,7 +173,7 @@ class OutputFormatter implements OutputFormatterInterface
             return strtr($output, ["\0" => '\\', '\\<' => '<']);
         }
 
-        return str_replace('\\<', '<', $output);
+        return preg_replace('~(?<!\\\\)(?:\\\\\\\\)*(\\\\<)~', '<', $output);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30095
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Pushed to see what tests do :)

- [ ] fix todo
- [ ] add tests

testing with

```
echo '\\\\<' . PHP_EOL;
$output->writeln('\\\\<');
$output->writeln('\\\\\\<info>boo\\</info>');
$output->writeln('\\\\<info>boo</info>');
```

ref: https://regex101.com/r/ZL7sI1/1