### PR TITLE
[Validator] fix 'this' variable in expression when the root value of the validation is an array

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -43,6 +43,10 @@ class ExpressionValidator extends ConstraintValidator
         $variables['value'] = $value;
         $variables['this'] = $this->context->getObject();
 
+        if (null === $variables['this'] && \is_array($this->context->getRoot()) && $this->isThisUsedAsAnArray($constraint->expression)) {
+            $variables['this'] = $this->context->getRoot();
+        }
+
         if (!$this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING))
@@ -61,5 +65,17 @@ class ExpressionValidator extends ConstraintValidator
         }
 
         return $this->expressionLanguage;
+    }
+
+    // Check if "this" is used as an array instead of Object
+    private function isThisUsedAsAnArray($constraintExpression)
+    {
+        foreach (array_keys($this->context->getRoot()) as $key) {
+            if (false !== strpos($constraintExpression, sprintf('this[\'%s\']', $key))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -54,6 +54,32 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testExpressionIsEvaluatedWithArrayValueWithRoot()
+    {
+        $array = ['data' => 2];
+        $constraint = new Expression([
+            'expression' => 'this[\'data\'] > 1',
+            'message' => 'myMessage',
+        ]);
+        $this->setRoot($array);
+        $this->validator->validate($array, $constraint);
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to get an item on a non-array
+     */
+    public function testExpressionIsEvaluatedWithArrayValueWithoutRoot()
+    {
+        $array = ['data' => 2];
+        $constraint = new Expression([
+            'expression' => 'this[\'data\'] > 1',
+            'message' => 'myMessage',
+        ]);
+        $this->validator->validate($array, $constraint);
+    }
+
     public function testSucceedingExpressionAtObjectLevel()
     {
         $constraint = new Expression('this.data == 1');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | #30568
| License       | MIT

fix 'this' variable in expression when the root value of the validation is an array instead of object.