### PR TITLE
Fix getSetMethodNormalizer to correctly ignore the attributes specified in "ignored_attributes"

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -179,7 +179,6 @@ FrameworkBundle
  * The `Templating\Helper\TranslatorHelper::transChoice()` method has been deprecated, use the `trans()` one instead with a `%count%` parameter.
  * Deprecated support for legacy translations directories `src/Resources/translations/` and `src/Resources/<BundleName>/translations/`, use `translations/` instead.
  * Support for the legacy directory structure in `translation:update` and `debug:translation` commands has been deprecated.
- * The `GetSetMethodNormalizer` class correctly ignores the attributes specified in "ignored_attributes".
 
 HttpFoundation
 --------------

--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -179,6 +179,7 @@ FrameworkBundle
  * The `Templating\Helper\TranslatorHelper::transChoice()` method has been deprecated, use the `trans()` one instead with a `%count%` parameter.
  * Deprecated support for legacy translations directories `src/Resources/translations/` and `src/Resources/<BundleName>/translations/`, use `translations/` instead.
  * Support for the legacy directory structure in `translation:update` and `debug:translation` commands has been deprecated.
+ * The `GetSetMethodNormalizer` class correctly ignores the attributes specified in "ignored_attributes".
 
 HttpFoundation
 --------------

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -110,7 +110,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
             $attributeName = lcfirst(substr($method->name, 0 === strpos($method->name, 'is') ? 2 : 3));
 
-            if ($this->isAllowedAttribute($object, $attributeName)) {
+            if ($this->isAllowedAttribute($object, $attributeName, null, $context)) {
                 $attributes[] = $attributeName;
             }
         }

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -110,7 +110,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
             $attributeName = lcfirst(substr($method->name, 0 === strpos($method->name, 'is') ? 2 : 3));
 
-            if ($this->isAllowedAttribute($object, $attributeName, null, $context)) {
+            if ($this->isAllowedAttribute($object, $attributeName, $format, $context)) {
                 $attributes[] = $attributeName;
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -329,6 +329,25 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->doTestUncallableCallbacks(true);
     }
 
+    public function testIgnoredAttributesInContext()
+    {
+        $ignoredAttributes = ['foo', 'bar', 'baz', 'object'];
+        $this->createNormalizer([GetSetMethodNormalizer::IGNORED_ATTRIBUTES => $ignoredAttributes]);
+
+        $obj = new GetSetDummy();
+        $obj->setFoo('foo');
+        $obj->setBar('bar');
+        $obj->setCamelCase(true);
+
+        $this->assertEquals(
+            [
+                'fooBar' => 'foobar',
+                'camelCase' => true,
+            ],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
     private function doTestUncallableCallbacks(bool $legacy = false)
     {
         $callbacks = ['bar' => null];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |4.2
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no    
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | #30453
| License       | MIT

The GetSetMethodNormalizer class correctly ignores the attributes specified in "ignored_attributes"