### PR TITLE
[Messenger] Ensure an exception is thrown when the AMQP connect() does not work

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -317,7 +317,7 @@ class Connection
             try {
                 $connection->{$connectMethod}();
             } catch (\AMQPConnectionException $e) {
-                $credentials = $this->connectionCredentials;
+                $credentials = $this->connectionConfiguration;
                 $credentials['password'] = '********';
 
                 throw new \AMQPException(sprintf('Could not connect to the AMQP server. Please verify the provided DSN. (%s)', json_encode($credentials)), 0, $e);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30557 
| License       | MIT
| Doc PR        | ø

This `connectionCredentials` instance escaped the renaming in #30557.