### PR TITLE
[Monolog] Disable DebugLogger in CLI

### DIFF
--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -75,6 +75,21 @@ class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
         $this->clear();
     }
 
+    public function removeDebugLogger()
+    {
+        foreach ($this->processors as $k => $processor) {
+            if ($processor instanceof DebugLoggerInterface) {
+                unset($this->processors[$k]);
+            }
+        }
+
+        foreach ($this->handlers as $k => $handler) {
+            if ($handler instanceof DebugLoggerInterface) {
+                unset($this->handlers[$k]);
+            }
+        }
+    }
+
     /**
      * Returns a DebugLoggerInterface instance if one is registered with this logger.
      *

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddDebugLogProcessorPass.php
@@ -30,6 +30,14 @@ class AddDebugLogProcessorPass implements CompilerPassInterface
         }
 
         $definition = $container->getDefinition('monolog.logger_prototype');
+        $definition->setConfigurator([__CLASS__, 'configureLogger']);
         $definition->addMethodCall('pushProcessor', [new Reference('debug.log_processor')]);
+    }
+
+    public static function configureLogger($logger)
+    {
+        if (method_exists($logger, 'removeDebugLogger') && \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
+            $logger->removeDebugLogger();
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   |
| Fixed tickets | #30333 https://github.com/symfony/monolog-bundle/issues/165 #25876
| License       | MIT
| Doc PR        | 


<details>
<summary>Considering this code:</summary>

```php
namespace App\Command;

use Psr\Log\LoggerInterface;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class LeakCommand extends Command
{
    protected static $defaultName = 'leak';

    private $logger;

    public function __construct(LoggerInterface $logger)
    {
        $this->logger = $logger;

        parent::__construct();
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $reportedAt = time();
        while (true) {
            $this->logger->info('Hello');

            if (time() - $reportedAt >= 1) {
                $output->writeln(sprintf('%dMb', memory_get_usage() / 1024 / 1024));
                $reportedAt = time();
            }
        }
    }
}
```

</details>

Without the patch
```
>…/dev/labs/symfony/website-skeleton(monolog %) bin/console leak
7Mb
28Mb
51Mb
76Mb
97Mb
````


With the patch 
```
>…/dev/labs/symfony/website-skeleton(monolog %) bin/console leak
6Mb
6Mb
6Mb
6Mb
```