### PR TITLE
[Translator] Prefer non-empty fallback translation over empty one

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -101,7 +101,9 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function get($id, $domain = 'messages')
     {
-        if (isset($this->messages[$domain][$id])) {
+        $messageExists = isset($this->messages[$domain][$id]);
+
+        if ($messageExists && '' !== $this->messages[$domain][$id]) {
             return $this->messages[$domain][$id];
         }
 
@@ -109,7 +111,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             return $this->fallbackCatalogue->get($id, $domain);
         }
 
-        return $id;
+        return $messageExists ? $this->messages[$domain][$id] : $id;
     }
 
     /**

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -117,10 +117,12 @@ class MessageCatalogueTest extends TestCase
         $catalogue = new MessageCatalogue('fr_FR', ['domain1' => ['foo' => 'foo'], 'domain2' => ['bar' => 'bar']]);
         $catalogue->addResource($r);
 
-        $catalogue1 = new MessageCatalogue('fr', ['domain1' => ['foo' => 'bar', 'foo1' => 'foo1']]);
+        $catalogue1 = new MessageCatalogue('fr', ['domain1' => ['foo' => 'bar', 'foo1' => 'foo1', 'empty' => '']]);
         $catalogue1->addResource($r1);
 
-        $catalogue2 = new MessageCatalogue('en');
+        $this->assertEquals('', $catalogue1->get('empty', 'domain1'));
+
+        $catalogue2 = new MessageCatalogue('en', ['domain1' => ['empty' => 'nonempty']]);
         $catalogue2->addResource($r2);
 
         $catalogue->addFallbackCatalogue($catalogue1);
@@ -128,6 +130,7 @@ class MessageCatalogueTest extends TestCase
 
         $this->assertEquals('foo', $catalogue->get('foo', 'domain1'));
         $this->assertEquals('foo1', $catalogue->get('foo1', 'domain1'));
+        $this->assertEquals('nonempty', $catalogue1->get('empty', 'domain1'));
 
         $this->assertEquals([$r, $r1, $r2], $catalogue->getResources());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I'm currently dealing with XLIFF, so can't say for other formats. But Symfony considers `<target />` there as valid translation. Even though XLIFF standard has no mention what should happen in such case, translation tools like Crowdin treat this as untranslated unit, so these empty tags are widespread way to mark unit as untranslated.

Result of this behaviour is that Symfony does not fallback to real, non-empty translation, which is unfortunate. This patch is compromise which should work for all other formats too.

Kinda related: [XLIFF export should be with empty targets](https://www.drupal.org/project/tmgmt/issues/2006786)
