### PR TITLE
[HttpClient] Add a mock client

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -5,4 +5,3 @@ CHANGELOG
 -----
 
  * added the component
- * added a mock client

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 -----
 
  * added the component
+ * added a mock client

--- a/src/Symfony/Component/HttpClient/MockClient.php
+++ b/src/Symfony/Component/HttpClient/MockClient.php
@@ -78,7 +78,10 @@ class MockClient implements HttpClientInterface
         return new ResponseStream($this->streamResponses($responses));
     }
 
-    public function addResponse(ResponseInterface $response): self
+    /**
+     * @return $this
+     */
+    public function addResponse(ResponseInterface $response)
     {
         $this->responses[] = $response;
 
@@ -102,14 +105,14 @@ class MockClient implements HttpClientInterface
                 $response->getHeaders(true);
             } catch (TransportExceptionInterface $e) {
                 yield $response => new ErrorChunk($didThrow, 0, $e);
+
+                continue;
             }
 
             try {
-                $content = $response->getContent(true);
-
-                yield $response => new FirstChunk(0, $content);
-                yield $response => new DataChunk(1, $content);
-                yield $response => new LastChunk(2, $content);
+                yield $response => new FirstChunk();
+                yield $response => new DataChunk(0, $content = $response->getContent(true));
+                yield $response => new LastChunk(\strlen($content));
             } catch (TransportExceptionInterface $e) {
                 yield $response => new ErrorChunk($didThrow, 0, $e);
             }

--- a/src/Symfony/Component/HttpClient/MockClient.php
+++ b/src/Symfony/Component/HttpClient/MockClient.php
@@ -89,7 +89,7 @@ class MockClient implements HttpClientInterface
     }
 
     /**
-     * Clear all predefined responses.
+     * Clears all predefined responses.
      */
     public function clear(): void
     {

--- a/src/Symfony/Component/HttpClient/MockClient.php
+++ b/src/Symfony/Component/HttpClient/MockClient.php
@@ -57,7 +57,11 @@ class MockClient implements HttpClientInterface
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
-        return $this->getNextResponse();
+        if (!\count($this->responses)) {
+            throw new TransportException('No predefined response to send. Please add one or more using "addResponse" method.');
+        }
+
+        return \array_shift($this->responses);
     }
 
     /**
@@ -82,20 +86,11 @@ class MockClient implements HttpClientInterface
     }
 
     /**
-     * Clear all predefined responses and requests.
+     * Clear all predefined responses.
      */
     public function clear(): void
     {
         $this->responses = [];
-    }
-
-    private function getNextResponse(): ResponseInterface
-    {
-        if (!\count($this->responses)) {
-            throw new TransportException('No predefined response to send. Please add one or more using "addResponse" method.');
-        }
-
-        return \array_shift($this->responses);
     }
 
     private function streamResponses(iterable $responses): \Generator

