### PR TITLE
Fix KernelTestCase compatibility for PhpUnit 8 (bis)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelShutdownOnTearDownTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelShutdownOnTearDownTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use PHPUnit\Framework\TestCase;
+
+// Auto-adapt to PHPUnit 8 that added a `void` return-type to the tearDown method
+
+if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {
+eval('
+    /**
+     * @internal
+     */
+    trait KernelShutdownOnTearDownTrait
+    {
+        protected function tearDown(): void
+        {
+            static::ensureKernelShutdown();
+        }
+    }
+');
+} else {
+    /**
+     * @internal
+     */
+    trait KernelShutdownOnTearDownTrait
+    {
+        /**
+         * @return void
+         */
+        protected function tearDown()
+        {
+            static::ensureKernelShutdown();
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 abstract class KernelTestCase extends TestCase
 {
+    use KernelShutdownOnTearDownTrait;
+
     protected static $class;
 
     /**
@@ -208,9 +210,7 @@ abstract class KernelTestCase extends TestCase
     }
 
     /**
-     * @after
-     *
-     * Shuts the kernel down if it was used in the test.
+     * Shuts the kernel down if it was used in the test - called by the tearDown method by default.
      */
     protected static function ensureKernelShutdown()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Follow up of #30084 and @Tobion's comment there.

Fabbot failure is a false-positive.