### PR TITLE
[HttpClient] Fix HttpOptions::setAuthBearer()

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -49,7 +49,7 @@ class HttpOptions
      */
     public function setAuthBearer(string $token)
     {
-        $this->options['bearer'] = $token;
+        $this->options['auth_bearer'] = $token;
 
         return $this;
     }

--- a/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpClient\HttpOptions;
  */
 class HttpOptionsTest extends TestCase
 {
-    public function provideSetAuth()
+    public function provideSetAuthBasic()
     {
         yield ['user:password', 'user', 'password'];
         yield ['user:password', 'user:password'];
@@ -28,10 +28,15 @@ class HttpOptionsTest extends TestCase
     }
 
     /**
-     * @dataProvider provideSetAuth
+     * @dataProvider provideSetAuthBasic
      */
-    public function testSetAuth(string $expected, string $user, string $password = '')
+    public function testSetAuthBasic(string $expected, string $user, string $password = '')
     {
         $this->assertSame($expected, (new HttpOptions())->setAuthBasic($user, $password)->toArray()['auth_basic']);
+    }
+
+    public function testSetAuthBearer()
+    {
+        $this->assertSame('foobar', (new HttpOptions())->setAuthBearer('foobar')->toArray()['auth_bearer']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a

I messed up the option name while rebasing...