### PR TITLE
[FrameworkBundle] Add a controller to send simple HTTP responses

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/SimpleController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/SimpleController.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Generates a simple HTTP Response.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class SimpleController
+{
+    public function __invoke(string $content = '', int $status = 200, array $headers = [], int $maxAge = null, int $sharedAge = null, bool $private = null): Response
+    {
+        $response = new Response($content, $status, $headers);
+
+        if ($maxAge) {
+            $response->setMaxAge($maxAge);
+        }
+
+        if ($sharedAge) {
+            $response->setSharedMaxAge($sharedAge);
+        }
+
+        if ($private) {
+            $response->setPrivate();
+        } elseif (false === $private || (null === $private && ($maxAge || $sharedAge))) {
+            $response->setPublic();
+        }
+
+        return $response;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/SimpleControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/SimpleControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Controller\SimpleController;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class SimpleControllerTest extends TestCase
+{
+    public function testSimpleResponse()
+    {
+        $response = (new SimpleController())('content', 203, ['Content-Type' => 'text/plain'], 10, 20);
+        $this->assertSame('content', $response->getContent());
+        $this->assertSame(203, $response->getStatusCode());
+        $this->assertSame('text/plain', $response->headers->get('Content-Type'));
+        $this->assertSame('max-age=10, public, s-maxage=20', $response->headers->get('Cache-Control'));
+    }
+
+    public function testPrivateResponse()
+    {
+        $response = (new SimpleController())('', 200, [], null, null, true);
+        $this->assertSame('private', $response->headers->get('Cache-Control'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes<!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

This PR adds a new built-in controller, similar to `TemplateController` and `RedirectController`, allowing to send simple HTTP response without having to write a custom controller:

```yaml
# config/routes.yaml
login:
  path: /my-page
  controller: Symfony\Bundle\FrameworkBundle\Controller\SimpleController
  defaults:
    content: 'A simple web page'
```

This is especially useful when dealing with the security system, here is a fully working example of a JSON-based login endpoint:

```yaml
# config/routes.yaml
login:
  path: /login
  methods: POST
  controller: Symfony\Bundle\FrameworkBundle\Controller\SimpleController
  defaults:
    content: '{"status": "success"}'
    _format: json
    private: true
```

```yaml
# config/packages/security.yaml
security:
    firewalls:
        main:
            anonymous: true
            json_login:
                check_path: /login
```

It can also be useful for the following use cases:

* Health check URL for Kubernetes / Nagios / whatever returning a 200 OK and a predefined string
* Secret URL returning a token proving you're the owner of a domain (Google Analytics validation for instance)
