### PR TITLE
[Translation] Add XLIFF 1 source to metadata to differentiate from attr

### DIFF
--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -105,6 +105,7 @@ class XliffFileLoader implements LoaderInterface
                 $catalogue->set((string) $source, $target, $domain);
 
                 $metadata = [
+                    'source' => (string) $translation->source,
                     'file' => [
                         'original' => (string) $fileAttributes['original'],
                     ],

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -86,6 +86,7 @@ class XliffFileLoaderTest extends TestCase
         $this->assertEquals(utf8_decode('bär'), $catalogue->get('foo', 'domain1'));
         $this->assertEquals(
             [
+                'source' => 'foo',
                 'notes' => [['content' => utf8_decode('bäz')]],
                 'id' => '1',
                 'file' => [
@@ -175,6 +176,7 @@ class XliffFileLoaderTest extends TestCase
 
         $this->assertEquals(
             [
+                'source' => 'foo',
                 'notes' => [['priority' => 1, 'content' => 'foo']],
                 'id' => '1',
                 'file' => [
@@ -186,6 +188,7 @@ class XliffFileLoaderTest extends TestCase
         // message without target
         $this->assertEquals(
             [
+                'source' => 'extrasource',
                 'notes' => [['content' => 'bar', 'from' => 'foo']],
                 'id' => '2',
                 'file' => [
@@ -197,6 +200,7 @@ class XliffFileLoaderTest extends TestCase
         // message with empty target
         $this->assertEquals(
             [
+                'source' => 'key',
                 'notes' => [
                     ['content' => 'baz'],
                     ['priority' => 2, 'from' => 'bar', 'content' => 'qux'],
@@ -304,6 +308,7 @@ class XliffFileLoaderTest extends TestCase
 
         $this->assertEquals(
             [
+                'source' => 'foo',
                 'id' => '1',
                 'file' => [
                     'original' => 'file.ext',
@@ -313,6 +318,7 @@ class XliffFileLoaderTest extends TestCase
         );
         $this->assertEquals(
             [
+                'source' => 'test',
                 'notes' => [['content' => 'note']],
                 'id' => '4',
                 'file' => [

--- a/src/Symfony/Component/Translation/Tests/fixtures/withnote.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/withnote.xlf
@@ -7,8 +7,8 @@
         <target>bar</target>
         <note priority="1">foo</note>
       </trans-unit>
-      <trans-unit id="2">
-        <source>extra</source>
+      <trans-unit id="2" resname="extra">
+        <source>extrasource</source>
         <note from="foo">bar</note>
       </trans-unit>
       <trans-unit id="123">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Here's our use case this patch solves:

We have 2 translation files. One is created by developer and has empty `<target>`. Second one is created by translator and has non-empty `<target>`, but same `<source>`.

Now, unlike Symfony fixtures, we also use `resname=` XLIFF1 attribute. This allows us to detect when translation is out of date, which happens when `<source>` in dev translation is changed, but `resname=` is not. As visualization which better illustrates problem:

dev.xlf:
```xml
<trans-unit id="source_is_different" resname="source_is_different">
    <source>Welcome to Calida</source>
</trans-unit>
```
real.xlf:
```xml
<trans-unit id="source_is_different" resname="source_is_different">
    <source>Welcome to Jacqueline</source>
    <target>Willkommen bei Jacqueline</target>
</trans-unit>
```

We need to be able to tell `<source>` for this pair is different (so we prepend alert glyph to translation message, to alert developer something is wrong). In current XliffFileLoader there is no way for consumer to figure out if translation key came from `resname` or `<source>`, so we had to copy whole loader.