### PR TITLE
[RFC][Serializer] Better handling of built in types

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -87,6 +87,7 @@ use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Symfony\Component\Serializer\Normalizer\BuiltInDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -1321,6 +1322,10 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(Yaml::class)) {
             $container->removeDefinition('serializer.encoder.yaml');
+        }
+
+        if (!class_exists(BuiltInDenormalizer::class)) {
+            $container->removeDefinition('serializer.denormalizer.builtin');
         }
 
         $serializerLoaders = [];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -73,6 +73,11 @@
             <tag name="serializer.normalizer" priority="-990" />
         </service>
 
+        <service id="serializer.denormalizer.builtin" class="Symfony\Component\Serializer\Normalizer\BuiltInDenormalizer">
+            <!-- Run before the object normalizer -->
+            <tag name="serializer.normalizer" priority="-980" />
+        </service>
+
         <!-- Loader -->
         <service id="serializer.mapping.chain_loader" class="Symfony\Component\Serializer\Mapping\Loader\LoaderChain">
             <argument type="collection" />

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -69,7 +69,7 @@ class PhpDocExtractorTest extends TestCase
             [
                 'files',
                 [
-                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'SplFileInfo')),
+                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'SplFileInfo')),
                     new Type(Type::BUILTIN_TYPE_RESOURCE),
                 ],
                 null,
@@ -77,8 +77,8 @@ class PhpDocExtractorTest extends TestCase
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
             ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')], null, null],
