### PR TITLE
[HttpClient] Parse common API error formats for better exception messages

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/Exception/HttpExceptionTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Exception/HttpExceptionTraitTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\HttpExceptionTrait;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class HttpExceptionTraitTest extends TestCase
+{
+    public function provideParseError()
+    {
+        yield ['application/ld+json', '{"hydra:title": "An error occurred", "hydra:description": "Some details"}'];
+        yield ['application/problem+json', '{"title": "An error occurred", "detail": "Some details"}'];
+        yield ['application/vnd.api+json', '{"title": "An error occurred", "detail": "Some details"}'];
+    }
+
+    /**
+     * @dataProvider provideParseError
+     */
+    public function testParseError(string $mimeType, string $json): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response
+            ->method('getInfo')
+            ->will($this->returnValueMap([
+                ['http_code', 400],
+                ['url', 'http://example.com'],
+                ['raw_headers', [
+                    'HTTP/1.1 400 Bad Request',
+                    'Content-Type: '.$mimeType,
+                ]],
+            ]));
+        $response->method('getContent')->willReturn($json);
+
+        $e = new TestException($response);
+        $this->assertSame(400, $e->getCode());
+        $this->assertSame(<<<ERROR
+An error occurred
+
+Some details
+ERROR
+, $e->getMessage());
+    }
+}
+
+class TestException extends \Exception
+{
+    use HttpExceptionTrait;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo?

Use extra details provided by popular error formats following to improve HTTP exception messages.
The following formats are supported:

* Hydra (default in API Platform)
* RFC 7807 (followed by Symfony's [ConstraintViolationListNormalizer](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php) and supported by API Platform and Apigility)
* JSON:API (because it respects the semantic of the RFC 7807)

It allows to write code like the following (here in a test context):

```php
    public function testBadRequest()
    {
        $this->expectException(ClientExceptionInterface::class);
        $this->expectExceptionCode(400); // HTTP status code
        $this->expectExceptionMessage(<<<ERROR
Validation Failed

users: This collection should contain 1 element or more.
users: The current logged in user must be part of the users owning this resource.
ERROR
);

        $response = (HttpClient::create())->request('POST', 'http://example.com/api/projects', [
            'json' => [
                'name' => 'My project',
            ],
        ]);
        $response->getContent();
    }
``` 

Port of https://github.com/api-platform/core/pull/2608#issuecomment-472510732.
