### PR TITLE
[HttpKernel] Change default log level for output streams

### DIFF
--- a/src/Symfony/Component/HttpKernel/Log/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Log/Logger.php
@@ -40,7 +40,7 @@ class Logger extends AbstractLogger
     public function __construct($minLevel = null, $output = 'php://stderr', callable $formatter = null)
     {
         if (null === $minLevel) {
-            $minLevel = LogLevel::WARNING;
+            $minLevel = 'php://stdout' === $output || 'php://stderr' === $output ? LogLevel::CRITICAL : LogLevel::WARNING;
 
             if (isset($_ENV['SHELL_VERBOSITY']) || isset($_SERVER['SHELL_VERBOSITY'])) {
                 switch ((int) (isset($_ENV['SHELL_VERBOSITY']) ? $_ENV['SHELL_VERBOSITY'] : $_SERVER['SHELL_VERBOSITY'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes (visual)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27510
| License       | MIT

**BEFORE**
![default-logger-level-before](https://user-images.githubusercontent.com/2028198/54072209-94e93980-4245-11e9-855a-2d32de797072.png)

**AFTER**
![default-logger-level-after](https://user-images.githubusercontent.com/2028198/54072210-9a468400-4245-11e9-96ec-ce5334aba72c.png)

This should improve the first DX/UX for console-based apps.
 