-            ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
-            ['nestedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING, false)))], null, null],
+            ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
+            ['nestedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_STRING, false)))], null, null],
             ['mixedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, null)], null, null],
             ['a', [new Type(Type::BUILTIN_TYPE_INT)], 'A.', null],
             ['b', [new Type(Type::BUILTIN_TYPE_OBJECT, true, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')], 'B.', null],
@@ -153,7 +153,7 @@ class PhpDocExtractorTest extends TestCase
             [
                 'files',
                 [
-                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'SplFileInfo')),
+                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'SplFileInfo')),
                     new Type(Type::BUILTIN_TYPE_RESOURCE),
                 ],
                 null,
@@ -161,8 +161,8 @@ class PhpDocExtractorTest extends TestCase
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
             ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')], null, null],
-            ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
-            ['nestedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING, false)))], null, null],
+            ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
+            ['nestedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_STRING, false)))], null, null],
             ['mixedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, null)], null, null],
             ['a', null, 'A.', null],
             ['b', null, 'B.', null],
@@ -193,7 +193,7 @@ class PhpDocExtractorTest extends TestCase
             [
                 'files',
                 [
-                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'SplFileInfo')),
+                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'SplFileInfo')),
                     new Type(Type::BUILTIN_TYPE_RESOURCE),
                 ],
                 null,
@@ -201,8 +201,8 @@ class PhpDocExtractorTest extends TestCase
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
             ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')], null, null],
-            ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
-            ['nestedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING, false)))], null, null],
+            ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
+            ['nestedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, new Type(Type::BUILTIN_TYPE_STRING, false)))], null, null],
             ['mixedCollection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, null, null)], null, null],
             ['a', null, 'A.', null],
             ['b', null, 'B.', null],

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -108,7 +108,7 @@ final class PhpDocTypeHelper
                 $collectionKeyType = null;
                 $collectionValueType = null;
             } else {
-                $collectionKeyType = new Type(Type::BUILTIN_TYPE_INT);
+                $collectionKeyType = null;
                 $collectionValueType = $this->createType($type, $nullable, substr($docType, 0, -2));
             }
 

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -155,7 +155,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
                 for ($j = 0; $j < $depth; ++$j) {
                     // Handle nested arrays
                     if ($j === ($depth - 1)) {
-                        $arr[$headers[$i][$j]] = $cols[$i];
+                        $arr[$headers[$i][$j]] = $cols[$i] === '' ? null : $cols[$i];
 
                         continue;
                     }

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -204,6 +204,8 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         foreach ($array as $key => $value) {
             if (\is_array($value)) {
                 $this->flatten($value, $result, $keySeparator, $parentKey.$key.$keySeparator, $escapeFormulas);
+            } elseif (\is_bool($value)) {
+                $result[$parentKey.$key] = $value ? '1' : '0';
             } else {
                 if ($escapeFormulas && \in_array(substr($value, 0, 1), $this->formulasStartCharacters, true)) {
                     $result[$parentKey.$key] = "\t".$value;

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -365,7 +365,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     private function parseXmlValue(\DOMNode $node, array $context = [])
     {
         if (!$node->hasChildNodes()) {
-            return $node->nodeValue;
+            return $node->nodeValue === '' ? null : $node->nodeValue;
         }
 
         if (1 === $node->childNodes->length && \in_array($node->firstChild->nodeType, [XML_TEXT_NODE, XML_CDATA_SECTION_NODE])) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -321,7 +321,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 return;
             }
 
-            [$builtinType, $class] = $this->flatternDenormalizationType($type, $context);
+            $childContext = $this->createChildContext($context, $attribute);
+            [$builtinType, $class] = $this->flatternDenormalizationType($type, $childContext);
 
             $expectedTypes[Type::BUILTIN_TYPE_OBJECT === $builtinType && $class ? $class : $builtinType] = true;
 
@@ -329,7 +330,6 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 throw new LogicException(sprintf('Cannot denormalize attribute "%s" for class "%s" because injected serializer is not a denormalizer', $attribute, $class));
             }
 
-            $childContext = $this->createChildContext($context, $attribute);
             if ($this->serializer->supportsDenormalization($data, $class ?? $builtinType, $format, $childContext)) {
                 return $this->serializer->denormalize($data, $class ?? $builtinType, $format, $childContext);
             }
@@ -361,11 +361,12 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             if (null !== $collectionKeyType = $type->getCollectionKeyType()) {
                 $context['key_types'][] = $collectionKeyType;
             }
-        } else {
-            return [$type->getBuiltinType(), $type->getClassName()];
+
+            return [$builtinType, $class];
         }
 
-        return [$builtinType, $class];
+        $context['value_nullable'] = $type->isNullable();
+        return [$type->getBuiltinType(), $type->getClassName()];
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/BuiltInDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BuiltInDenormalizer.php
@@ -1,0 +1,69 @@
+<?php
+
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Exception\BadMethodCallException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Exception\ExtraAttributesException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\RuntimeException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+
+class BuiltInDenormalizer implements DenormalizerInterface
+{
+    protected $defaultContext = [];
+
+    public function __construct(array $defaultContext = [])
+    {
+        $this->defaultContext = array_merge($defaultContext, $defaultContext);
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        // JSON only has a Number type corresponding to both int and float PHP types.
+        // PHP's json_encode, JavaScript's JSON.stringify, Go's json.Marshal as well as most other JSON encoders convert
+        // floating-point numbers like 12.0 to 12 (the decimal part is dropped when possible).
+        // PHP's json_decode automatically converts Numbers without a decimal part to integers.
+        // To circumvent this behavior, integers are converted to floats when denormalizing JSON based formats and when
+        // a float is expected.
+        if (Type::BUILTIN_TYPE_FLOAT === $class && \is_int($data) && false !== strpos($format, JsonEncoder::FORMAT)) {
+            return (float) $data;
+        }
+
+        // XML and CSV formats dont represent ints, floats or bools, so we convert strings into these formats
+        if ($format === XmlEncoder::FORMAT || $format === CsvEncoder::FORMAT) {
+            if (Type::BUILTIN_TYPE_INT === $class && \is_string($data) && (string)(int) $data === $data) {
+                return (int) $data;
+            }
+            if (Type::BUILTIN_TYPE_FLOAT === $class && \is_string($data) && (string)(float) $data === $data) {
+                return (float) $data;
+            }
+            if (Type::BUILTIN_TYPE_BOOL === $class && ($data === '1' || $data === '0' || $data === '')) {
+                return $data === '1' ? true : false;
+            }
+        }
+
+        if (('\is_'.$class)($data)) {
+            return $data;
+        }
+
+        if ($context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] ?? $this->defaultContext[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] ?? false) {
+            return $data;
+        }
+
+        throw new NotNormalizableValueException(sprintf('The type of the data must be "%s" ("%s" given).', $class, \gettype($data)));
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return in_array($type, [Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT, Type::BUILTIN_TYPE_STRING, TYPE::BUILTIN_TYPE_BOOL, Type::BUILTIN_TYPE_ARRAY]);
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/BuiltInDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BuiltInDenormalizer.php
@@ -46,7 +46,7 @@ class BuiltInDenormalizer implements DenormalizerInterface
             if (Type::BUILTIN_TYPE_FLOAT === $class && \is_string($data) && (string)(float) $data === $data) {
                 return (float) $data;
             }
-            if (Type::BUILTIN_TYPE_BOOL === $class && ($data === '1' || $data === '0' || $data === '')) {
+            if (Type::BUILTIN_TYPE_BOOL === $class && ($data === '1' || $data === '0')) {
                 return $data === '1' ? true : false;
             }
         }

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
@@ -140,9 +141,11 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
             return $object->getMimeType();
         }
 
-        if ($this->mimeTypeGuesser && $mimeType = $this->mimeTypeGuesser->guess($object->getPathname())) {
-            return $mimeType;
-        }
+        try {
+            if ($this->mimeTypeGuesser && $mimeType = $this->mimeTypeGuesser->guess($object->getPathname())) {
+                return $mimeType;
+            }
+        } catch (FileNotFoundException $e) {}
 
         return 'application/octet-stream';
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -34,7 +34,7 @@ interface DenormalizerInterface
      * @param string $format  Format the given data was extracted from
      * @param array  $context Options available to the denormalizer
      *
-     * @return object
+     * @return mixed
      *
      * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
      * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -37,7 +37,7 @@ interface SerializerInterface
      * @param string $format
      * @param array  $context
      *
-     * @return object
+     * @return mixed
      */
     public function deserialize($data, $type, $format, array $context = []);
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -481,6 +481,22 @@ CSV
         $this->assertEquals([], $this->encoder->decode('', 'csv'));
     }
 
+    public function testDecodeEmtpyValue()
+    {
+        $expected = [
+            ['foo' => ['a' => '1', 'b' => null]],
+        ];
+
+        $this->assertSame($expected, $this->encoder->decode(<<<'CSV'
+foo.a,foo.b
+1,
+
+CSV
+            , 'csv', [
+                CsvEncoder::AS_COLLECTION_KEY => true, // Can be removed in 5.0
+            ]));
+    }
+
     public function testEncodeWithBoolValue()
     {
         $expectedCsv = <<<'CSV'

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -480,4 +480,17 @@ CSV
     {
         $this->assertEquals([], $this->encoder->decode('', 'csv'));
     }
+
+    public function testEncodeWithBoolValue()
+    {
+        $expectedCsv = <<<'CSV'
+foo,bar
+1,0
+
+CSV;
+
+        $actualXml = $this->encoder->encode(['foo' => true, 'bar' => false], 'csv');
+
+        $this->assertEquals($expectedCsv, $actualXml);
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -247,6 +247,26 @@ XML;
         $this->assertEquals('foo', $this->encoder->decode($source, 'xml'));
     }
 
+    public function testEncodeNull()
+    {
+        $array = [
+            'person' => null,
+        ];
+
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response><person/></response>'."\n";
+
+        $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
+    }
+
+    public function testDecodeNull()
+    {
+        $source = '<?xml version="1.0"?>'."\n".
+            '<response><person/></response>'."\n";
+
+        $this->assertSame(['person' => null], $this->encoder->decode($source, 'xml'));
+    }
+
     public function testDecodeBigDigitAttributes()
     {
         $source = <<<XML
@@ -303,7 +323,7 @@ XML;
             'node' => [
                 '@a' => '018',
                 '@b' => '-12.11',
-                '#' => '',
+                '#' => null,
             ],
         ];
         $this->assertSame($expected, $data);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class ArrayDenormalizerTest extends TestCase
@@ -38,12 +41,12 @@ class ArrayDenormalizerTest extends TestCase
     {
         $this->serializer->expects($this->at(0))
             ->method('denormalize')
-            ->with(['foo' => 'one', 'bar' => 'two'])
+            ->with(['foo' => 'one', 'bar' => 'two'], __NAMESPACE__.'\ArrayDummy')
             ->will($this->returnValue(new ArrayDummy('one', 'two')));
 
         $this->serializer->expects($this->at(1))
             ->method('denormalize')
-            ->with(['foo' => 'three', 'bar' => 'four'])
+            ->with(['foo' => 'three', 'bar' => 'four'], __NAMESPACE__.'\ArrayDummy')
             ->will($this->returnValue(new ArrayDummy('three', 'four')));
 
         $result = $this->denormalizer->denormalize(
@@ -58,6 +61,110 @@ class ArrayDenormalizerTest extends TestCase
             [
                 new ArrayDummy('one', 'two'),
                 new ArrayDummy('three', 'four'),
+            ],
+            $result
+        );
+    }
+
+    public function testDenormalizeNested()
+    {
+        $m = $this->getMockBuilder(DenormalizerInterface::class)
+            ->getMock();
+
+        $denormalizer = new ArrayDenormalizer();
+        $serializer = new Serializer([$denormalizer, $m]);
+        $denormalizer->setSerializer($serializer);
+
+        $m->method('denormalize')
+            ->with(['foo' => 'one', 'bar' => 'two'], __NAMESPACE__.'\ArrayDummy')
+            ->willReturn(new ArrayDummy('one', 'two'));
+
+        $m->method('supportsDenormalization')
+            ->with($this->anything(), __NAMESPACE__.'\ArrayDummy')
+            ->willReturn(true);
+
+        $result = $denormalizer->denormalize(
+            [
+                [
+                    ['foo' => 'one', 'bar' => 'two'],
+                ],
+            ],
+            __NAMESPACE__.'\ArrayDummy[][]',
+            null,
+            ['key_types' => [new Type('int'), new Type('int')]]
+        );
+
+        $this->assertEquals(
+            [[
+                new ArrayDummy('one', 'two'),
+            ]],
+            $result
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\NotNormalizableValueException
+     */
+    public function testDenormalizeCheckKeyType()
+    {
+        $this->denormalizer->denormalize(
+            [
+                ['foo' => 'one', 'bar' => 'two'],
+            ],
+            __NAMESPACE__.'\ArrayDummy[]',
+            null,
+            ['key_type' => new Type('string')]
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\NotNormalizableValueException
+     */
+    public function testDenormalizeCheckKeyTypes()
+    {
+        $this->denormalizer->denormalize(
+            [
+                ['foo' => 'one', 'bar' => 'two'],
+            ],
+            __NAMESPACE__.'\ArrayDummy[]',
+            null,
+            ['key_types' => [new Type('string')]]
+        );
+    }
+
+    public function testDenormalizeNestedCheckKeyTypes()
+    {
+        $m = $this->getMockBuilder(DenormalizerInterface::class)
+            ->getMock();
+
+        $denormalizer = new ArrayDenormalizer();
+        $serializer = new Serializer([$denormalizer, $m]);
+        $denormalizer->setSerializer($serializer);
+
+        $m->method('denormalize')
+            ->with(['foo' => 'one', 'bar' => 'two'], __NAMESPACE__.'\ArrayDummy')
+            ->willReturn(new ArrayDummy('one', 'two'));
+
+        $m->method('supportsDenormalization')
+            ->with($this->anything(), __NAMESPACE__.'\ArrayDummy')
+            ->willReturn(true);
+
+        $result = $denormalizer->denormalize(
+            [
+                'top' => [
+                    ['foo' => 'one', 'bar' => 'two'],
+                ],
+            ],
+            __NAMESPACE__.'\ArrayDummy[][]',
+            null,
+            ['key_types' => [new Type('string')], 'key_type' => new Type('int')]
+        );
+
+        $this->assertEquals(
+            [
+                'top' => [
+                    new ArrayDummy('one', 'two'),
+                ],
             ],
             $result
         );

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BuiltInDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BuiltInDenormalizerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\BuiltInDenormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class BuiltInDenormalizerTest extends TestCase
+{
+    /**
+     * @var BuiltInDenormalizer
+     */
+    private $denormalizer;
+
+    protected function setUp()
+    {
+        $this->denormalizer = new BuiltInDenormalizer();
+    }
+
+    /**
+     * @dataProvider basicTypes
+     */
+    public function testDenormalize($value, $type)
+    {
+        $this->assertTrue($this->denormalizer->supportsDenormalization($value, $type));
+
+        $result = $this->denormalizer->denormalize($value, $type);
+        $this->assertEquals($value, $result);
+    }
+
+    public function basicTypes()
+    {
+        return [
+            [1, 'int'],
+            [1.1, 'float'],
+            ['hello', 'string'],
+            [true, 'bool'],
+            [false, 'bool'],
+            [[], 'array']
+        ];
+    }
+
+    /**
+     * @dataProvider basicTypesWrong
+     * @expectedException \Symfony\Component\Serializer\Exception\NotNormalizableValueException
+     */
+    public function testFailDenormalize($value, $type)
+    {
+        $result = $this->denormalizer->denormalize($value, $type);
+        $this->assertEquals($value, $result);
+    }
+
+    public function basicTypesWrong()
+    {
+        return [
+            [1.1, 'int'],
+            [1, 'float'],
+            [1, 'string'],
+            [1, 'bool'],
+            ['hello', 'array']
+        ];
+    }
+
+    /**
+     * @dataProvider castTypes
+     */
+    public function testCastDenormalize($value, $type, $corrected, $format)
+    {
+        $result = $this->denormalizer->denormalize($value, $type, $format);
+        $this->assertEquals($corrected, $result);
+    }
+
+    public function castTypes()
+    {
+        return [
+            ['1', 'int', 1, 'xml'],
+            ['1.1', 'float', 1.1, 'xml'],
+            ['1', 'bool', true, 'xml'],
+            ['0', 'bool', false, 'xml'],
+            ['1', 'int', 1, 'csv'],
+            ['1.1', 'float', 1.1, 'csv'],
+            ['1', 'bool', true, 'csv'],
+            ['0', 'bool', false, 'csv'],
+            [1, 'float', 1.0, 'json']
+        ];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
@@ -22,6 +22,7 @@ class DataUriNormalizerTest extends TestCase
 {
     const TEST_GIF_DATA = 'data:image/gif;base64,R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=';
     const TEST_TXT_DATA = 'data:text/plain,K%C3%A9vin%20Dunglas%0A';
+    const TEST_TXT_DATA_NO_MIME = 'data:application/octet-stream;base64,S8OpdmluIER1bmdsYXMK';
     const TEST_TXT_CONTENT = "Kévin Dunglas\n";
 
     /**
@@ -76,6 +77,19 @@ class DataUriNormalizerTest extends TestCase
         $data = $this->normalizer->normalize($file);
 
         $this->assertSame(self::TEST_TXT_DATA, $data);
+        $this->assertSame(self::TEST_TXT_CONTENT, file_get_contents($data));
+    }
+
+    /**
+     * @requires extension fileinfo
+     */
+    public function testNormalizeDataUrl()
+    {
+        $file = new \SplFileObject(self::TEST_TXT_DATA);
+
+        $data = $this->normalizer->normalize($file);
+
+        $this->assertSame(self::TEST_TXT_DATA_NO_MIME, $data);
         $this->assertSame(self::TEST_TXT_CONTENT, file_get_contents($data));
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -837,17 +837,18 @@ class ObjectNormalizerTest extends TestCase
         $serializer->denormalize(['date' => 'foo'], ObjectOuter::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     * @expectedExceptionMessage The type of the key "a" must be "int" ("string" given).
-     */
-    public function testRejectInvalidKey()
+    public function testAcceptValidKey()
     {
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = new ObjectNormalizer(null, null, null, $extractor);
         $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
 
-        $serializer->denormalize(['inners' => ['a' => ['foo' => 1]]], ObjectOuter::class);
+        $result = new ObjectOuter();
+        $inner = new ObjectInner();
+        $inner->foo = 1;
+        $result->setInners(['a' => $inner]);
+
+        $this->assertEquals($result, $serializer->denormalize(['inners' => ['a' => ['foo' => 1]]], ObjectOuter::class));
     }
 
     public function testDoNotRejectInvalidTypeOnDisableTypeEnforcementContextOption()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\BuiltInDenormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -818,7 +819,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = new ObjectNormalizer(null, null, null, $extractor);
-        $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
+        $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer, new BuiltInDenormalizer()]);
 
         $this->assertSame(10.0, $serializer->denormalize(['number' => 10], JsonNumber::class, 'json')->number);
         $this->assertSame(10.0, $serializer->denormalize(['number' => 10], JsonNumber::class, 'jsonld')->number);

--- a/src/Symfony/Component/Serializer/Tests/SerializerEndToEndTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerEndToEndTest.php
@@ -270,6 +270,79 @@ baz
 
 CSV
             ],
+            'string keys' => [
+                ['first' => new Baz('baz'), 'second' => new Baz('baz2')],
+                Baz::class.'[]',
+                ['key_types' => [new Type(Type::BUILTIN_TYPE_STRING)]],
+                <<<XML
+<?xml version="1.0"?>
+<response>
+  <first>
+    <name>baz</name>
+  </first>
+  <second>
+    <name>baz2</name>
+  </second>
+</response>
+
+XML
+                , <<<JSON
+{
+  "first": {
+    "name": "baz"
+  },
+  "second": {
+    "name": "baz2"
+  }
+}
+JSON
+                , <<<YAML
+first:
+  name: baz
+second:
+  name: baz2
+
+YAML
+                , <<<CSV
+first.name,second.name
+baz,baz2
+
+CSV
+            ],
+            'string keys in object' => [
+                new Quz(['a' => 'a', 'b' => 'b']),
+                Quz::class,
+                [CsvEncoder::AS_COLLECTION_KEY => false],
+                <<<XML
+<?xml version="1.0"?>
+<response>
+  <data>
+    <a>a</a>
+    <b>b</b>
+  </data>
+</response>
+
+XML
+                , <<<JSON
+{
+  "data": {
+    "a": "a",
+    "b": "b"
+  }
+}
+JSON
+                , <<<YAML
+data:
+  a: a
+  b: b
+
+YAML
+                , <<<CSV
+data.a,data.b
+a,b
+
+CSV
+            ],
             'qaz' => $this->qazData()
         ];
     }

--- a/src/Symfony/Component/Serializer/Tests/SerializerEndToEndTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerEndToEndTest.php
@@ -97,6 +97,9 @@ class SerializerEndToEndTest extends TestCase
      */
     public function testXml($object, $type, $context, $xml, $json, $yaml, $csv)
     {
+        if (!$xml) {
+            $this->markTestSkipped(sprintf('Xml doesnt support this (%s) data type', $type));
+        }
         $data = $this->serializer->serialize($object, 'xml', $context);
         $this->assertXmlStringEqualsXmlString($xml, $data);
     }
@@ -106,6 +109,9 @@ class SerializerEndToEndTest extends TestCase
      */
     public function testDeserializeXml($object, $type, $context, $xml, $json, $yaml, $csv)
     {
+        if (!$xml) {
+            $this->markTestSkipped(sprintf('Xml doesnt support this (%s) data type', $type));
+        }
         $deserialized = $this->serializer->deserialize($xml, $type, 'xml', $context);
         $this->assertEquals($object, $deserialized);
     }
@@ -115,6 +121,9 @@ class SerializerEndToEndTest extends TestCase
      */
     public function testJson($object, $type, $context, $xml, $json, $yaml, $csv)
     {
+        if (!$json) {
+            $this->markTestSkipped(sprintf('Json doesnt support this (%s) data type', $type));
+        }
         $data = $this->serializer->serialize($object, 'json', $context);
         $this->assertJsonStringEqualsJsonString($json, $data);
     }
@@ -124,6 +133,9 @@ class SerializerEndToEndTest extends TestCase
      */
     public function testDeserializeJson($object, $type, $context, $xml, $json, $yaml, $csv)
     {
+        if (!$json) {
+            $this->markTestSkipped(sprintf('Json doesnt support this (%s) data type', $type));
+        }
         $deserialized = $this->serializer->deserialize($json, $type, 'json', $context);
         $this->assertEquals($object, $deserialized);
     }
@@ -133,6 +145,9 @@ class SerializerEndToEndTest extends TestCase
      */
     public function testYaml($object, $type, $context, $xml, $json, $yaml, $csv)
     {
+        if (!$yaml) {
+            $this->markTestSkipped(sprintf('Yaml doesnt support this (%s) data type', $type));
+        }
         $data = $this->serializer->serialize($object, 'yaml', $context);
         $this->assertYamlStringEqualsYamlString($yaml, $data);
     }
@@ -142,6 +157,9 @@ class SerializerEndToEndTest extends TestCase
      */
     public function testDeserializeYaml($object, $type, $context, $xml, $json, $yaml, $csv)
     {
+        if (!$yaml) {
+            $this->markTestSkipped(sprintf('Yaml doesnt support this (%s) data type', $type));
+        }
         $deserialized = $this->serializer->deserialize($yaml, $type, 'yaml', $context);
         $this->assertEquals($object, $deserialized);
     }
@@ -151,6 +169,9 @@ class SerializerEndToEndTest extends TestCase
      */
     public function testCsv($object, $type, $context, $xml, $json, $yaml, $csv)
     {
+        if (!$csv) {
+            $this->markTestSkipped(sprintf('Csv doesnt support this (%s) data type', $type));
+        }
         $data = $this->serializer->serialize($object, 'csv', array_merge([
             'as_collection' => true,
         ], $context));
@@ -162,6 +183,9 @@ class SerializerEndToEndTest extends TestCase
      */
     public function testDeserializeCsv($object, $type, $context, $xml, $json, $yaml, $csv)
     {
+        if (!$csv) {
+            $this->markTestSkipped(sprintf('Csv doesnt support this (%s) data type', $type));
+        }
         $deserialized = $this->serializer->deserialize($csv, $type, 'csv', array_merge([
             'as_collection' => true,
         ], $context));
@@ -185,11 +209,7 @@ JSON
                 , <<<YAML
 hello
 YAML
-                , <<<CSV
-0
-hello
-
-CSV
+                , null
             ],
             'string array' => [
                 ['hello', 'world'],
@@ -210,11 +230,7 @@ JSON
 - hello
 - world
 YAML
-                , <<<CSV
-0,1
-hello,world
-
-CSV
+                , null
             ],
             'baz' => [
                 new Baz('baz'),
@@ -274,19 +290,7 @@ CSV
                 ['first' => new Baz('baz'), 'second' => new Baz('baz2')],
                 Baz::class.'[]',
                 ['key_types' => [new Type(Type::BUILTIN_TYPE_STRING)]],
-                <<<XML
-<?xml version="1.0"?>
-<response>
-  <first>
-    <name>baz</name>
-  </first>
-  <second>
-    <name>baz2</name>
-  </second>
-</response>
-
-XML
-                , <<<JSON
+                null, <<<JSON
 {
   "first": {
     "name": "baz"
@@ -303,26 +307,13 @@ second:
   name: baz2
 
 YAML
-                , <<<CSV
-first.name,second.name
-baz,baz2
-
-CSV
+                , null
             ],
             'string keys in object' => [
                 new Quz(['a' => 'a', 'b' => 'b']),
                 Quz::class,
                 [CsvEncoder::AS_COLLECTION_KEY => false],
-                <<<XML
-<?xml version="1.0"?>
-<response>
-  <data>
-    <a>a</a>
-    <b>b</b>
-  </data>
-</response>
-
-XML
+                null
                 , <<<JSON
 {
   "data": {
@@ -351,6 +342,7 @@ CSV
     {
         $qaz = new Qaz();
         $qaz->setQazString('foo');
+        $qaz->setQazStringEmpty('');
         $qaz->setQazInt(123);
         $qaz->setQazFloat(3.14);
         $qaz->setQazBool(true);
@@ -376,7 +368,6 @@ CSV
         $qaz->setQazDateArrayArray([[\DateTime::createFromFormat(DATE_ISO8601, '2019-05-17T12:05:06+02:00')], [\DateTime::createFromFormat(DATE_ISO8601, '2020-06-17T12:05:06+02:00')]]);
         $qaz->setQazBazArrayArray([[new Baz('baz5'), new Baz('baz6')], [new Baz('baz7'), new Baz('baz8')]]);
         $qaz->setQazBazArrayArrayOneItem([[new Baz('baz9')]]);
-        $qaz->setQazIntOption(1);
 
         return [
             $qaz,
@@ -386,6 +377,7 @@ CSV
 <?xml version="1.0"?>
 <response>
   <qazstring>foo</qazstring>
+  <qazstringempty></qazstringempty>
   <qazint>123</qazint>
   <qazfloat>3.14</qazfloat>
   <qazbool>1</qazbool>
@@ -498,14 +490,16 @@ CSV
     </item>
   </qazbazarrayarrayoneitem>
   <qazstringoption/>
-  <qazintoption>1</qazintoption>
+  <qazintoption/>
   <qazdateoption/>
+  <qazbazoption/>
 </response>
 
 XML
             , <<<JSON
 {
   "qazString": "foo",
+  "qazStringEmpty": "",
   "qazInt": 123,
   "qazFloat": 3.14,
   "qazBool": true,
@@ -650,13 +644,15 @@ XML
     ]
   ],
   "qazStringOption": null,
-  "qazIntOption": 1,
-  "qazDateOption": null
+  "qazIntOption": null,
+  "qazDateOption": null,
+  "qazBazOption": null
 }
 
 JSON
             , <<<YAML
 qazString: foo
+qazStringEmpty: ''
 qazInt: 123
 qazFloat: 3.14
 qazBool: true
@@ -761,15 +757,15 @@ qazBazArrayArrayOneItem:
     -
       name: baz9
 qazStringOption: null
-qazIntOption: 1
+qazIntOption: null
 qazDateOption: null
-
+qazBazOption: null
 
 YAML
 
             , <<<CSV
-qazString,qazInt,qazFloat,qazBool,qazBoolFalse,qazDate,qazDateImmut,qazInterval,qazData,qazBaz.name,qazArray.0,qazArray.1,qazArray.2,qazStringArray.0,qazStringArray.1,qazIntArray.0,qazIntArray.1,qazIntArray.2,qazFloatArray.0,qazFloatArray.1,qazFloatArray.2,qazBoolArray.0,qazBoolArray.1,qazBoolArray.2,qazDateArray.0,qazDateArray.1,qazBazArray.0.name,qazBazArray.1.name,qazBazArrayOneItem.0.name,qazArrayArray.0.0,qazArrayArray.0.1,qazArrayArray.0.2,qazArrayArray.1.0,qazArrayArray.1.1,qazArrayArray.1.2,qazStringArrayArray.0.0,qazStringArrayArray.0.1,qazStringArrayArray.1.0,qazStringArrayArray.1.1,qazIntArrayArray.0.0,qazIntArrayArray.0.1,qazIntArrayArray.0.2,qazIntArrayArray.1.0,qazIntArrayArray.1.1,qazIntArrayArray.1.2,qazFloatArrayArray.0.0,qazFloatArrayArray.0.1,qazFloatArrayArray.0.2,qazFloatArrayArray.1.0,qazFloatArrayArray.1.1,qazFloatArrayArray.1.2,qazBoolArrayArray.0.0,qazBoolArrayArray.0.1,qazBoolArrayArray.0.2,qazBoolArrayArray.1.0,qazBoolArrayArray.1.1,qazBoolArrayArray.1.2,qazDateArrayArray.0.0,qazDateArrayArray.1.0,qazBazArrayArray.0.0.name,qazBazArrayArray.0.1.name,qazBazArrayArray.1.0.name,qazBazArrayArray.1.1.name,qazBazArrayArrayOneItem.0.0.name,qazStringOption,qazIntOption,qazDateOption
-foo,123,3.14,1,,2019-01-17T12:05:06+02:00,2019-02-17T12:05:06+02:00,P0Y0M1DT0H0M0S,"data:application/octet-stream;base64,SGVsbG8sIFdvcmxkIQ==",baz1,1,2.1,1,foo,bar,1,2,3,1.1,2.2,3.3,1,,1,2019-03-17T12:05:06+02:00,2020-04-17T12:05:06+02:00,baz2,baz3,baz4,15,16,1.7,19,2,2.1,foo2,bar2,baz2,qaz2,4,5,6,7,8,9,4.4,5.5,6.6,7.7,8.8,9.9,1,1,,,,1,2019-05-17T12:05:06+02:00,2020-06-17T12:05:06+02:00,baz5,baz6,baz7,baz8,baz9,,1,
+qazString,qazStringEmpty,qazInt,qazFloat,qazBool,qazBoolFalse,qazDate,qazDateImmut,qazInterval,qazData,qazBaz.name,qazArray.0,qazArray.1,qazArray.2,qazStringArray.0,qazStringArray.1,qazIntArray.0,qazIntArray.1,qazIntArray.2,qazFloatArray.0,qazFloatArray.1,qazFloatArray.2,qazBoolArray.0,qazBoolArray.1,qazBoolArray.2,qazDateArray.0,qazDateArray.1,qazBazArray.0.name,qazBazArray.1.name,qazBazArrayOneItem.0.name,qazArrayArray.0.0,qazArrayArray.0.1,qazArrayArray.0.2,qazArrayArray.1.0,qazArrayArray.1.1,qazArrayArray.1.2,qazStringArrayArray.0.0,qazStringArrayArray.0.1,qazStringArrayArray.1.0,qazStringArrayArray.1.1,qazIntArrayArray.0.0,qazIntArrayArray.0.1,qazIntArrayArray.0.2,qazIntArrayArray.1.0,qazIntArrayArray.1.1,qazIntArrayArray.1.2,qazFloatArrayArray.0.0,qazFloatArrayArray.0.1,qazFloatArrayArray.0.2,qazFloatArrayArray.1.0,qazFloatArrayArray.1.1,qazFloatArrayArray.1.2,qazBoolArrayArray.0.0,qazBoolArrayArray.0.1,qazBoolArrayArray.0.2,qazBoolArrayArray.1.0,qazBoolArrayArray.1.1,qazBoolArrayArray.1.2,qazDateArrayArray.0.0,qazDateArrayArray.1.0,qazBazArrayArray.0.0.name,qazBazArrayArray.0.1.name,qazBazArrayArray.1.0.name,qazBazArrayArray.1.1.name,qazBazArrayArrayOneItem.0.0.name,qazStringOption,qazIntOption,qazDateOption,qazBazOption
+foo,,123,3.14,1,0,2019-01-17T12:05:06+02:00,2019-02-17T12:05:06+02:00,P0Y0M1DT0H0M0S,"data:application/octet-stream;base64,SGVsbG8sIFdvcmxkIQ==",baz1,1,2.1,1,foo,bar,1,2,3,1.1,2.2,3.3,1,0,1,2019-03-17T12:05:06+02:00,2020-04-17T12:05:06+02:00,baz2,baz3,baz4,15,16,1.7,19,2,2.1,foo2,bar2,baz2,qaz2,4,5,6,7,8,9,4.4,5.5,6.6,7.7,8.8,9.9,1,1,0,0,0,1,2019-05-17T12:05:06+02:00,2020-06-17T12:05:06+02:00,baz5,baz6,baz7,baz8,baz9,,,,
 
 CSV
         ];
@@ -803,6 +799,11 @@ class Qaz
      * @var string
      */
     private $qazString;
+
+    /**
+     * @var string
+     */
+    private $qazStringEmpty;
 
     /**
      * @var int
@@ -944,6 +945,11 @@ class Qaz
      */
     private $qazDateOption;
 
+    /**
+     * @var ?Baz
+     */
+    private $qazBazOption;
+
     public function getQazString(): string
     {
         return $this->qazString;
@@ -952,6 +958,16 @@ class Qaz
     public function setQazString(string $qazString): void
     {
         $this->qazString = $qazString;
+    }
+
+    public function getQazStringEmpty(): string
+    {
+        return $this->qazStringEmpty;
+    }
+
+    public function setQazStringEmpty(string $qazStringEmpty): void
+    {
+        $this->qazStringEmpty = $qazStringEmpty;
     }
 
     public function getQazInt(): int
@@ -1322,6 +1338,16 @@ class Qaz
     public function setQazDateOption(?\DateTime $qazDateOption): void
     {
         $this->qazDateOption = $qazDateOption;
+    }
+
+    public function getQazBazOption(): ?Baz
+    {
+        return $this->qazBazOption;
+    }
+
+    public function setQazBazOption(?Baz $qazBazOption): void
+    {
+        $this->qazBazOption = $qazBazOption;
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerEndToEndTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerEndToEndTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\BuiltInDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
 use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
@@ -62,6 +63,7 @@ class SerializerEndToEndTest extends TestCase
             new ConstraintViolationListNormalizer(),
             new DateIntervalNormalizer(),
             new DataUriNormalizer(),
+            new BuiltInDenormalizer(),
             new ArrayDenormalizer(),
             new ObjectNormalizer(
                 $classMetadata,

--- a/src/Symfony/Component/Serializer/Tests/SerializerEndToEndTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerEndToEndTest.php
@@ -1,0 +1,1275 @@
+<?php
+
+
+namespace Symfony\Component\Serializer\Tests;
+
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
+use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class SerializerEndToEndTest extends TestCase
+{
+    /** @var SerializerInterface */
+    private $serializer;
+
+    private function assertYamlStringEqualsYamlString($expected, $actual)
+    {
+        $expectedParsed = Yaml::parse($expected);
+        $actualParsed = Yaml::parse($actual);
+
+        $this->assertEquals($expectedParsed, $actualParsed, 'Failed to assert that ' .$actual.' is equal to '.$expected);
+    }
+
+    private function assertCsvStringEqualsCsvString($expected, $actual)
+    {
+        $expectedParsed = str_getcsv($expected);
+        $actualParsed = str_getcsv($actual);
+
+        $this->assertEquals($expectedParsed, $actualParsed, 'Failed to assert that ' .$actual.' is equal to '.$expected);
+    }
+
+    public function setUp()
+    {
+        $classMetadata = new ClassMetadataFactory(new LoaderChain([new AnnotationLoader(new AnnotationReader())]));
+        $this->serializer = new Serializer([
+            new JsonSerializableNormalizer(),
+            new DateTimeNormalizer(),
+            new ConstraintViolationListNormalizer(),
+            new DateIntervalNormalizer(),
+            new DataUriNormalizer(),
+            new ArrayDenormalizer(),
+            new ObjectNormalizer(
+                $classMetadata,
+                new MetadataAwareNameConverter($classMetadata),
+                new PropertyAccessor(false, false, new ArrayAdapter(0, false)),
+                new PropertyInfoExtractor([
+                    new SerializerExtractor($classMetadata),
+                    new ReflectionExtractor(),
+                ], [
+                    new PhpDocExtractor(),
+                    new ReflectionExtractor(),
+                ], [
+                    new PhpDocExtractor()
+                ], [
+                    new ReflectionExtractor()
+                ], [
+                    new ReflectionExtractor()
+                ]),
+                new ClassDiscriminatorFromClassMetadata($classMetadata)
+            ),
+        ], [
+            new XmlEncoder(),
+            new JsonEncoder(),
+            new YamlEncoder(),
+            new CsvEncoder()
+        ]);
+    }
+
+    /**
+     * @dataProvider data
+     */
+    public function testXml($object, $type, $context, $xml, $json, $yaml, $csv)
+    {
+        $data = $this->serializer->serialize($object, 'xml', $context);
+        $this->assertXmlStringEqualsXmlString($xml, $data);
+    }
+
+    /**
+     * @dataProvider data
+     */
+    public function testDeserializeXml($object, $type, $context, $xml, $json, $yaml, $csv)
+    {
+        $deserialized = $this->serializer->deserialize($xml, $type, 'xml', $context);
+        $this->assertEquals($object, $deserialized);
+    }
+
+    /**
+     * @dataProvider data
+     */
+    public function testJson($object, $type, $context, $xml, $json, $yaml, $csv)
+    {
+        $data = $this->serializer->serialize($object, 'json', $context);
+        $this->assertJsonStringEqualsJsonString($json, $data);
+    }
+
+    /**
+     * @dataProvider data
+     */
+    public function testDeserializeJson($object, $type, $context, $xml, $json, $yaml, $csv)
+    {
+        $deserialized = $this->serializer->deserialize($json, $type, 'json', $context);
+        $this->assertEquals($object, $deserialized);
+    }
+
+    /**
+     * @dataProvider data
+     */
+    public function testYaml($object, $type, $context, $xml, $json, $yaml, $csv)
+    {
+        $data = $this->serializer->serialize($object, 'yaml', $context);
+        $this->assertYamlStringEqualsYamlString($yaml, $data);
+    }
+
+    /**
+     * @dataProvider data
+     */
+    public function testDeserializeYaml($object, $type, $context, $xml, $json, $yaml, $csv)
+    {
+        $deserialized = $this->serializer->deserialize($yaml, $type, 'yaml', $context);
+        $this->assertEquals($object, $deserialized);
+    }
+
+    /**
+     * @dataProvider data
+     */
+    public function testCsv($object, $type, $context, $xml, $json, $yaml, $csv)
+    {
+        $data = $this->serializer->serialize($object, 'csv', array_merge([
+            'as_collection' => true,
+        ], $context));
+        $this->assertCsvStringEqualsCsvString($csv, $data);
+    }
+
+    /**
+     * @dataProvider data
+     */
+    public function testDeserializeCsv($object, $type, $context, $xml, $json, $yaml, $csv)
+    {
+        $deserialized = $this->serializer->deserialize($csv, $type, 'csv', array_merge([
+            'as_collection' => true,
+        ], $context));
+        $this->assertEquals($object, $deserialized);
+    }
+
+    public function data() {
+        return [
+            'simple string' => [
+                'hello',
+                'string',
+                [CsvEncoder::AS_COLLECTION_KEY => false],
+                <<<XML
+<?xml version="1.0"?>
+<response>hello</response>
+
+XML
+                , <<<JSON
+"hello"
+JSON
+                , <<<YAML
+hello
+YAML
+                , <<<CSV
+0
+hello
+
+CSV
+            ],
+            'string array' => [
+                ['hello', 'world'],
+                'string[]',
+                [],
+                <<<XML
+<?xml version="1.0"?>
+<response>
+  <item key="0">hello</item>
+  <item key="1">world</item>
+</response>
+
+XML
+                , <<<JSON
+["hello", "world"]
+JSON
+                , <<<YAML
+- hello
+- world
+YAML
+                , <<<CSV
+0,1
+hello,world
+
+CSV
+            ],
+            'baz' => [
+                new Baz('baz'),
+                Baz::class,
+                [CsvEncoder::AS_COLLECTION_KEY => false],
+                <<<XML
+<?xml version="1.0"?>
+<response>
+  <name>baz</name>
+</response>
+
+XML
+                , <<<JSON
+{
+  "name":"baz"
+}
+JSON
+                , <<<YAML
+name: baz
+YAML
+                , <<<CSV
+name
+baz
+
+CSV
+            ],
+            'baz array' => [
+                [new Baz('baz')],
+                Baz::class.'[]',
+                [],
+                <<<XML
+<?xml version="1.0"?>
+<response>
+  <item key="0">
+    <name>baz</name>
+  </item>
+</response>
+
+XML
+                , <<<JSON
+[
+  {
+    "name":"baz"
+  }
+]
+JSON
+                , <<<YAML
+- name: baz
+YAML
+                , <<<CSV
+name
+baz
+
+CSV
+            ],
+            'qaz' => $this->qazData()
+        ];
+    }
+
+    private function qazData(): array
+    {
+        $qaz = new Qaz();
+        $qaz->setQazString('foo');
+        $qaz->setQazInt(123);
+        $qaz->setQazFloat(3.14);
+        $qaz->setQazBool(true);
+        $qaz->setQazBoolFalse(false);
+        $qaz->setQazDate(\DateTime::createFromFormat(DATE_ISO8601, '2019-01-17T12:05:06+02:00'));
+        $qaz->setQazDateImmut(\DateTimeImmutable::createFromFormat(DATE_ISO8601, '2019-02-17T12:05:06+02:00'));
+        $qaz->setQazInterval(new \DateInterval('P1D'));
+        $qaz->setQazData(new \SplFileObject('data:,Hello%2C%20World!'));
+        $qaz->setQazBaz(new Baz('baz1'));
+        $qaz->setQazArray([1, 2.1, true]);
+        $qaz->setQazStringArray(['foo', 'bar']);
+        $qaz->setQazIntArray([1, 2, 3]);
+        $qaz->setQazFloatArray([1.1, 2.2, 3.3]);
+        $qaz->setQazBoolArray([true, false, true]);
+        $qaz->setQazDateArray([\DateTime::createFromFormat(DATE_ISO8601, '2019-03-17T12:05:06+02:00'), \DateTime::createFromFormat(DATE_ISO8601, '2020-04-17T12:05:06+02:00')]);
+        $qaz->setQazBazArray([new Baz('baz2'), new Baz('baz3')]);
+        $qaz->setQazBazArrayOneItem([new Baz('baz4')]);
+        $qaz->setQazArrayArray([[15, 16, 1.7], [19, 2.0, 2.1]]);
+        $qaz->setQazStringArrayArray([['foo2', 'bar2'], ['baz2', 'qaz2']]);
+        $qaz->setQazIntArrayArray([[4, 5, 6], [7, 8, 9]]);
+        $qaz->setQazFloatArrayArray([[4.4, 5.5, 6.6], [7.7, 8.8, 9.9]]);
+        $qaz->setQazBoolArrayArray([[true, true, false], [false, false, true]]);
+        $qaz->setQazDateArrayArray([[\DateTime::createFromFormat(DATE_ISO8601, '2019-05-17T12:05:06+02:00')], [\DateTime::createFromFormat(DATE_ISO8601, '2020-06-17T12:05:06+02:00')]]);
+        $qaz->setQazBazArrayArray([[new Baz('baz5'), new Baz('baz6')], [new Baz('baz7'), new Baz('baz8')]]);
+        $qaz->setQazBazArrayArrayOneItem([[new Baz('baz9')]]);
+        $qaz->setQazIntOption(1);
+
+        return [
+            $qaz,
+            Qaz::class,
+            [CsvEncoder::AS_COLLECTION_KEY => false],
+            <<<XML
+<?xml version="1.0"?>
+<response>
+  <qazstring>foo</qazstring>
+  <qazint>123</qazint>
+  <qazfloat>3.14</qazfloat>
+  <qazbool>1</qazbool>
+  <qazboolfalse>0</qazboolfalse>
+  <qazdate>2019-01-17t12:05:06+02:00</qazdate>
+  <qazdateimmut>2019-02-17t12:05:06+02:00</qazdateimmut>
+  <qazinterval>P0Y0M1DT0H0M0S</qazinterval>
+  <qazdata>data:application/octet-stream;base64,sgvsbg8sifdvcmxkiq==</qazdata>
+  <qazbaz>
+    <name>baz1</name>
+  </qazbaz>
+  <qazarray>1</qazarray>
+  <qazarray>2.1</qazarray>
+  <qazarray>1</qazarray>
+  <qazstringarray>foo</qazstringarray>
+  <qazstringarray>bar</qazstringarray>
+  <qazintarray>1</qazintarray>
+  <qazintarray>2</qazintarray>
+  <qazintarray>3</qazintarray>
+  <qazfloatarray>1.1</qazfloatarray>
+  <qazfloatarray>2.2</qazfloatarray>
+  <qazfloatarray>3.3</qazfloatarray>
+  <qazboolarray>1</qazboolarray>
+  <qazboolarray>0</qazboolarray>
+  <qazboolarray>1</qazboolarray>
+  <qazdatearray>2019-03-17t12:05:06+02:00</qazdatearray>
+  <qazdatearray>2020-04-17t12:05:06+02:00</qazdatearray>
+  <qazbazarray>
+    <name>baz2</name>
+  </qazbazarray>
+  <qazbazarray>
+    <name>baz3</name>
+  </qazbazarray>
+  <qazbazarrayoneitem>
+    <name>baz4</name>
+  </qazbazarrayoneitem>
+  <qazarrayarray>
+    <item key="0">15</item>
+    <item key="1">16</item>
+    <item key="2">1.7</item>
+  </qazarrayarray>
+  <qazarrayarray>
+    <item key="0">19</item>
+    <item key="1">2</item>
+    <item key="2">2.1</item>
+  </qazarrayarray>
+  <qazstringarrayarray>
+    <item key="0">foo2</item>
+    <item key="1">bar2</item>
+  </qazstringarrayarray>
+  <qazstringarrayarray>
+    <item key="0">baz2</item>
+    <item key="1">qaz2</item>
+  </qazstringarrayarray>
+  <qazintarrayarray>
+    <item key="0">4</item>
+    <item key="1">5</item>
+    <item key="2">6</item>
+  </qazintarrayarray>
+  <qazintarrayarray>
+    <item key="0">7</item>
+    <item key="1">8</item>
+    <item key="2">9</item>
+  </qazintarrayarray>
+  <qazfloatarrayarray>
+    <item key="0">4.4</item>
+    <item key="1">5.5</item>
+    <item key="2">6.6</item>
+  </qazfloatarrayarray>
+  <qazfloatarrayarray>
+    <item key="0">7.7</item>
+    <item key="1">8.8</item>
+    <item key="2">9.9</item>
+  </qazfloatarrayarray>
+  <qazboolarrayarray>
+    <item key="0">1</item>
+    <item key="1">1</item>
+    <item key="2">0</item>
+  </qazboolarrayarray>
+  <qazboolarrayarray>
+    <item key="0">0</item>
+    <item key="1">0</item>
+    <item key="2">1</item>
+  </qazboolarrayarray>
+  <qazdatearrayarray>
+    <item key="0">2019-05-17t12:05:06+02:00</item>
+  </qazdatearrayarray>
+  <qazdatearrayarray>
+    <item key="0">2020-06-17t12:05:06+02:00</item>
+  </qazdatearrayarray>
+  <qazbazarrayarray>
+    <item key="0">
+      <name>baz5</name>
+    </item>
+    <item key="1">
+      <name>baz6</name>
+    </item>
+  </qazbazarrayarray>
+  <qazbazarrayarray>
+    <item key="0">
+      <name>baz7</name>
+    </item>
+    <item key="1">
+      <name>baz8</name>
+    </item>
+  </qazbazarrayarray>
+  <qazbazarrayarrayoneitem>
+    <item key="0">
+      <name>baz9</name>
+    </item>
+  </qazbazarrayarrayoneitem>
+  <qazstringoption/>
+  <qazintoption>1</qazintoption>
+  <qazdateoption/>
+</response>
+
+XML
+            , <<<JSON
+{
+  "qazString": "foo",
+  "qazInt": 123,
+  "qazFloat": 3.14,
+  "qazBool": true,
+  "qazBoolFalse": false,
+  "qazDate": "2019-01-17T12:05:06+02:00",
+  "qazDateImmut": "2019-02-17T12:05:06+02:00",
+  "qazInterval": "P0Y0M1DT0H0M0S",
+  "qazData": "data:application/octet-stream;base64,SGVsbG8sIFdvcmxkIQ==",
+  "qazBaz": {
+    "name": "baz1"
+  },
+  "qazArray": [
+    1,
+    2.1,
+    true
+  ],
+  "qazStringArray": [
+    "foo",
+    "bar"
+  ],
+  "qazIntArray": [
+    1,
+    2,
+    3
+  ],
+  "qazFloatArray": [
+    1.1,
+    2.2,
+    3.3
+  ],
+  "qazBoolArray": [
+    true,
+    false,
+    true
+  ],
+  "qazDateArray": [
+    "2019-03-17T12:05:06+02:00",
+    "2020-04-17T12:05:06+02:00"
+  ],
+  "qazBazArray": [
+    {
+      "name": "baz2"
+    },
+    {
+      "name": "baz3"
+    }
+  ],
+  "qazBazArrayOneItem": [
+    {
+      "name": "baz4"
+    }
+  ],
+  "qazArrayArray": [
+    [
+      15,
+      16,
+      1.7
+    ],
+    [
+      19,
+      2,
+      2.1
+    ]
+  ],
+  "qazStringArrayArray": [
+    [
+      "foo2",
+      "bar2"
+    ],
+    [
+      "baz2",
+      "qaz2"
+    ]
+  ],
+  "qazIntArrayArray": [
+    [
+      4,
+      5,
+      6
+    ],
+    [
+      7,
+      8,
+      9
+    ]
+  ],
+  "qazFloatArrayArray": [
+    [
+      4.4,
+      5.5,
+      6.6
+    ],
+    [
+      7.7,
+      8.8,
+      9.9
+    ]
+  ],
+  "qazBoolArrayArray": [
+    [
+      true,
+      true,
+      false
+    ],
+    [
+      false,
+      false,
+      true
+    ]
+  ],
+  "qazDateArrayArray": [
+    [
+      "2019-05-17T12:05:06+02:00"
+    ],
+    [
+      "2020-06-17T12:05:06+02:00"
+    ]
+  ],
+  "qazBazArrayArray": [
+    [
+      {
+        "name": "baz5"
+      },
+      {
+        "name": "baz6"
+      }
+    ],
+    [
+      {
+        "name": "baz7"
+      },
+      {
+        "name": "baz8"
+      }
+    ]
+  ],
+  "qazBazArrayArrayOneItem": [
+    [
+      {
+        "name": "baz9"
+      }
+    ]
+  ],
+  "qazStringOption": null,
+  "qazIntOption": 1,
+  "qazDateOption": null
+}
+
+JSON
+            , <<<YAML
+qazString: foo
+qazInt: 123
+qazFloat: 3.14
+qazBool: true
+qazBoolFalse: false
+qazDate: '2019-01-17T12:05:06+02:00'
+qazDateImmut: '2019-02-17T12:05:06+02:00'
+qazInterval: P0Y0M1DT0H0M0S
+qazData: 'data:application/octet-stream;base64,SGVsbG8sIFdvcmxkIQ=='
+qazBaz:
+  name: baz1
+qazArray:
+  - 1
+  - 2.1
+  - true
+qazStringArray:
+  - foo
+  - bar
+qazIntArray:
+  - 1
+  - 2
+  - 3
+qazFloatArray:
+  - 1.1
+  - 2.2
+  - 3.3
+qazBoolArray:
+  - true
+  - false
+  - true
+qazDateArray:
+  - '2019-03-17T12:05:06+02:00'
+  - '2020-04-17T12:05:06+02:00'
+qazBazArray:
+  -
+    name: baz2
+  -
+    name: baz3
+qazBazArrayOneItem:
+  -
+    name: baz4
+qazArrayArray:
+  -
+    - 15
+    - 16
+    - 1.7
+  -
+    - 19
+    - 2
+    - 2.1
+qazStringArrayArray:
+  -
+    - foo2
+    - bar2
+  -
+    - baz2
+    - qaz2
+qazIntArrayArray:
+  -
+    - 4
+    - 5
+    - 6
+  -
+    - 7
+    - 8
+    - 9
+qazFloatArrayArray:
+  -
+    - 4.4
+    - 5.5
+    - 6.6
+  -
+    - 7.7
+    - 8.8
+    - 9.9
+qazBoolArrayArray:
+  -
+    - true
+    - true
+    - false
+  -
+    - false
+    - false
+    - true
+qazDateArrayArray:
+  -
+    - '2019-05-17T12:05:06+02:00'
+  -
+    - '2020-06-17T12:05:06+02:00'
+qazBazArrayArray:
+  -
+    -
+      name: baz5
+    -
+      name: baz6
+  -
+    -
+      name: baz7
+    -
+      name: baz8
+qazBazArrayArrayOneItem:
+  -
+    -
+      name: baz9
+qazStringOption: null
+qazIntOption: 1
+qazDateOption: null
+
+
+YAML
+
+            , <<<CSV
+qazString,qazInt,qazFloat,qazBool,qazBoolFalse,qazDate,qazDateImmut,qazInterval,qazData,qazBaz.name,qazArray.0,qazArray.1,qazArray.2,qazStringArray.0,qazStringArray.1,qazIntArray.0,qazIntArray.1,qazIntArray.2,qazFloatArray.0,qazFloatArray.1,qazFloatArray.2,qazBoolArray.0,qazBoolArray.1,qazBoolArray.2,qazDateArray.0,qazDateArray.1,qazBazArray.0.name,qazBazArray.1.name,qazBazArrayOneItem.0.name,qazArrayArray.0.0,qazArrayArray.0.1,qazArrayArray.0.2,qazArrayArray.1.0,qazArrayArray.1.1,qazArrayArray.1.2,qazStringArrayArray.0.0,qazStringArrayArray.0.1,qazStringArrayArray.1.0,qazStringArrayArray.1.1,qazIntArrayArray.0.0,qazIntArrayArray.0.1,qazIntArrayArray.0.2,qazIntArrayArray.1.0,qazIntArrayArray.1.1,qazIntArrayArray.1.2,qazFloatArrayArray.0.0,qazFloatArrayArray.0.1,qazFloatArrayArray.0.2,qazFloatArrayArray.1.0,qazFloatArrayArray.1.1,qazFloatArrayArray.1.2,qazBoolArrayArray.0.0,qazBoolArrayArray.0.1,qazBoolArrayArray.0.2,qazBoolArrayArray.1.0,qazBoolArrayArray.1.1,qazBoolArrayArray.1.2,qazDateArrayArray.0.0,qazDateArrayArray.1.0,qazBazArrayArray.0.0.name,qazBazArrayArray.0.1.name,qazBazArrayArray.1.0.name,qazBazArrayArray.1.1.name,qazBazArrayArrayOneItem.0.0.name,qazStringOption,qazIntOption,qazDateOption
+foo,123,3.14,1,,2019-01-17T12:05:06+02:00,2019-02-17T12:05:06+02:00,P0Y0M1DT0H0M0S,"data:application/octet-stream;base64,SGVsbG8sIFdvcmxkIQ==",baz1,1,2.1,1,foo,bar,1,2,3,1.1,2.2,3.3,1,,1,2019-03-17T12:05:06+02:00,2020-04-17T12:05:06+02:00,baz2,baz3,baz4,15,16,1.7,19,2,2.1,foo2,bar2,baz2,qaz2,4,5,6,7,8,9,4.4,5.5,6.6,7.7,8.8,9.9,1,1,,,,1,2019-05-17T12:05:06+02:00,2020-06-17T12:05:06+02:00,baz5,baz6,baz7,baz8,baz9,,1,
+
+CSV
+        ];
+    }
+}
+
+class Baz
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}
+
+class Qaz
+{
+    /**
+     * @var string
+     */
+    private $qazString;
+
+    /**
+     * @var int
+     */
+    private $qazInt;
+
+    /**
+     * @var float
+     */
+    private $qazFloat;
+
+    /**
+     * @var bool
+     */
+    private $qazBool;
+
+    /**
+     * @var bool
+     */
+    private $qazBoolFalse;
+
+    /**
+     * @var \DateTime
+     */
+    private $qazDate;
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    private $qazDateImmut;
+
+    /**
+     * @var \DateInterval
+     */
+    private $qazInterval;
+
+    /**
+     * @var \SplFileInfo
+     */
+    private $qazData;
+
+    /**
+     * @var Baz
+     */
+    private $qazBaz;
+
+    /**
+     * @var array
+     */
+    private $qazArray;
+
+    /**
+     * @var string[]
+     */
+    private $qazStringArray;
+
+    /**
+     * @var int[]
+     */
+    private $qazIntArray;
+
+    /**
+     * @var float[]
+     */
+    private $qazFloatArray;
+
+    /**
+     * @var bool[]
+     */
+    private $qazBoolArray;
+
+    /**
+     * @var \DateTime[]
+     */
+    private $qazDateArray;
+
+    /**
+     * @var Baz[]
+     */
+    private $qazBazArray;
+
+    /**
+     * @var Baz[]
+     */
+    private $qazBazArrayOneItem;
+
+    /**
+     * @var array
+     */
+    private $qazArrayArray;
+
+    /**
+     * @var string[][]
+     */
+    private $qazStringArrayArray;
+
+    /**
+     * @var int[][]
+     */
+    private $qazIntArrayArray;
+
+    /**
+     * @var float[][]
+     */
+    private $qazFloatArrayArray;
+
+    /**
+     * @var bool[][]
+     */
+    private $qazBoolArrayArray;
+
+    /**
+     * @var \DateTime[][]
+     */
+    private $qazDateArrayArray;
+
+    /**
+     * @var Baz[][]
+     */
+    private $qazBazArrayArray;
+
+    /**
+     * @var Baz[][]
+     */
+    private $qazBazArrayArrayOneItem;
+
+    /**
+     * @var ?string
+     */
+    private $qazStringOption;
+
+    /**
+     * @var ?int
+     */
+    private $qazIntOption;
+
+    /**
+     * @var ?\DateTime
+     */
+    private $qazDateOption;
+
+    public function getQazString(): string
+    {
+        return $this->qazString;
+    }
+
+    public function setQazString(string $qazString): void
+    {
+        $this->qazString = $qazString;
+    }
+
+    public function getQazInt(): int
+    {
+        return $this->qazInt;
+    }
+
+    public function setQazInt(int $qazInt): void
+    {
+        $this->qazInt = $qazInt;
+    }
+
+    public function getQazFloat(): float
+    {
+        return $this->qazFloat;
+    }
+
+    public function setQazFloat(float $qazFloat): void
+    {
+        $this->qazFloat = $qazFloat;
+    }
+
+    public function isQazBool(): bool
+    {
+        return $this->qazBool;
+    }
+
+    public function setQazBool(bool $qazBool): void
+    {
+        $this->qazBool = $qazBool;
+    }
+
+    public function isQazBoolFalse(): bool
+    {
+        return $this->qazBoolFalse;
+    }
+
+    public function setQazBoolFalse(bool $qazBoolFalse): void
+    {
+        $this->qazBoolFalse = $qazBoolFalse;
+    }
+
+    public function getQazDate(): \DateTime
+    {
+        return $this->qazDate;
+    }
+
+    public function setQazDate(\DateTime $qazDate): void
+    {
+        $this->qazDate = $qazDate;
+    }
+
+    public function getQazDateImmut(): \DateTimeImmutable
+    {
+        return $this->qazDateImmut;
+    }
+
+    public function setQazDateImmut(\DateTimeImmutable $qazDateImmut): void
+    {
+        $this->qazDateImmut = $qazDateImmut;
+    }
+
+    public function getQazInterval(): \DateInterval
+    {
+        return $this->qazInterval;
+    }
+
+    public function setQazInterval(\DateInterval $qazInterval): void
+    {
+        $this->qazInterval = $qazInterval;
+    }
+
+    public function getQazData(): \SplFileInfo
+    {
+        return $this->qazData;
+    }
+
+    public function setQazData(\SplFileInfo $qazData): void
+    {
+        $this->qazData = $qazData;
+    }
+
+    public function getQazBaz(): Baz
+    {
+        return $this->qazBaz;
+    }
+
+    public function setQazBaz(Baz $qazBaz): void
+    {
+        $this->qazBaz = $qazBaz;
+    }
+
+    public function getQazArray(): array
+    {
+        return $this->qazArray;
+    }
+
+    public function setQazArray(array $qazArray): void
+    {
+        $this->qazArray = $qazArray;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getQazStringArray(): array
+    {
+        return $this->qazStringArray;
+    }
+
+    /**
+     * @param string[] $qazStringArray
+     */
+    public function setQazStringArray(array $qazStringArray): void
+    {
+        $this->qazStringArray = $qazStringArray;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getQazIntArray(): array
+    {
+        return $this->qazIntArray;
+    }
+
+    /**
+     * @param int[] $qazIntArray
+     */
+    public function setQazIntArray(array $qazIntArray): void
+    {
+        $this->qazIntArray = $qazIntArray;
+    }
+
+    /**
+     * @return float[]
+     */
+    public function getQazFloatArray(): array
+    {
+        return $this->qazFloatArray;
+    }
+
+    /**
+     * @param float[] $qazFloatArray
+     */
+    public function setQazFloatArray(array $qazFloatArray): void
+    {
+        $this->qazFloatArray = $qazFloatArray;
+    }
+
+    /**
+     * @return bool[]
+     */
+    public function getQazBoolArray(): array
+    {
+        return $this->qazBoolArray;
+    }
+
+    /**
+     * @param bool[] $qazBoolArray
+     */
+    public function setQazBoolArray(array $qazBoolArray): void
+    {
+        $this->qazBoolArray = $qazBoolArray;
+    }
+
+    /**
+     * @return \DateTime[]
+     */
+    public function getQazDateArray(): array
+    {
+        return $this->qazDateArray;
+    }
+
+    /**
+     * @param \DateTime[] $qazDateArray
+     */
+    public function setQazDateArray(array $qazDateArray): void
+    {
+        $this->qazDateArray = $qazDateArray;
+    }
+
+    /**
+     * @return Baz[]
+     */
+    public function getQazBazArray(): array
+    {
+        return $this->qazBazArray;
+    }
+
+    /**
+     * @param Baz[] $qazBazArray
+     */
+    public function setQazBazArray(array $qazBazArray): void
+    {
+        $this->qazBazArray = $qazBazArray;
+    }
+
+    /**
+     * @return Baz[]
+     */
+    public function getQazBazArrayOneItem(): array
+    {
+        return $this->qazBazArrayOneItem;
+    }
+
+    /**
+     * @param Baz[] $qazBazArrayOneItem
+     */
+    public function setQazBazArrayOneItem(array $qazBazArrayOneItem): void
+    {
+        $this->qazBazArrayOneItem = $qazBazArrayOneItem;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQazArrayArray(): array
+    {
+        return $this->qazArrayArray;
+    }
+
+    /**
+     * @param array $qazArrayArray
+     */
+    public function setQazArrayArray(array $qazArrayArray): void
+    {
+        $this->qazArrayArray = $qazArrayArray;
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getQazStringArrayArray(): array
+    {
+        return $this->qazStringArrayArray;
+    }
+
+    /**
+     * @param string[][] $qazStringArrayArray
+     */
+    public function setQazStringArrayArray(array $qazStringArrayArray): void
+    {
+        $this->qazStringArrayArray = $qazStringArrayArray;
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function getQazIntArrayArray(): array
+    {
+        return $this->qazIntArrayArray;
+    }
+
+    /**
+     * @param int[][] $qazIntArrayArray
+     */
+    public function setQazIntArrayArray(array $qazIntArrayArray): void
+    {
+        $this->qazIntArrayArray = $qazIntArrayArray;
+    }
+
+    /**
+     * @return float[][]
+     */
+    public function getQazFloatArrayArray(): array
+    {
+        return $this->qazFloatArrayArray;
+    }
+
+    /**
+     * @param float[][] $qazFloatArrayArray
+     */
+    public function setQazFloatArrayArray(array $qazFloatArrayArray): void
+    {
+        $this->qazFloatArrayArray = $qazFloatArrayArray;
+    }
+
+    /**
+     * @return bool[][]
+     */
+    public function getQazBoolArrayArray(): array
+    {
+        return $this->qazBoolArrayArray;
+    }
+
+    /**
+     * @param bool[][] $qazBoolArrayArray
+     */
+    public function setQazBoolArrayArray(array $qazBoolArrayArray): void
+    {
+        $this->qazBoolArrayArray = $qazBoolArrayArray;
+    }
+
+    /**
+     * @return \DateTime[][]
+     */
+    public function getQazDateArrayArray(): array
+    {
+        return $this->qazDateArrayArray;
+    }
+
+    /**
+     * @param \DateTime[][] $qazDateArrayArray
+     */
+    public function setQazDateArrayArray(array $qazDateArrayArray): void
+    {
+        $this->qazDateArrayArray = $qazDateArrayArray;
+    }
+
+    /**
+     * @return Baz[][]
+     */
+    public function getQazBazArrayArray(): array
+    {
+        return $this->qazBazArrayArray;
+    }
+
+    /**
+     * @param Baz[][] $qazBazArrayArray
+     */
+    public function setQazBazArrayArray(array $qazBazArrayArray): void
+    {
+        $this->qazBazArrayArray = $qazBazArrayArray;
+    }
+
+    /**
+     * @return Baz[][]
+     */
+    public function getQazBazArrayArrayOneItem(): array
+    {
+        return $this->qazBazArrayArrayOneItem;
+    }
+
+    /**
+     * @param Baz[][] $qazBazArrayArrayOneItem
+     */
+    public function setQazBazArrayArrayOneItem(array $qazBazArrayArrayOneItem): void
+    {
+        $this->qazBazArrayArrayOneItem = $qazBazArrayArrayOneItem;
+    }
+
+    public function getQazStringOption(): ?string
+    {
+        return $this->qazStringOption;
+    }
+
+    public function setQazStringOption(?string $qazStringOption): void
+    {
+        $this->qazStringOption = $qazStringOption;
+    }
+
+    public function getQazIntOption(): ?int
+    {
+        return $this->qazIntOption;
+    }
+
+    public function setQazIntOption(?int $qazIntOption): void
+    {
+        $this->qazIntOption = $qazIntOption;
+    }
+
+    public function getQazDateOption(): ?\DateTime
+    {
+        return $this->qazDateOption;
+    }
+
+    public function setQazDateOption(?\DateTime $qazDateOption): void
+    {
+        $this->qazDateOption = $qazDateOption;
+    }
+}
+
+class Quz
+{
+    /**
+     * @var string[]
+     */
+    private $data;
+
+    /**
+     * @param string[] $data
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 - probably should be master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | not yet

There are a few changes, that all sort of go together. I'm quite interested to see what thoughts people have about this.

The biggest change is to add a test that serializes, and then deserializes some data and checks the results are the same. It tries to cover all the potential data types. The other changes help to make this test pass.

There is a new denormalizer, that handles 'built in' data types, such as 'string', 'int'. This gives a few nice improvements
 - we can now ask the deserailizer for 'string', 'int' and 'string[]'
 - removes logic for handling 'string[]' etc from ObjectNormalizer as it can now just ask the serializer for this.

Changed Csv encoder to encode false bools as 0, instead of '', this is a BC change, because the output has changed, but seems a) more correct/useful b) makes the decoding back to bool simpler

Changed Xml and CSV decoders to return empty values as null instead of '' (empty string), again, this seems more 'correct' and produces less problems where we have a field expecting say 'int' and it gets a string assigned.

Now the only unclear case is decoding of what should be an empty string, and the builtindenormalizer handles this where it can. I do this by adding to the context if a field should be nullable, and converting null to '' for fields that are non-nullable.

There is one more, maybe more contorversial change - Currently deserializer only allows arrays with int keys, this happens because PropertyInfo always marks arrays as having int keys, but obviously php and json and yaml and have these situations, (the long story is that i was trying to deserialize packagists api which has structure `{ "packagename" : {"version": {package: name, etc... }, "version2": {...}}`). So I removed the 'key' type from PropertyInfo, and now it allows keys of both ints and strings, doesnt appear to break any tests.



 
