### PR TITLE
[Serializer] Feature/embedded serialization

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/Embedded.php
+++ b/src/Symfony/Component/Serializer/Annotation/Embedded.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @Embedded().
+ *
+ * @Annotation
+ * @Target({"PROPERTY"})
+ *
+ * @author Jibé Barth <barth.jib@gmail.com>
+ */
+final class Embedded
+{
+    public function __construct(array $data)
+    {
+        if (!empty($data['value'])) {
+            throw new InvalidArgumentException(sprintf('Annotation "%s" doesn\'t accept parameters.', \get_class($this)));
+        }
+    }
+}

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added the list of constraint violations' parameters in `ConstraintViolationListNormalizer`
+ * Added a `@Embedded` annotation to serialize/deserialize from/in subobject. Also work with `embedded=true` in attribute node in XML and `embedded: true` in Yaml.
 
 4.2.0
 -----

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -50,6 +50,15 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public $serializedName;
 
+    /**
+     * @var bool
+     *
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link isEmbedded()} instead.
+     */
+    public $embedded = false;
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -113,6 +122,16 @@ class AttributeMetadata implements AttributeMetadataInterface
         return $this->serializedName;
     }
 
+    public function isEmbedded(): bool
+    {
+        return $this->embedded;
+    }
+
+    public function setEmbedded(bool $isEmbedded)
+    {
+        $this->embedded = $isEmbedded;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -131,6 +150,8 @@ class AttributeMetadata implements AttributeMetadataInterface
         if (null === $this->serializedName) {
             $this->serializedName = $attributeMetadata->getSerializedName();
         }
+
+        $this->setEmbedded($attributeMetadata->isEmbedded());
     }
 
     /**
@@ -140,6 +161,6 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public function __sleep()
     {
-        return ['name', 'groups', 'maxDepth', 'serializedName'];
+        return ['name', 'groups', 'maxDepth', 'serializedName', 'embedded'];
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -68,6 +68,18 @@ interface AttributeMetadataInterface
     public function getSerializedName(): ?string;
 
     /**
+     * Gets the attribute need to be embedded.
+     *
+     * @return bool
+     */
+    public function isEmbedded(): bool;
+
+    /**
+     * @param bool $isEmbedded
+     */
+    public function setEmbedded(bool $isEmbedded);
+
+    /**
      * Merges an {@see AttributeMetadataInterface} with in the current one.
      */
     public function merge(self $attributeMetadata);

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Mapping\Loader;
 
 use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Serializer\Annotation\Embedded;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\MaxDepth;
 use Symfony\Component\Serializer\Annotation\SerializedName;
@@ -71,6 +72,8 @@ class AnnotationLoader implements LoaderInterface
                         $attributesMetadata[$property->name]->setMaxDepth($annotation->getMaxDepth());
                     } elseif ($annotation instanceof SerializedName) {
                         $attributesMetadata[$property->name]->setSerializedName($annotation->getSerializedName());
+                    } elseif ($annotation instanceof Embedded) {
+                        $attributesMetadata[$property->name]->setEmbedded(true);
                     }
 
                     $loaded = true;

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -58,7 +58,6 @@ class XmlFileLoader extends FileLoader
                     $attributeMetadata = new AttributeMetadata($attributeName);
                     $classMetadata->addAttributeMetadata($attributeMetadata);
                 }
-
                 foreach ($attribute->group as $group) {
                     $attributeMetadata->addGroup((string) $group);
                 }
@@ -69,6 +68,10 @@ class XmlFileLoader extends FileLoader
 
                 if (isset($attribute['serialized-name'])) {
                     $attributeMetadata->setSerializedName((string) $attribute['serialized-name']);
+                }
+
+                if (true === filter_var($attribute['embedded'], \FILTER_VALIDATE_BOOLEAN)) {
+                    $attributeMetadata->setEmbedded(true);
                 }
             }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -93,6 +93,10 @@ class YamlFileLoader extends FileLoader
 
                     $attributeMetadata->setSerializedName($data['serialized_name']);
                 }
+
+                if (isset($data['embedded']) && true === $data['embedded']) {
+                    $attributeMetadata->setEmbedded(true);
+                }
             }
         }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
@@ -48,7 +48,7 @@
         </xsd:choice>
         <xsd:attribute name="type-property" type="xsd:string" use="required" />
     </xsd:complexType>
-    
+
     <xsd:complexType name="discriminator-map-mapping">
         <xsd:attribute name="type" type="xsd:string" use="required" />
         <xsd:attribute name="class" type="xsd:string" use="required" />
@@ -78,6 +78,7 @@
                 </xsd:restriction>
             </xsd:simpleType>
         </xsd:attribute>
+        <xsd:attribute name="embedded" type="xsd:boolean" />
     </xsd:complexType>
 
 </xsd:schema>

