### PR TITLE
[WebProfilerBundle] Fix row update on finish ajax request

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -212,11 +212,11 @@
             pendingRequests--;
             var row = request.DOMNode;
             /* Unpack the children from the row */
-            var profilerCell = row.children[0];
-            var methodCell = row.children[1];
-            var statusCodeCell = row.children[3];
+            var profilerCell = row.children[1];
+            var methodCell = row.children[2];
+            var statusCodeCell = row.children[4];
             var statusCodeElem = statusCodeCell.children[0];
-            var durationCell = row.children[5];
+            var durationCell = row.children[6];
 
             if (request.error) {
                 row.className = 'sf-ajax-request sf-ajax-request-error';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

```
Uncaught TypeError: Cannot read property 'setAttribute' of undefined
    at finishAjaxRequest
    at XMLHttpRequest.<anonymous>
```

Continuation of https://github.com/symfony/symfony/pull/30130
