### PR TITLE
Improvement of message consumption for messenger with AMQP

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -15,6 +15,15 @@ CHANGELOG
 
  * [BC BREAK] If listening to exceptions while using `AmqpSender` or `AmqpReceiver`, `\AMQPException` is
    no longer thrown in favor of `TransportException`.
+   
+ * Added `prefetch_count` AMQP option which set the channel prefetch count
+ 
+ * Added `consume_fatal` (default `true`) and `consume_requeue` (default `false`) AMQP options which allow consumer to
+   continue processing messages or nack it with requeue.
+
+ * Added `UnrecoverableMessageExceptionInterface` and `RecoverableMessageExceptionInterface` into AMQP transport
+   exception for nack with or without requeue, and then continue to consume the other messages.
+ 
 
 4.2.0
 -----

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpReceiverTest.php
@@ -201,8 +201,8 @@ class AmqpReceiverTest extends TestCase
         $receiver = new AmqpReceiver($connection, $serializer);
         $count = 0;
         $receiver->receive(function () use (&$count, $receiver) {
-            $count++;
-            if ($count === 1) {
+            ++$count;
+            if (1 === $count) {
                 throw new UnrecoverableMessageException('Temporary...');
             }
             $receiver->stop();
@@ -230,8 +230,8 @@ class AmqpReceiverTest extends TestCase
         $receiver = new AmqpReceiver($connection, $serializer);
         $count = 0;
         $receiver->receive(function () use (&$count, $receiver) {
-            $count++;
-            if ($count === 1) {
+            ++$count;
+            if (1 === $count) {
                 throw new InterruptException('Temporary...');
             }
             $receiver->stop();

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
@@ -251,6 +251,22 @@ class ConnectionTest extends TestCase
         $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[attributes][delivery_mode]=2&queue[attributes][headers][token]=uuid&queue[flags]=1', [], true, $factory);
         $connection->publish('body', $headers);
     }
+
+    public function testSetChannelPrefetchWhenSetup()
+    {
+        $factory = new TestAmqpFactory(
+            $amqpConnection = $this->createMock(\AMQPConnection::class),
+            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpExchange = $this->createMock(\AMQPExchange::class)
+        );
+
+        $amqpChannel->expects($this->exactly(2))->method('setPrefetchCount')->with(2);
+        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?prefetch_count=2', [], true, $factory);
+        $connection->setup();
+        $connection = Connection::fromDsn('amqp://localhost/%2f/messages', ['prefetch_count' => 2], true, $factory);
+        $connection->setup();
+    }
 }
 
 class TestAmqpFactory extends AmqpFactory

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -79,7 +79,7 @@ class AmqpReceiver implements ReceiverInterface
             } catch (\Throwable $e) {
                 $connectionCredentials = $this->connection->getConnectionCredentials() + [
                         'consume_fatal' => true,
-                        'consume_requeue' => false
+                        'consume_requeue' => false,
                 ];
                 $flag = $connectionCredentials['consume_requeue'] ? AMQP_REQUEUE : AMQP_NOPARAM;
                 try {

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -185,7 +185,7 @@ class Connection
 
     public function setup(): void
     {
-        if (!$this->channel()->isConnected()) {
+        if (null === $this->amqpChannel || false === $this->amqpChannel->isConnected()) {
             $this->clear();
         }
 
@@ -206,6 +206,9 @@ class Connection
             }
 
             $this->amqpChannel = $this->amqpFactory->createChannel($connection);
+            if (isset($this->connectionCredentials['prefetch_count'])) {
+                $this->amqpChannel->setPrefetchCount($this->connectionCredentials['prefetch_count']);
+            }
         }
 
         return $this->amqpChannel;

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Exception/RecoverableMessageExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Exception/RecoverableMessageExceptionInterface.php
@@ -20,12 +20,8 @@ namespace Symfony\Component\Messenger\Transport\AmqpExt\Exception;
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
  *
- * @deprecated use RecoverableMessageExceptionInterface or UnrecoverableMessageExceptionInterface instead. Now, it is
- * handle as a `\Throwable`: `nack` instead of `reject`
- *
- *
  * @experimental in 4.2
  */
-interface RejectMessageExceptionInterface extends \Throwable
+interface RecoverableMessageExceptionInterface extends \Throwable
 {
 }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Exception/RecoverableMessageExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Exception/RecoverableMessageExceptionInterface.php
@@ -12,15 +12,14 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt\Exception;
 
 /**
- * If something goes wrong while consuming and handling a message from the AMQP broker, there are two choices: rejecting
- * or re-queuing the message.
+ * If something goes wrong while consuming and handling a message from the AMQP broker, if the exception that is thrown
+ * by the bus while dispatching the message implements this interface, the message will be nack and re-queued.
  *
- * If the exception that is thrown by the bus while dispatching the message implements this interface, the message will
- * be rejected. Otherwise, it will be re-queued.
+ * Bus continue handling messages.
  *
- * @author Samuel Roze <samuel.roze@gmail.com>
+ * @author Frederic Bouchery <frederic@bouchery.fr>
  *
- * @experimental in 4.2
+ * @experimental in 4.3
  */
 interface RecoverableMessageExceptionInterface extends \Throwable
 {

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Exception/UnrecoverableMessageExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Exception/UnrecoverableMessageExceptionInterface.php
@@ -12,15 +12,14 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt\Exception;
 
 /**
- * If something goes wrong while consuming and handling a message from the AMQP broker, there are two choices: rejecting
- * or re-queuing the message.
+ * If something goes wrong while consuming and handling a message from the AMQP broker, if the exception that is thrown
+ * by the bus while dispatching the message implements this interface, the message will be nack and not re-queued.
  *
- * If the exception that is thrown by the bus while dispatching the message implements this interface, the message will
- * be rejected. Otherwise, it will be re-queued.
+ * Bus continue handling messages.
  *
- * @author Samuel Roze <samuel.roze@gmail.com>
+ * @author Frederic Bouchery <frederic@bouchery.fr>
  *
- * @experimental in 4.2
+ * @experimental in 4.3
  */
 interface UnrecoverableMessageExceptionInterface extends \Throwable
 {

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Exception/UnrecoverableMessageExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Exception/UnrecoverableMessageExceptionInterface.php
@@ -20,12 +20,8 @@ namespace Symfony\Component\Messenger\Transport\AmqpExt\Exception;
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
  *
- * @deprecated use RecoverableMessageExceptionInterface or UnrecoverableMessageExceptionInterface instead. Now, it is
- * handle as a `\Throwable`: `nack` instead of `reject`
- *
- *
  * @experimental in 4.2
  */
-interface RejectMessageExceptionInterface extends \Throwable
+interface UnrecoverableMessageExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
* Added Messenger AMQP options `consume_fatal` and `consume_requeue` to allow consumer to continue processing other messages without stopping
* Added Messenger `UnrecoverableMessageExceptionInterface` and `RecoverableMessageExceptionInterface` into * AMQP transport into exception to allow handler to nack messages with or without requeue
* Standardized Messenger AMQP rejection with `nack` (`reject` is a `nack` without multiple rejections abilities which is not used in Messenger context).

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
