### PR TITLE
Alias for each assets package

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
 use Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher;
 use Symfony\Bundle\FullStack;
+use Symfony\Component\Asset\PackageInterface;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
@@ -996,6 +997,7 @@ class FrameworkExtension extends Extension
             }
 
             $container->setDefinition('assets._package_'.$name, $this->createPackageDefinition($package['base_path'], $package['base_urls'], $version));
+            $container->registerAliasForArgument('assets._package_'.$name, PackageInterface::class, $name.'.package');
             $namedPackages[$name] = new Reference('assets._package_'.$name);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | ?     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

Add autowiring by type + name on assets packages
```yaml
framework:
    assets:
        packages:
            xxx:
                base_urls: 'xxxx'
```
```php
<?php

class MyService 
{
    private $xxxPackage;

    public function __construct(PackageInterface $xxxPackage) 
    {
        $this->xxxPackage = $xxxPackage;
        ...
    }

    public function myMethod(): string
    {
        return $this->xxxPackage->getUrl('some-image.png');
    }
}
```
instead of:
```php
<?php

class MyService 
{
    private $packages;

    public function __construct(Packages $packages) 
    {
        $this->packages = $packages;
        ...
    }

    public function myMethod(): string
    {
        return $this->packages->getPackage('xxx')->getUrl('some-image.png');
    }
}
```