### PR TITLE
[Messenger] Added SecurityMiddleware

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -39,6 +39,10 @@
             <argument type="service" id="debug.stopwatch" />
         </service>
 
+        <service id="messenger.middleware.security" class="Symfony\Component\Messenger\Middleware\SecurityMiddleware">
+            <argument type="service" id="security.authorization_checker" />
+        </service>
+
         <!-- Logging -->
         <service id="messenger.middleware.logging" class="Symfony\Component\Messenger\Middleware\LoggingMiddleware">
             <tag name="monolog.logger" channel="messenger" />

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,9 +4,9 @@ CHANGELOG
 4.3.0
 -----
 
+ * Added `SecurityMiddleware`
  * Added `PhpSerializer` which uses PHP's native `serialize()` and
    `unserialize()` to serialize messages to a transport
-
  * [BC BREAK] If no serializer were passed, the default serializer
    changed from `Serializer` to `PhpSerializer` inside `AmqpReceiver`,
    `AmqpSender`, `AmqpTransport` and `AmqpTransportFactory`.

--- a/src/Symfony/Component/Messenger/Middleware/SecurityMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SecurityMiddleware.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class SecurityMiddleware implements MiddlewareInterface
+{
+    private $authorizationChecker;
+
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker)
+    {
+        $this->authorizationChecker = $authorizationChecker;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $message = $envelope->getMessage();
+
+        if (!$this->authorizationChecker->isGranted([], $message)) {
+            $e = new AccessDeniedException();
+            $e->setSubject($message);
+
+            throw $e;
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/SecurityMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SecurityMiddlewareTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\SecurityMiddleware;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class SecurityMiddlewareTest extends MiddlewareTestCase
+{
+    public function testExecutedNextMiddlewareWhenGranted(): void
+    {
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker
+            ->expects(self::once())
+            ->method('isGranted')
+            ->with([], self::isInstanceOf(DummyMessage::class))
+            ->willReturn(true);
+
+        $middleware = new SecurityMiddleware($authorizationChecker);
+
+        $envelope = new Envelope(new DummyMessage('he'));
+        self::assertSame($envelope, $middleware->handle($envelope, $this->getStackMock()));
+    }
+
+    public function testThrowsAccessDeniedWhenAccessIsDenied(): void
+    {
+        $envelope = new Envelope(new DummyMessage('he'));
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker
+            ->expects(self::once())
+            ->method('isGranted')
+            ->with([], self::isInstanceOf(DummyMessage::class))
+            ->willReturn(false);
+
+        $middleware = new SecurityMiddleware($authorizationChecker);
+
+        $this->expectException(AccessDeniedException::class);
+
+        $middleware->handle($envelope, $this->getStackMock(false));
+    }
+}

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -28,7 +28,8 @@
         "symfony/serializer": "~3.4|~4.0",
         "symfony/stopwatch": "~3.4|~4.0",
         "symfony/validator": "~3.4|~4.0",
-        "symfony/var-dumper": "~3.4|~4.0"
+        "symfony/var-dumper": "~3.4|~4.0",
+        "symfony/security-core": "~3.4|~4.0"
     },
     "suggest": {
         "enqueue/messenger-adapter": "For using the php-enqueue library as a transport."


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | Todo

The `SecurityMiddleware` uses the Security `AuthorizationChecker` to determine if a Message is allowed to pass through. _I created this initially for the Park-Manager project but it's generic enough to be part of the Messenger component._