### PR TITLE
[Validator] Add the missing translations for the French (fr) locale

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -322,6 +322,14 @@
                 <source>This is not a valid UUID.</source>
                 <target>Ceci n'est pas un UUID valide.</target>
             </trans-unit>
+            <trans-unit id="84">
+                <source>This value should be a multiple of {{ compared_value }}.</source>
+                <target>Cette valeur doit être un multiple de {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="85">
+                <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
+                <target>Ce code d'identification d'entreprise (BIC) n'est pas associé à l'IBAN {{ iban }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30164
| License       | MIT
| Doc PR        | -

To simplify things, translated files contains all the keys of the English file in `master` branch. That's why our translations in 3.4 branch contain the keys `id = 84` and `id = 85` even if that is not used in 3.4 branch.

I propose to also include that unused key in the French file to make it easier to keep things in sync.
