### PR TITLE
[Cache] added DSN support for rediss in AbstractAdapter and RedisTrait

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -132,7 +132,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
         if (!\is_string($dsn)) {
             throw new InvalidArgumentException(sprintf('The %s() method expect argument #1 to be string, %s given.', __METHOD__, \gettype($dsn)));
         }
-        if (0 === strpos($dsn, 'redis:')) {
+        if (0 === strpos($dsn, 'redis:') || 0 === strpos($dsn, 'rediss:')) {
             return RedisAdapter::createConnection($dsn, $options);
         }
         if (0 === strpos($dsn, 'memcached:')) {

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -31,30 +31,33 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
         return $adapter;
     }
 
-    public function testCreateConnection()
+    /**
+     * @dataProvider provideValidSchemes
+     */
+    public function testCreateConnection($dsnScheme)
     {
-        $redis = RedisAdapter::createConnection('redis:?host[h1]&host[h2]&host[/foo:]');
+        $redis = RedisAdapter::createConnection($dsnScheme.':?host[h1]&host[h2]&host[/foo:]');
         $this->assertInstanceOf(\RedisArray::class, $redis);
         $this->assertSame(['h1:6379', 'h2:6379', '/foo'], $redis->_hosts());
         @$redis = null; // some versions of phpredis connect on destruct, let's silence the warning
 
         $redisHost = getenv('REDIS_HOST');
 
-        $redis = RedisAdapter::createConnection('redis://'.$redisHost);
+        $redis = RedisAdapter::createConnection($dsnScheme.'://'.$redisHost);
         $this->assertInstanceOf(\Redis::class, $redis);
         $this->assertTrue($redis->isConnected());
         $this->assertSame(0, $redis->getDbNum());
 
-        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'/2');
+        $redis = RedisAdapter::createConnection($dsnScheme.'://'.$redisHost.'/2');
         $this->assertSame(2, $redis->getDbNum());
 
-        $redis = RedisAdapter::createConnection('redis://'.$redisHost, ['timeout' => 3]);
+        $redis = RedisAdapter::createConnection($dsnScheme.'://'.$redisHost, ['timeout' => 3]);
         $this->assertEquals(3, $redis->getTimeout());
 
-        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'?timeout=4');
+        $redis = RedisAdapter::createConnection($dsnScheme.'://'.$redisHost.'?timeout=4');
         $this->assertEquals(4, $redis->getTimeout());
 
-        $redis = RedisAdapter::createConnection('redis://'.$redisHost, ['read_timeout' => 5]);
+        $redis = RedisAdapter::createConnection($dsnScheme.'://'.$redisHost, ['read_timeout' => 5]);
         $this->assertEquals(5, $redis->getReadTimeout());
     }
 
@@ -85,6 +88,14 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
     public function testInvalidCreateConnection($dsn)
     {
         RedisAdapter::createConnection($dsn);
+    }
+
+    public function provideValidSchemes()
+    {
+        return [
+            ['redis'],
+            ['rediss'],
+        ];
     }
 
     public function provideInvalidCreateConnection()

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -80,15 +80,19 @@ trait RedisTrait
      */
     public static function createConnection($dsn, array $options = [])
     {
-        if (0 !== strpos($dsn, 'redis:')) {
-            throw new InvalidArgumentException(sprintf('Invalid Redis DSN: %s does not start with "redis:".', $dsn));
+        if (0 === strpos($dsn, 'redis:')) {
+            $scheme = 'redis';
+        } elseif (0 === strpos($dsn, 'rediss:')) {
+            $scheme = 'rediss';
+        } else {
+            throw new InvalidArgumentException(sprintf('Invalid Redis DSN: %s does not start with "redis:" or "rediss".', $dsn));
         }
 
         if (!\extension_loaded('redis') && !class_exists(\Predis\Client::class)) {
             throw new CacheException(sprintf('Cannot find the "redis" extension nor the "predis/predis" package: %s', $dsn));
         }
 
-        $params = preg_replace_callback('#^redis:(//)?(?:(?:[^:@]*+:)?([^@]*+)@)?#', function ($m) use (&$auth) {
+        $params = preg_replace_callback('#^'.$scheme.':(//)?(?:(?:[^:@]*+:)?([^@]*+)@)?#', function ($m) use (&$auth) {
             if (isset($m[2])) {
                 $auth = $m[2];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes 
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes   
| Fixed tickets | https://github.com/symfony/symfony/issues/30573
| License       | MIT

A fix for this issue: https://github.com/symfony/symfony/issues/30573
Support for "rediss:" in DSN added.
