### PR TITLE
[Security\Guard] bump lowest version of security-core

### DIFF
--- a/src/Symfony/Component/Security/Guard/composer.json
+++ b/src/Symfony/Component/Security/Guard/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^5.5.9|>=7.0.8",
-        "symfony/security-core": "~2.8|~3.0|~4.0",
+        "symfony/security-core": "~3.4.22|^4.2.3",
         "symfony/security-http": "^3.3.13|~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Forgotten in #30006 so that `PostAuthenticationGuardToken` can call `AbstractToken::doSerialize()`.