### PR TITLE
Removed non-existing parameters for LogoutUrlGenerator calls

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\SecurityBundle\Templating\Helper;
 
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\Templating\Helper\Helper;
 
@@ -38,7 +37,7 @@ class LogoutUrlHelper extends Helper
      */
     public function getLogoutPath($key)
     {
-        return $this->generator->getLogoutPath($key, UrlGeneratorInterface::ABSOLUTE_PATH);
+        return $this->generator->getLogoutPath($key);
     }
 
     /**
@@ -50,7 +49,7 @@ class LogoutUrlHelper extends Helper
      */
     public function getLogoutUrl($key)
     {
-        return $this->generator->getLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_URL);
+        return $this->generator->getLogoutUrl($key);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Is there a reason these arguments are in place, though they dont actually exist as parameters for `LogoutUrlGenerator::getLogoutPath` and `::getLogoutUrl`?
see https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php#L76
and https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php#L88

If there is no reason, this PR can be merged, because this parameter makes no sense there. ;-)
