### PR TITLE
Allow user to set the project dir

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -83,12 +83,13 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     const END_OF_MAINTENANCE = '07/2019';
     const END_OF_LIFE = '01/2020';
 
-    public function __construct(string $environment, bool $debug)
+    public function __construct(string $environment, bool $debug, string $projectDir = null)
     {
         $this->environment = $environment;
         $this->debug = $debug;
         $this->rootDir = $this->getRootDir(false);
         $this->name = $this->getName(false);
+        $this->projectDir = $projectDir;
     }
 
     public function __clone()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |  <!-- symfony/symfony-docs#... required for new features -->

Currently, the project directory is defined by the location of the composer.json file.

That file is not required in production, which therefore [breaks the method getProjectDir](https://github.com/symfony/symfony/issues/23950) (who sends back null).
The offered solution, while working, requires the developer to implement it, and uses inheritance override, while a more aesthetic solution could be used.

This does not fix the behaviour, but allows the developer to pass the project dir as a parameter.

While this solution does not include BC break or anything, it is important to notice that it includes
**an optional parameter**.

[Object instantiation in the framework bundle recipe](https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.2/public/index.php#L23) could be updated as follow (in another PR):

```php
$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
```

```php
$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], dirname(__DIR__));
```