### PR TITLE
[Messenger] deprecate LoggingMiddleware in favor of providing a logger to SendMessageMiddleware

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -61,6 +61,7 @@ Messenger
 ---------
 
  * `Amqp` transport does not throw `\AMQPException` anymore, catch `TransportException` instead.
+ * Deprecated the `LoggingMiddleware` class, pass a logger to `SendMessageMiddleware` instead.
 
 Routing
 -------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -207,6 +207,11 @@ HttpKernel
  * Removed `ConfigDataCollector::getApplicationName()`
  * Removed `ConfigDataCollector::getApplicationVersion()`
 
+Messenger
+---------
+
+ * The `LoggingMiddleware` class has been removed, pass a logger to `SendMessageMiddleware` instead.
+
 Monolog
 -------
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1598,7 +1598,7 @@ class FrameworkExtension extends Extension
         }
 
         $defaultMiddleware = [
-            'before' => [['id' => 'logging']],
+            'before' => [],
             'after' => [['id' => 'send_message'], ['id' => 'handle_message']],
         ];
         foreach ($config['buses'] as $busId => $bus) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -13,7 +13,11 @@
             <argument type="collection" /> <!-- Messages to send and handle -->
         </service>
         <service id="messenger.middleware.send_message" class="Symfony\Component\Messenger\Middleware\SendMessageMiddleware">
+            <tag name="monolog.logger" channel="messenger" />
             <argument type="service" id="messenger.senders_locator" />
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore" />
+            </call>
         </service>
 
         <!-- Message encoding/decoding -->
@@ -28,7 +32,11 @@
 
         <!-- Middleware -->
         <service id="messenger.middleware.handle_message" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">
+            <tag name="monolog.logger" channel="messenger" />
             <argument /> <!-- Bus handler resolver -->
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore" />
+            </call>
         </service>
 
         <service id="messenger.middleware.validation" class="Symfony\Component\Messenger\Middleware\ValidationMiddleware">
@@ -37,12 +45,6 @@
 
         <service id="messenger.middleware.traceable" class="Symfony\Component\Messenger\Middleware\TraceableMiddleware" abstract="true">
             <argument type="service" id="debug.stopwatch" />
-        </service>
-
-        <!-- Logging -->
-        <service id="messenger.middleware.logging" class="Symfony\Component\Messenger\Middleware\LoggingMiddleware">
-            <tag name="monolog.logger" channel="messenger" />
-            <argument type="service" id="logger" />
         </service>
 
         <!-- Discovery -->

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -701,14 +701,12 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->has('messenger.bus.commands'));
         $this->assertSame([], $container->getDefinition('messenger.bus.commands')->getArgument(0));
         $this->assertEquals([
-            ['id' => 'logging'],
             ['id' => 'send_message'],
             ['id' => 'handle_message'],
         ], $container->getParameter('messenger.bus.commands.middleware'));
         $this->assertTrue($container->has('messenger.bus.events'));
         $this->assertSame([], $container->getDefinition('messenger.bus.events')->getArgument(0));
         $this->assertEquals([
-            ['id' => 'logging'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
             ['id' => 'send_message'],
             ['id' => 'handle_message'],

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,15 +6,13 @@ CHANGELOG
 
  * Added `PhpSerializer` which uses PHP's native `serialize()` and
    `unserialize()` to serialize messages to a transport
-
  * [BC BREAK] If no serializer were passed, the default serializer
    changed from `Serializer` to `PhpSerializer` inside `AmqpReceiver`,
    `AmqpSender`, `AmqpTransport` and `AmqpTransportFactory`.
-
  * Added `TransportException` to mark an exception transport-related
-
  * [BC BREAK] If listening to exceptions while using `AmqpSender` or `AmqpReceiver`, `\AMQPException` is
    no longer thrown in favor of `TransportException`.
+ * Deprecated `LoggingMiddleware`, pass a logger to `SendMessageMiddleware` instead.
 
 4.2.0
 -----

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -170,8 +170,8 @@ EOF
 
         $io->comment('Quit the worker with CONTROL-C.');
 
-        if (!$output->isDebug()) {
-            $io->comment('Re-run the command with a -vvv option to see logs about consumed messages.');
+        if (OutputInterface::VERBOSITY_VERBOSE > $output->getVerbosity()) {
+            $io->comment('Re-run the command with a -vv option to see logs about consumed messages.');
         }
 
         $worker = new Worker($receiver, $bus);

--- a/src/Symfony/Component/Messenger/Middleware/LoggingMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/LoggingMiddleware.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Component\Messenger\Middleware;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.3, pass a logger to SendMessageMiddleware instead.', LoggingMiddleware::class), E_USER_DEPRECATED);
+
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  *
- * @experimental in 4.2
+ * @deprecated since 4.3, pass a logger to SendMessageMiddleware instead
  */
 class LoggingMiddleware implements MiddlewareInterface
 {

--- a/src/Symfony/Component/Messenger/Tests/Middleware/LoggingMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/LoggingMiddlewareTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\Messenger\Middleware\LoggingMiddleware;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
+/**
+ * @group legacy
+ */
 class LoggingMiddlewareTest extends MiddlewareTestCase
 {
     public function testDebugLogAndNextMiddleware()

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "psr/log": "~1.0"
     },
     "require-dev": {
-        "psr/log": "~1.0",
         "symfony/console": "~3.4|~4.0",
         "symfony/dependency-injection": "~3.4.19|^4.1.8",
         "symfony/http-kernel": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Discussing with @simensen, we figured out the currently logged messages are not precise enough.
Logging is a cross-cutting concern: splitting it in a dedicated middleware means losing details - or building complexity.
Let's make things simple and log the best messages depending on the internal situation.

While the component is experimental, removing the `LoggingMiddleware` altogether would break FrameworkBundle 4.2 when it is used with Messenger 4.3. Not worth the trouble when it's two lines to deprecate IMHO.