### PR TITLE
[Form] Allow to disable and customize PercentType symbol

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -106,12 +106,16 @@
 {%- endblock dateinterval_widget %}
 
 {% block percent_widget -%}
-    <div class="input-group">
-        {{- block('form_widget_simple') -}}
-        <div class="input-group-append">
-            <span class="input-group-text">%</span>
+    {%- if symbol -%}
+        <div class="input-group">
+            {{- block('form_widget_simple') -}}
+            <div class="input-group-append">
+                <span class="input-group-text">{{ symbol|default('%') }}</span>
+            </div>
         </div>
-    </div>
+    {%- else -%}
+        {{- block('form_widget_simple') -}}
+    {%- endif -%}
 {%- endblock percent_widget %}
 
 {% block file_widget -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
@@ -26,10 +26,14 @@
 {%- endblock money_widget %}
 
 {% block percent_widget -%}
-    <div class="input-group">
+    {%- if symbol -%}
+        <div class="input-group">
+            {{- block('form_widget_simple') -}}
+            <span class="input-group-addon">{{ symbol|default('%') }}</span>
+        </div>
+    {%- else -%}
         {{- block('form_widget_simple') -}}
-        <span class="input-group-addon">%</span>
-    </div>
+    {%- endif -%}
 {%- endblock percent_widget %}
 
 {% block datetime_widget -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -196,7 +196,7 @@
 
 {%- block percent_widget -%}
     {%- set type = type|default('text') -%}
-    {{ block('form_widget_simple') }} %
+    {{ block('form_widget_simple') }}{% if symbol %} {{ symbol|default('%') }}{% endif %}
 {%- endblock percent_widget -%}
 
 {%- block password_widget -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -43,12 +43,18 @@
 
 {% block percent_widget -%}
     <div class="row collapse">
-        <div class="small-9 large-10 columns">
-            {{- block('form_widget_simple') -}}
-        </div>
-        <div class="small-3 large-2 columns">
-            <span class="postfix">%</span>
-        </div>
+        {%- if symbol -%}
+            <div class="small-9 large-10 columns">
+                {{- block('form_widget_simple') -}}
+            </div>
+            <div class="small-3 large-2 columns">
+                <span class="postfix">{{ symbol|default('%') }}</span>
+            </div>
+        {%- else -%}
+            <div class="small-12 large-12 columns">
+                {{- block('form_widget_simple') -}}
+            </div>
+        {%- endif -%}
     </div>
 {%- endblock percent_widget %}
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Tests\AbstractLayoutTest;
 
@@ -2175,24 +2176,22 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPercentNoSymbol()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1, array('symbol' => false));
-
-        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+        $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => false]);
+        $this->assertWidgetMatchesXpath($form->createView(), ['id' => 'my&id', 'attr' => ['class' => 'my&class']],
 '/input
-            [@id="my&id"]
-            [@type="text"]
-            [@name="name"]
-            [@class="my&class form-control"]
-            [@value="10"]
+    [@id="my&id"]
+    [@type="text"]
+    [@name="name"]
+    [@class="my&class form-control"]
+    [@value="10"]
 '
         );
     }
 
     public function testPercentCustomSymbol()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1, array('symbol' => '‱'));
-
-        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+        $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => '‱']);
+        $this->assertWidgetMatchesXpath($form->createView(), ['id' => 'my&id', 'attr' => ['class' => 'my&class']],
 '/div
     [@class="input-group"]
     [

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -2173,6 +2173,43 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    public function testPercentNoSymbol()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1, array('symbol' => false));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+'/input
+            [@id="my&id"]
+            [@type="text"]
+            [@name="name"]
+            [@class="my&class form-control"]
+            [@value="10"]
+'
+        );
+    }
+
+    public function testPercentCustomSymbol()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1, array('symbol' => '‱'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+'/div
+    [@class="input-group"]
+    [
+        ./input
+            [@id="my&id"]
+            [@type="text"]
+            [@name="name"]
+            [@class="my&class form-control"]
+            [@value="10"]
+        /following-sibling::span
+            [@class="input-group-addon"]
+            [contains(.., "‱")]
+    ]
+'
+        );
+    }
+
     public function testCheckedRadio()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RadioType', true);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
@@ -1128,4 +1128,45 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 '
         );
     }
