### PR TITLE
[HttpKernel] Better exception page when the invokable controller returns nothing 

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/ControllerDoesNotReturnResponseException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ControllerDoesNotReturnResponseException.php
@@ -67,9 +67,15 @@ class ControllerDoesNotReturnResponseException extends \LogicException
         if (\is_object($controller)) {
             $r = new \ReflectionClass($controller);
 
+            try {
+                $line = $r->getMethod('__invoke')->getEndLine();
+            } catch (\ReflectionException $e) {
+                $line = $r->getEndLine();
+            }
+
             return [
                 'file' => $r->getFileName(),
-                'line' => $r->getEndLine(),
+                'line' => $line,
             ];
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -215,20 +215,19 @@ class HttpKernelTest extends TestCase
     public function testHandleWhenTheControllerDoesNotReturnAResponse()
     {
         $dispatcher = new EventDispatcher();
-        $kernel = $this->getHttpKernel($dispatcher, function () { return 'foo'; });
+        $kernel = $this->getHttpKernel($dispatcher, function () {});
 
         try {
             $kernel->handle(new Request());
 
             $this->fail('The kernel should throw an exception.');
         } catch (ControllerDoesNotReturnResponseException $e) {
+            $first = $e->getTrace()[0];
+
+            // `file` index the array starting at 0, and __FILE__ starts at 1
+            $line = file($first['file'])[$first['line'] - 2];
+            $this->assertContains('// call controller', $line);
         }
-
-        $first = $e->getTrace()[0];
-
-        // `file` index the array starting at 0, and __FILE__ starts at 1
-        $line = file($first['file'])[$first['line'] - 2];
-        $this->assertContains('// call controller', $line);
     }
 
     public function testHandleWhenTheControllerDoesNotReturnAResponseButAViewIsRegistered()


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | #27138
| License       | MIT
| Doc PR        | 

---

__Prerequisites__
_Configure invokable controller_
```php
# config/routes.yaml
index:
    path: /
    controller: App\Controller\Start
```

__Before:__
![before](https://user-images.githubusercontent.com/11414342/53577698-ca739000-3b7e-11e9-98ac-8c8e27626fbe.png)

__After:__
![after](https://user-images.githubusercontent.com/11414342/53577733-df502380-3b7e-11e9-8377-a4a97ea73df8.png)

---

Take a look for an enhancement/refactoring in `HttpKernel.php`