### PR TITLE
[Validator] Fixed duplicate UUID

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Validator\Constraints;
  */
 class LessThanOrEqual extends AbstractComparison
 {
-    const TOO_HIGH_ERROR = '079d7420-2d13-460c-8756-de810eeb37d2';
+    const TOO_HIGH_ERROR = '30fbb013-d015-4232-8b3b-8f3be97a7e14';
 
     protected static $errorNames = [
         self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30285
| License       | MIT
| Doc PR        | N/A

Fixes the `TOO_HIGH_ERROR` constant had the same value in two different constraints: `LessThan` and `LessThanOrEqual`.
