### PR TITLE
[Twig] Add a env variable call in AppVariable

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -193,11 +193,11 @@ class AppVariable
         if (null === $name || '' === $name) {
             return null;
         }
-        
+
         if (null === $this->requestStack) {
             throw new \RuntimeException(sprintf('The app.request variable is not available'));
-        }    
-        
+        }
+
         $request = $this->getRequest();
 
         return null !== $request ? $request->server->get($name) : null;

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -180,4 +180,20 @@ class AppVariable
 
         return $result;
     }
+
+    /**
+     * Return a environment variable (defined in .env for example)
+     *
+     * If the $name is null or empty, null is returned.
+     *
+     * @return null|string
+     */
+    public function getEnv($name = null)
+    {
+        if (\is_null($name) || '' === $name) {
+            return null;
+        }
+
+        return $this->getRequest()->server->get($name);
+    }
 }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -194,6 +194,12 @@ class AppVariable
             return null;
         }
 
-        return $this->getRequest()->server->get($name);
+        try {
+            $request = $this->getRequest();
+        } catch (\RuntimeException $exception) {
+            return null;
+        }
+
+        return ! \is_null($request) ? $request->server->get($name) : null;
     }
 }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -193,12 +193,12 @@ class AppVariable
         if (null === $name || '' === $name) {
             return null;
         }
-
-        try {
-            $request = $this->getRequest();
-        } catch (\RuntimeException $exception) {
-            return null;
-        }
+        
+        if (null === $this->requestStack) {
+            throw new \RuntimeException(sprintf('The app.request variable is not available'));
+        }    
+        
+        $request = $this->getRequest();
 
         return null !== $request ? $request->server->get($name) : null;
     }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -182,15 +182,15 @@ class AppVariable
     }
 
     /**
-     * Return a environment variable (defined in .env for example)
+     * Return a environment variable (defined in .env for example).
      *
      * If the $name is null or empty, null is returned.
      *
-     * @return null|string
+     * @return string|null
      */
     public function getEnv($name = null)
     {
-        if (\is_null($name) || '' === $name) {
+        if (null === $name || '' === $name) {
             return null;
         }
 
@@ -200,6 +200,6 @@ class AppVariable
             return null;
         }
 
-        return ! \is_null($request) ? $request->server->get($name) : null;
+        return null !== $request ? $request->server->get($name) : null;
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -233,6 +233,11 @@ class AppVariableTest extends TestCase
         );
     }
 
+    public function testGetEnv(): void
+    {
+        // To define
+    }
+
     protected function setRequestStack($request)
     {
         $requestStackMock = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -236,9 +236,8 @@ class AppVariableTest extends TestCase
     public function testGetEnvWithoutValidKey(): void
     {
         $request = new Request();
-        $requestStack = $this->setRequestStack($request);
 
-        $this->appVariable->setRequestStack($requestStack);
+        $this->setRequestStack($request);
 
         $this->assertNull($this->appVariable->getEnv(''));
     }
@@ -247,9 +246,8 @@ class AppVariableTest extends TestCase
     {
         $request = new Request();
         $request->server->set('this-key-exist', 'this-value-exist');
-        $requestStack = $this->setRequestStack($request);
 
-        $this->appVariable->setRequestStack($requestStack);
+        $this->setRequestStack($request);
 
         $this->assertNotNull($this->appVariable->getEnv('this-key-exist'));
     }

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -233,9 +233,25 @@ class AppVariableTest extends TestCase
         );
     }
 
-    public function testGetEnv(): void
+    public function testGetEnvWithoutValidKey(): void
     {
-        // To define
+        $request = new Request();
+        $requestStack = $this->setRequestStack($request);
+
+        $this->appVariable->setRequestStack($requestStack);
+
+        $this->assertNull($this->appVariable->getEnv(''));
+    }
+
+    public function testGetEnvWithValidKey(): void
+    {
+        $request = new Request();
+        $request->server->set('this-key-exist', 'this-value-exist');
+        $requestStack = $this->setRequestStack($request);
+
+        $this->appVariable->setRequestStack($requestStack);
+
+        $this->assertNotNull($this->appVariable->getEnv('this-key-exist'));
     }
 
     protected function setRequestStack($request)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no 
| Tests pass?   | no
| Fixed tickets | none
| License       | MIT
| Doc PR        | To be created

Hi everyone, 

Small PR about the `AppVariable` class, since 3.3, we can now access the flash message using `getFlashes()` (shortened to `flashes()` in Twig templates), since > 3.4, we can now use a `.env` file to define environment variable, problem is, what if we need to access a value in a template? 

Small exemple:

> Let's imagine that I need to define a hardcoded URL in my `.env` file and pass it (maybe as an API endpoint?) to JS? 

Actually, this look like this:

```twig
# ... 
<script type="text/javascript">
    randomMethod('{{ app.request.server.get('key')|e('js') }}'); 
</script>
```

That's not really a problem but I think that we can have a shortcut (like the flash one) which allow us to write easier-to-read code: 

```twig
# ... 
<script type="text/javascript">
    randomMethod('{{ app.env('key')|e('js') }}'); 
</script>
```

Actually, this PR does not support the array usage (but this could be added if needed): 

```twig
# ... 
<section>
    {% for key, value in app.env(['firstKey', 'secondKey']) }} %}
        # ...
    {% endfor %}
</section>
```

This PR is based on a recent project where I needed to pass the `Mercure` hub URL to my JS code, the JS code made a call to the HUB and I can't pass the URL in a plain value in my template (as it can change due to Docker and server configuration). 

This PR is not fully tested for now (mainly for the array usage and the case where `Request` is null) but it can be improved) but I thought that it could be a good idea to discuss it before finishing the tests. 

Thanks for the feedback.