### PR TITLE
[Bridge][Twig] DebugCommand - fix escaping and filter

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -100,6 +101,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);
+        $decorated = $io->isDecorated();
 
         // BC to be removed in 4.0
         if (__CLASS__ !== \get_class($this)) {
@@ -114,29 +116,35 @@ EOF
             throw new \RuntimeException('The Twig environment needs to be set.');
         }
 
+        $filter = $input->getArgument('filter');
         $types = ['functions', 'filters', 'tests', 'globals'];
 
         if ('json' === $input->getOption('format')) {
             $data = [];
             foreach ($types as $type) {
                 foreach ($this->twig->{'get'.ucfirst($type)}() as $name => $entity) {
-                    $data[$type][$name] = $this->getMetadata($type, $entity);
+                    if (!$filter || false !== strpos($name, $filter)) {
+                        $data[$type][$name] = $this->getMetadata($type, $entity);
+                    }
                 }
             }
-            $data['tests'] = array_keys($data['tests']);
+
+            if (isset($data['tests'])) {
+                $data['tests'] = array_keys($data['tests']);
+            }
+
             $data['loader_paths'] = $this->getLoaderPaths();
-            $io->writeln(json_encode($data));
+            $data = json_encode($data, JSON_PRETTY_PRINT);
+            $io->writeln($decorated ? OutputFormatter::escape($data) : $data);
 
             return 0;
         }
-
-        $filter = $input->getArgument('filter');
 
         foreach ($types as $index => $type) {
             $items = [];
             foreach ($this->twig->{'get'.ucfirst($type)}() as $name => $entity) {
                 if (!$filter || false !== strpos($name, $filter)) {
-                    $items[$name] = $name.$this->getPrettyMetadata($type, $entity);
+                    $items[$name] = $name.$this->getPrettyMetadata($type, $entity, $decorated);
                 }
             }
 
@@ -262,7 +270,7 @@ EOF
         }
     }
 
-    private function getPrettyMetadata($type, $entity)
+    private function getPrettyMetadata($type, $entity, $decorated)
     {
         if ('tests' === $type) {
             return '';
@@ -274,7 +282,7 @@ EOF
                 return '(unknown?)';
             }
         } catch (\UnexpectedValueException $e) {
-            return ' <error>'.$e->getMessage().'</error>';
+            return sprintf(' <error>%s</error>', $decorated ? OutputFormatter::escape($e->getMessage()) : $e->getMessage());
         }
 
         if ('globals' === $type) {
@@ -282,7 +290,9 @@ EOF
                 return ' = object('.\get_class($meta).')';
             }
 
-            return ' = '.substr(@json_encode($meta), 0, 50);
+            $description = substr(@json_encode($meta), 0, 50);
+
+            return sprintf(' = %s', $decorated ? OutputFormatter::escape($description) : $description);
         }
 
         if ('functions' === $type) {

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -87,6 +87,10 @@ class CommandTester
      */
     public function getDisplay($normalize = false)
     {
+        if (null === $this->output) {
+            throw new \RuntimeException('Output not initialized, did you execute the command before requesting the display?');
+        }
+
         rewind($this->output->getStream());
 
         $display = stream_get_contents($this->output->getStream());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

The PR fixes:
- output escaping was not done for decorated consoles
- filter was not applied when using format json

+ added some tests for paths currently not tested

