### PR TITLE
Fix case when multiple loaders are providing paths for the same namespace

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -264,7 +264,7 @@ EOF
                     $namespace = '@'.$namespace;
                 }
 
-                $loaderPaths[$namespace] = $paths;
+                $loaderPaths[$namespace] = array_merge($loaderPaths[$namespace] ?? [], $paths);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Fixes @stof https://github.com/symfony/symfony/pull/30440#discussion_r267316027

Let me know if a test case is necessary for this.

Cheers!