### PR TITLE
[Mime] Fix generate message id with named address

### DIFF
--- a/src/Symfony/Component/Mime/Message.php
+++ b/src/Symfony/Component/Mime/Message.php
@@ -97,7 +97,7 @@ class Message extends RawMessage
         }
 
         if (!$headers->has('Message-ID')) {
-            $headers->addIdHeader('Message-ID', $this->generateMessageId($sender->toString()));
+            $headers->addIdHeader('Message-ID', $this->generateMessageId($sender->getAddress()));
         }
 
         // remove the Bcc field which should NOT be part of the sent message

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\NamedAddress;
 use Symfony\Component\Mime\Part\TextPart;
 
 class MessageTest extends TestCase
@@ -88,6 +89,15 @@ class MessageTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         (new Message())->getPreparedHeaders();
+    }
+
+    public function testGetPreparedHeadersWithNamedFrom()
+    {
+        $message = new Message();
+        $message->getHeaders()->addMailboxListHeader('From', [new NamedAddress('fabien@symfony.com', 'Fabien')]);
+        $h = $message->getPreparedHeaders();
+        $this->assertEquals(new MailboxListHeader('From', [new NamedAddress('fabien@symfony.com', 'Fabien')]), $h->get('From'));
+        $this->assertTrue($h->has('Message-Id'));
     }
 
     public function testGetPreparedHeadersHasSenderWhenNeeded()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | 

When using a NamedAddress in from(), the generated MessageId don't pass the validation.
In effect, the email passed to generateMessageId look like this `Fabien <fabien@symfony.com>` and the strstr transform email in this `4641b2b294b53fe983a05b1a@symfony.com>`
By passing the address only instead of toString, it's fixed.
 
<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