--- a/src/Symfony/Component/HttpClient/MockClient.php
+++ b/src/Symfony/Component/HttpClient/MockClient.php
@@ -99,21 +99,15 @@ class MockClient implements HttpClientInterface
     private function streamResponses(iterable $responses): \Generator
     {
         foreach ($responses as $response) {
-            $didThrow = false;
-
             try {
                 $response->getHeaders(true);
-            } catch (TransportExceptionInterface $e) {
-                yield $response => new ErrorChunk($didThrow, 0, $e);
 
-                continue;
-            }
-
-            try {
                 yield $response => new FirstChunk();
                 yield $response => new DataChunk(0, $content = $response->getContent(true));
                 yield $response => new LastChunk(\strlen($content));
             } catch (TransportExceptionInterface $e) {
+                $didThrow = false;
+
                 yield $response => new ErrorChunk($didThrow, 0, $e);
             }
         }

--- a/src/Symfony/Component/HttpClient/MockClient.php
+++ b/src/Symfony/Component/HttpClient/MockClient.php
@@ -95,6 +95,7 @@ class MockClient implements HttpClientInterface
     private function streamNext(): \Generator
     {
         $response = $this->getNextResponse();
+        $didThrow = false;
 
         try {
             $response->getHeaders(true);

--- a/src/Symfony/Component/HttpClient/MockClient.php
+++ b/src/Symfony/Component/HttpClient/MockClient.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient;
+
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * Provides a way to tests the HttpClient without making actual HTTP requests.
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class MockClient implements HttpClientInterface
+{
+    use HttpClientTrait;
+
+    /**
+     * Predefined responses. Throw a TransportExceptionInterface when none provided.
+     *
+     * @var ResponseInterface[]
+     */
+    private $responses = [];
+
+    /**
+     * Predefined streamed responses. Throw a TransportExceptionInterface when none provided.
+     *
+     * @var ResponseStreamInterface[]
+     */
+    private $streams = [];
+
+    private $requests = [];
+
+    private $streamedRequests = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        if (!\count($this->responses)) {
+            throw new TransportException('No predefined response to send. Please add one or more using "addResponse" method.');
+        }
+
+        [$url, $options] = static::prepareRequest($method, $url, $options, [], true);
+        $this->requests[] = compact('method', 'url', 'options');
+
+        return \array_shift($this->responses);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    {
+        if (!\count($this->streams)) {
+            throw new TransportException('No predefined response to send. Please add one or more using "addResponseStream" method.');
+        }
+
+        $this->streamedRequests[] = $responses;
+
+        return \array_shift($this->streams);
+    }
+
+    public function addResponse(ResponseInterface $response): self
+    {
+        $this->responses[] = $response;
+
+        return $this;
+    }
+
+    public function addResponseStream(ResponseStreamInterface $response): self
+    {
+        $this->streams[] = $response;
+
+        return $this;
+    }
+
+    /**
+     * Get all the call to ::request() made by the client.
+     */
+    public function getRequests(): array
+    {
+        return $this->requests;
+    }
+
+    /**
+     * Get all the call to ::stream() made by the client.
+     */
+    public function getStreamedRequests(): array
+    {
+        return $this->streamedRequests;
+    }
+
+    /**
+     * Clear all predefined responses and requests.
+     */
+    public function clear(): void
+    {
+        $this->responses = [];
+        $this->streams = [];
+        $this->requests = [];
+        $this->streamedRequests = [];
+    }
+}

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -22,7 +22,7 @@ class MockResponse implements ResponseInterface
 {
     use ResponseTrait;
 
-    protected const DEFAULT_INFO = [
+    private const DEFAULT_INFO = [
         'raw_headers' => [],    // An array modelled after the special $http_response_header variable
         'redirect_count' => 0,  // The number of redirects followed while executing the request
         'redirect_url' => null, // The resolved location of redirect responses, null otherwise
@@ -40,7 +40,7 @@ class MockResponse implements ResponseInterface
 
     public function __construct(string $content = '', int $code = 200, array $headers = [], array $info = [], ?callable $initializer = null)
     {
-        $default = static::DEFAULT_INFO;
+        $default = self::DEFAULT_INFO;
         $default['start_time'] = microtime(true);
 
         $this->content = $content;

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * A test-friendly response.
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class MockResponse implements ResponseInterface
+{
+    use ResponseTrait;
+
+    protected const DEFAULT_INFO = [
+        'raw_headers' => [],    // An array modelled after the special $http_response_header variable
+        'redirect_count' => 0,  // The number of redirects followed while executing the request
+        'redirect_url' => null, // The resolved location of redirect responses, null otherwise
+        'start_time' => 0.0,    // The time when the request was sent or 0.0 when it's pending
+        'http_method' => 'GET', // The HTTP verb of the last request
+        'http_code' => 0,       // The last response code or 0 when it is not known yet
+        'error' => null,        // The error message when the transfer was aborted, null otherwise
+        'data' => null,         // The value of the "data" request option, null if not set
+        'url' => '',            // The last effective URL of the request
+    ];
+    /**
+     * @var callable|null
+     */
+    private $initializer;
+
+    public function __construct(string $content = '', int $code = 200, array $headers = [], array $info = [], ?callable $initializer = null)
+    {
+        $default = static::DEFAULT_INFO;
+        $default['start_time'] = microtime(true);
+
+        $this->content = $content;
+        $this->info = \array_merge($default, $info);
+        $this->info['http_code'] = $code;
+        $this->initializer = $initializer;
+        $this->headers = $headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInfo(string $type = null)
+    {
+        if ($type) {
+            return $this->info[$type] ?? null;
+        }
+
+        return $this->info;
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        if ($this->initializer) {
+            ($this->initializer)($this);
+            $this->initializer = null;
+        }
+
+        if ($throw) {
+            $this->checkStatusCode();
+        }
+
+        return $this->content;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function close(): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function schedule(self $response, array &$runningResponses): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function perform(\stdClass $multi, array &$responses): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function select(\stdClass $multi, float $timeout): int
+    {
+        return 42;
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/MockClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockClientTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpClient\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -21,8 +22,7 @@ class MockClientTest extends TestCase
 {
     public function testStream()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->any())->method('getContent')->willReturn('{"foo": "bar"}');
+        $response = new MockResponse('{"foo": "bar"}');
 
         $client = new MockClient();
 
@@ -52,7 +52,7 @@ class MockClientTest extends TestCase
     public function testRequest()
     {
         /** @var ResponseInterface $response */
-        $response = $this->createMock(ResponseInterface::class);
+        $response = new MockResponse();
         $client = new MockClient();
         $client->addResponse($response);
 

--- a/src/Symfony/Component/HttpClient/Tests/MockClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockClientTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockClient;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+class MockClientTest extends TestCase
+{
+    public function testStream()
+    {
+        $expected = [$this->createMock(ResponseInterface::class)];
+        /** @var ResponseStreamInterface $response */
+        $response = $this->createMock(ResponseStreamInterface::class);
+        $client = new MockClient();
+        $client->addResponseStream($response);
+
+        $this->assertSame($response, $client->stream($expected));
+        $requests = $client->getStreamedRequests();
+        $this->assertCount(1, $requests);
+        $this->assertSame($expected, $requests[0]);
+    }
+
+    public function testRequest()
+    {
+        /** @var ResponseInterface $response */
+        $response = $this->createMock(ResponseInterface::class);
+        $client = new MockClient();
+        $client->addResponse($response);
+
+        $this->assertSame($response, $client->request('GET', '/whatever?q=foo', ['base_uri' => 'http://example.org']));
+        $requests = $client->getRequests();
+        $this->assertCount(1, $requests);
+        $this->assertSame('GET', $requests[0]['method']);
+        $this->assertSame('http://example.org/whatever?q=foo', implode('', $requests[0]['url']));
+    }
+
+    public function testRequestWithoutResponse()
+    {
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('No predefined response to send. Please add one or more using "addResponse" method.');
+
+        (new MockClient())->request('GET', '/whatever?q=foo', ['base_uri' => 'http://example.org']);
+    }
+
+    public function testStreamWithoutResponse()
+    {
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('No predefined response to send. Please add one or more using "addResponseStream" method.');
+
+        (new MockClient())->stream([]);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/MockClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockClientTest.php
@@ -14,23 +14,25 @@ namespace Symfony\Component\HttpClient\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockClient;
+use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
-use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 class MockClientTest extends TestCase
 {
     public function testStream()
     {
-        $expected = [$this->createMock(ResponseInterface::class)];
-        /** @var ResponseStreamInterface $response */
-        $response = $this->createMock(ResponseStreamInterface::class);
-        $client = new MockClient();
-        $client->addResponseStream($response);
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->any())->method('getContent')->willReturn('{"foo": "bar"}');
 
-        $this->assertSame($response, $client->stream($expected));
-        $requests = $client->getStreamedRequests();
-        $this->assertCount(1, $requests);
-        $this->assertSame($expected, $requests[0]);
+        $client = new MockClient([$response]);
+
+        foreach ($client->stream([]) as $chunk) {
+            $this->assertInstanceOf(ChunkInterface::class, $chunk);
+
+            if ($chunk->isLast()) {
+                $this->assertSame('{"foo": "bar"}', $chunk->getContent());
+            }
+        }
     }
 
     public function testRequest()
@@ -41,10 +43,6 @@ class MockClientTest extends TestCase
         $client->addResponse($response);
 
         $this->assertSame($response, $client->request('GET', '/whatever?q=foo', ['base_uri' => 'http://example.org']));
-        $requests = $client->getRequests();
-        $this->assertCount(1, $requests);
-        $this->assertSame('GET', $requests[0]['method']);
-        $this->assertSame('http://example.org/whatever?q=foo', implode('', $requests[0]['url']));
     }
 
     public function testRequestWithoutResponse()
@@ -53,13 +51,5 @@ class MockClientTest extends TestCase
         $this->expectExceptionMessage('No predefined response to send. Please add one or more using "addResponse" method.');
 
         (new MockClient())->request('GET', '/whatever?q=foo', ['base_uri' => 'http://example.org']);
-    }
-
-    public function testStreamWithoutResponse()
-    {
-        $this->expectException(TransportException::class);
-        $this->expectExceptionMessage('No predefined response to send. Please add one or more using "addResponseStream" method.');
-
-        (new MockClient())->stream([]);
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/MockClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockClientTest.php
@@ -25,14 +25,15 @@ class MockClientTest extends TestCase
         $response = new MockResponse('{"foo": "bar"}');
 
         $client = new MockClient();
+        $chunks = '';
 
         foreach ($client->stream($response) as $chunk) {
             $this->assertInstanceOf(ChunkInterface::class, $chunk);
 
-            if ($chunk->isLast()) {
-                $this->assertSame('{"foo": "bar"}', $chunk->getContent());
-            }
+            $chunks .= $chunk->getContent();
         }
+
+        $this->assertSame('{"foo": "bar"}', $chunks);
     }
 
     public function testStreamWithUnhappyResponse()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | TODO

Add a new `MockClient` usable for test purpose:
```php
/** @var ResponseInterface $response */
$response = $this->createMock(ResponseInterface::class);
$client = new MockClient();

// Add one or more predefined responses
$client->addResponse($response);

$client->request('GET', '/whatever', ['base_uri' => 'http://example.org']);
```

WDYT?