### PR TITLE
(HttpFoundation) Better approach to determine is_numeric value

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -103,7 +103,7 @@ class Cookie
         // convert expiration time to a Unix timestamp
         if ($expire instanceof \DateTimeInterface) {
             $expire = $expire->format('U');
-        } elseif (!is_numeric($expire)) {
+        } elseif (preg_match('~\D~', $expire)) {
             $expire = strtotime($expire);
 
             if (false === $expire) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master  <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | no    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


What it does (as an alternative to ```is_numaric```), is use preg_match to check whether any non-numeric characters exist in the variable. If non-numeric characters exist, it calls strtotime,. If non-numeric characters don't exist, it calls nothing 

(HttpFoundation) Better approach to determine is_numeric value