### PR TITLE
[Form][TwigBridge] Add row_attr to form theme

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -325,7 +325,7 @@
     {%- if help is not empty -%}
         {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
     {%- endif -%}
-    <div>
+    <div {% with {attr: row_attr|default({})} %}{{ block('attributes') }}{% endwith %}>
         {{- form_label(form) -}}
         {{- form_errors(form) -}}
         {{- form_widget(form, widget_attr) -}}
@@ -334,7 +334,7 @@
 {%- endblock form_row -%}
 
 {%- block button_row -%}
-    <div>
+    <div {% with {attr: row_attr|default({})} %}{{ block('attributes') }}{% endwith %}>
         {{- form_widget(form) -}}
     </div>
 {%- endblock button_row -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | waiting for confirmation to implement
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Currently you need to copy the whole form_row block if you just want to add a class to the form_row div. Instead we could introduce a `row_attr` which can then simple be set the following in the theme e.g.:

```twig
{% block form_row %}
    {% set row_attr = { class: 'form__field' } %}
    {{ parent() }}
{% endblock %}
```

or in php:

```
$builder->add('test', TextType::class, ['row_attr' => ['class' => 'form__field']]);
```
