### PR TITLE
[VarDumper] dump Closures' parameters once: in their signatures

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -52,18 +52,7 @@ class ReflectionCaster
             return [];
         }
 
-        if (isset($a[$prefix.'parameters'])) {
-            foreach ($a[$prefix.'parameters']->value as &$v) {
-                $param = $v;
-                $v = new EnumStub([]);
-                foreach (static::castParameter($param, [], $stub, true) as $k => $param) {
-                    if ("\0" === $k[0]) {
-                        $v->value[substr($k, 3)] = $param;
-                    }
-                }
-                unset($v->value['position'], $v->value['isVariadic'], $v->value['byReference'], $v);
-            }
-        }
+        unset($a[$prefix.'parameters']);
 
         if ($f = $c->getFileName()) {
             $a[$prefix.'file'] = new LinkStub($f, $c->getStartLine());

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -70,10 +70,7 @@ EOTXT
         $this->assertDumpMatchesFormat(
             <<<'EOTXT'
 Closure($x) {
-%Aparameters: {
-    $x: {}
-  }
-  use: {
+%Ause: {
     $a: 123
     $b: & 123
   }

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -81,13 +81,6 @@ array:24 [
   "closure" => Closure(\$a, PDO &\$b = null) {#%d
     class: "Symfony\Component\VarDumper\Tests\Dumper\CliDumperTest"
     this: Symfony\Component\VarDumper\Tests\Dumper\CliDumperTest {#%d …}
-    parameters: {
-      \$a: {}
-      &\$b: {
-        typeHint: "PDO"
-        default: null
-      }
-    }
     file: "%s%eTests%eFixtures%edumb-var.php"
     line: "{$var['line']} to {$var['line']}"
   }

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -85,13 +85,6 @@ class HtmlDumperTest extends TestCase
     <span class=sf-dump-meta>class</span>: "<span class=sf-dump-str title="Symfony\Component\VarDumper\Tests\Dumper\HtmlDumperTest
 55 characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-class">Symfony\Component\VarDumper\Tests\Dumper</span><span class=sf-dump-ellipsis>\</span>HtmlDumperTest</span>"
     <span class=sf-dump-meta>this</span>: <abbr title="Symfony\Component\VarDumper\Tests\Dumper\HtmlDumperTest" class=sf-dump-note>HtmlDumperTest</abbr> {<a class=sf-dump-ref>#%d</a> &%s;}
-    <span class=sf-dump-meta>parameters</span>: {<samp>
-      <span class=sf-dump-meta>\$a</span>: {}
-      <span class=sf-dump-meta>&amp;\$b</span>: {<samp>
-        <span class=sf-dump-meta>typeHint</span>: "<span class=sf-dump-str title="3 characters">PDO</span>"
-        <span class=sf-dump-meta>default</span>: <span class=sf-dump-const>null</span>
-      </samp>}
-    </samp>}
     <span class=sf-dump-meta>file</span>: "<span class=sf-dump-str title="{$var['file']}
 %d characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class=sf-dump-ellipsis>%e</span>Tests%eFixtures%edumb-var.php</span>"
     <span class=sf-dump-meta>line</span>: "<span class=sf-dump-str title="%d characters">{$var['line']} to {$var['line']}</span>"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | not really
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Now that closures are dumped with their signature, dumping parameters is noisy duplicate info.