### PR TITLE
[Security] Add @uses PHPDoc annotations to AccessDecisionManager

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -72,6 +72,11 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      */
     public function decide(TokenInterface $token, array $attributes, $object = null)
     {
+        /*
+         * @uses AccessDecisionManager::decideAffirmative()
+         * @uses AccessDecisionManager::decideConsensus()
+         * @uses AccessDecisionManager::decideUnanimous()
+         */
         return $this->{$this->strategy}($token, $attributes, $object);
     }
 


### PR DESCRIPTION
Add @uses PHPDoc annotations above variable method call to indicate which methods it uses

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

I have added `@uses` tags to indicate that the `Symfony\Component\Security\Core\Authorization\AccessDecisionManager::decide()` method's code is using the methods `decideAffirmative()`, `decideConsensus()` and `decideUnanimous()`. This will help humans, IDEs and other analysis tools to detects usages of these methods.