### PR TITLE
Fixed some types in function calls

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -129,6 +129,6 @@ class TranslationDefaultDomainNodeVisitor extends AbstractNodeVisitor
 
     private function getVarName()
     {
-        return sprintf('__internal_%s', hash('sha256', uniqid(mt_rand(), true), false));
+        return sprintf('__internal_%s', hash('sha256', uniqid((string) mt_rand(), true), false));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -47,7 +47,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
                 }
             }
 
-            $uniqueName = md5($name.uniqid(mt_rand(), true));
+            $uniqueName = md5($name.uniqid((string) mt_rand(), true));
             $placeholder = sprintf('env_%s_%s', str_replace(':', '_', $env), $uniqueName);
             $this->envPlaceholders[$env][$placeholder] = $placeholder;
 

--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -59,7 +59,7 @@ class FileFormField extends FormField
             $name = $info['basename'];
 
             // copy to a tmp location
-            $tmp = sys_get_temp_dir().'/'.strtr(substr(base64_encode(hash('sha256', uniqid(mt_rand(), true), true)), 0, 7), '/', '_');
+            $tmp = sys_get_temp_dir().'/'.strtr(substr(base64_encode(hash('sha256', uniqid((string) mt_rand(), true), true)), 0, 7), '/', '_');
             if (array_key_exists('extension', $info)) {
                 $tmp .= '.'.$info['extension'];
             }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -58,7 +58,7 @@ class Filesystem
             }
 
             // Stream context created to allow files overwrite when using FTP stream wrapper - disabled by default
-            if (false === $target = @fopen($targetFile, 'w', null, stream_context_create(['ftp' => ['overwrite' => true]]))) {
+            if (false === $target = @fopen($targetFile, 'w', false, stream_context_create(['ftp' => ['overwrite' => true]]))) {
                 throw new IOException(sprintf('Failed to copy "%s" to "%s" because target file could not be opened for writing.', $originFile, $targetFile), 0, null, $originFile);
             }
 
@@ -145,7 +145,7 @@ class Filesystem
     public function touch($files, $time = null, $atime = null)
     {
         foreach ($this->toIterable($files) as $file) {
-            $touch = $time ? @touch($file, $time, $atime) : @touch($file);
+            $touch = $time ? @touch($file, $time, null !== $atime ? $atime : $time) : @touch($file);
             if (true !== $touch) {
                 throw new IOException(sprintf('Failed to touch "%s".', $file), 0, null, $file);
             }
@@ -641,7 +641,7 @@ class Filesystem
         // Loop until we create a valid temp file or have reached 10 attempts
         for ($i = 0; $i < 10; ++$i) {
             // Create a unique filename
-            $tmpFile = $dir.'/'.$prefix.uniqid(mt_rand(), true);
+            $tmpFile = $dir.'/'.$prefix.uniqid((string) mt_rand(), true);
 
             // Use fopen instead of file_exists as some streams do not support stat
             // Use mode 'x+' to atomically check existence and create to avoid a TOCTOU vulnerability

--- a/src/Symfony/Component/Finder/Comparator/NumberComparator.php
+++ b/src/Symfony/Component/Finder/Comparator/NumberComparator.php
@@ -41,7 +41,7 @@ class NumberComparator extends Comparator
      */
     public function __construct($test)
     {
-        if (!preg_match('#^\s*(==|!=|[<>]=?)?\s*([0-9\.]+)\s*([kmg]i?)?\s*$#i', $test, $matches)) {
+        if (!preg_match('#^\s*(==|!=|[<>]=?)?\s*([0-9\.]+)\s*([kmg]i?)?\s*$#i', (string) $test, $matches)) {
             throw new \InvalidArgumentException(sprintf('Don\'t understand "%s" as a number test.', $test));
         }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -148,7 +148,7 @@ class Profiler
             return;
         }
 
-        $profile = new Profile(substr(hash('sha256', uniqid(mt_rand(), true)), 0, 6));
+        $profile = new Profile(substr(hash('sha256', uniqid((string) mt_rand(), true)), 0, 6));
         $profile->setTime(time());
         $profile->setUrl($request->getUri());
         $profile->setMethod($request->getMethod());

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -47,7 +47,7 @@ class VarCloner extends AbstractCloner
                                         // or null if the original value is used directly
 
         if (!self::$hashMask) {
-            self::$gid = uniqid(mt_rand(), true); // Unique string used to detect the special $GLOBALS variable
+            self::$gid = uniqid((string) mt_rand(), true); // Unique string used to detect the special $GLOBALS variable
             self::initHashMask();
         }
         $gid = self::$gid;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I was playing with PHPStan and found lots of issues in Symfony code. This PR solves some of those issues related to type mismatch in some PHP function calls:

* Parameter 3 $use_include_path of function fopen() expects bool, null given.
* Parameter 3 $atime of function touch() expects int, int|null given.
* Parameter 1 $prefix of function uniqid() expects string, int given.
* Parameter 2 $subject of function preg_match() expects string, int|string given.

There are many more issues. I'm not sure if you want me to update this PR to fix all of them ... or close this as "not worth it". Thanks.