### PR TITLE
[PHPCS] Add orderer_class_elements rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,6 +13,7 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'fopen_flags' => false,
         'ordered_imports' => true,
+        'orderer_class_elements' => true,
         'protected_to_private' => false,
         // Part of @Symfony:risky in PHP-CS-Fixer 2.13.0. To be removed from the config file once upgrading
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced'],

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,8 +12,8 @@ return PhpCsFixer\Config::create()
         'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
         'array_syntax' => ['syntax' => 'short'],
         'fopen_flags' => false,
-        'ordered_imports' => true,
         'orderer_class_elements' => true,
+        'ordered_imports' => true,
         'protected_to_private' => false,
         // Part of @Symfony:risky in PHP-CS-Fixer 2.13.0. To be removed from the config file once upgrading
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced'],

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,7 +12,7 @@ return PhpCsFixer\Config::create()
         'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
         'array_syntax' => ['syntax' => 'short'],
         'fopen_flags' => false,
-        'orderer_class_elements' => true,
+        'ordered_class_elements' => true,
         'ordered_imports' => true,
         'protected_to_private' => false,
         // Part of @Symfony:risky in PHP-CS-Fixer 2.13.0. To be removed from the config file once upgrading


### PR DESCRIPTION
Q	A
Branch?	master
Bug fix?	no
New feature?	no
BC breaks?	no
Deprecations?	no
Tests pass?	yes
Fixed tickets	
License	MIT
Doc PR	
The .php_cs.dist file is not adding ordered_class_elements rule that is a symfony coding standard.

You can see list of rules at https://cs.symfony.com.

This PR will help symfony projects to directly use this file and respect symfony coding standards.