### PR TITLE
Fixed the DebugClassLoader compatibility with eval()'d code on Darwin

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -390,6 +390,11 @@ class DebugClassLoader
 
         $dirFiles = self::$darwinCache[$kDir][1];
 
+        if (!isset($dirFiles[$file]) && ') : eval()\'d code' === substr($file, -17)) {
+            // Get the file name from "file_name.php(123) : eval()'d code"
+            $file = substr($file, 0, strrpos($file, '(', -17));
+        }
+
         if (isset($dirFiles[$file])) {
             return $real .= $dirFiles[$file];
         }

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -385,6 +385,11 @@ class DebugClassLoaderTest extends TestCase
 
         $this->assertSame([], $deprecations);
     }
+
+    public function testEvaluatedCode()
+    {
+        $this->assertTrue(class_exists(__NAMESPACE__.'\Fixtures\DefinitionInEvaluatedCode', true));
+    }
 }
 
 class ClassLoader

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DefinitionInEvaluatedCode.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DefinitionInEvaluatedCode.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+eval('
+    namespace Symfony\Component\Debug\Tests\Fixtures;
+
+    class DefinitionInEvaluatedCode
+    {
+    }
+');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30362
| License       | MIT

When a class is defined in an `eval()` block, the reported file name is `file_name.php(123) : eval()'d code`, which prevents `DebugClassLoader::darwinRealpath()` from locating/normalizing the file name, and triggers a notice.