### PR TITLE
[PropertyAccess] Fixed PropertyPathBuilder remove that fails to reset internal indexes

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -257,9 +257,8 @@ class PropertyPathBuilder
             }
 
             // All remaining elements should be removed
-            for (; $i < $length; ++$i) {
-                unset($this->elements[$i], $this->isIndex[$i]);
-            }
+            $this->elements = \array_slice($this->elements, 0, $i);
+            $this->isIndex = \array_slice($this->isIndex, 0, $i);
         } else {
             $diff = $insertionLength - $cutLength;
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
@@ -285,4 +285,25 @@ class PropertyPathBuilderTest extends TestCase
     {
         $this->builder->remove(-1);
     }
+
+    public function testRemoveAndAppendAtTheEnd()
+    {
+        $this->builder->remove($this->builder->getLength() - 1);
+
+        $path = new PropertyPath('old1[old2].old3[old4][old5]');
+
+        $this->assertEquals($path, $this->builder->getPropertyPath());
+
+        $this->builder->appendProperty('old7');
+
+        $path = new PropertyPath('old1[old2].old3[old4][old5].old7');
+
+        $this->assertEquals($path, $this->builder->getPropertyPath());
+
+        $this->builder->remove($this->builder->getLength() - 1);
+
+        $path = new PropertyPath('old1[old2].old3[old4][old5]');
+
+        $this->assertEquals($path, $this->builder->getPropertyPath());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30389
| License       | MIT
| Doc PR        | -

In addition to the fix (first commit), this PR adds \ to all not-yet-prefixed native functions in the PropertyPathBuilder (second commit).

NB: the behavior fixed here actually appeared in 2.2