### PR TITLE
Dispatching two events when a message is sent & handled

### DIFF
--- a/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
+++ b/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * Event is dispatched before a message is sent to the transport.
+ *
+ * The event is *only* dispatched if the message will actually
+ * be sent to at least one transport. If the message is sent
+ * to multiple transports, the message is dispatched only one time.
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class SendMessageToTransportsEvent extends Event
+{
+    private $envelope;
+
+    public function __construct(Envelope $envelope)
+    {
+        $this->envelope = $envelope;
+    }
+
+    public function getEnvelope(): Envelope
+    {
+        return $this->envelope;
+    }
+
+    public function setEnvelope(Envelope $envelope)
+    {
+        $this->envelope = $envelope;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | TODO

Alternative to #30646. This uses a more generic system, so you could do anything when a message is sent. The main use-case is when a message is dispatched by a 3rd party.

I didn't try to add *exhaustive* events everywhere: I added an event for a very specific use-case:

When a message is dispatched by a 3rd party, being able to add stamps (e.g. `DelayStamp` or a future `AmqpRoutingKeyStamp` before the message is sent. Example:

```php
class MailerMessageSendToTransportEventSubscriber implements EventSubscriberInterface
{
    public function onSendMessage(SendMessageToTransportsEvent $event)
    {
        $envelope = $event->getEnvelope();
        if (!$envelope->getMessage() instanceof SomeMailerMessage) {
            return;
        }

        $event->setEnvelope($envelope->with(new AmpqRoutingKeyStamp('mailer-route')));
    }

    public static function getSubscribedEvents()
    {
        return [SendMessageToTransportsEvent::class => 'onSendMessage'];
    }
}
```

Along with #30557, we will now have the following events, regarding async messages:
* Event when a message is sent to transports (this PR)
* Event when a message is received from transport, but before handling it
* Event when a message is received from transport and after handling it