### PR TITLE
[HttpClient] strengthen bearer validation

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -84,8 +84,8 @@ trait HttpClientTrait
             throw new InvalidArgumentException(sprintf('Option "auth_basic" must be string or an array, %s given.', \gettype($options['auth_basic'])));
         }
 
-        if (!\is_string($options['auth_bearer'] ?? '')) {
-            throw new InvalidArgumentException(sprintf('Option "auth_bearer" must be string, %s given.', \gettype($options['auth_bearer'])));
+        if (isset($options['auth_bearer']) && (!\is_string($options['auth_bearer']) || !preg_match('{^[-._~+/0-9a-zA-Z]++=*+$}', $options['auth_bearer']))) {
+            throw new InvalidArgumentException(sprintf('Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, %s given.', \is_string($options['auth_bearer']) ? 'invalid string' : \gettype($options['auth_bearer'])));
         }
 
         if (isset($options['auth_basic'], $options['auth_bearer'])) {

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -174,11 +174,20 @@ class HttpClientTraitTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpClient\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Option "auth_bearer" must be string, object given.
+     * @expectedExceptionMessage Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, object given.
      */
     public function testInvalidAuthBearerOption()
     {
         self::prepareRequest('POST', 'http://example.com', ['auth_bearer' => new \stdClass()], HttpClientInterface::OPTIONS_DEFAULTS);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpClient\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, invalid string given.
+     */
+    public function testInvalidAuthBearerValue()
+    {
+        self::prepareRequest('POST', 'http://example.com', ['auth_bearer' => "a\nb"], HttpClientInterface::OPTIONS_DEFAULTS);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Better be sure CR/LF/etc cannot be passed inside raw header values, opening potential security risks.