### PR TITLE
[HttpFoundation][Proposal] Add a new EmptyResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/EmptyResponse.php
+++ b/src/Symfony/Component/HttpFoundation/EmptyResponse.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+class EmptyResponse extends Response
+{
+    /**
+     * @param array $headers
+     */
+    public function __construct(array $headers = [])
+    {
+        parent::__construct(null, Response::HTTP_NO_CONTENT, $headers);
+    }
+
+    /**
+     * Factory method for chainability.
+     *
+     * Example:
+     *
+     *     return Response::create()
+     *         ->setSharedMaxAge(300);
+     *
+     * @param array $headers An array of response headers
+     *
+     * @return static
+     */
+    public static function create($content = '', $status = 200, $headers = [])
+    {
+        return new static($headers);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no   
| Deprecations? |no 
| Tests pass?   | yes    
| Fixed tickets | none
| License       | MIT
| Doc PR        | todo if accepted

Hello,

please note, that this PR is a **proposal**.

Working on an API, I recently needed to return multiple times a `new Response()` with no body and a 204 (HTTP no content) code.

I'm wordering If adding this new `EmptyResponse` that would be a shortcut of `new Response(null, Reponse::HTTP_NO_CONTENT)` would be useful or no.

Please let me know what do you think.