### PR TITLE
[TwigBridge] Remove usages of the spaceless tag

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/custom_widgets.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/custom_widgets.html.twig
@@ -1,25 +1,19 @@
-{% block _text_id_widget %}
-{% spaceless %}
+{% block _text_id_widget -%}
     <div id="container">
-        {{ form_widget(form) }}
+        {{- form_widget(form) -}}
     </div>
-{% endspaceless %}
-{% endblock _text_id_widget %}
+{%- endblock _text_id_widget %}
 
-{% block _names_entry_label %}
-{% spaceless %}
+{% block _names_entry_label -%}
     {% if label is empty %}
-        {% set label = name|humanize %}
-    {% endif %}
+        {%- set label = name|humanize -%}
+    {% endif -%}
     <label>Custom label: {{ label|trans({}, translation_domain) }}</label>
-{% endspaceless %}
-{% endblock _names_entry_label %}
+{%- endblock _names_entry_label %}
 
-{% block _name_c_entry_label %}
-{% spaceless %}
+{% block _name_c_entry_label -%}
     {% if label is empty %}
-        {% set label = name|humanize %}
-    {% endif %}
+        {%- set label = name|humanize -%}
+    {% endif -%}
     <label>Custom name label: {{ label|trans({}, translation_domain) }}</label>
-{% endspaceless %}
-{% endblock _name_c_entry_label %}
+{%- endblock _name_c_entry_label %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme.html.twig
@@ -1,6 +1,4 @@
 {% block form_widget_simple %}
-{% spaceless %}
-    {% set type = type|default('text') %}
+    {%- set type = type|default('text') -%}
     <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme" />
-{% endspaceless %}
-{% endblock form_widget_simple %}
+{%- endblock form_widget_simple %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme_extends.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme_extends.html.twig
@@ -1,8 +1,6 @@
 {% extends 'form_div_layout.html.twig' %}
 
 {% block form_widget_simple %}
-{% spaceless %}
-    {% set type = type|default('text') %}
+    {%- set type = type|default('text') -%}
     <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme" />
-{% endspaceless %}
-{% endblock form_widget_simple %}
+{%- endblock form_widget_simple %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme_use.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/theme_use.html.twig
@@ -1,8 +1,6 @@
 {% use 'form_div_layout.html.twig' %}
 
 {% block form_widget_simple %}
-{% spaceless %}
-    {% set type = type|default('text') %}
+    {%- set type = type|default('text') -%}
     <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" rel="theme" />
-{% endspaceless %}
-{% endblock form_widget_simple %}
+{%- endblock form_widget_simple %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The spaceless tag is deprecated since version 2.7.