### PR TITLE
[Debug] detect annotations before blank docblock lines

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -233,7 +233,7 @@ class DebugClassLoader
         // Detect annotations on the class
         if (false !== $doc = $refl->getDocComment()) {
             foreach (['final', 'deprecated', 'internal'] as $annotation) {
-                if (false !== \strpos($doc, $annotation) && preg_match('#\n\s+\* @'.$annotation.'(?:( .+?)\.?)?\r?\n\s+\*(?: @|/$)#s', $doc, $notice)) {
+                if (false !== \strpos($doc, $annotation) && preg_match('#\n\s+\* @'.$annotation.'(?:( .+?)\.?)?\r?\n\s+\*(?: @|/$|\r?\n)#s', $doc, $notice)) {
                     self::${$annotation}[$class] = isset($notice[1]) ? preg_replace('#\.?\r?\n( \*)? *(?= |\r?\n|$)#', '', $notice[1]) : '';
                 }
             }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/FinalClasses.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/FinalClasses.php
@@ -64,7 +64,6 @@ class FinalClass6
  * @author John Doe
  *
  * @final another
- *
  *        multiline comment...
  *
  * @return string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This fixes the tests and a small issue after the CS changes made in df1d50dcc2eb9ea1fce54ea9eb557247ca5b349a for #29920.