### PR TITLE
[Messenger] Add a BC layer for the `ConsumeMessagesCommand` arguments

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
    and `BusNameStamp` were added, which allow you to add a bus identifier
    to the `Envelope` then find the correct bus when receiving from
    the transport. See `ConsumeMessagesCommand`.
- * An optional `ConsumeMessagesCommand` constructor argument was removed.
+ * The optional `$busNames` constructor argument of the class `ConsumeMessagesCommand` was removed.
  * [BC BREAK] 2 new methods were added to `ReceiverInterface`:
    `ack()` and `reject()`.
  * [BC BREAK] Error handling was moved from the receivers into

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -43,8 +43,14 @@ class ConsumeMessagesCommand extends Command
     private $retryStrategyLocator;
     private $eventDispatcher;
 
-    public function __construct(ContainerInterface $busLocator, ContainerInterface $receiverLocator, LoggerInterface $logger = null, array $receiverNames = [], ContainerInterface $retryStrategyLocator = null, EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(ContainerInterface $busLocator, ContainerInterface $receiverLocator, LoggerInterface $logger = null, array $receiverNames = [], /* ContainerInterface */ $retryStrategyLocator = null, EventDispatcherInterface $eventDispatcher = null)
     {
+        if (\is_array($retryStrategyLocator)) {
+            @trigger_error(sprintf('The 5th argument of the class "%s" should be a retry-strategy locator, an array of bus names as a value is deprecated since Symfony 4.3.', __CLASS__), E_USER_DEPRECATED);
+
+            $retryStrategyLocator = null;
+        }
+
         $this->busLocator = $busLocator;
         $this->receiverLocator = $receiverLocator;
         $this->logger = $logger;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no - removing some
| Deprecations? | yes (files already updated in previous PR)
| Tests pass?   | yes 
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

Instead of conflicting `symfony/messenger` with an old `symfony/framework-bundle`, let's add a simple BC layer.
