### PR TITLE
[Routing] Exposed "utf8" option, defaults "locale" and "format" in configuration

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -31,6 +31,9 @@ class Route
     private $methods = [];
     private $schemes = [];
     private $condition;
+    private $locale;
+    private $format;
+    private $utf8;
 
     /**
      * @param array $data An array of key/value parameters
@@ -51,6 +54,21 @@ class Route
         if (isset($data['path']) && \is_array($data['path'])) {
             $data['localized_paths'] = $data['path'];
             unset($data['path']);
+        }
+
+        if (isset($data['locale'])) {
+            $data['defaults']['_locale'] = $data['locale'];
+            unset($data['locale']);
+        }
+
+        if (isset($data['format'])) {
+            $data['defaults']['_format'] = $data['format'];
+            unset($data['format']);
+        }
+
+        if (isset($data['utf8'])) {
+            $data['options']['utf8'] = filter_var($data['utf8'], FILTER_VALIDATE_BOOLEAN) ?: false;
+            unset($data['utf8']);
         }
 
         foreach ($data as $key => $value) {

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * deprecated `generator_base_class`, `generator_cache_class`, `matcher_base_class` and `matcher_cache_class` router options
  * deprecated implementing `Serializable` for `Route` and `CompiledRoute`; if you serialize them, please
    ensure your unserialization logic can recover from a failure related to an updated serialization format
+ * exposed `utf8` Route option, defaults "locale" and "format" in configuration loaders and configurators
 
 4.2.0
 -----

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -58,6 +58,18 @@ trait RouteTrait
     }
 
     /**
+     * Whether paths should accept utf8 encoding.
+     *
+     * @return $this
+     */
+    final public function utf8(bool $utf8 = true)
+    {
+        $this->route->addOptions(['utf8' => $utf8]);
+
+        return $this;
+    }
+
+    /**
      * Sets the condition.
      *
      * @return $this
@@ -121,6 +133,30 @@ trait RouteTrait
     final public function controller($controller)
     {
         $this->route->addDefaults(['_controller' => $controller]);
+
+        return $this;
+    }
+
+    /**
+     * Adds the "_locale" entry to defaults.
+     *
+     * @return $this
+     */
+    final public function locale(string $locale)
+    {
+        $this->route->addDefaults(['_locale' => $locale]);
+
+        return $this;
+    }
+
+    /**
+     * Adds the "_format" entry to defaults.
+     *
+     * @return $this
+     */
+    final public function format(string $format)
+    {
+        $this->route->addDefaults(['_format' => $format]);
 
         return $this;
     }

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -168,6 +168,7 @@ class XmlFileLoader extends FileLoader
 
         $this->setCurrentDir(\dirname($path));
 
+        /** @var RouteCollection[] $imported */
         $imported = $this->import($resource, ('' !== $type ? $type : null), false, $file);
 
         if (!\is_array($imported)) {
@@ -311,6 +312,15 @@ class XmlFileLoader extends FileLoader
             }
 
             $defaults['_controller'] = $controller;
