### PR TITLE
[WebProfilerBundle] toolbar: invisible route name in Firefox

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -103,6 +103,7 @@
 .sf-toolbar-block > a:hover {
     display: block;
     text-decoration: none;
+    color: inherit;
 }
 
 .sf-toolbar-block span {
@@ -514,7 +515,7 @@ div.sf-toolbar .sf-toolbar-block a:hover {
 @media (min-width: 1024px) {
     .sf-toolbar-block .sf-toolbar-info-piece-additional,
     .sf-toolbar-block .sf-toolbar-info-piece-additional-detail {
-        display: inline-block;
+        display: inline;
     }
 
     .sf-toolbar-block .sf-toolbar-info-piece-additional:empty,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29858
| License       | MIT
| Doc PR        | -

This fixes #29858, fixing a bug that prevents Route name displaying in debug toolbar on Firefox
