### PR TITLE
Serializer: Use the context in supports calls

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -223,7 +223,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
 
                 if (!$normalizer instanceof CacheableSupportsMethodInterface || !$normalizer->hasCacheableSupportsMethod()) {
                     $this->normalizerCache[$format][$type][$k] = false;
-                } elseif ($normalizer->supportsNormalization($data, $format)) {
+                } elseif ($normalizer->supportsNormalization($data, $format, $context)) {
                     $this->normalizerCache[$format][$type][$k] = true;
                     break;
                 }
@@ -264,7 +264,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
 
                 if (!$normalizer instanceof CacheableSupportsMethodInterface || !$normalizer->hasCacheableSupportsMethod()) {
                     $this->denormalizerCache[$format][$class][$k] = false;
-                } elseif ($normalizer->supportsDenormalization(null, $class, $format)) {
+                } elseif ($normalizer->supportsDenormalization(null, $class, $format, $context)) {
                     $this->denormalizerCache[$format][$class][$k] = true;
                     break;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 (4.0 has the correct call)
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

In both of these calls, `$context` was missing. It was available in 3.4 when @dunglas introduced the `ContextAware(De)NormalizerInterface`. My guess is that we missed this when reviewing the Cache thingy that was added recently (4.1).
