### PR TITLE
[Validator] Fix email constraint default loose mode

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -335,6 +335,7 @@ Validator
  * The `checkMX` and `checkHost` options of the `Email` constraint were removed
  * The `Email::__construct()` 'strict' property has been removed. Use 'mode'=>"strict" instead.
  * Calling `EmailValidator::__construct()` method with a boolean parameter has been removed, use `EmailValidator("strict")` instead.
+ * The `EmailValidator` default mode "loose" does not accept email addresses beginning with whitespace characters anymore.
  * Removed the `checkDNS` and `dnsMessage` options from the `Url` constraint.
  * The component is now decoupled from `symfony/translation` and uses `Symfony\Contracts\Translation\TranslatorInterface` instead
  * The `ValidatorBuilderInterface` has been removed and `ValidatorBuilder` is now final

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -32,7 +32,7 @@ class EmailValidator extends ConstraintValidator
     /**
      * @internal
      */
-    const PATTERN_LOOSE = '/^.+\@\S+\.\S+$/';
+    const PATTERN_LOOSE = '/^\S+\@\S+\.\S+$/';
 
     private static $emailPatterns = [
         Email::VALIDATION_MODE_LOOSE => self::PATTERN_LOOSE,

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -138,6 +138,8 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
             ['example@'],
             ['example@localhost'],
             ['foo@example.com bar'],
+            [' foo@example.com'],
+            ['foo@example.com foo@example.com'],
         ];
     }
 
@@ -265,6 +267,8 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     {
         return [
             ['test@example.com test'],
+            [' test@example.com'],
+            ['test@example.com test@example.com'],
             ['user  name@example.com'],
             ['user   name@example.com'],
             ['example.@example.co.uk'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

Current default behavior for EmailConstraint is to use the `loose` mode, this mode uses the regexp `/^.+\@\S+\.\S+$/` which considers email addresses starting with whitespace characters as valid.

So for instance, these emails are considered valid (which does not seem to be the case... at least, they broke my application):
```
 foo@example.com
```
```
foo@example.com foo@example.com
```

The `strict` mode already consider those email addresses as invalid 👏... but it's a shame to have to rely on a third party library only because of some whitespace characters 😞 

As a fix, I propose the regexp: `/^\S+\@\S+\.\S+$/`. 
I didn't find anything explaining why this is not already the default regexp...

To avoid BC breaks, I suggest to merge this in `5.x`, but it's up to you.