### PR TITLE
[TwigBridge] rename parent_form() to form_parent()

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 4.3.0
 -----
 
- * added the `parent_form()` function that allows to reliably retrieve the parent form in Twig templates
+ * added the `form_parent()` function that allows to reliably retrieve the parent form in Twig templates
 
 4.2.0
 -----

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -54,7 +54,7 @@ class FormExtension extends AbstractExtension
             new TwigFunction('form_start', null, ['node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => ['html']]),
             new TwigFunction('form_end', null, ['node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => ['html']]),
             new TwigFunction('csrf_token', ['Symfony\Component\Form\FormRenderer', 'renderCsrfToken']),
-            new TwigFunction('parent_form', 'Symfony\Bridge\Twig\Extension\twig_get_parent_form'),
+            new TwigFunction('form_parent', 'Symfony\Bridge\Twig\Extension\twig_get_form_parent'),
         ];
     }
 
@@ -120,7 +120,7 @@ function twig_is_root_form(FormView $formView)
 /**
  * @internal
  */
-function twig_get_parent_form(FormView $formView): ?FormView
+function twig_get_form_parent(FormView $formView): ?FormView
 {
     return $formView->parent;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#11049

We got some feedback on the blog post that form_parent() would be better
for consistency with all the existing form_*() functions. I think that
user has a point about that.
