### PR TITLE
compatibility with phpunit8

### DIFF
--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -20,12 +20,14 @@ use Symfony\Component\Form\Forms;
  */
 abstract class FormIntegrationTestCase extends TestCase
 {
+    use TestCaseSetUpTearDownTrait;
+
     /**
      * @var FormFactoryInterface
      */
     protected $factory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())

--- a/src/Symfony/Component/Form/Test/TestCaseSetUpTearDownTrait.php
+++ b/src/Symfony/Component/Form/Test/TestCaseSetUpTearDownTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Test;
+
+use PHPUnit\Framework\TestCase;
+
+// Auto-adapt to PHPUnit 8 that added a `void` return-type to the setUp/tearDown methods
+
+if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {
+    eval('
+    namespace Symfony\Component\Form\Test;
+
+    /**
+     * @internal
+     */
+    trait TestCaseSetUpTearDownTrait
+    {
+        private function doSetUp(): void
+        {
+        }
+
+        private function doTearDown(): void
+        {
+        }
+    
+        protected function setUp(): void
+        {
+            $this->doSetUp();
+        }
+        
+        protected function tearDown(): void
+        {
+            $this->doTearDown();
+        }
+    }
+');
+} else {
+    /**
+     * @internal
+     */
+    trait TestCaseSetUpTearDownTrait
+    {
+        /**
+         * @return void
+         */
+        private function doSetUp()
+        {
+        }
+
+        /**
+         * @return void
+         */
+        private function doTearDown()
+        {
+        }
+
+        /**
+         * @return void
+         */
+        protected function setUp()
+        {
+            $this->doSetUp();
+        }
+
+        /**
+         * @return void
+         */
+        protected function tearDown()
+        {
+            $this->doTearDown();
+        }
+    }
+}

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -17,6 +17,8 @@ use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 abstract class TypeTestCase extends FormIntegrationTestCase
 {
+    use TestCaseSetUpTearDownTrait;
+
     /**
      * @var FormBuilder
      */
@@ -27,7 +29,7 @@ abstract class TypeTestCase extends FormIntegrationTestCase
      */
     protected $dispatcher;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -35,7 +37,7 @@ abstract class TypeTestCase extends FormIntegrationTestCase
         $this->builder = new FormBuilder('', null, $this->dispatcher, $this->factory);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (\in_array(ValidatorExtensionTrait::class, class_uses($this))) {
             $this->validator = null;

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -29,6 +29,8 @@ use Symfony\Component\Validator\Mapping\PropertyMetadata;
  */
 abstract class ConstraintValidatorTestCase extends TestCase
 {
+    use TestCaseSetUpTearDownTrait;
+
     /**
      * @var ExecutionContextInterface
      */
@@ -48,7 +50,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
     protected $constraint;
     protected $defaultTimezone;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->group = 'MyGroup';
         $this->metadata = null;
@@ -70,7 +72,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $this->setDefaultTimezone('UTC');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->restoreDefaultTimezone();
     }

--- a/src/Symfony/Component/Validator/Test/TestCaseSetUpTearDownTrait.php
+++ b/src/Symfony/Component/Validator/Test/TestCaseSetUpTearDownTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Test;
+
+use PHPUnit\Framework\TestCase;
+
+// Auto-adapt to PHPUnit 8 that added a `void` return-type to the setUp/tearDown methods
+
+if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {
+    eval('
+    namespace Symfony\Component\Validator\Test;
+
+    /**
+     * @internal
+     */
+    trait TestCaseSetUpTearDownTrait
+    {
+        private function doSetUp(): void
+        {
+        }
+
+        private function doTearDown(): void
+        {
+        }
+    
+        protected function setUp(): void
+        {
+            $this->doSetUp();
+        }
+        
+        protected function tearDown(): void
+        {
+            $this->doTearDown();
+        }
+    }
+');
+} else {
+    /**
+     * @internal
+     */
+    trait TestCaseSetUpTearDownTrait
+    {
+        /**
+         * @return void
+         */
+        private function doSetUp()
+        {
+        }
+
+        /**
+         * @return void
+         */
+        private function doTearDown()
+        {
+        }
+
+        /**
+         * @return void
+         */
+        protected function setUp()
+        {
+            $this->doSetUp();
+        }
+
+        /**
+         * @return void
+         */
+        protected function tearDown()
+        {
+            $this->doTearDown();
+        }
+    }
+}


### PR DESCRIPTION
This basically adds the same phpunit8 compatibility layer added in https://github.com/symfony/symfony/pull/30084 (but for other test classes)
See also discussion in https://github.com/symfony/symfony/issues/30071

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30071 
| License       | MIT
| Doc PR        | none

