### PR TITLE
fix lost namespace in eval

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelShutdownOnTearDownTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelShutdownOnTearDownTrait.php
@@ -16,7 +16,9 @@ use PHPUnit\Framework\TestCase;
 // Auto-adapt to PHPUnit 8 that added a `void` return-type to the tearDown method
 
 if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {
-eval('
+    eval('
+    namespace Symfony\Bundle\FrameworkBundle\Test;
+
     /**
      * @internal
      */


### PR DESCRIPTION
Bugfix:
phpunit8 tearDown() declaration
