### PR TITLE
[Form] be able to specify the input format for times

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -38,7 +38,8 @@ CHANGELOG
        }
    }
    ```
- * added new option `input_format` to `DateType` and `DateTimeType` to specify the date format when using the `string` input.
+ * added the `input_format` option to `DateType`, `DateTimeType`, and `TimeType` to specify the input format when setting
+   the `input` option to `string`
 
 4.2.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -164,7 +164,7 @@ class TimeType extends AbstractType
             $builder->addModelTransformer(new DateTimeImmutableToDateTimeTransformer());
         } elseif ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'H:i:s')
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], $options['input_format'])
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
@@ -257,6 +257,7 @@ class TimeType extends AbstractType
             'seconds' => range(0, 59),
             'widget' => 'choice',
             'input' => 'datetime',
+            'input_format' => 'H:i:s',
             'with_minutes' => true,
             'with_seconds' => false,
             'model_timezone' => null,
@@ -298,6 +299,7 @@ class TimeType extends AbstractType
         $resolver->setAllowedTypes('hours', 'array');
         $resolver->setAllowedTypes('minutes', 'array');
         $resolver->setAllowedTypes('seconds', 'array');
+        $resolver->setAllowedTypes('input_format', 'string');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -80,6 +80,22 @@ class TimeTypeTest extends BaseTypeTest
         $this->assertEquals($input, $form->getViewData());
     }
 
+    public function testSubmitStringWithCustomFormat()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, '11:33', [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'string',
+            'input_format' => 'H:i',
+        ]);
+
+        $form->submit('03:24');
+
+        $this->assertEquals('03:24', $form->getData());
+        $this->assertEquals('03:24', $form->getViewData());
+    }
+
     public function testSubmitTimestamp()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#10882

This expands the work started in #29887 to also allow to configure the input format for string inputs in the `TimeType`.