### PR TITLE
[HttpClient] changes minimal php version to use curl push function

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -64,8 +64,8 @@ final class CurlHttpClient implements HttpClientInterface
             'dnsCache' => [[], [], []],
         ];
 
-        // Skip configuring HTTP/2 push when it's unsupported or buggy, see https://bugs.php.net/76675
-        if (\PHP_VERSION_ID < 70215 || \PHP_VERSION_ID === 70300 || \PHP_VERSION_ID === 70301) {
+        // Skip configuring HTTP/2 push when it's unsupported or buggy, see https://bugs.php.net/bug.php?id=77535
+        if (\PHP_VERSION_ID < 70217 || (\PHP_VERSION_ID >= 70300 && \PHP_VERSION_ID < 70304)) {
             return;
         }
 
@@ -74,8 +74,7 @@ final class CurlHttpClient implements HttpClientInterface
             return;
         }
 
-        // Keep a dummy "onPush" reference to work around a refcount bug in PHP
-        curl_multi_setopt($mh, CURLMOPT_PUSHFUNCTION, $multi->onPush = static function ($parent, $pushed, array $rawHeaders) use ($multi) {
+        curl_multi_setopt($mh, CURLMOPT_PUSHFUNCTION, static function ($parent, $pushed, array $rawHeaders) use ($multi) {
             return self::handlePush($parent, $pushed, $rawHeaders, $multi);
         });
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR       | 

Adding some changes to CurlHttpClient to avoid potential bugs in php < 7.2.17 or php < 7.3.4. 
For more information check these bugs : 
- https://bugs.php.net/bug.php?id=77747
- https://bugs.php.net/bug.php?id=77535

Resolve by the following commit by Nikic : 
- https://github.com/php/php-src/commit/97f9fd6949a52d1eb30c3e1c90f0789b57c29468