### PR TITLE
[Debug] Fix deprecation false positive

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -334,7 +334,7 @@ class DebugClassLoader
             if ($finalOrInternal || $method->isConstructor() || false === \strpos($doc, '@param') || StatelessInvocation::class === $class) {
                 continue;
             }
-            if (!preg_match_all('#\n\s+\* @param (.*?)(?<= )\$([a-zA-Z0-9_\x7f-\xff]++)#', $doc, $matches, PREG_SET_ORDER)) {
+            if (!preg_match_all('#\n\s+\* @param ([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff[\]<>]+)? \$([a-zA-Z0-9_\x7f-\xff]++)#', $doc, $matches, PREG_SET_ORDER)) {
                 continue;
             }
             if (!isset(self::$annotatedParameters[$class][$method->name])) {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/ClassWithAnnotatedParameters.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/ClassWithAnnotatedParameters.php
@@ -31,4 +31,11 @@ class ClassWithAnnotatedParameters
     public function isSymfony()
     {
     }
+
+    /**
+     * @param callable (string $foo) $callback a callback
+     */
+    public function methodWithCallback(callable $callback)
+    {
+    }
 }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/SubClassWithAnnotatedParameters.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/SubClassWithAnnotatedParameters.php
@@ -21,4 +21,8 @@ class SubClassWithAnnotatedParameters extends ClassWithAnnotatedParameters imple
     public function whereAmI()
     {
     }
+
+    public function methodWithCallback(callable $callback)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR fixes unexpected deprecation notices when the format of a `@param` annotation is invalid, e.g.:
```php
/**
 * @param callable (string $foo) $callback
 */
```

I got the issue when using code from `amphp/amp`: https://github.com/amphp/amp/blob/master/lib/Promise.php
```
  1x: The "Amp\Failure::onResolve()" method will require a new "callable(\Throwable|null $reason" argument in the next major version of its parent class "Amp\Promise", not defining it is deprecated.
    1x in TaskWorker::Amp\Parallel\Worker\{closure} from Amp\Parallel\Worker
```

The current fix makes the regular expression match argument types more strictly but I'm not sure Symfony should be responsible of triggering those deprecation notices for external packages in the first place. If we limit the notices to Symfony codebase, we can assume the current regular expression is ok.