### PR TITLE
[Console] handles multi-byte characters in autocomplete

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -308,6 +308,10 @@ class QuestionHelper extends Helper
 
                 continue;
             } else {
+                if ("\x80" <= $c) {
+                    $c .= fread($inputStream, ["\xC0" => 1, "\xD0" => 1, "\xE0" => 2, "\xF0" => 3][$c & "\xF0"]);
+                }
+
                 $output->write($c);
                 $ret .= $c;
                 ++$i;

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -237,6 +237,43 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $this->assertSame('b', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
     }
 
+    public function getInputs()
+    {
+        return [
+            ['$'], // 1 byte character
+            ['¢'], // 2 bytes character
+            ['€'], // 3 bytes character
+            ['𐍈'], // 4 bytes character
+        ];
+    }
+
+    /**
+     * @dataProvider getInputs
+     */
+    public function testAskWithAutocompleteWithMultiByteCharacter($character)
+    {
+        if (!$this->hasSttyAvailable()) {
+            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+        }
+
+        $inputStream = $this->getInputStream("$character\n");
+
+        $possibleChoices = [
+            '$' => '1 byte character',
+            '¢' => '2 bytes character',
+            '€' => '3 bytes character',
+            '𐍈' => '4 bytes character',
+        ];
+
+        $dialog = new QuestionHelper();
+        $dialog->setHelperSet(new HelperSet([new FormatterHelper()]));
+
+        $question = new ChoiceQuestion('Please select a character', $possibleChoices);
+        $question->setMaxAttempts(1);
+
+        $this->assertSame($character, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+    }
+
     public function testAutocompleteWithTrailingBackslash()
     {
         if (!$this->hasSttyAvailable()) {


### PR DESCRIPTION
fixes #29966 

| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29966   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

I used the `mb_ord` to detect whether the amount of bytes read is valid before proceeding.  I limit the number of bytes read to 4 before giving up because characters can use at most 4 bytes.
The test passes with or without the fix though.