### PR TITLE
Remove "internal" annotation from datacollector serialization methods

### DIFF
--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -228,9 +228,6 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
         return $this->data;
     }
 
-    /**
-     * @internal
-     */
     public function serialize()
     {
         if ($this->hasVarDumper) {

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -40,9 +40,6 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
      */
     private $cloner;
 
-    /**
-     * @internal
-     */
     public function serialize()
     {
         $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
@@ -51,9 +48,6 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
         return $isCalledFromOverridingMethod ? $this->data : serialize($this->data);
     }
 
-    /**
-     * @internal
-     */
     public function unserialize($data)
     {
         $this->data = \is_array($data) ? $data : unserialize($data);

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -176,9 +176,6 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
         $this->clonesIndex = 0;
     }
 
-    /**
-     * @internal
-     */
     public function serialize()
     {
         if ($this->clonesCount !== $this->clonesIndex) {
@@ -198,9 +195,6 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
         return $ser;
     }
 
-    /**
-     * @internal
-     */
     public function unserialize($data)
     {
         $this->data = unserialize($data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I've been a bit too aggressively adding `@internal` in #30035.