### PR TITLE
[Form] Fix debug form when using partial type name

### DIFF
--- a/src/Symfony/Component/Form/Command/DebugCommand.php
+++ b/src/Symfony/Component/Form/Command/DebugCommand.php
@@ -115,7 +115,7 @@ EOF
                 sort($options[$k]);
             }
         } else {
-            if (!class_exists($class)) {
+            if (!class_exists($class) || !is_subclass_of($class, FormTypeInterface::class)) {
                 $class = $this->getFqcnTypeClass($input, $io, $class);
             }
             $resolvedType = $this->formRegistry->getType($class);

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -66,6 +66,15 @@ TXT
         $this->assertContains('Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")', $tester->getDisplay());
     }
 
+    public function testDebugDateTimeType()
+    {
+        $tester = $this->createCommandTester();
+        $tester->execute(['class' => 'DateTime'], ['decorated' => false, 'interactive' => false]);
+
+        $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        $this->assertContains('Symfony\Component\Form\Extension\Core\Type\DateTimeType (Block prefix: "datetime")', $tester->getDisplay());
+    }
+
     public function testDebugFormTypeOption()
     {
         $tester = $this->createCommandTester();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Since https://github.com/symfony/symfony/pull/29452 (4.3) we have the possibility of passing a partial type name. This fixes the case where `debug:form dateTime` doesn't work as expected:
```bash
In FormRegistry.php line 89:
                                                                                                        
  [Symfony\Component\Form\Exception\InvalidArgumentException]                                           
  Could not load type "dateTime": class does not implement "Symfony\Component\Form\FormTypeInterface". 
```