### PR TITLE
Autoconfig: don't automatically tag decorators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -113,14 +113,17 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 $definition->setShared($shared);
             }
 
-            $i = \count($instanceofTags);
-            while (0 <= --$i) {
-                foreach ($instanceofTags[$i] as $k => $v) {
-                    foreach ($v as $v) {
-                        if ($definition->hasTag($k) && \in_array($v, $definition->getTag($k))) {
-                            continue;
+            // Don't add tags to service decorators
+            if (null === $definition->getDecoratedService()) {
+                $i = \count($instanceofTags);
+                while (0 <= --$i) {
+                    foreach ($instanceofTags[$i] as $k => $v) {
+                        foreach ($v as $v) {
+                            if ($definition->hasTag($k) && \in_array($v, $definition->getTag($k))) {
+                                continue;
+                            }
+                            $definition->addTag($k, $v);
                         }
-                        $definition->addTag($k, $v);
                     }
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30391   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a