### PR TITLE
[VarDumper] Implement DsCaster

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added `DsCaster` to support dumping the contents of data structures from the Ds extension
+
 4.2.0
 -----
 
@@ -34,4 +39,4 @@ CHANGELOG
 2.7.0
 -----
 
- * deprecated Cloner\Data::getLimitedClone(). Use withMaxDepth, withMaxItemsPerDepth or withRefHandles instead.
+ * deprecated `Cloner\Data::getLimitedClone()`. Use `withMaxDepth`, `withMaxItemsPerDepth` or `withRefHandles` instead.

--- a/src/Symfony/Component/VarDumper/Caster/DsCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DsCaster.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Ds\Deque;
+use Ds\Map;
+use Ds\PriorityQueue;
+use Ds\Queue;
+use Ds\Set;
+use Ds\Stack;
+use Ds\Vector;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Casts Ds extension classes to array representation.
+ *
+ * @author Jáchym Toušek <enumag@gmail.com>
+ */
+class DsCaster
+{
+    /**
+     * @param Set|Deque|Vector|Stack|Queue|PriorityQueue $c
+     */
+    public static function castDs($c, array $a, Stub $stub, bool $isNested): array
+    {
+        $prefix = Caster::PREFIX_VIRTUAL;
+        $a = $c->toArray();
+        $a[$prefix.'capacity'] = $c->capacity();
+
+        return $a;
+    }
+
+    public static function castMap(Map $c, array $a, Stub $stub, bool $isNested): array
+    {
+        $prefix = Caster::PREFIX_VIRTUAL;
+        $a = $c->pairs()->toArray();
+        $a[$prefix.'capacity'] = $c->capacity();
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -125,6 +125,14 @@ abstract class AbstractCloner implements ClonerInterface
 
         'Memcached' => ['Symfony\Component\VarDumper\Caster\MemcachedCaster', 'castMemcached'],
 
+        'Ds\Set' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castDs'],
+        'Ds\Vector' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castDs'],
+        'Ds\Deque' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castDs'],
+        'Ds\Stack' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castDs'],
+        'Ds\Queue' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castDs'],
+        'Ds\PriorityQueue' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castDs'],
+        'Ds\Map' => ['Symfony\Component\VarDumper\Caster\DsCaster', 'castMap'],
+
         ':curl' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castCurl'],
         ':dba' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'],
         ':dba persistent' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When dumping the data structures from [Ds extension](http://php.net/manual/en/book.ds.php) Symfony only shows the class name but not the actual data. So in this PR I tried to write a Caster for these data structures.

Map can't be simply casted to array because it can contain objects as keys so I dump the pairs instead.