### PR TITLE
[Cache] Fix perf when using RedisCluster by reducing roundtrips to the servers

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
+{
+    public static function setupBeforeClass()
+    {
+        if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
+        }
+        self::$redis = new \Predis\Client(explode(' ', $hosts), ['cluster' => 'redis']);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$redis = null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This is slimmed down version of: https://github.com/symfony/symfony/pull/28269 _(many of the fixes there are already part of 3.4)_

Does:
- Adds test coverage for Predis with RedisCluster
- Removes usage of key versioning when on RedisCluster, besides performance aspect of that it simplifies / aligning clear() handling across all clients
- reuse doDelete() from clear to make sure we call singular del calls when in predis cluster