### PR TITLE
[Form] add more values to `false_values` of CheckboxType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * deprecated the `ChoiceLoaderInterface` implementation in `CountryType`, `LanguageType`, `LocaleType` and `CurrencyType`
  * added `input=datetime_immutable` to DateType, TimeType, DateTimeType
  * added `rounding_mode` option to MoneyType
+ * added additional values (`false`, `'false'` and `'off'`) to the default value of `false_values` from `CheckboxType`
 
 4.0.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -59,7 +59,7 @@ class CheckboxType extends AbstractType
             'value' => '1',
             'empty_data' => $emptyData,
             'compound' => false,
-            'false_values' => [null],
+            'false_values' => [null, false, 'false', 'off'],
         ]);
 
         $resolver->setAllowedTypes('false_values', 'array');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -83,15 +83,26 @@ class CheckboxTypeTest extends BaseTypeTest
         $this->assertEquals('foobar', $form->getViewData());
     }
 
-    public function testSubmitWithValueUnchecked()
+    /**
+     * @dataProvider provideSubmitWithValueUnchecked
+     */
+    public function testSubmitWithValueUnchecked($value)
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'value' => 'foobar',
         ]);
-        $form->submit(null);
+        $form->submit($value);
 
         $this->assertFalse($form->getData());
         $this->assertNull($form->getViewData());
+    }
+
+    public function provideSubmitWithValueUnchecked()
+    {
+        yield [null];
+        yield [false];
+        yield ['false'];
+        yield ['off'];
     }
 
     public function testSubmitWithEmptyValueChecked()
@@ -189,7 +200,6 @@ class CheckboxTypeTest extends BaseTypeTest
     {
         return [
             [''],
-            ['false'],
             ['0'],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | not sure
| New feature?  | not sure
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Ref: https://github.com/symfony/symfony/issues/13589

When consuming a Symfony Form through an API, like manually calling the URL with form data in the URL (e.g.: `?my_checkbox=false` or `?my_checkbox=off`), it does not work because it interpret those values as `true`.

We already encountered this _issue_ on 2/3 projects and I'm probably sure we are not the only one.
To prevent this, I think it would be nice to add more false values to the CheckboxType type.

What do you think about it?

Thanks