### PR TITLE
[Messenger] Added transport agnostic exception

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -50,6 +50,11 @@ HttpFoundation
  * The `FileinfoMimeTypeGuesser` class has been deprecated,
    use `Symfony\Component\Mime\FileinfoMimeTypeGuesser` instead.
 
+Messenger
+---------
+
+ * `Amqp` transport does not throw `\AMQPException` anymore, catch `TransportException` instead.
+
 Routing
 -------
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
 
  * Added `TransportException` to mark an exception transport-related
 
- * [BC BREAK] If listening to exceptions while using `AmqpSender`, `\AMQPException` is
+ * [BC BREAK] If listening to exceptions while using `AmqpSender` or `AmqpReceiver`, `\AMQPException` is
    no longer thrown in favor of `TransportException`.
 
 4.2.0

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -11,6 +11,11 @@ CHANGELOG
    changed from `Serializer` to `PhpSerializer` inside `AmqpReceiver`,
    `AmqpSender`, `AmqpTransport` and `AmqpTransportFactory`.
 
+ * Added `TransportException` to mark an exception transport-related
+
+ * [BC BREAK] If listening to exceptions while using `AmqpSender`, `\AMQPException` is
+   no longer thrown in favor of `TransportException`.
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Messenger/Exception/TransportException.php
+++ b/src/Symfony/Component/Messenger/Exception/TransportException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * @author Eric Masoero <em@studeal.fr>
+ *
+ * @experimental in 4.2
+ */
+class TransportException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpSenderTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpSenderTest.php
@@ -39,7 +39,7 @@ class AmqpSenderTest extends TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Messenger\Exception\TransportException
+     * @expectedException \Symfony\Component\Messenger\Exception\TransportException
      */
     public function testItThrowsATransportExceptionIfItCannotSendTheMessage()
     {

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpSenderTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpSenderTest.php
@@ -37,4 +37,22 @@ class AmqpSenderTest extends TestCase
         $sender = new AmqpSender($connection, $serializer);
         $sender->send($envelope);
     }
+
+    /**
+     * @expectedException Symfony\Component\Messenger\Exception\TransportException
+     */
+    public function testItThrowsATransportExceptionIfItCannotSendTheMessage()
+    {
+        $envelope = new Envelope(new DummyMessage('Oy'));
+        $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
+
+        $serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
+        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+
+        $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $connection->method('publish')->with($encoded['body'], $encoded['headers'])->willThrowException(new \AMQPException());
+
+        $sender = new AmqpSender($connection, $serializer);
+        $sender->send($envelope);
+    }
 }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\AmqpExt\Exception\RejectMessageExceptionInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
@@ -61,11 +62,21 @@ class AmqpReceiver implements ReceiverInterface
 
                 $this->connection->ack($AMQPEnvelope);
             } catch (RejectMessageExceptionInterface $e) {
-                $this->connection->reject($AMQPEnvelope);
+                try {
+                    $this->connection->reject($AMQPEnvelope);
+                } catch (\AMQPException $exception) {
+                    throw new TransportException($exception->getMessage(), 0, $exception);
+                }
 
                 throw $e;
+            } catch (\AMQPException $e) {
+                throw new TransportException($e->getMessage(), 0, $e);
             } catch (\Throwable $e) {
-                $this->connection->nack($AMQPEnvelope, AMQP_REQUEUE);
+                try {
+                    $this->connection->nack($AMQPEnvelope, AMQP_REQUEUE);
+                } catch (\AMQPException $exception) {
+                    throw new TransportException($exception->getMessage(), 0, $exception);
+                }
 
                 throw $e;
             } finally {

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -45,7 +45,7 @@ class AmqpSender implements SenderInterface
         try {
             $this->connection->publish($encodedMessage['body'], $encodedMessage['headers']);
         } catch (\AMQPException $e) {
-            throw new TransportException('Current transport was not able to send given message, please try again');
+            throw new TransportException('Current transport was not able to send given message, please try again', 0, $e);
         }
 
         return $envelope;

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -45,7 +45,7 @@ class AmqpSender implements SenderInterface
         try {
             $this->connection->publish($encodedMessage['body'], $encodedMessage['headers']);
         } catch (\AMQPException $e) {
-            throw new TransportException('Current transport was not able to send given message, please try again', 0, $e);
+            throw new TransportException($e->getMessage(), 0, $e);
         }
 
         return $envelope;

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -41,7 +42,11 @@ class AmqpSender implements SenderInterface
     {
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $this->connection->publish($encodedMessage['body'], $encodedMessage['headers']);
+        try {
+            $this->connection->publish($encodedMessage['body'], $encodedMessage['headers']);
+        } catch (\AMQPException $e) {
+            throw new TransportException('Current transport was not able to send given message, please try again');
+        }
 
         return $envelope;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30346 
| License       | MIT
| Doc PR        | TODO

As described in #30346, client code shouldn't care about which transport is currently used by the message bus. This pr adds a new generic exception that is thrown by the `AmqpSender` if the message couldn't be delivered.
