### PR TITLE
[Tests] fixed compatbility of assertEquals(): void

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
@@ -13,18 +13,11 @@ namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToHtml5LocalDateTimeTransformer;
+use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 
 class DateTimeToHtml5LocalDateTimeTransformerTest extends TestCase
 {
-    public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
-    {
-        if ($expected instanceof \DateTime && $actual instanceof \DateTime) {
-            $expected = $expected->format('c');
-            $actual = $actual->format('c');
-        }
-
-        parent::assertEquals($expected, $actual, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
-    }
+    use DateTimeEqualsTrait;
 
     public function transformProvider()
     {
@@ -96,7 +89,7 @@ class DateTimeToHtml5LocalDateTimeTransformerTest extends TestCase
         $transformer = new DateTimeToHtml5LocalDateTimeTransformer($toTz, $fromTz);
 
         if (null !== $to) {
-            $this->assertEquals(new \DateTime($to), $transformer->reverseTransform($from));
+            $this->assertDateTimeEquals(new \DateTime($to), $transformer->reverseTransform($from));
         } else {
             $this->assertNull($transformer->reverseTransform($from));
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -13,10 +13,13 @@ namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
+use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class DateTimeToLocalizedStringTransformerTest extends TestCase
 {
+    use DateTimeEqualsTrait;
+
     protected $dateTime;
     protected $dateTimeWithoutSeconds;
 
@@ -37,16 +40,6 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
     {
         $this->dateTime = null;
         $this->dateTimeWithoutSeconds = null;
-    }
-
-    public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
-    {
-        if ($expected instanceof \DateTime && $actual instanceof \DateTime) {
-            $expected = $expected->format('c');
-            $actual = $actual->format('c');
-        }
-
-        parent::assertEquals($expected, $actual, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
     }
 
     public function dataProvider()
@@ -152,7 +145,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
 
         $dateTime = new \DateTime('2010-02-03 04:05');
 
-        $this->assertEquals(
+        $this->assertDateTimeEquals(
             $dateTime->format('c'),
             $transformer->reverseTransform('03.02.2010, 04:05')->format('c')
         );
@@ -217,14 +210,14 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
 
         $output = new \DateTime($output);
 
-        $this->assertEquals($output, $transformer->reverseTransform($input));
+        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input));
     }
 
     public function testReverseTransformFullTime()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::FULL);
 
-        $this->assertEquals($this->dateTime, $transformer->reverseTransform('03.02.2010, 04:05:06 GMT+00:00'));
+        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010, 04:05:06 GMT+00:00'));
     }
 
     public function testReverseTransformFromDifferentLocale()
@@ -233,7 +226,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
 
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC');
 
-        $this->assertEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Feb 3, 2010, 04:05 AM'));
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Feb 3, 2010, 04:05 AM'));
     }
 
     public function testReverseTransformWithDifferentTimezones()
@@ -243,7 +236,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
         $dateTime = new \DateTime('2010-02-03 04:05:00 Asia/Hong_Kong');
         $dateTime->setTimezone(new \DateTimeZone('America/New_York'));
 
-        $this->assertEquals($dateTime, $transformer->reverseTransform('03.02.2010, 04:05'));
+        $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('03.02.2010, 04:05'));
     }
 
     public function testReverseTransformOnlyDateWithDifferentTimezones()
@@ -252,21 +245,21 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
 
         $dateTime = new \DateTime('2017-01-10 11:00', new \DateTimeZone('Europe/Berlin'));
 
-        $this->assertEquals($dateTime, $transformer->reverseTransform('2017-01-10'));
+        $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('2017-01-10'));
     }
 
     public function testReverseTransformWithDifferentPatterns()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
 
-        $this->assertEquals($this->dateTime, $transformer->reverseTransform('02*2010*03 04|05|06'));
+        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('02*2010*03 04|05|06'));
     }
 
     public function testReverseTransformDateOnlyWithDstIssue()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('Europe/Rome', 'Europe/Rome', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'dd/MM/yyyy');
 
-        $this->assertEquals(
+        $this->assertDateTimeEquals(
             new \DateTime('1978-05-28', new \DateTimeZone('Europe/Rome')),
             $transformer->reverseTransform('28/05/1978')
         );
@@ -276,7 +269,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
     {
         $transformer = new DateTimeToLocalizedStringTransformer('Europe/Rome', 'Europe/Rome', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, "'day': dd 'month': MM 'year': yyyy");
 
-        $this->assertEquals(
+        $this->assertDateTimeEquals(
             new \DateTime('1978-05-28', new \DateTimeZone('Europe/Rome')),
             $transformer->reverseTransform('day: 28 month: 05 year: 1978')
         );
@@ -330,7 +323,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::SHORT);
 
-        $this->assertEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('31.04.10 04:05'));
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('31.04.10 04:05'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -13,9 +13,12 @@ namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToRfc3339Transformer;
+use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 
 class DateTimeToRfc3339TransformerTest extends TestCase
 {
+    use DateTimeEqualsTrait;
+
     protected $dateTime;
     protected $dateTimeWithoutSeconds;
 
@@ -31,16 +34,6 @@ class DateTimeToRfc3339TransformerTest extends TestCase
     {
         $this->dateTime = null;
         $this->dateTimeWithoutSeconds = null;
-    }
-
-    public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
-    {
-        if ($expected instanceof \DateTime && $actual instanceof \DateTime) {
-            $expected = $expected->format('c');
-            $actual = $actual->format('c');
-        }
-
-        parent::assertEquals($expected, $actual, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
     }
 
     public function allProvider()
@@ -108,7 +101,7 @@ class DateTimeToRfc3339TransformerTest extends TestCase
         $transformer = new DateTimeToRfc3339Transformer($toTz, $fromTz);
 
         if (null !== $to) {
-            $this->assertEquals(new \DateTime($to), $transformer->reverseTransform($from));
+            $this->assertDateTimeEquals(new \DateTime($to), $transformer->reverseTransform($from));
         } else {
             $this->assertNull($transformer->reverseTransform($from));
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/Traits/DateTimeEqualsTrait.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/Traits/DateTimeEqualsTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits;
+
+/**
+ * @internal
+ */
+trait DateTimeEqualsTrait
+{
+    public static function assertDateTimeEquals($expected, $actual)
+    {
+        if ($expected instanceof \DateTime && $actual instanceof \DateTime) {
+            $expected = $expected->format('c');
+            $actual = $actual->format('c');
+        }
+
+        parent::assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Same as #30474.