### PR TITLE
[Intl] Add compile binary

### DIFF
--- a/src/Symfony/Component/Intl/Resources/bin/compile
+++ b/src/Symfony/Component/Intl/Resources/bin/compile
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ $1 == force || ! $(docker ps -a | grep symfony-intl) ]]; then
+    docker rm -f symfony-intl
+    docker create --name symfony-intl -it -v /tmp:/tmp -v $(pwd):/app -w /app jakzal/php-intl:7.2-63.1 bash
+    docker start symfony-intl
+    docker exec symfony-intl bash -xc "apt-get update && apt-get -y install build-essential"
+else
+    docker start symfony-intl
+fi;
+
+docker exec -u $(id -u):$(id -g) symfony-intl php src/Symfony/Component/Intl/Resources/bin/update-data.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no-ish
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Compile the Intl data by invoking a single command, and make it work out-of-the-box. (Split from #28831)

```bash
$ src/Symfony/Component/Intl/Resources/bin/compile
```

run in repository root because of 

https://github.com/symfony/symfony/blob/b7e798ef745a09ca2e76fba4afad0a04fcbd9195/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php#L141

3.4 is ok, 4.2 is not because of #28833 but new locales are introduced in https://github.com/symfony/symfony/pull/28977/files#diff-f52da32e1ee6b93598814090d0749aa6R1

So as long as 3.4 is supported, but branches above add filters etc. during generation we're risking this discrepancy. I suggest after merge in upper branches to re-run `compile` (potential for automating, but run if needed :))