### PR TITLE
[Validator] Add allowSpaces and allowLowerCase option in IBAN/BIC constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -31,6 +31,7 @@ class Bic extends Constraint
     const INVALID_COUNTRY_CODE_ERROR = '1ce76f8d-3c1f-451c-9e62-fe9c3ed486ae';
     const INVALID_CASE_ERROR = '11884038-3312-4ae5-9d04-699f782130c7';
     const INVALID_IBAN_COUNTRY_CODE_ERROR = '29a2c3bb-587b-4996-b6f5-53081364cea5';
+    const INVALID_SPACES_ERROR = 'cf0325f4-5c35-47a8-a360-51dac05b6540';
 
     protected static $errorNames = [
         self::INVALID_LENGTH_ERROR => 'INVALID_LENGTH_ERROR',
@@ -38,12 +39,15 @@ class Bic extends Constraint
         self::INVALID_BANK_CODE_ERROR => 'INVALID_BANK_CODE_ERROR',
         self::INVALID_COUNTRY_CODE_ERROR => 'INVALID_COUNTRY_CODE_ERROR',
         self::INVALID_CASE_ERROR => 'INVALID_CASE_ERROR',
+        self::INVALID_SPACES_ERROR => 'INVALID_SPACES_ERROR',
     ];
 
     public $message = 'This is not a valid Business Identifier Code (BIC).';
     public $ibanMessage = 'This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.';
     public $iban;
     public $ibanPropertyPath;
+    public $allowLowerCase = false;
+    public $allowSpaces = true;
 
     public function __construct($options = null)
     {

--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -72,6 +72,15 @@ class BicValidator extends ConstraintValidator
             throw new UnexpectedValueException($value, 'string');
         }
 
+        if (!$constraint->allowSpaces && false !== strpos($value, ' ')) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Bic::INVALID_SPACES_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
         $canonicalize = str_replace(' ', '', $value);
 
         // the bic must be either 8 or 11 characters long
@@ -122,7 +131,7 @@ class BicValidator extends ConstraintValidator
         }
 
         // should contain uppercase characters only
-        if (strtoupper($canonicalize) !== $canonicalize) {
+        if (!$constraint->allowLowerCase && strtoupper($canonicalize) !== $canonicalize) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Bic::INVALID_CASE_ERROR)

--- a/src/Symfony/Component/Validator/Constraints/Iban.php
+++ b/src/Symfony/Component/Validator/Constraints/Iban.php
@@ -28,6 +28,8 @@ class Iban extends Constraint
     const CHECKSUM_FAILED_ERROR = 'b9401321-f9bf-4dcb-83c1-f31094440795';
     const INVALID_FORMAT_ERROR = 'c8d318f1-2ecc-41ba-b983-df70d225cf5a';
     const NOT_SUPPORTED_COUNTRY_CODE_ERROR = 'e2c259f3-4b46-48e6-b72e-891658158ec8';
+    const INVALID_CASE_ERROR = 'd58f8108-22b8-4a4b-a151-09b40fa416a6';
+    const INVALID_SPACES_ERROR = 'cf0325f4-5c35-47a8-a360-51dac05b6540';
 
     protected static $errorNames = [
         self::INVALID_COUNTRY_CODE_ERROR => 'INVALID_COUNTRY_CODE_ERROR',
@@ -35,7 +37,11 @@ class Iban extends Constraint
         self::CHECKSUM_FAILED_ERROR => 'CHECKSUM_FAILED_ERROR',
         self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',
         self::NOT_SUPPORTED_COUNTRY_CODE_ERROR => 'NOT_SUPPORTED_COUNTRY_CODE_ERROR',
+        self::INVALID_CASE_ERROR => 'INVALID_CASE_ERROR',
+        self::INVALID_SPACES_ERROR => 'INVALID_SPACES_ERROR',
     ];
 
     public $message = 'This is not a valid International Bank Account Number (IBAN).';
+    public $allowLowerCase = true;
+    public $allowSpaces = true;
 }

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -156,6 +156,24 @@ class IbanValidator extends ConstraintValidator
 
         $value = (string) $value;
 
+        if (!$constraint->allowSpaces && false !== strpos($value, ' ')) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Iban::INVALID_SPACES_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        if (!$constraint->allowLowerCase && strtoupper($value) !== $value) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Iban::INVALID_CASE_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
         // Remove spaces and convert to uppercase
         $canonicalized = str_replace(' ', '', strtoupper($value));
 
@@ -182,7 +200,7 @@ class IbanValidator extends ConstraintValidator
         }
 
         // ...have a format available
-        if (!array_key_exists($countryCode, self::$formats)) {
+        if (!\array_key_exists($countryCode, self::$formats)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Iban::NOT_SUPPORTED_COUNTRY_CODE_ERROR)

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -256,6 +256,34 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         yield ['BARCGGSA', 'GB12 CPBK 0892 9965 0449 911'];
         yield ['BARCVGSA', 'GB12 CPBK 0892 9965 0449 911'];
     }
+
+    public function testValidBicAllowLowerCase()
+    {
+        $constraint = new Bic([
+            'allowLowerCase' => true,
+        ]);
+
+        $this->validator->validate('DeutAT2LXXX', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidBicDisallowSpaces()
+    {
+        $bic = 'DEUTA T2LX XX';
+
+        $constraint = new Bic([
+            'allowSpaces' => false,
+            'message' => 'myMessage',
+        ]);
+
+        $this->validator->validate($bic, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$bic.'"')
+            ->setCode(Bic::INVALID_SPACES_ERROR)
+            ->assertRaised();
+    }
 }
 
 class BicComparisonTestClass

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -432,6 +432,67 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
+    public function testValidIbanAllowLowerCase()
+    {
+        $iban = 'fr14 2004 1010 0505 0001 3M02 606';
+
+        $constraint = new Iban([
+            'message' => 'myMessage',
+            'allowLowerCase' => true,
+        ]);
+
+        $this->validator->validate($iban, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidIbanDisallowLowerCase()
+    {
+        $iban = 'fr14 2004 1010 0505 0001 3M02 606';
+
+        $constraint = new Iban([
+            'message' => 'myMessage',
+            'allowLowerCase' => false,
+        ]);
+
+        $this->validator->validate($iban, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$iban.'"')
+            ->setCode(Iban::INVALID_CASE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testValidIbanAllowSpaces()
+    {
+        $iban = 'FR14 2004 1010 0505 0001 3M02 606';
+
+        $constraint = new Iban([
+            'allowSpaces' => true,
+        ]);
+
+        $this->validator->validate($iban, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidIbanDisallowSpaces()
+    {
+        $iban = 'FR14 2004 1010 0505 0001 3M02 606';
+
+        $constraint = new Iban([
+            'message' => 'myMessage',
+            'allowSpaces' => false,
+        ]);
+
+        $this->validator->validate($iban, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$iban.'"')
+            ->setCode(Iban::INVALID_SPACES_ERROR)
+            ->assertRaised();
+    }
+
     private function assertViolationRaised($iban, $code)
     {
         $constraint = new Iban([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28232
| License       | MIT
|Doc PR     | [https://github.com/symfony/symfony-docs/pull/11000](https://github.com/symfony/symfony-docs/pull/11000)

This PR allow to add options for BIC and IBAN constraints. I added allowSpaces and allowLowerCase options.
By default BIC allow spaces and disallow lower case, IBAN allow spaces and allow lower case.
It not same in order to avoid BC.
