### PR TITLE
[Translations] added missing Croatian validators

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
@@ -318,6 +318,22 @@
                 <source>Error</source>
                 <target>Greška</target>
             </trans-unit>
+            <trans-unit id="83">
+                <source>This is not a valid UUID.</source>
+                <target>Ovo nije validan UUID.</target>
+            </trans-unit>
+            <trans-unit id="84">
+                <source>This value should be a multiple of {{ compared_value }}.</source>
+                <target>Ova vrijednost treba biti višekratnik od {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="85">
+                <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
+                <target>Poslovni identifikacijski broj (BIC) nije povezan sa IBAN brojem {{ iban }}.</target>
+            </trans-unit>
+            <trans-unit id="86">
+                <source>This value should be valid JSON.</source>
+                <target>Ova vrijednost treba biti validan JSON.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 up to 4.2 for bug fixes 
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no   
| Deprecations? | no 
| Tests pass?   | yes  
| Fixed tickets | #30167  
| License       | MIT

[Validator] Add the missing translations for the Croatian ("hr") locale #30167