### PR TITLE
[Form] Avoid a form type extension appears many times in debug:form

### DIFF
--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -102,9 +102,9 @@ class FormPass implements CompilerPassInterface
             } elseif (method_exists($serviceDefinition->getClass(), 'getExtendedTypes')) {
                 $extendsTypes = false;
 
+                $typeExtensionsClasses[] = $serviceDefinition->getClass();
                 foreach ($serviceDefinition->getClass()::getExtendedTypes() as $extendedType) {
                     $typeExtensions[$extendedType][] = new Reference($serviceId);
-                    $typeExtensionsClasses[] = $serviceDefinition->getClass();
                     $extendsTypes = true;
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | #30394    <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This PR fixes #30394. Avoid a form type extension appears many times in debug:form command. This is caused by new 4.2 feature getExtendedTypes().
