### PR TITLE
[VarDumper] Keep a ref to objects to ensure their handle cannot be reused while cloning

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -33,6 +33,7 @@ class VarCloner extends AbstractCloner
         $indexedArrays = [];       // Map of queue indexes that hold numerically indexed arrays
         $hardRefs = [];            // Map of original zval hashes to stub objects
         $objRefs = [];             // Map of original object handles to their stub object counterpart
+        $objects = [];             // Keep a ref to objects to ensure their handle cannot be reused while cloning
         $resRefs = [];             // Map of original resource handles to their stub object counterpart
         $values = [];              // Map of stub objects' hashes to original values
         $maxItems = $this->maxItems;
@@ -200,6 +201,7 @@ class VarCloner extends AbstractCloner
                         }
                         if (empty($objRefs[$h])) {
                             $objRefs[$h] = $stub;
+                            $objects[] = $v;
                         } else {
                             $stub = $objRefs[$h];
                             ++$stub->refCount;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fixes the root issue that led to https://github.com/symfony/symfony/pull/30311#issuecomment-466457434