### PR TITLE
improve $this->projectDir empty check

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
@@ -96,7 +96,7 @@ final class SourceContextProvider implements ContextProviderInterface
         $context = ['name' => $name, 'file' => $file, 'line' => $line];
         $context['file_excerpt'] = $fileExcerpt;
 
-        if (null !== $this->projectDir) {
+        if (null !== $this->projectDir && strlen($this->projectDir) > 0) {
             $context['project_dir'] = $this->projectDir;
             if (0 === strpos($file, $this->projectDir)) {
                 $context['file_relative'] = ltrim(substr($file, \strlen($this->projectDir)), \DIRECTORY_SEPARATOR);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4 up to 4.2 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | dunno    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | Unlicense
| Doc PR        | N/A <!-- required for new features -->

if projectDir is set to an empty string (instead of  NULL), you risk getting this exception:

`strpos(): Empty needle {"exception":"[object] (ErrorException(code: 0): strpos(): Empty needle at /vendor/symfony/var-dumper/Dumper/ContextProvider/SourceContextProvider.php:101)`

issue was noticed at https://stackoverflow.com/questions/54823993/laravel-dd-helper-function-returns-error-500/54824410#