+        }
+        if ($node->hasAttribute('locale')) {
+            $defaults['_locale'] = $node->getAttribute('locale');
+        }
+        if ($node->hasAttribute('format')) {
+            $defaults['_format'] = $node->getAttribute('format');
+        }
+        if ($node->hasAttribute('utf8')) {
+            $options['utf8'] = XmlUtils::phpize($node->getAttribute('utf8'));
         }
 
         return [$defaults, $requirements, $options, $condition, $paths, $prefixes];

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -28,7 +28,7 @@ use Symfony\Component\Yaml\Yaml;
 class YamlFileLoader extends FileLoader
 {
     private static $availableKeys = [
-        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix', 'trailing_slash_on_root',
+        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix', 'trailing_slash_on_root', 'locale', 'format', 'utf8',
     ];
     private $yamlParser;
 
@@ -125,6 +125,15 @@ class YamlFileLoader extends FileLoader
         if (isset($config['controller'])) {
             $defaults['_controller'] = $config['controller'];
         }
+        if (isset($config['locale'])) {
+            $defaults['_locale'] = $config['locale'];
+        }
+        if (isset($config['format'])) {
+            $defaults['_format'] = $config['format'];
+        }
+        if (isset($config['utf8'])) {
+            $options['utf8'] = $config['utf8'];
+        }
 
         if (\is_array($config['path'])) {
             $route = new Route('', $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
@@ -165,6 +174,15 @@ class YamlFileLoader extends FileLoader
 
         if (isset($config['controller'])) {
             $defaults['_controller'] = $config['controller'];
+        }
+        if (isset($config['locale'])) {
+            $defaults['_locale'] = $config['locale'];
+        }
+        if (isset($config['format'])) {
+            $defaults['_format'] = $config['format'];
+        }
+        if (isset($config['utf8'])) {
+            $options['utf8'] = $config['utf8'];
         }
 
         $this->setCurrentDir(\dirname($path));

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -52,6 +52,9 @@
     <xsd:attribute name="schemes" type="xsd:string" />
     <xsd:attribute name="methods" type="xsd:string" />
     <xsd:attribute name="controller" type="xsd:string" />
+    <xsd:attribute name="locale" type="xsd:string" />
+    <xsd:attribute name="format" type="xsd:string" />
+    <xsd:attribute name="utf8" type="xsd:boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="import">
@@ -67,7 +70,10 @@
     <xsd:attribute name="schemes" type="xsd:string" />
     <xsd:attribute name="methods" type="xsd:string" />
     <xsd:attribute name="controller" type="xsd:string" />
+    <xsd:attribute name="locale" type="xsd:string" />
+    <xsd:attribute name="format" type="xsd:string" />
     <xsd:attribute name="trailing-slash-on-root" type="xsd:boolean" />
+    <xsd:attribute name="utf8" type="xsd:boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="default" mixed="true">

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/GlobalDefaultsClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/GlobalDefaultsClass.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/defaults", locale="g_locale", format="g_format")
+ */
+class GlobalDefaultsClass
+{
+    /**
+     * @Route("/specific-locale", name="specific_locale", locale="s_locale")
+     */
+    public function locale()
+    {
+    }
+
+    /**
+     * @Route("/specific-format", name="specific_format", format="s_format")
+     */
+    public function format()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/Utf8ActionControllers.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/Utf8ActionControllers.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/test", utf8=true)
+ */
+class Utf8ActionControllers
+{
+    /**
+     * @Route(name="one")
+     */
+    public function one()
+    {
+    }
+
+    /**
+     * @Route(name="two", utf8=false)
+     */
+    public function two()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/defaults.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/defaults.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->add('defaults', '/defaults')
+        ->locale('en')
+        ->format('html')
+    ;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/defaults.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="defaults" path="/defaults" locale="en" format="html" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/defaults.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/defaults.yml
@@ -1,0 +1,4 @@
+defaults:
+  path: /defaults
+  locale: en
+  format: html

--- a/src/Symfony/Component/Routing/Tests/Fixtures/imported-with-defaults.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/imported-with-defaults.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes
+        ->add('one', '/one')
+        ->add('two', '/two')->defaults(['specific' => 'imported'])
+    ;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/imported-with-defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/imported-with-defaults.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="one" path="/one" />
+    <route id="two" path="/two">
+        <default key="specific">imported</default>
+    </route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/imported-with-defaults.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/imported-with-defaults.yml
@@ -1,0 +1,7 @@
+one:
+  path: /one
+
+two:
+  path: /two
+  defaults:
+    specific: imported

--- a/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->import('imported-with-defaults.php')
+        ->prefix('/defaults')
+        ->locale('g_locale')
+        ->format('g_format')
+    ;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="imported-with-defaults.xml" prefix="/defaults"
+            locale="g_locale"
+            format="g_format" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.yml
@@ -1,0 +1,5 @@
+defaults:
+  resource: imported-with-defaults.yml
+  prefix: /defaults
+  locale: g_locale
+  format: g_format

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-utf8.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-utf8.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes
+        ->add('utf8_one', '/one')
+        ->add('utf8_two', '/two')
+    ;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-utf8.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-utf8.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing">
+
+    <route id="utf8_one" path="/one" />
+    <route id="utf8_two" path="/two" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-utf8.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-utf8.yml
@@ -1,0 +1,5 @@
+utf8_one:
+    path: /one
+
+utf8_two:
+    path: /two

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-utf8.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-utf8.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->import('imported-with-utf8.php')->utf8();
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-utf8.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-utf8.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+    <import resource="imported-with-utf8.xml" utf8="true" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-utf8.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-utf8.yml
@@ -1,0 +1,3 @@
+utf8_routes:
+    resource: imported-with-utf8.yml
+    utf8: true

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/utf8.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/utf8.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes
+        ->add('some_route', '/')
+        ->add('some_utf8_route', '/utf8')->utf8()
+    ;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/utf8.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/utf8.yml
@@ -1,0 +1,6 @@
+some_route:
+    path: /
+
+some_utf8_route:
+    path: /utf8
+    utf8: true

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\AbstractClassCon
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\ActionPathController;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\DefaultValueController;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\ExplicitLocalizedActionPathController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\GlobalDefaultsClass;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\InvokableController;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\InvokableLocalizedController;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\LocalizedActionPathController;
@@ -35,6 +36,7 @@ use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\PrefixedActionLo
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\PrefixedActionPathController;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\RequirementsWithoutPlaceholderNameController;
 use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\RouteWithPrefixController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\Utf8ActionControllers;
 
 class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 {
@@ -155,6 +157,32 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->assertCount(4, $routes);
         $this->assertEquals('/the/path', $routes->get('put.en')->getPath());
         $this->assertEquals('/the/path', $routes->get('post.en')->getPath());
+    }
+
+    public function testGlobalDefaultsRoutesLoadWithAnnotation()
+    {
+        $routes = $this->loader->load(GlobalDefaultsClass::class);
+        $this->assertCount(2, $routes);
+
+        $specificLocaleRoute = $routes->get('specific_locale');
+
+        $this->assertSame('/defaults/specific-locale', $specificLocaleRoute->getPath());
+        $this->assertSame('s_locale', $specificLocaleRoute->getDefault('_locale'));
+        $this->assertSame('g_format', $specificLocaleRoute->getDefault('_format'));
+
+        $specificFormatRoute = $routes->get('specific_format');
+
+        $this->assertSame('/defaults/specific-format', $specificFormatRoute->getPath());
+        $this->assertSame('g_locale', $specificFormatRoute->getDefault('_locale'));
+        $this->assertSame('s_format', $specificFormatRoute->getDefault('_format'));
+    }
+
+    public function testUtf8RoutesLoadWithAnnotation()
+    {
+        $routes = $this->loader->load(Utf8ActionControllers::class);
+        $this->assertCount(2, $routes);
+        $this->assertTrue($routes->get('one')->getOption('utf8'), 'The route must accept utf8');
+        $this->assertFalse($routes->get('two')->getOption('utf8'), 'The route must not accept utf8');
     }
 
     public function testRouteWithPathWithPrefix()

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -84,6 +84,80 @@ class PhpFileLoaderTest extends TestCase
         );
     }
 
+    public function testLoadingRouteWithDefaults()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
+        $routes = $loader->load('defaults.php');
+
+        $this->assertCount(1, $routes);
+
+        $defaultsRoute = $routes->get('defaults');
+
+        $this->assertSame('/defaults', $defaultsRoute->getPath());
+        $this->assertSame('en', $defaultsRoute->getDefault('_locale'));
+        $this->assertSame('html', $defaultsRoute->getDefault('_format'));
+    }
+
+    public function testLoadingImportedRoutesWithDefaults()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
+        $routes = $loader->load('importer-with-defaults.php');
+
+        $this->assertCount(2, $routes);
+
+        $expectedRoutes = new RouteCollection();
+        $expectedRoutes->add('one', $localeRoute = new Route('/defaults/one'));
+        $localeRoute->setDefault('_locale', 'g_locale');
+        $localeRoute->setDefault('_format', 'g_format');
+        $expectedRoutes->add('two', $formatRoute = new Route('/defaults/two'));
+        $formatRoute->setDefault('_locale', 'g_locale');
+        $formatRoute->setDefault('_format', 'g_format');
+        $formatRoute->setDefault('specific', 'imported');
+
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/imported-with-defaults.php'));
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/importer-with-defaults.php'));
+
+        $this->assertEquals($expectedRoutes, $routes);
+    }
+
+    public function testLoadingUtf8Route()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/localized']));
+        $routes = $loader->load('utf8.php');
+
+        $this->assertCount(2, $routes);
+
+        $expectedRoutes = new RouteCollection();
+        $expectedRoutes->add('some_route', new Route('/'));
+
+        $expectedRoutes->add('some_utf8_route', $route = new Route('/utf8'));
+        $route->setOption('utf8', true);
+
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/localized/utf8.php'));
+
+        $this->assertEquals($expectedRoutes, $routes);
+    }
+
+    public function testLoadingUtf8ImportedRoutes()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/localized']));
+        $routes = $loader->load('importer-with-utf8.php');
+
+        $this->assertCount(2, $routes);
+
+        $expectedRoutes = new RouteCollection();
+        $expectedRoutes->add('utf8_one', $one = new Route('/one'));
+        $one->setOption('utf8', true);
+
+        $expectedRoutes->add('utf8_two', $two = new Route('/two'));
+        $two->setOption('utf8', true);
+
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/localized/imported-with-utf8.php'));
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/localized/importer-with-utf8.php'));
+
+        $this->assertEquals($expectedRoutes, $routes);
+    }
+
     public function testRoutingConfigurator()
     {
         $locator = new FileLocator([__DIR__.'/../Fixtures']);

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -13,7 +13,10 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Tests\Fixtures\CustomXmlFileLoader;
 
 class XmlFileLoaderTest extends TestCase
@@ -83,24 +86,79 @@ class XmlFileLoaderTest extends TestCase
         }
     }
 
