### PR TITLE
Create a hyperlink to interfaces/classes that can be autowired

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -66,6 +66,8 @@
         </service>
 
         <service id="console.command.debug_autowiring" class="Symfony\Bundle\FrameworkBundle\Command\DebugAutowiringCommand">
+            <argument>null</argument>
+            <argument type="service" id="debug.file_link_formatter" on-invalid="null"/>
             <tag name="console.command" command="debug:autowiring" />
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Added hyperlink to definition of interfaces/classes that can be used for autowiring.
But I need help with: 
- the aliases are becoming hyperlinks too, but shouldn't.
It's outputting `<fg=yellow;href=phpstorm://open?file=filepath&line=17>Symfony\Contracts\Translation\TranslatorInterface</> <fg=cyan>(translator.default)</>`

- it currently works with phpstorm because it's hardcoded but it should work with framework.ide option, but don't know what the best approach is to support that config option.