### PR TITLE
[Routing][UrlGenerator] set defaultLocale to 'en' instead of null

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -67,7 +67,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         '%7C' => '|',
     ];
 
-    public function __construct(RouteCollection $routes, RequestContext $context, LoggerInterface $logger = null, string $defaultLocale = null)
+    public function __construct(RouteCollection $routes, RequestContext $context, LoggerInterface $logger = null, string $defaultLocale = 'en')
     {
         $this->routes = $routes;
         $this->context = $context;

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -162,6 +162,40 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/de', $url);
     }
 
+    public function testGenerateForRouteWithLocale()
+    {
+        $routes = $this->getRoutes('test.nl', new Route('/testing/nl'));
+        $generator = $this->getGenerator($routes);
+        $context = new RequestContext('/app.php');
+        $context->setParameter('_locale', 'nl');
+        $generator->setContext($context);
+        $url = $generator->generate('test');
+
+        $this->assertSame('/app.php/testing/nl', $url);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
+     */
+    public function testGenerateForRouteWithInvalidLocale()
+    {
+        $routes = $this->getRoutes('test.en', new Route('/testing/en'));
+        $generator = $this->getGenerator($routes);
+        $context = new RequestContext('/app.php');
+        $context->setParameter('_locale', 'nl');
+        $generator->setContext($context);
+        $generator->generate('test');
+    }
+
+    public function testGenerateForRouteWithoutDefaultLocale()
+    {
+        $routes = $this->getRoutes('test.en', new Route('/testing/en'));
+        $generator = $this->getGenerator($routes);
+        $url = $generator->generate('test');
+
+        $this->assertSame('/app.php/testing/en', $url);
+    }
+
     /**
      * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30010
| License       | MIT

Fix : Twig path function fails for internationalized routes