### PR TITLE
[Debug][DebugClassLoader] Detect annotations before blank docblock lines on final and internal methods

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -307,7 +307,7 @@ class DebugClassLoader
             }
 
             foreach (['final', 'internal'] as $annotation) {
-                if (false !== \strpos($doc, $annotation) && preg_match('#\n\s+\* @'.$annotation.'(?:( .+?)\.?)?\r?\n\s+\*(?: @|/$)#s', $doc, $notice)) {
+                if (false !== \strpos($doc, $annotation) && preg_match('#\n\s+\* @'.$annotation.'(?:( .+?)\.?)?\r?\n\s+\*(?: @|/$|\r?\n)#s', $doc, $notice)) {
                     $message = isset($notice[1]) ? preg_replace('#\.?\r?\n( \*)? *(?= |\r?\n|$)#', '', $notice[1]) : '';
                     self::${$annotation.'Methods'}[$class][$method->name] = [$class, $message];
                 }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/FinalMethod.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/FinalMethod.php
@@ -13,6 +13,8 @@ class FinalMethod
 
     /**
      * @final
+     *
+     * @return int
      */
     public function finalMethod2()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

@xabbuh Follow up of https://github.com/symfony/symfony/pull/30437