### PR TITLE
[DI] fix casting AutowiringFailedException to string when its callback throws

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -226,7 +226,16 @@ class AutowirePass extends AbstractRecursivePass
                     if ($parameter->isDefaultValueAvailable()) {
                         $value = $parameter->getDefaultValue();
                     } elseif (!$parameter->allowsNull()) {
-                        throw new AutowiringFailedException($this->currentId, $failureMessage);
+                        if (\function_exists('xdebug_disable')) {
+                            xdebug_disable();
+                        }
+                        try {
+                            throw new AutowiringFailedException($this->currentId, $failureMessage);
+                        } finally {
+                            if (\function_exists('xdebug_enable')) {
+                                xdebug_enable();
+                            }
+                        }
                     }
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -84,10 +84,15 @@ class PassConfig
             new RemoveUnusedDefinitionsPass(),
             new InlineServiceDefinitionsPass(new AnalyzeServiceReferencesPass()),
             new AnalyzeServiceReferencesPass(),
-            new DefinitionErrorExceptionPass(),
             new CheckExceptionOnInvalidReferenceBehaviorPass(),
             new ResolveHotPathPass(),
         ]];
+
+        $this->afterRemovingPasses = [
+            100 => [
+                new DefinitionErrorExceptionPass(),
+            ],
+        ];
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
@@ -47,7 +47,11 @@ class AutowiringFailedException extends RuntimeException
                 $messageCallback = $this->messageCallback;
                 $this->messageCallback = null;
 
-                return $this->message = $messageCallback();
+                try {
+                    return $this->message = $messageCallback();
+                } catch (\Throwable $e) {
+                    return $this->message = $e->getMessage();
+                }
             }
         };
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30571
| License       | MIT
| Doc PR        | -

ping @weaverryan