### PR TITLE
Adding a middleware to allow you to "hook into" the stamping process

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -76,6 +76,7 @@ use Symfony\Component\Lock\StoreInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\Stamper\EnvelopeStamperInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -398,6 +399,8 @@ class FrameworkExtension extends Extension
             ->addTag('messenger.message_handler');
         $container->registerForAutoconfiguration(TransportFactoryInterface::class)
             ->addTag('messenger.transport_factory');
+        $container->registerForAutoconfiguration(EnvelopeStamperInterface::class)
+            ->addTag('messenger.envelope_stamper');
         $container->registerForAutoconfiguration(MimeTypeGuesserInterface::class)
             ->addTag('mime.mime_type_guesser');
         $container->registerForAutoconfiguration(LoggerAwareInterface::class)
@@ -1616,8 +1619,14 @@ class FrameworkExtension extends Extension
         }
 
         $defaultMiddleware = [
-            'before' => [['id' => 'dispatch_after_current_bus']],
-            'after' => [['id' => 'send_message'], ['id' => 'handle_message']],
+            'before' => [
+                ['id' => 'envelope_stamper_middleware'],
+                ['id' => 'dispatch_after_current_bus'],
+            ],
+            'after' => [
+                ['id' => 'send_message'],
+                ['id' => 'handle_message'],
+            ],
         ];
         foreach ($config['buses'] as $busId => $bus) {
             $middleware = $bus['middleware'];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -41,6 +41,10 @@
 
         <service id="messenger.middleware.dispatch_after_current_bus" class="Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware" />
 
+        <service id="messenger.middleware.envelope_stamper_middleware" class="Symfony\Component\Messenger\Middleware\EnvelopeStamperMiddleware">
+            <argument type="tagged" tag="messenger.envelope_stamper" />
+        </service>
+
         <service id="messenger.middleware.validation" class="Symfony\Component\Messenger\Middleware\ValidationMiddleware">
             <argument type="service" id="validator" />
         </service>

--- a/src/Symfony/Component/Messenger/Middleware/EnvelopeStamperMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/EnvelopeStamperMiddleware.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\Stamper\EnvelopeStamperInterface;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class EnvelopeStamperMiddleware implements MiddlewareInterface
+{
+    private $envelopeStampers;
+
+    /**
+     * @param EnvelopeStamperInterface[] $envelopeStampers
+     */
+    public function __construct(iterable $envelopeStampers)
+    {
+        $this->envelopeStampers = $envelopeStampers;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        foreach ($this->envelopeStampers as $envelopeStamper) {
+            $envelope = $envelopeStamper->stampEnvelope($envelope);
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/Stamper/EnvelopeStamperInterface.php
+++ b/src/Symfony/Component/Messenger/Middleware/Stamper/EnvelopeStamperInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware\Stamper;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * Classes used by EnvelopeStamperMiddleware that can add stamps to envelope.
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+interface EnvelopeStamperInterface
+{
+    /**
+     * Apply new stamps and return the new envelope.
+     */
+    public function stampEnvelope(Envelope $envelope): Envelope;
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/EnvelopeStamperMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/EnvelopeStamperMiddlewareTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\EnvelopeStamperMiddleware;
+use Symfony\Component\Messenger\Middleware\Stamper\EnvelopeStamperInterface;
+
+class EnvelopeStamperMiddlewareTest extends TestCase
+{
+    public function testHandleCallsStampers()
+    {
+        $stamper1 = $this->createMock(EnvelopeStamperInterface::class);
+        $stamper2 = $this->createMock(EnvelopeStamperInterface::class);
+
+        $envelopeOriginal = new Envelope(new \stdClass());
+        $envelopeAfterStamper1 = new Envelope(new \stdClass());
+        $envelopeAfterStamper2 = new Envelope(new \stdClass());
+
+        $stamper1->expects($this->once())
+            ->method('stampEnvelope')
+            ->with($envelopeOriginal)
+            ->willReturn($envelopeAfterStamper1);
+
+        $stamper2->expects($this->once())
+            ->method('stampEnvelope')
+            ->with($envelopeAfterStamper1)
+            ->willReturn($envelopeAfterStamper2);
+
+        $stamperMiddleware = new EnvelopeStamperMiddleware([$stamper1, $stamper2]);
+        $bus = new MessageBus([$stamperMiddleware]);
+        $actualFinalEnvelope = $bus->dispatch($envelopeOriginal);
+        $this->assertSame($envelopeAfterStamper2, $actualFinalEnvelope);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | TODO

When a 3rd party dispatches a message, the user may need to apply some custom stamps to that message - especially stamps that configure how that message is handled by the transport. We already have one simple example of this from #30557 - the `DelayStamp`. This would allow the user to very easily (without needing to create a middleware and register it) add this stamp to a 3rd party message, or future stamps (e.g. stamps for transport/queue priority).