### PR TITLE
Do not validate child constraints if form has no validation groups

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -44,6 +44,11 @@ class FormValidator extends ConstraintValidator
         if ($form->isSubmitted() && $form->isSynchronized()) {
             // Validate the form data only if transformation succeeded
             $groups = self::getValidationGroups($form);
+
+            if (!$groups) {
+                return;
+            }
+
             $data = $form->getData();
 
             // Validate the data against its own constraints

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -220,6 +220,28 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testDontValidateChildConstraintsIfCallableNoValidationGroups()
+    {
+        $formOptions = [
+            'constraints' => [new Valid()],
+            'validation_groups' => [],
+        ];
+        $form = $this->getBuilder('name', null, $formOptions)
+            ->setCompound(true)
+            ->setDataMapper(new PropertyPathMapper())
+            ->getForm();
+        $childOptions = ['constraints' => [new NotBlank()]];
+        $child = $this->getCompoundForm(new \stdClass(), $childOptions);
+        $form->add($child);
+        $form->submit([]);
+
+        $this->expectNoValidate();
+
+        $this->validator->validate($form, new Form());
+
+        $this->assertNoViolation();
+    }
+
     public function testDontValidateIfNotSynchronized()
     {
         $object = new \stdClass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

If a form has `Valid` constraint and `validation_groups` set to an empty array (to disable validation) then its children were still validated using default validation group because `FormValidator` validated the form data using the empty array validation group here
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php#L76

and then `RecursiveContextualValidator` treats the empty array as default validation group here.

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php#L86
