### PR TITLE
[OptionsResolver] Add a new method addNormalizer and normalization hierarchy

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added `OptionsResolver::addNormalizer` method
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/OptionsResolver/Debug/OptionsResolverIntrospector.php
+++ b/src/Symfony/Component/OptionsResolver/Debug/OptionsResolverIntrospector.php
@@ -85,6 +85,14 @@ class OptionsResolverIntrospector
      */
     public function getNormalizer(string $option): \Closure
     {
+        return current($this->getNormalizers($option));
+    }
+
+    /**
+     * @throws NoConfigurationException when no normalizer is configured
+     */
+    public function getNormalizers(string $option): array
+    {
         return ($this->get)('normalizers', $option, sprintf('No normalizer was set for the "%s" option.', $option));
     }
 

--- a/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
@@ -201,6 +201,42 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame('bar', $debug->getNormalizer('foo'));
     }
 
+    public function testGetNormalizers()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('foo');
+        $resolver->addNormalizer('foo', $normalizer1 = function () {});
+        $resolver->addNormalizer('foo', $normalizer2 = function () {});
+
+        $debug = new OptionsResolverIntrospector($resolver);
+        $this->assertSame([$normalizer1, $normalizer2], $debug->getNormalizers('foo'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\NoConfigurationException
+     * @expectedExceptionMessage No normalizer was set for the "foo" option.
+     */
+    public function testGetNormalizersThrowsOnNoConfiguredValue()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('foo');
+
+        $debug = new OptionsResolverIntrospector($resolver);
+        $debug->getNormalizers('foo');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
+     * @expectedExceptionMessage The option "foo" does not exist.
+     */
+    public function testGetNormalizersThrowsOnNotDefinedOption()
+    {
+        $resolver = new OptionsResolver();
+
+        $debug = new OptionsResolverIntrospector($resolver);
+        $debug->getNormalizers('foo');
+    }
+
     public function testGetDeprecationMessage()
     {
         $resolver = new OptionsResolver();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30310
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11103


### 3rd-party package

<details><summary>Given: (CLICK ME)</summary>
<p>

Generic type:
```php
class FooType extends AbstractType
{
    private $registry;

    public function __construct(ManagerRegistry $registry)
    {
        $this->registry = $registry;
    }

    // buildForm ...

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setRequired('class');
        $resolver->setDefaults([
            'em' => null,
            'query' => null,
        ]);
        $resolver->setAllowedTypes('em', ['null', 'string']);
        $resolver->setAllowedTypes('query', ['null', 'callable']);

        $resolver->setNormalizer('em', function (Options $options, $em) {
            if (null !== $em) {
                return $this->registry->getManager($em);
            }

            return $this->registry->getManagerForClass($options['class']);
        });

        $resolver->setNormalizer('query', function (Options $options, $query) {
            if (\is_callable($query)) {
                $query = $query($options['em']->getRepository($options['class']));

                if (!$query instanceof Query) {
                    throw new UnexpectedTypeException($query, 'Doctrine\ORM\Query');
                }
            }

            return $query;
        });
    }
}
```
</p>
</details>

### App context

<details><summary>Before (CLICK ME)</summary>
<p>

Normalizing the new allowed value will require to override the parent's normalizer:
```php
class BarType extends AbstractType
{
    private $registry;

    public function __construct(ManagerRegistry $registry)
    {
        $this->registry = $registry;
    }

    // buildForm ...

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->addAllowedTypes('em', 'Doctrine\ORM\EntityManagerInterface');

        $resolver->setNormalizer('em', function (Options $options, $em) {
            if ($em instanceof EntityManagerInterface) {
                return $em;
            }

            if (null !== $em) {
                return $this->registry->getManager($em);
            }

            return $this->registry->getManagerForClass($options['class']);
        });

        $resolver->addAllowedTypes('query', 'string');

        $resolver->setNormalizer('query', function (Options $options, $query) {
            if (\is_callable($query)) {
                $query = $query($options['em']->getRepository($options['class']));

                if (!$query instanceof Query) {
                    throw new UnexpectedTypeException($query, 'Doctrine\ORM\Query');
                }
            }

            if (\is_string($query)) {
                $query = $options['em']->createQuery($query);
            }

            return $query;
        });
    }

    public function getParent()
    {
        return FooType::class;
    }
}
```
</p>
</details>

<details><summary>After (CLICK ME)</summary>
<p>

The new normalizer is added to the stack and it'll receive the previously normalized value or if `forcePrepend = true` the validated value:
```php
class BarType extends AbstractType
{
    // buildForm ...

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->addAllowedTypes('em', 'Doctrine\ORM\EntityManagerInterface');

        $resolver->addNormalizer('em', function (Options $options, $em) {
            if ($em instanceof EntityManagerInterface) {
                return $em;
            }

            return $em;
        }, true); // $forcePrepend = true (3rd argument)

        $resolver->addAllowedTypes('query', 'string');

        $resolver->addNormalizer('query', function (Options $options, $query) {
            if (\is_string($query)) {
                $query = $options['em']->createQuery($query);
            }

            return $query;
        });
    }

    public function getParent()
    {
        return FooType::class;
    }
}
```
</p>
</details>
