### PR TITLE
Check if Client exists when test.client does not exist, to provide clearer exception message

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -36,7 +36,10 @@ abstract class WebTestCase extends KernelTestCase
         try {
             $client = $kernel->getContainer()->get('test.client');
         } catch (ServiceNotFoundException $e) {
-            throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit component is not available. Try running "composer require symfony/browser-kit".');
+            if (class_exists(Client::class)) {
+                throw new \LogicException('You cannot create the client used in functional tests if the "framework.test" config is not set to true.');
+            }
+            throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit component is not available. Try running "composer require symfony/browser-kit"');
         }
 
         $client->setServerParameters($server);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30420
| License       | MIT

The `DotEnv` component does not overwrite by using environment variables declared in `.env` files.

In the `FrameworkExtension` will be checked if the framework.test config is set to a non-false value, if so it will load the `test.xml` file which contains the definition for the `test.client` service.

When running `php bin/phpunit` it will use `phpunit.xml.dist` but because we defined `APP_ENV` in our system it will not load `test.xml` so when creating a client to do functional tests, we'll get an exception which isn't correct: `You cannot create the client used in functional tests if the BrowserKit component is not available. Try running "composer require symfony/browser-kit"`

This PR aims to add a clearer exception message which indicates what really should be done to fix the error message.