--- a/src/Symfony/Component/Serializer/Tests/Annotation/EmbeddedTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/EmbeddedTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Annotation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Annotation\Embedded;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * @author Jibé Barth <barth.jib@gmail.com>
+ */
+class EmbeddedTest extends TestCase
+{
+    public function testEmbeddedConstructor()
+    {
+        $embedded = new Embedded(['value' => []]);
+        $this->assertInstanceOf(Embedded::class, $embedded);
+    }
+
+    public function testEmbeddedEmptyParameters()
+    {
+        $embedded = new Embedded([]);
+        $this->assertInstanceOf(Embedded::class, $embedded);
+    }
+
+    public function testNotEmptyArrayEmbeddedParameter()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Embedded(['value' => 12]);
+    }
+
+    public function testInvalidEmbeddedParameter()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Embedded(['value' => ['a', 1, new \stdClass()]]);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EmbeddedDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EmbeddedDummy.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Embedded;
+
+/**
+ * @author Jibé Barth <barth.jib@gmail.com>
+ */
+class EmbeddedDummy
+{
+    /**
+     * @var EmbeddedDummyChild
+     * @Embedded()
+     */
+    public $foo;
+
+    /**
+     * @var string
+     */
+    public $simple;
+
+    public function __construct()
+    {
+        $this->foo = new EmbeddedDummyChild();
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EmbeddedDummyChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EmbeddedDummyChild.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Jibé Barth <barth.jib@gmail.com>
+ */
+class EmbeddedDummyChild
+{
+    /**
+     * @var string
+     */
+    public $bar;
+
+    /**
+     * @var string
+     */
+    public $baz;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -34,4 +34,8 @@
         <attribute name="foo" />
     </class>
 
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\EmbeddedDummy">
+        <attribute name="foo" embedded="true" />
+    </class>
+
 </serializer>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -24,3 +24,7 @@
       second: 'Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild'
   attributes:
     foo: ~
+'Symfony\Component\Serializer\Tests\Fixtures\EmbeddedDummy':
+  attributes:
+    foo:
+      embedded: true

--- a/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
@@ -57,6 +57,14 @@ class AttributeMetadataTest extends TestCase
         $this->assertEquals('serialized_name', $attributeMetadata->getSerializedName());
     }
 
+    public function testEmbedded()
+    {
+        $attributeMetadata = new AttributeMetadata('name');
+        $attributeMetadata->setEmbedded(true);
+
+        $this->assertTrue($attributeMetadata->isEmbedded());
+    }
+
     public function testMerge()
     {
         $attributeMetadata1 = new AttributeMetadata('a1');
@@ -68,12 +76,14 @@ class AttributeMetadataTest extends TestCase
         $attributeMetadata2->addGroup('c');
         $attributeMetadata2->setMaxDepth(2);
         $attributeMetadata2->setSerializedName('a3');
+        $attributeMetadata2->setEmbedded(true);
 
         $attributeMetadata1->merge($attributeMetadata2);
 
         $this->assertEquals(['a', 'b', 'c'], $attributeMetadata1->getGroups());
         $this->assertEquals(2, $attributeMetadata1->getMaxDepth());
         $this->assertEquals('a3', $attributeMetadata1->getSerializedName());
+        $this->assertTrue($attributeMetadata1->isEmbedded());
     }
 
     public function testSerialize()
@@ -83,6 +93,7 @@ class AttributeMetadataTest extends TestCase
         $attributeMetadata->addGroup('b');
         $attributeMetadata->setMaxDepth(3);
         $attributeMetadata->setSerializedName('serialized_name');
+        $attributeMetadata->setEmbedded(true);
 
         $serialized = serialize($attributeMetadata);
         $this->assertEquals($attributeMetadata, unserialize($serialized));

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\EmbeddedDummy;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
 
 /**
@@ -104,5 +105,14 @@ class AnnotationLoaderTest extends TestCase
         $this->loader->loadClassMetadata($classMetadata);
 
         $this->assertEquals(TestClassMetadataFactory::createClassMetadata(true), $classMetadata);
+    }
+
+    public function testLoadEmbedded()
+    {
+        $classMetadata = new ClassMetadata(EmbeddedDummy::class);
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertTrue($attributesMetadata['foo']->isEmbedded());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\EmbeddedDummy;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
 
 /**
@@ -91,5 +92,14 @@ class XmlFileLoaderTest extends TestCase
         $expected->addAttributeMetadata(new AttributeMetadata('foo'));
 
         $this->assertEquals($expected, $classMetadata);
+    }
+
+    public function testEmbedded()
+    {
+        $classMetadata = new ClassMetadata(EmbeddedDummy::class);
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertTrue($attributesMetadata['foo']->isEmbedded());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\EmbeddedDummy;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
 
 /**
@@ -106,5 +107,23 @@ class YamlFileLoaderTest extends TestCase
         $expected->addAttributeMetadata(new AttributeMetadata('foo'));
 
         $this->assertEquals($expected, $classMetadata);
+    }
+
+    public function testEmbeddedEnabled()
+    {
+        $classMetadata = new ClassMetadata(EmbeddedDummy::class);
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertTrue($attributesMetadata['foo']->isEmbedded());
+    }
+
+    public function testEmbeddedDisabled()
+    {
+        $classMetadata = new ClassMetadata(AbstractDummy::class);
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertFalse($attributesMetadata['foo']->isEmbedded());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | TODO <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

## Description 

For a better [Separating Concern](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/tutorials/embeddables.html#separating-concerns-using-embeddables), we sometime split our models with submodel.

```php
class MyObject {
   /**
    * @var string
    */
   public $name;
	
    /**
     * @var Coordinate
     */
    public $coordinate;
}

class Coordinate {
    public $latitude;
    public $longitude;
}
``` 

However, when we must deal with data from another API, we can receive something like this : 

```json
{
    "name": "Hello",
    "latitude": "1,2230",
    "longitude": "47,2098"
}
```
Without creating a custom normalizer, we cannot directly denormalize this in `MyObject`.

This propose to add an `@Embedded` annotation, that indicate some properties are carried by a sub object

```php
class MyObject {
   /**
    * @var string
    */
   public $name;
	
    /**
     * @var Coordinate
     * @Embedded()
     */
    public $coordinate;
}
``` 

With this, the denormalization process will fill the `Coordinate` object with correct values. 

The normalization process will do the same jobs.

What do you think ? Does it seem like a relevant addition to the component ?

## To do
- [x] add XML attribute and YAML key
- [x] add a CHANGELOG.md entry
- [ ] add a doc PR