### PR TITLE
[Security/Http] Make UserValueResolver accept any subtype of UserInterface

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/SecurityUserValueResolver.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityUserValueResolver.php
@@ -40,7 +40,8 @@ final class SecurityUserValueResolver implements ArgumentValueResolverInterface
     public function supports(Request $request, ArgumentMetadata $argument)
     {
         // only security user implementations are supported
-        if (UserInterface::class !== $argument->getType()) {
+        $type = $argument->getType();
+        if (UserInterface::class !== $type && !is_subclass_of($type, UserInterface::class)) {
             return false;
         }
 

--- a/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
@@ -35,7 +35,8 @@ final class UserValueResolver implements ArgumentValueResolverInterface
     public function supports(Request $request, ArgumentMetadata $argument)
     {
         // only security user implementations are supported
-        if (UserInterface::class !== $argument->getType()) {
+        $type = $argument->getType();
+        if (UserInterface::class !== $type && !is_subclass_of($type, UserInterface::class)) {
             return false;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
@@ -64,6 +63,20 @@ class UserValueResolverTest extends TestCase
 
         $resolver = new UserValueResolver($tokenStorage);
         $metadata = new ArgumentMetadata('foo', UserInterface::class, false, false, null);
+
+        $this->assertTrue($resolver->supports(Request::create('/'), $metadata));
+        $this->assertSame([$user], iterator_to_array($resolver->resolve(Request::create('/'), $metadata)));
+    }
+
+    public function testResolveWithSubclass()
+    {
+        $user = $this->getMockForAbstractClass(DummySubUser::class);
+        $token = new UsernamePasswordToken($user, 'password', 'provider');
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($token);
+
+        $resolver = new UserValueResolver($tokenStorage);
+        $metadata = new ArgumentMetadata('foo', DummySubUser::class, false, false, null);
 
         $this->assertTrue($resolver->supports(Request::create('/'), $metadata));
         $this->assertSame([$user], iterator_to_array($resolver->resolve(Request::create('/'), $metadata)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master/4.3
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no (not sure)
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

With a controller we can inject the `UserInterface` object like this:

```php
public function index(Request $request, UserInterface $user = null): Response
{
    // ...
}
```

However, this has a drawback: it hides the _domain_ user for actions that need the right type-hint, else, it means we're "blind", which means that we must add `if ($user instanceof MyUserObject) { /* ... */}` to execute our logic.

The goal of this PR is to allow this:

```php
use App\Entity\User;
// ...
public function index(Request $request, User $user = null): Response
{
    // ...
}
```

This is just a basic suggestion that is quite straightforward (so if it's not suitable, feel free to tell me, if you know the component better than me 👍 )!

If it's not possible, I also thought about creating a `SecurityTokenValueResolver`, also probably straightforward 👍 (will probably work on a separate PR for this)