### PR TITLE
Remove unnecessary ProgressBar stdout writes (fixes flickering)

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -466,19 +466,16 @@ final class ProgressBar
     {
         if ($this->overwrite) {
             if (!$this->firstRun) {
-                // Move the cursor to the beginning of the line
-                $this->output->write("\x0D");
-
-                // Erase the line
-                $this->output->write("\x1B[2K");
-
                 // Erase previous lines
                 if ($this->formatLineCount > 0) {
-                    $this->output->write(str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount));
+                    $message = str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount).$message;
                 }
+
+                // Move the cursor to the beginning of the line and erase the line
+                $message = "\x0D\x1B[2K$message";
             }
         } elseif ($this->step > 0) {
-            $this->output->writeln('');
+            $message = PHP_EOL.$message;
         }
 
         $this->firstRun = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Currently ProgressBar flickers when writing a lot.

![ezgif-4-ad817e1834](https://user-images.githubusercontent.com/496233/38173299-44482400-35bc-11e8-88b6-83b480d55905.gif)

This patch fixes it and it's buttery smooth now.

Additionally, this improves performance by 60%. Test code
```php
$maxSteps = 1000000;
$progressBar = new ProgressBar(new ConsoleOutput(), $maxSteps);
for ($i=0; $i<= $maxSteps; $i++) {
    $progressBar->advance();
}
```