### PR TITLE
[HttpClient] yield a last chunk for completed responses also

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -165,10 +165,6 @@ final class NativeResponse implements ResponseInterface
      */
     private static function schedule(self $response, array &$runningResponses): void
     {
-        if (null === $response->buffer) {
-            return;
-        }
-
         if (!isset($runningResponses[$i = $response->multi->id])) {
             $runningResponses[$i] = [$response->multi, []];
         }
@@ -177,6 +173,12 @@ final class NativeResponse implements ResponseInterface
             $response->multi->pendingResponses[] = $response;
         } else {
             $runningResponses[$i][1][$response->id] = $response;
+        }
+
+        if (null === $response->buffer) {
+            // Response already completed
+            $response->multi->handlesActivity[$response->id][] = null;
+            $response->multi->handlesActivity[$response->id][] = null !== $response->info['error'] ? new TransportException($response->info['error']) : null;
         }
     }
 

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -194,8 +194,8 @@ abstract class HttpClientTestCase extends TestCase
         $this->assertSame($response, $r);
         $this->assertNotNull($chunk->getError());
 
+        $this->expectException(TransportExceptionInterface::class);
         foreach ($client->stream($response) as $chunk) {
-            $this->fail('Already errored responses shouldn\'t be yielded');
         }
     }
 
@@ -340,6 +340,16 @@ abstract class HttpClientTestCase extends TestCase
 
         $this->assertSame($response, $r);
         $this->assertSame(['f', 'l'], $result);
+
+        $chunk = null;
+        $i = 0;
+
+        foreach ($client->stream($response) as $chunk) {
+            ++$i;
+        }
+
+        $this->assertSame(1, $i);
+        $this->assertTrue($chunk->isLast());
     }
 
     public function testAddToStream()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When a response completed, streaming it again yields no chunks right now.
This PR makes it yield a `LastChunk` - or an `ErrorChunk` when applicable.
The reasoning for the previous behavior was that streams should yield only activity from the network.
But this looks more complex to use in practice. The proposed behavior is simpler to reason about I think.