### PR TITLE
[DI] replace "nullable" env processor by improving the "default" one

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,8 +5,7 @@ CHANGELOG
 -----
 
  * added `%env(trim:...)%` processor to trim a string value
- * added `%env(default:...)%` processor to fallback to a default value
- * added `%env(nullable:...)%` processor to allow empty variables to be processed as null values
+ * added `%env(default:param_name:...)%` processor to fallback to a parameter or to null when using `%env(default::...)%`
  * added support for deprecating aliases
  * made `ContainerParametersResource` final and not implement `Serializable` anymore
  * added ability to define an index for a tagged collection

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -39,7 +39,6 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'int' => ['int'],
             'json' => ['array'],
             'key' => ['bool', 'int', 'float', 'string', 'array'],
-            'nullable' => ['bool', 'int', 'float', 'string', 'array'],
             'resolve' => ['string'],
             'default' => ['bool', 'int', 'float', 'string', 'array'],
             'string' => ['string'],

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -440,7 +440,7 @@ class EnvVarProcessorTest extends TestCase
     public function testGetEnvNullable($value, $processed)
     {
         $processor = new EnvVarProcessor(new Container());
-        $result = $processor->getEnv('nullable', 'foo', function ($name) use ($value) {
+        $result = $processor->getEnv('default', ':foo', function ($name) use ($value) {
             $this->assertSame('foo', $name);
 
             return $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Neither `nullable` nor `default` are released yet.
I propose to replace the `nullable` processor (see #29767) with an improved `default` one (from #28976).
`%env(default::FOO)%` now defaults to `null` when the env var doesn't exist or compares to false".

ping @jderusse @bpolaszek 