### PR TITLE
[VarDumper] Add function dumpif to dump vars conditionally

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `DsCaster` to support dumping the contents of data structures from the Ds extension
+ * added `dumpif` function to dump vars conditionally
 
 4.2.0
 -----

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -31,6 +31,26 @@ if (!function_exists('dump')) {
     }
 }
 
+if (!function_exists('dumpif')) {
+    /**
+     * @author Tales Santos <tales.augusto.santos@gmail.com>
+     */
+    function dumpif($var, ...$moreVars)
+    {
+        $condition = array_pop($moreVars);
+
+        if (!is_callable($condition)) {
+            throw new \InvalidArgumentException('You should provide a condition in order to dump $var');
+        }
+
+        if (true !== call_user_func($condition)) {
+            return $var;
+        }
+
+        return dump($var, $moreVars);
+    }
+}
+
 if (!function_exists('dd')) {
     function dd(...$vars)
     {

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
@@ -87,7 +87,6 @@ class FunctionsTest extends TestCase
         $var2 = 'b';
 
         dumpif($var1, $var2);
-
     }
 
     protected function setupVarDumper()

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
@@ -46,6 +46,50 @@ class FunctionsTest extends TestCase
         $this->assertEquals([$var1, $var2, $var3], $return);
     }
 
+    public function testDumpConditionallyShouldTriggerTheDumper()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+
+        ob_start();
+        dumpif($var1, function () {
+            return true;
+        });
+        $out = ob_get_clean();
+
+        $this->assertNotEmpty($out);
+    }
+
+    public function testDumpConditionallyShouldNotTriggerTheDumper()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+
+        ob_start();
+        dumpif($var1, function () {
+            return false;
+        });
+        $out = ob_get_clean();
+
+        $this->assertEmpty($out);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testDumpConditionallyWithoutCallableShouldThrowException()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+        $var2 = 'b';
+
+        dumpif($var1, $var2);
+
+    }
+
     protected function setupVarDumper()
     {
         $cloner = new VarCloner();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | to be written if this PR is accepted

This is a simple feature to allow users to dump vars conditionally. A code like this:

```php
foreach ($collection as $item) {
    if ($item === 'b') {
        dump($item);
    }
}
```

Can be rewrite by this:

```php
foreach ($collection as $item) {
    dumpif($item, function () use ($item) {
        return $item === 'b';
    });
}
```

`dumpif` has the same behavior of `dump` function, so you can add more vars as well:

```php
foreach ($collection as $item) {
    dumpif($var1, $var2, $var3, function () use ($item) {
        return $item === 'b';
    });
}
```