### PR TITLE
[Debug][ErrorHandler] Preserve next error handler

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -517,6 +517,11 @@ class ErrorHandler
                 $errorAsException ? ['exception' => $errorAsException] : [],
             ];
         } else {
+            if (!\defined('HHVM_VERSION')) {
+                $currentErrorHandler = set_error_handler('var_dump');
+                restore_error_handler();
+            }
+
             try {
                 $this->isRecursive = true;
                 $level = ($type & $level) ? $this->loggers[$type][1] : LogLevel::DEBUG;
@@ -525,7 +530,7 @@ class ErrorHandler
                 $this->isRecursive = false;
 
                 if (!\defined('HHVM_VERSION')) {
-                    set_error_handler([$this, __FUNCTION__]);
+                    set_error_handler($currentErrorHandler);
                 }
             }
         }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/ErrorHandlerThatUsesThePreviousOne.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/ErrorHandlerThatUsesThePreviousOne.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+class ErrorHandlerThatUsesThePreviousOne
+{
+    private static $previous;
+
+    public static function register()
+    {
+        $handler = new static();
+
+        self::$previous = set_error_handler([$handler, 'handleError']);
+
+        return $handler;
+    }
+
+    public function handleError($type, $message, $file, $line, $context)
+    {
+        return \call_user_func(self::$previous, $type, $message, $file, $line, $context);
+    }
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/LoggerThatSetAnErrorHandler.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/LoggerThatSetAnErrorHandler.php
@@ -2,13 +2,14 @@
 
 namespace Symfony\Component\Debug\Tests\Fixtures;
 
-use Psr\Log\AbstractLogger;
+use Symfony\Component\Debug\BufferingLogger;
 
-class LoggerThatSetAnErrorHandler extends AbstractLogger
+class LoggerThatSetAnErrorHandler extends BufferingLogger
 {
     public function log($level, $message, array $context = [])
     {
         set_error_handler('is_string');
+        parent::log($level, $message, $context);
         restore_error_handler();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/30140
| License       | MIT
| Doc PR        | -

Thank you @cuchac

Getting the current error handler in the error handler itself actually works. If you try to see the content of the `$currentErrorHandler` var however, you will always see `null`. That's why I thought it was impossible. Because I did not test from end to end until today.