### PR TITLE
[Cache] Only delete one key at a time when on Predis + Cluster

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -272,7 +272,17 @@ trait RedisTrait
      */
     protected function doDelete(array $ids)
     {
-        if ($ids) {
+        if (!$ids) {
+            return true;
+        }
+
+        if ($this->redis instanceof \Predis\Client && $this->redis->getConnection() instanceof ClusterInterface) {
+            $this->pipeline(function () use ($ids) {
+                foreach ($ids as $id) {
+                    yield 'del' => [$id];
+                }
+            })->rewind();
+        } else {
             $this->redis->del($ids);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Makes sure deletes when on Predis  Cluster is only done one by one as it's not able to send the keys to right cluster node like RedisCluster can.

_This is backport of logic from 4.x to fix this. With one tweak; make sure to only do this when on cluster so not all Predis users pay the penalty for it._


