### PR TITLE
[Filesystem] Fix mirroring a directory into itself or in his child with realpath checks

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -569,6 +569,10 @@ class Filesystem
         }
 
         foreach ($iterator as $file) {
+            if ($file->getPathName() === $targetDir) {
+                continue;
+            }
+
             if (false === strpos($file->getPath(), $originDir)) {
                 throw new IOException(sprintf('Unable to mirror "%s" directory. If the origin directory is relative, try using "realpath" before calling the mirror method.', $originDir), 0, null, $originDir);
             }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1372,6 +1372,31 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->mirror($sourcePath, $targetPath, $iterator);
     }
 
+    public function testMirrorAvoidCopyingTargetDirectoryIfInSourceDirectory()
+    {
+        $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;
+        $directory = $sourcePath.'directory'.\DIRECTORY_SEPARATOR;
+        $file1 = $directory.'file1';
+        $file2 = $sourcePath.'file2';
+
+        mkdir($sourcePath);
+        mkdir($directory);
+        file_put_contents($file1, 'FILE1');
+        file_put_contents($file2, 'FILE2');
+
+        $targetPath = $sourcePath.'target'.\DIRECTORY_SEPARATOR;
+
+        $this->filesystem->mirror($sourcePath, $targetPath);
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertTrue(is_dir($targetPath.'directory'));
+
+        $this->assertFileEquals($file1, $targetPath.'directory'.\DIRECTORY_SEPARATOR.'file1');
+        $this->assertFileEquals($file2, $targetPath.'file2');
+
+        $this->assertFileNotExists($targetPath.'target');
+    }
+
     /**
      * @dataProvider providePathsForIsAbsolutePath
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none / PR #29857 
| License       | MIT
| Doc PR        | n/a

This this the continuity of #29857 by @Fleuv 

Fix a bug while trying to mirror a directory into itself or in a child
Adding handle real path checks when mirroring.