### PR TITLE
Upgrade zookeeper ext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,7 @@ before_install:
           tfold ext.apcu tpecl apcu-5.1.16 apcu.so $INI
           tfold ext.mongodb tpecl mongodb-1.6.0alpha1 mongodb.so $INI
           tfold ext.igbinary tpecl igbinary-2.0.8 igbinary.so $INI
-          tfold ext.zookeeper tpecl zookeeper-0.6.0 zookeeper.so $INI
+          tfold ext.zookeeper tpecl zookeeper-0.7.1 zookeeper.so $INI
           tfold ext.amqp tpecl amqp-1.9.4 amqp.so $INI
       done
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

This bumps the zookeeper extension to recent versions. versions > 0.6.0 and < 0.7.1 caused segfaults. This seems to be fixed in the latest version