### PR TITLE
allow to skip tests based on the supported version

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -30,6 +30,8 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
      */
     private $em;
 
+    protected static $supportedFeatureSetVersion = 304;
+
     protected function getExtensions()
     {
         $manager = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -57,6 +57,8 @@ class EntityTypeTest extends BaseTypeTest
      */
     private $emRegistry;
 
+    protected static $supportedFeatureSetVersion = 304;
+
     protected function setUp()
     {
         $this->em = DoctrineTestHelper::createTestEntityManager();

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\Tests\AbstractLayoutTest;
 
 abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 {
+    protected static $supportedFeatureSetVersion = 304;
+
     public function testLabelOnForm()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\DateType');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -31,6 +31,8 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
      */
     private $renderer;
 
+    protected static $supportedFeatureSetVersion = 304;
+
     protected function setUp()
     {
         parent::setUp();

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -30,6 +30,8 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
      */
     private $renderer;
 
+    protected static $supportedFeatureSetVersion = 304;
+
     protected function setUp()
     {
         parent::setUp();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -27,6 +27,8 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
      */
     protected $engine;
 
+    protected static $supportedFeatureSetVersion = 304;
+
     protected function getExtensions()
     {
         // should be moved to the Form component once absolute file paths are supported

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -27,6 +27,8 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
      */
     protected $engine;
 
+    protected static $supportedFeatureSetVersion = 304;
+
     public function testStartTagHasNoActionAttributeWhenActionIsEmpty()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, [

--- a/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Test;
 
+use Symfony\Component\Form\Tests\VersionAwareTest;
+
 /**
  * Base class for performance tests.
  *
@@ -21,6 +23,8 @@ namespace Symfony\Component\Form\Test;
  */
 abstract class FormPerformanceTestCase extends FormIntegrationTestCase
 {
+    use VersionAwareTest;
+
     /**
      * @var int
      */

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Test\FormIntegrationTestCase;
 
 abstract class AbstractLayoutTest extends FormIntegrationTestCase
 {
+    use VersionAwareTest;
+
     protected $csrfTokenManager;
     protected $testableFeatures = [];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Form\Tests\VersionAwareTest;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class BaseTypeTest extends TypeTestCase
 {
+    use VersionAwareTest;
+
     const TESTED_TYPE = '';
 
     public function testPassDisabledAsOption()

--- a/src/Symfony/Component/Form/Tests/VersionAwareTest.php
+++ b/src/Symfony/Component/Form/Tests/VersionAwareTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+trait VersionAwareTest
+{
+    protected static $supportedFeatureSetVersion = 304;
+
+    /**
+     * @param int $requiredFeatureSetVersion
+     */
+    protected function requiresFeatureSet($requiredFeatureSetVersion)
+    {
+        if ($requiredFeatureSetVersion > static::$supportedFeatureSetVersion) {
+            $this->markTestSkipped(sprintf('Test requires features from symfony/form %.2f but only version %.2f is supported.', $requiredFeatureSetVersion / 100, static::$supportedFeatureSetVersion / 100));
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Writing tests for Form related features in the Doctrine and Twig bridges
as well as the FrameworkBundle is a pain as soon as these tests are run
with more recent versions of the Form component. This is due to the fact
that our tests in the bridges and bundle extend test cases from the
component. The tests in the component are expanded with every feature
that gets added there. However, these new features are not present in
the other packages in older version and we thus need to be able to skip
them somehow.
