### PR TITLE
[VarDumper] fix serializing Stub instances

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/Stub.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Stub.php
@@ -39,22 +39,29 @@ class Stub
     public $position = 0;
     public $attr = [];
 
+    private static $defaultProperties = [];
+
     /**
      * @internal
      */
     public function __sleep()
     {
-        $this->serialized = [$this->class, $this->position, $this->cut, $this->type, $this->value, $this->handle, $this->refCount, $this->attr];
+        $properties = [];
 
-        return ['serialized'];
-    }
+        if (!isset(self::$defaultProperties[$c = \get_class($this)])) {
+            self::$defaultProperties[$c] = get_class_vars($c);
 
-    /**
-     * @internal
-     */
-    public function __wakeup()
-    {
-        list($this->class, $this->position, $this->cut, $this->type, $this->value, $this->handle, $this->refCount, $this->attr) = $this->serialized;
-        unset($this->serialized);
+            foreach ((new \ReflectionClass($c))->getStaticProperties() as $k => $v) {
+                unset(self::$defaultProperties[$c][$k]);
+            }
+        }
+
+        foreach (self::$defaultProperties[$c] as $k => $v) {
+            if ($this->$k !== $v) {
+                $properties[] = $k;
+            }
+        }
+
+        return $properties;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

There are more properties in child classes, and we can skip serializing properties that are set to their default values.