### PR TITLE
[Workflow] Remove deprecated usage

### DIFF
--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -27,7 +27,7 @@ class GuardEvent extends Event
     /**
      * {@inheritdoc}
      */
-    public function __construct($subject, Marking $marking, Transition $transition, $workflowName = 'unnamed')
+    public function __construct($subject, Marking $marking, Transition $transition, $workflowName = null)
     {
         parent::__construct($subject, $marking, $transition, $workflowName);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4 up to 4.2 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  |no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

This is a little improvement suggestion because string usage is deprecated while it's still the default value. `null` is also deprecated but is required for BC.