### PR TITLE
[DX] Fix PHPDoc of Container*::set

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -517,8 +517,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Sets a service.
      *
-     * @param string $id      The service identifier
-     * @param object $service The service instance
+     * @param string          $id      The service identifier
+     * @param object|callable $service The service instance
      *
      * @throws BadMethodCallException When this ContainerBuilder is compiled
      */

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -32,8 +32,8 @@ interface ContainerInterface extends PsrContainerInterface
     /**
      * Sets a service.
      *
-     * @param string $id      The service identifier
-     * @param object $service The service instance
+     * @param string          $id      The service identifier
+     * @param object|callable $service The service instance
      */
     public function set($id, $service);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT

I've discovered this inconsistency while writing a redistributable bundle, and using PHPStan. It's possible to use a callable as a service in the DI container, but the `set` method doesn't report this correctly.