+
+    public function testPercentNoSymbol()
+    {
+        $form = $this->factory->createNamed('name', PercentType::class, 0.1, array('symbol' => false));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+            '/input
+            [@id="my&id"]
+            [@type="text"]
+            [@name="name"]
+            [@class="my&class form-control"]
+            [@value="10"]
+'
+        );
+    }
+
+    public function testPercentCustomSymbol()
+    {
+        $form = $this->factory->createNamed('name', PercentType::class, 0.1, array('symbol' => '‱'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+            '/div
+    [@class="input-group"]
+    [
+        ./input
+            [@id="my&id"]
+            [@type="text"]
+            [@name="name"]
+            [@class="my&class form-control"]
+            [@value="10"]
+            /following-sibling::div
+                [@class="input-group-append"]
+                [
+                    ./span
+                    [@class="input-group-text"]
+                    [contains(.., "‱")]
+                ]
+    ]
+'
+        );
+    }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
@@ -1082,7 +1082,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['id' => 'my&id', 'attr' => ['class' => 'my&class']],
-            '/div
+'/div
     [@class="input-group"]
     [
         ./div
@@ -1108,7 +1108,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         $form = $this->factory->createNamed('name', PercentType::class, 0.1);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['id' => 'my&id', 'attr' => ['class' => 'my&class']],
-            '/div
+'/div
     [@class="input-group"]
     [
         ./input
@@ -1131,25 +1131,23 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testPercentNoSymbol()
     {
-        $form = $this->factory->createNamed('name', PercentType::class, 0.1, array('symbol' => false));
-
-        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
-            '/input
-            [@id="my&id"]
-            [@type="text"]
-            [@name="name"]
-            [@class="my&class form-control"]
-            [@value="10"]
+        $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => false]);
+        $this->assertWidgetMatchesXpath($form->createView(), ['id' => 'my&id', 'attr' => ['class' => 'my&class']],
+'/input
+    [@id="my&id"]
+    [@type="text"]
+    [@name="name"]
+    [@class="my&class form-control"]
+    [@value="10"]
 '
         );
     }
 
     public function testPercentCustomSymbol()
     {
-        $form = $this->factory->createNamed('name', PercentType::class, 0.1, array('symbol' => '‱'));
-
-        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
-            '/div
+        $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => '‱']);
+        $this->assertWidgetMatchesXpath($form->createView(), ['id' => 'my&id', 'attr' => ['class' => 'my&class']],
+'/div
     [@class="input-group"]
     [
         ./input

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_widget.html.php
@@ -1,13 +1,2 @@
-<?php
-
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
-$symbol = $symbol !== false ? (!empty($symbol) ? ' ' . $symbol : ' %') : '';
-echo $view['form']->block($form, 'form_widget_simple', ['type' => isset($type) ? $type : 'text']) . $symbol; ?>
+<?php $symbol = false !== $symbol ? ($symbol ? ' '.$symbol : ' %') : '' ?>
+<?php echo $view['form']->block($form, 'form_widget_simple', ['type' => isset($type) ? $type : 'text']).$symbol ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_widget.html.php
@@ -1,1 +1,13 @@
-<?php echo $view['form']->block($form, 'form_widget_simple', ['type' => isset($type) ? $type : 'text']) ?> %
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$symbol = $symbol !== false ? (!empty($symbol) ? ' ' . $symbol : ' %') : '';
+echo $view['form']->block($form, 'form_widget_simple', ['type' => isset($type) ? $type : 'text']) . $symbol; ?>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 4.3.0
 -----
 
- * added a `symbol` option to the `PercentType` that allows to disable the output of the percent character
+ * added a `symbol` option to the `PercentType` that allows to disable or customize the output of the percent character
  * Using the `format` option of `DateType` and `DateTimeType` when the `html5` option is enabled is deprecated.
  * Using names for buttons that do not start with a letter, a digit, or an underscore is deprecated and will lead to an
    exception in 5.0.

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.3.0
 -----
 
+ * added a `symbol` option to the `PercentType` that allows to disable the output of the percent character
  * Using the `format` option of `DateType` and `DateTimeType` when the `html5` option is enabled is deprecated.
  * Using names for buttons that do not start with a letter, a digit, or an underscore is deprecated and will lead to an
    exception in 5.0.

--- a/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\DataTransformer\PercentToLocalizedStringTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PercentType extends AbstractType
@@ -29,10 +31,19 @@ class PercentType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['symbol'] = $options['symbol'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'scale' => 0,
+            'symbol' => '%',
             'type' => 'fractional',
             'compound' => false,
         ]);
@@ -43,6 +54,7 @@ class PercentType extends AbstractType
         ]);
 
         $resolver->setAllowedTypes('scale', 'int');
+        $resolver->setAllowedTypes('symbol', array('bool', 'string'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
@@ -54,7 +54,7 @@ class PercentType extends AbstractType
         ]);
 
         $resolver->setAllowedTypes('scale', 'int');
-        $resolver->setAllowedTypes('symbol', array('bool', 'string'));
+        $resolver->setAllowedTypes('symbol', ['bool', 'string']);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\SkippedTestError;
+use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormView;
@@ -1947,9 +1948,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testPercentNoSymbol()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1, array('symbol' => false));
+        $this->requiresFeatureSet(403);
 
-        $this->assertWidgetMatchesXpath($form->createView(), array(),
+        $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => false]);
+        $this->assertWidgetMatchesXpath($form->createView(), [],
 '/input
     [@type="text"]
     [@name="name"]
@@ -1961,9 +1963,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testPercentCustomSymbol()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1, array('symbol' => '‱'));
+        $this->requiresFeatureSet(403);
 
-        $this->assertWidgetMatchesXpath($form->createView(), array(),
+        $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => '‱']);
+        $this->assertWidgetMatchesXpath($form->createView(), [],
 '/input
     [@type="text"]
     [@name="name"]

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1945,6 +1945,34 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
+    public function testPercentNoSymbol()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1, array('symbol' => false));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/input
+    [@type="text"]
+    [@name="name"]
+    [@value="10"]
+    [not(contains(.., "%"))]
+'
+        );
+    }
+
+    public function testPercentCustomSymbol()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1, array('symbol' => '‱'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/input
+    [@type="text"]
+    [@name="name"]
+    [@value="10"]
+    [contains(.., "‱")]
+'
+        );
+    }
+
     public function testCheckedRadio()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RadioType', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #28796   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#11078

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

## `PercentType` `symbol` option
As of this writing, Symfony will forcibly append a percentage sign (`%`) to all input fields that are of the PercentType form type. This PR will introduce a boolean flag called `symbol` that, when `false`, will not display the percentage sign. Each of the default layouts that define percent_widget will respect this option. You could also use a customised string as value for `symbol` option.

By default, this new option will be set to `true` so that it maintains backward compatibility. The unit tests have been updated where appropriate, and a new unit test has been added (as appropriate).
