### PR TITLE
[Security] Change FormAuthenticator if condition

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -107,7 +107,7 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
             $password = ParameterBagUtils::getRequestParameterValue($request, $this->options['password_parameter']);
         }
 
-        if (!\is_string($username) || (\is_object($username) && !\method_exists($username, '__toString'))) {
+        if (!\is_string($username) && (!\is_object($username) || !\method_exists($username, '__toString'))) {
             throw new BadRequestHttpException(sprintf('The key "%s" must be a string, "%s" given.', $this->options['username_parameter'], \gettype($username)));
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -85,7 +85,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
             $password = ParameterBagUtils::getRequestParameterValue($request, $this->options['password_parameter']);
         }
 
-        if (!\is_string($username) || (\is_object($username) && !\method_exists($username, '__toString'))) {
+        if (!\is_string($username) && (!\is_object($username) || !\method_exists($username, '__toString'))) {
             throw new BadRequestHttpException(sprintf('The key "%s" must be a string, "%s" given.', $this->options['username_parameter'], \gettype($username)));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30341
| License       | MIT
| Doc PR        | -

I changed the if condition in `SimpleFormAuthenticationListener` and `UsernamePasswordFormAuthenticationListener` based on the solution provided by @nikic in issue #30341 

#OpenSourceFriday