-    public function testUtf8Route()
+    public function testLoadingRouteWithDefaults()
+    {
+        $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
+        $routes = $loader->load('defaults.xml');
+
+        $this->assertCount(1, $routes);
+
+        $defaultsRoute = $routes->get('defaults');
+
+        $this->assertSame('/defaults', $defaultsRoute->getPath());
+        $this->assertSame('en', $defaultsRoute->getDefault('_locale'));
+        $this->assertSame('html', $defaultsRoute->getDefault('_format'));
+    }
+
+    public function testLoadingImportedRoutesWithDefaults()
+    {
+        $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
+        $routes = $loader->load('importer-with-defaults.xml');
+
+        $this->assertCount(2, $routes);
+
+        $expectedRoutes = new RouteCollection();
+        $expectedRoutes->add('one', $localeRoute = new Route('/defaults/one'));
+        $localeRoute->setDefault('_locale', 'g_locale');
+        $localeRoute->setDefault('_format', 'g_format');
+        $expectedRoutes->add('two', $formatRoute = new Route('/defaults/two'));
+        $formatRoute->setDefault('_locale', 'g_locale');
+        $formatRoute->setDefault('_format', 'g_format');
+        $formatRoute->setDefault('specific', 'imported');
+
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/imported-with-defaults.xml'));
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/importer-with-defaults.xml'));
+
+        $this->assertEquals($expectedRoutes, $routes);
+    }
+
+    public function testLoadingUtf8Route()
     {
         $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/localized']));
-        $routeCollection = $loader->load('utf8.xml');
-        $routes = $routeCollection->all();
+        $routes = $loader->load('utf8.xml');
 
-        $this->assertCount(2, $routes, 'Two routes are loaded');
-        $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
+        $this->assertCount(2, $routes);
 
-        $utf8Route = $routeCollection->get('app_utf8');
+        $expectedRoutes = new RouteCollection();
+        $expectedRoutes->add('app_utf8', $route = new Route('/utf8'));
+        $route->setOption('utf8', true);
 
-        $this->assertSame('/utf8', $utf8Route->getPath());
-        $this->assertTrue($utf8Route->getOption('utf8'), 'Must be utf8');
+        $expectedRoutes->add('app_no_utf8', $route = new Route('/no-utf8'));
+        $route->setOption('utf8', false);
 
-        $noUtf8Route = $routeCollection->get('app_no_utf8');
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/localized/utf8.xml'));
 
-        $this->assertSame('/no-utf8', $noUtf8Route->getPath());
-        $this->assertFalse($noUtf8Route->getOption('utf8'), 'Must not be utf8');
+        $this->assertEquals($expectedRoutes, $routes);
+    }
+
+    public function testLoadingUtf8ImportedRoutes()
+    {
+        $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/localized']));
+        $routes = $loader->load('importer-with-utf8.xml');
+
+        $this->assertCount(2, $routes);
+
+        $expectedRoutes = new RouteCollection();
+        $expectedRoutes->add('utf8_one', $one = new Route('/one'));
+        $one->setOption('utf8', true);
+
+        $expectedRoutes->add('utf8_two', $two = new Route('/two'));
+        $two->setOption('utf8', true);
+
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/localized/imported-with-utf8.xml'));
+        $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/localized/importer-with-utf8.xml'));
+
+        $this->assertEquals($expectedRoutes, $routes);
     }
 
     public function testLoadLocalized()

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -24,7 +24,7 @@
         "symfony/yaml": "~3.4|~4.0",
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/dependency-injection": "~3.4|~4.0",
-        "doctrine/annotations": "~1.0",
+        "doctrine/annotations": "~1.2",
         "psr/log": "~1.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | symfony/symfony-docs#11126

A sibling to #30501, everything is in the title :).