### PR TITLE
[Serializer] Add Support of recursive denormalization on object_to_populate

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added the list of constraint violations' parameters in `ConstraintViolationListNormalizer`
  * added support for serializing `DateTimeZone` objects
+ * added a `deep_object_to_populate` context option to recursive denormalize on `object_to_populate` object.
 
 4.2.0
 -----

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -38,6 +39,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     const SKIP_NULL_VALUES = 'skip_null_values';
     const MAX_DEPTH_HANDLER = 'max_depth_handler';
     const EXCLUDE_FROM_CACHE_KEY = 'exclude_from_cache_key';
+    const DEEP_OBJECT_TO_POPULATE = 'deep_object_to_populate';
 
     private $propertyTypeExtractor;
     private $typesCache = [];
@@ -272,6 +274,13 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 }
 
                 continue;
+            }
+
+            if ($context[self::DEEP_OBJECT_TO_POPULATE] ?? $this->defaultContext[self::DEEP_OBJECT_TO_POPULATE] ?? false) {
+                try {
+                    $context[self::OBJECT_TO_POPULATE] = $this->getAttributeValue($object, $attribute, $format, $context);
+                } catch (NoSuchPropertyException $e) {
+                }
             }
 
             $value = $this->validateAndDenormalize($class, $attribute, $value, $format, $context);

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectToPopulateTrait.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectToPopulateTrait.php
@@ -26,7 +26,7 @@ trait ObjectToPopulateTrait
      */
     protected function extractObjectToPopulate($class, array $context, $key = null)
     {
-        $key = $key ?: 'object_to_populate';
+        $key = $key ?? AbstractNormalizer::OBJECT_TO_POPULATE;
 
         if (isset($context[$key]) && \is_object($context[$key]) && $context[$key] instanceof $class) {
             return $context[$key];

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DeepObjectPopulateChildDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DeepObjectPopulateChildDummy.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Jérôme Desjardin <jewome62@gmail.com>
+ */
+class DeepObjectPopulateChildDummy
+{
+    public $foo;
+
+    public $bar;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DeepObjectPopulateParentDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DeepObjectPopulateParentDummy.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Jérôme Desjardin <jewome62@gmail.com>
+ */
+class DeepObjectPopulateParentDummy
+{
+    /**
+     * @var DeepObjectPopulateChildDummy|null
+     */
+    private $child;
+
+    public function setChild(?DeepObjectPopulateChildDummy $child)
+    {
+        $this->child = $child;
+    }
+
+    public function getChild(): ?DeepObjectPopulateChildDummy
+    {
+        return $this->child;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | Pending
| Fixed tickets | #21669
| License       | MIT
| Doc PR        | Pending

Currently the deserialization re-create new sub-object with object_to_populate.
This option permit to make object_to_populate recursive.