### PR TITLE
[Messenger] Make 'headers' key optional for encoded messages

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpSenderTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpSenderTest.php
@@ -37,4 +37,19 @@ class AmqpSenderTest extends TestCase
         $sender = new AmqpSender($connection, $serializer);
         $sender->send($envelope);
     }
+
+    public function testItSendsTheEncodedMessageWithoutHeaders()
+    {
+        $envelope = new Envelope(new DummyMessage('Oy'));
+        $encoded = ['body' => '...'];
+
+        $serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
+        $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
+
+        $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $connection->expects($this->once())->method('publish')->with($encoded['body'], []);
+
+        $sender = new AmqpSender($connection, $serializer);
+        $sender->send($envelope);
+    }
 }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -41,7 +41,7 @@ class AmqpSender implements SenderInterface
     {
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $this->connection->publish($encodedMessage['body'], $encodedMessage['headers']);
+        $this->connection->publish($encodedMessage['body'], $encodedMessage['headers'] ?? []);
 
         return $envelope;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30455 
| License       | MIT