### PR TITLE
[PropertyInfo] Removes useless namespace

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DefaultValue.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DefaultValue.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
-
 /*
  * This file is part of the Symfony package.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Removes a duplicated namespace in test file. The target branch is `master` because [this feature](https://github.com/symfony/symfony/commit/f6510cda40193e9e586ca5c801594a286e3854f7) was not released yet.
