### PR TITLE
[PropertyInfo] Use a single cache item per method

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -24,6 +24,13 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface
 {
     private $propertyInfoExtractor;
     private $cacheItemPool;
+
+    /**
+     * A cache of property information, first keyed by the method called and
+     * then by the serialized method arguments.
+     *
+     * @var array
+     */
     private $arrayCache = [];
 
     public function __construct(PropertyInfoExtractorInterface $propertyInfoExtractor, CacheItemPoolInterface $cacheItemPool)
@@ -98,22 +105,34 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface
         }
 
         // Calling rawurlencode escapes special characters not allowed in PSR-6's keys
-        $key = rawurlencode($method.'.'.$serializedArguments);
-
-        if (\array_key_exists($key, $this->arrayCache)) {
-            return $this->arrayCache[$key];
+        $encodedMethod = \rawurlencode($method);
+        if (\array_key_exists($encodedMethod, $this->arrayCache) && \array_key_exists($serializedArguments, $this->arrayCache[$encodedMethod])) {
+            return $this->arrayCache[$encodedMethod][$serializedArguments];
         }
 
-        $item = $this->cacheItemPool->getItem($key);
+        $item = $this->cacheItemPool->getItem($encodedMethod);
 
+        $data = $item->get();
         if ($item->isHit()) {
-            return $this->arrayCache[$key] = $item->get();
+            $this->arrayCache[$encodedMethod] = $data[$encodedMethod];
+            // Only match if the specific arguments have been cached.
+            if (\array_key_exists($serializedArguments, $data[$encodedMethod])) {
+                return $this->arrayCache[$encodedMethod][$serializedArguments];
+            }
+        }
+
+        // It's possible that the method has been called, but with different
+        // arguments, in which case $data will already be initialized.
+        if (!$data) {
+            $data = [];
         }
 
         $value = \call_user_func_array([$this->propertyInfoExtractor, $method], $arguments);
-        $item->set($value);
+        $data[$encodedMethod][$serializedArguments] = $value;
+        $this->arrayCache[$encodedMethod][$serializedArguments] = $value;
+        $item->set($data);
         $this->cacheItemPool->save($item);
 
-        return $this->arrayCache[$key] = $value;
+        return $this->arrayCache[$encodedMethod][$serializedArguments];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29977
| License       | MIT
| Doc PR        | none

This PR changes how property metadata is cached, significantly reducing the number of calls made between PHP and the backend cache. Instead of storing one cache item per method and set of arguments, a single cache item is stored per method. This matches well with real-world use, where most properties in an object will need to be inspected.

It's not clear to me if performance improvements fall under "bug fix", though I will say that we would have had to rewrite our code to remove PropertyInfo without this change.

Note that the absolute numbers in the above PR are best case. In production environments where memcache is on a remote server, we were seeing multiple seconds consumed by memcache calls.