### PR TITLE
[FrameworkBundle] Fix UrlGenerator::generate to return an empty string instead of null

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -37,6 +37,7 @@ FrameworkBundle
  * Not passing the project directory to the constructor of the `AssetsInstallCommand` is deprecated. This argument will
    be mandatory in 5.0.
  * Deprecated the "Psr\SimpleCache\CacheInterface" / "cache.app.simple" service, use "Symfony\Contracts\Cache\CacheInterface" / "cache.app" instead.
+ * The `generate()` method of the `UrlGenerator` class can return an empty string instead of null.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Component/Routing/Generator/ConfigurableRequirementsInterface.php
+++ b/src/Symfony/Component/Routing/Generator/ConfigurableRequirementsInterface.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Routing\Generator;
  * The possible configurations and use-cases:
  * - setStrictRequirements(true): Throw an exception for mismatching requirements. This
  *   is mostly useful in development environment.
- * - setStrictRequirements(false): Don't throw an exception but return null as URL for
+ * - setStrictRequirements(false): Don't throw an exception but return an empty string as URL for
  *   mismatching requirements and log the problem. Useful when you cannot control all
  *   params because they come from third party libs but don't want to have a 404 in
  *   production environment. It should log the mismatch so one can review it.

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -171,7 +171,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                             $this->logger->error($message, ['parameter' => $varName, 'route' => $name, 'expected' => $token[2], 'given' => $mergedParams[$varName]]);
                         }
 
-                        return;
+                        return '';
                     }
 
                     $url = $token[1].$mergedParams[$varName].$url;
@@ -226,7 +226,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                             $this->logger->error($message, ['parameter' => $token[3], 'route' => $name, 'expected' => $token[2], 'given' => $mergedParams[$token[3]]]);
                         }
 
-                        return;
+                        return '';
                     }
 
                     $routeHost = $token[1].$mergedParams[$token[3]].$routeHost;

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -203,7 +203,7 @@ class UrlGeneratorTest extends TestCase
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', ['foo' => '1'], ['foo' => 'd+']));
         $generator = $this->getGenerator($routes);
         $generator->setStrictRequirements(false);
-        $this->assertNull($generator->generate('test', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_URL));
+        $this->assertSame('', $generator->generate('test', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     public function testGenerateForRouteWithInvalidOptionalParameterNonStrictWithLogger()
@@ -214,7 +214,7 @@ class UrlGeneratorTest extends TestCase
             ->method('error');
         $generator = $this->getGenerator($routes, [], $logger);
         $generator->setStrictRequirements(false);
-        $this->assertNull($generator->generate('test', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_URL));
+        $this->assertSame('', $generator->generate('test', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     public function testGenerateForRouteWithInvalidParameterButDisabledRequirementsCheck()
@@ -489,7 +489,7 @@ class UrlGeneratorTest extends TestCase
         $routes = $this->getRoutes('test', new Route('/', [], ['foo' => 'bar'], [], '{foo}.example.com'));
         $generator = $this->getGenerator($routes);
         $generator->setStrictRequirements(false);
-        $this->assertNull($generator->generate('test', ['foo' => 'baz'], UrlGeneratorInterface::ABSOLUTE_PATH));
+        $this->assertSame('', $generator->generate('test', ['foo' => 'baz'], UrlGeneratorInterface::ABSOLUTE_PATH));
     }
 
     public function testHostIsCaseInsensitive()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30306
| License       | MIT

Fix #30306 : Controller::generateUrl() must be of the type string, null returned
