### PR TITLE
[framworkbundle] fix search in debug:autowiring command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -110,7 +110,7 @@ EOF
                 if ($serviceAlias->isDeprecated()) {
                     $serviceLine .= ' - <fg=magenta>deprecated</>';
                 }
-            } elseif (!$all) {
+            } elseif (!$all && !$search) {
                 continue;
             }
             $text[] = $serviceLine;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -75,13 +75,13 @@ class DebugAutowiringCommandTest extends WebTestCase
 
     public function testSearchNotAliasedService()
     {
-        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml']);
 
         $application = new Application(static::$kernel);
         $application->setAutoExit(false);
 
         $tester = new ApplicationTester($application);
-        $tester->run(array('command' => 'debug:autowiring', 'search' => 'redirect'));
+        $tester->run(['command' => 'debug:autowiring', 'search' => 'redirect']);
 
         $this->assertContains('Symfony\Bundle\FrameworkBundle\Controller\RedirectController', $tester->getDisplay());
         $this->assertNotContains('Symfony\Component\Routing\RouterInterface', $tester->getDisplay());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -72,4 +72,18 @@ class DebugAutowiringCommandTest extends WebTestCase
         $this->assertContains('No autowirable classes or interfaces found matching "foo_fake"', $tester->getErrorOutput());
         $this->assertEquals(1, $tester->getStatusCode());
     }
+
+    public function testSearchNotAliasedService()
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:autowiring', 'search' => 'redirect'));
+
+        $this->assertContains('Symfony\Bundle\FrameworkBundle\Controller\RedirectController', $tester->getDisplay());
+        $this->assertNotContains('Symfony\Component\Routing\RouterInterface', $tester->getDisplay());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30493 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

When searching for autowiring class : 

If the class not found the command return exception ` [ERROR] No autowirable classes or interfaces found matching "fake" `

But After adding the option **all** to the command ( To shwing no aliased services), if someone search for no aliased services without the option **all**. the command command will return empty result and not exception.

I suggested if someone adding search argument. the command must return the aliased and no aliased services. I think it would be better to return the aliased and no aliased services for devs.
