### PR TITLE
[HttpFoundation] Add getJson method to Http Request object

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * deprecated `MimeType` and `MimeTypeExtensionGuesser` in favor of `Symfony\Component\Mime\MimeTypes`.
  * deprecated `FileBinaryMimeTypeGuesser` in favor of `Symfony\Component\Mime\FileBinaryMimeTypeGuesser`.
  * deprecated `FileinfoMimeTypeGuesser` in favor of `Symfony\Component\Mime\FileinfoMimeTypeGuesser`.
+ * added `getJsonDecoded` method in Request.
 
 4.2.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Exception/JsonException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/JsonException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Exception;
+
+final class JsonException extends \RuntimeException implements RequestExceptionInterface
+{
+}

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation;
 
 use Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException;
+use Symfony\Component\HttpFoundation\Exception\JsonException;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -1527,6 +1528,30 @@ class Request
         }
 
         return $this->content;
+    }
+
+    /**
+     * Return request body content as json decoded.
+     *
+     * @return mixed
+     *
+     * @throws JsonException
+     */
+    public function getJsonDecoded(int $depth = 512, int $options = 0)
+    {
+        $body = $this->getContent();
+
+        if ('' === $body) {
+            throw new JsonException('Unable to parse empty request body.');
+        }
+
+        $json = json_decode($body, true, $depth, $options);
+
+        if (JSON_ERROR_NONE !== $errorCode = json_last_error()) {
+            throw new JsonException(sprintf('Unable to parse JSON: %s.', json_last_error_msg()), $errorCode);
+        }
+
+        return $json;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | TBD

Add a `getJson` helper method to automatically decode a JSON request string to an array.

This is useful in the cases when using, for example, Axios to do AJAX requests. The request content cannot be retrieved using the `$request->request` object and is only available using the `getContent` method (which just returns the full JSON string and needs to be manually decoded).