### PR TITLE
[FrameworkBundle] Update Client class to KernelBrowser

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -36,7 +36,7 @@ abstract class WebTestCase extends KernelTestCase
         try {
             $client = $kernel->getContainer()->get('test.client');
         } catch (ServiceNotFoundException $e) {
-            if (class_exists(Client::class)) {
+            if (class_exists(KernelBrowser::class)) {
                 throw new \LogicException('You cannot create the client used in functional tests if the "framework.test" config is not set to true.');
             }
             throw new \LogicException('You cannot create the client used in functional tests if the BrowserKit component is not available. Try running "composer require symfony/browser-kit"');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I updated recently the WebTestCase with a check to provide a better/more clear exception message (see #30479). After that change @fabpot renamed different `Client` classes in components to a clearer name (for ex Client in HttpKernel is now KernelBrowser etc.). This PR aims to replace the Client in WebTestCase to the new name class name.