### PR TITLE
[PropertyInfo] Fix undefined variable fromConstructor when passing context to getTypes

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -112,7 +112,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
 
         if (
-            $context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction &&
+            ($context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction) &&
             $fromConstructor = $this->extractFromConstructor($class, $property)
         ) {
             return $fromConstructor;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -293,4 +293,29 @@ class ReflectionExtractorTest extends TestCase
             [NotInstantiable::class, 'foo', false],
         ];
     }
+
+    /**
+     * @dataProvider constructorTypesProvider
+     */
+    public function testExtractTypeConstructor(string $class, string $property, array $type = null)
+    {
+        /* Check that constructor extractions works by default, and if passed in via context.
+           Check that null is returned if constructor extraction is disabled */
+        $this->assertEquals($type, $this->extractor->getTypes($class, $property, []));
+        $this->assertEquals($type, $this->extractor->getTypes($class, $property, ['enable_constructor_extraction' => true]));
+        $this->assertNull($this->extractor->getTypes($class, $property, ['enable_constructor_extraction' => false]));
+    }
+
+    public function constructorTypesProvider(): array
+    {
+        return [
+            // php71 dummy has following constructor: __construct(string $string, int $intPrivate)
+            [Php71Dummy::class, 'string', [new Type(Type::BUILTIN_TYPE_STRING, false)]],
+            [Php71Dummy::class, 'intPrivate', [new Type(Type::BUILTIN_TYPE_INT, false)]],
+            // Php71DummyExtended2 adds int $intWithAccessor
+            [Php71DummyExtended2::class, 'intWithAccessor', [new Type(Type::BUILTIN_TYPE_INT, false)]],
+            [Php71DummyExtended2::class, 'intPrivate', [new Type(Type::BUILTIN_TYPE_INT, false)]],
+            [DefaultValue::class, 'foo', null],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1, 4.2, master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | symfony/symfony-docs#10969
| License       | MIT
| Doc PR        | 

If passing context to getTypes, it checks value of $context['enable_constructor_extraction'] for true/false or the constructor value of enableConstructorExtraction and should then populate fromConstructor if necessary. The missing brackets around the first part of this check mean that fromConstructor is only applied if context is not set.

This fixes the issue described at [symfony/symfony-docs#10969](https://github.com/symfony/symfony-docs/pull/10969)