### PR TITLE
Debug finalized config in debug:config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -66,6 +66,14 @@ class ConfigDebugCommandTest extends WebTestCase
         $this->assertContains('Unable to find configuration for "test.foo"', $tester->getDisplay());
     }
 
+    public function testDumpWithPrefixedEnv()
+    {
+        $tester = $this->createCommandTester();
+        $tester->execute(['name' => 'FrameworkBundle']);
+
+        $this->assertContains("cookie_httponly: '%env(bool:COOKIE_HTTPONLY)%'", $tester->getDisplay());
+    }
+
     /**
      * @return CommandTester
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/config.yml
@@ -4,7 +4,10 @@ imports:
 framework:
     secret: '%secret%'
     default_locale: '%env(LOCALE)%'
+    session:
+        cookie_httponly: '%env(bool:COOKIE_HTTPONLY)%'
 
 parameters:
     env(LOCALE): en
+    env(COOKIE_HTTPONLY): '1'
     secret: test

--- a/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
@@ -28,11 +28,15 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
 {
     private static $typeFixtures = ['array' => [], 'bool' => false, 'float' => 0.0, 'int' => 0, 'string' => ''];
 
+    private $extensionConfig = [];
+
     /**
      * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {
+        $this->extensionConfig = [];
+
         if (!class_exists(BaseNode::class) || !$extensions = $container->getExtensions()) {
             return;
         }
@@ -77,7 +81,7 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
                 }
 
                 try {
-                    $processor->processConfiguration($configuration, $config);
+                    $this->extensionConfig[$name] = $processor->processConfiguration($configuration, $config);
                 } catch (TreeWithoutRootNodeException $e) {
                 }
             }
@@ -86,6 +90,18 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
         }
 
         $resolvingBag->clearUnusedEnvPlaceholders();
+    }
+
+    /**
+     * @internal
+     */
+    public function getExtensionConfig(): array
+    {
+        try {
+            return $this->extensionConfig;
+        } finally {
+            $this->extensionConfig = [];
+        }
     }
 
     private static function getType($value): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30637
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Re-processing the extension config in `debug:config` causes a lot of steps to be ignored, basically everything in `ValidateEnvPlaceholdersPass`.

As such we trigger a misleading error when this command is invoked.