### PR TITLE
[Mime] added Headers::toArray()

### DIFF
--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -210,13 +210,23 @@ final class Headers
     public function toString(): string
     {
         $string = '';
-        foreach ($this->getAll() as $header) {
-            if ('' !== $header->getBodyAsString()) {
-                $string .= $header->toString()."\r\n";
-            }
+        foreach ($this->toArray() as $str) {
+            $string .= $str."\r\n";
         }
 
         return $string;
+    }
+
+    public function toArray(): array
+    {
+        $arr = [];
+        foreach ($this->getAll() as $header) {
+            if ('' !== $header->getBodyAsString()) {
+                $arr[] = $header->toString();
+            }
+        }
+
+        return $arr;
     }
 
     /**

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -231,4 +231,15 @@ class HeadersTest extends TestCase
         $headers->addTextHeader('Zip', '');
         $this->assertEquals("Foo: bar\r\n", $headers->toString());
     }
+
+    public function testToArray()
+    {
+        $headers = new Headers();
+        $headers->addIdHeader('Message-ID', 'some@id');
+        $headers->addTextHeader('Foo', str_repeat('a', 60).pack('C', 0x8F));
+        $this->assertEquals([
+            'Message-ID: <some@id>',
+            "Foo: =?utf-8?Q?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?=\r\n =?utf-8?Q?aaaa?=",
+        ], $headers->toArray());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

That helps when using the Mime component to create a form submission HTTP body (where you need to merge the headers of the MIME body with the HTTP headers):

```php
$body->getPreparedHeaders()->toArray();

vs

foreach ($body->getPreparedHeaders()->getAll() as $header) {
      $headers[] = $header->toString();
}
```
