### PR TITLE
[RouterDebugCommand] add link to Controllers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -34,12 +35,14 @@ class RouterDebugCommand extends Command
 {
     protected static $defaultName = 'debug:router';
     private $router;
+    private $fileLinkFormatter;
 
-    public function __construct(RouterInterface $router)
+    public function __construct(RouterInterface $router, FileLinkFormatter $fileLinkFormatter = null)
     {
         parent::__construct();
 
         $this->router = $router;
+        $this->fileLinkFormatter = $fileLinkFormatter;
     }
 
     /**
@@ -74,7 +77,7 @@ EOF
     {
         $io = new SymfonyStyle($input, $output);
         $name = $input->getArgument('name');
-        $helper = new DescriptorHelper();
+        $helper = new DescriptorHelper($this->fileLinkFormatter);
         $routes = $this->router->getRouteCollection();
 
         if ($name) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Helper/DescriptorHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Helper/DescriptorHelper.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\MarkdownDescriptor;
 use Symfony\Bundle\FrameworkBundle\Console\Descriptor\TextDescriptor;
 use Symfony\Bundle\FrameworkBundle\Console\Descriptor\XmlDescriptor;
 use Symfony\Component\Console\Helper\DescriptorHelper as BaseDescriptorHelper;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 
 /**
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
@@ -24,10 +25,10 @@ use Symfony\Component\Console\Helper\DescriptorHelper as BaseDescriptorHelper;
  */
 class DescriptorHelper extends BaseDescriptorHelper
 {
-    public function __construct()
+    public function __construct(FileLinkFormatter $fileLinkFormatter = null)
     {
         $this
-            ->register('txt', new TextDescriptor())
+            ->register('txt', new TextDescriptor($fileLinkFormatter))
             ->register('xml', new XmlDescriptor())
             ->register('json', new JsonDescriptor())
             ->register('md', new MarkdownDescriptor())

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -111,6 +111,7 @@
 
         <service id="console.command.router_debug" class="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand">
             <argument type="service" id="router" />
+            <argument type="service" id="debug.file_link_formatter" on-invalid="null" />
             <tag name="console.command" command="debug:router" />
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Adds a link to the controller method on your IDE from dev's terminal: 

<img width="734" alt="pr-debug-router" src="https://user-images.githubusercontent.com/29813575/54141007-1f3bc400-4425-11e9-82d0-1b37498d4953.png">

Configuration in your `services.yaml`:

```yaml
parameters:
    debug.file_link_format: phpstorm://open?file=%%f&line=%%l
```