### PR TITLE
[HttpClient] Add a ScopingHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/ScopingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/ScopingHttpClient.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient;
+
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * Auto-configure the default options based on the requested URL.
+ *
+ * @author Anthony Martin <anthony.martin@sensiolabs.com>
+ *
+ * @experimental in 4.3
+ */
+class ScopingHttpClient implements HttpClientInterface
+{
+    use HttpClientTrait;
+
+    private $client;
+    private $defaultOptionsByRegexp;
+    private $defaultRegexp;
+
+    public function __construct(HttpClientInterface $client, array $defaultOptionsByRegexp, string $defaultRegexp = null)
+    {
+        $this->client = $client;
+        $this->defaultOptionsByRegexp = $defaultOptionsByRegexp;
+        $this->defaultRegexp = $defaultRegexp;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        $url = self::parseUrl($url, $options['query'] ?? []);
+
+        if (\is_string($options['base_uri'] ?? null)) {
+            $options['base_uri'] = self::parseUrl($options['base_uri']);
+        }
+
+        try {
+            $url = implode('', self::resolveUrl($url, $options['base_uri'] ?? null));
+        } catch (InvalidArgumentException $e) {
+            if (null === $this->defaultRegexp) {
+                throw $e;
+            }
+
+            [$url, $options] = self::prepareRequest($method, implode('', $url), $options, $this->defaultOptionsByRegexp[$this->defaultRegexp], true);
+            $url = implode('', $url);
+        }
+
+        foreach ($this->defaultOptionsByRegexp as $regexp => $defaultOptions) {
+            if (preg_match("{{$regexp}}A", $url)) {
+                $options = self::mergeDefaultOptions($options, $defaultOptions, true);
+                break;
+            }
+        }
+
+        return $this->client->request($method, $url, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    {
+        return $this->client->stream($responses, $timeout);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/ScopingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/ScopingHttpClientTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+
+class ScopingHttpClientTest extends TestCase
+{
+    public function testRelativeUrl()
+    {
+        $mockClient = new MockHttpClient([]);
+        $client = new ScopingHttpClient($mockClient, []);
+
+        $this->expectException(InvalidArgumentException::class);
+        $client->request('GET', '/foo');
+    }
+
+    public function testRelativeUrlWithDefaultRegexp()
+    {
+        $mockClient = new MockHttpClient(new MockResponse());
+        $client = new ScopingHttpClient($mockClient, ['.*' => ['base_uri' => 'http://example.com']], '.*');
+
+        $this->assertSame('http://example.com/foo', $client->request('GET', '/foo')->getInfo('url'));
+    }
+
+    /**
+     * @dataProvider provideMatchingUrls
+     */
+    public function testMatchingUrls(string $regexp, string $url, array $options)
+    {
+        $mockClient = new MockHttpClient(new MockResponse());
+        $client = new ScopingHttpClient($mockClient, $options);
+
+        $response = $client->request('GET', $url);
+        $reuestedOptions = $response->getRequestOptions();
+
+        $this->assertEquals($reuestedOptions['case'], $options[$regexp]['case']);
+    }
+
+    public function provideMatchingUrls()
+    {
+        $defaultOptions = [
+            '.*/foo-bar' => ['case' => 1],
+            '.*' => ['case' => 2],
+        ];
+
+        yield ['regexp' => '.*/foo-bar', 'url' => 'http://example.com/foo-bar', 'default_options' => $defaultOptions];
+        yield ['regexp' => '.*', 'url' => 'http://example.com/bar-foo', 'default_options' => $defaultOptions];
+        yield ['regexp' => '.*', 'url' => 'http://example.com/foobar', 'default_options' => $defaultOptions];
+    }
+
+    public function testMatchingUrlsAndOptions()
+    {
+        $defaultOptions = [
+            '.*/foo-bar' => ['headers' => ['x-app' => 'unit-test-foo-bar']],
+            '.*' => ['headers' => ['content-type' => 'text/html']],
+        ];
+
+        $mockResponses = [
+            new MockResponse(),
+            new MockResponse(),
+            new MockResponse(),
+        ];
+
+        $mockClient = new MockHttpClient($mockResponses);
+        $client = new ScopingHttpClient($mockClient, $defaultOptions);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar', ['json' => ['url' => 'http://example.com']]);
+        $requestOptions = $response->getRequestOptions();
+        $this->assertEquals($requestOptions['json']['url'], 'http://example.com');
+        $this->assertEquals($requestOptions['headers']['x-app'][0], $defaultOptions['.*/foo-bar']['headers']['x-app']);
+
+        $response = $client->request('GET', 'http://example.com/bar-foo', ['headers' => ['x-app' => 'unit-test']]);
+        $requestOptions = $response->getRequestOptions();
+        $this->assertEquals($requestOptions['headers']['x-app'][0], 'unit-test');
+        $this->assertEquals($requestOptions['headers']['content-type'][0], 'text/html');
+
+        $response = $client->request('GET', 'http://example.com/foobar-foo', ['headers' => ['x-app' => 'unit-test']]);
+        $requestOptions = $response->getRequestOptions();
+        $this->assertEquals($requestOptions['headers']['x-app'][0], 'unit-test');
+        $this->assertEquals($requestOptions['headers']['content-type'][0], 'text/html');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR is a follow up of #30592 by @XuruDragon, with two main differences:
- I think `ScopingHttpClient` might be a better name for what is called a `ConditionalHttpClient` there,
- the `FrameworkBundle` part is removed so that it can be submitted separately later on.

With a `ScopingHttpClient`, you can add some default options conditionally based on the requested URL and a regexp that it should match. This allows building clients that add e.g. credentials based on the requested scheme/host/path.

When the requested URL is a relative one, a default index can be provided - whose corresponding default options (the `base_uri` one especially) will be used to turn it into an absolute URL.

Regexps are anchored on their left side.

E.g. this defines a client that will send some github token when a request is made to the corresponding API, and will not send those credentials if any other host is requested, while also turning relative URLs to github ones:
```php
$client = HttpClient::create();
$githubClient = new ScopingClient($client, [
    'http://api\.github\.com/' => [
        'base_uri' => 'http://api.github.com/',
        'headers' => ['Authorization: token '.$githubToken],
    ],
], 'http://api\.github\.com/');
```

Of course, it's possible to define several regexps as keys so that one can create a client that is authenticated against several hosts/paths.