### PR TITLE
(WIP) [HttpClient] Add a Record & Replay callback to the MockHttpClient.

### DIFF
--- a/src/Symfony/Component/HttpClient/RecordAndReplayCallback.php
+++ b/src/Symfony/Component/HttpClient/RecordAndReplayCallback.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseNamingStrategyInterface;
+use Symfony\Contracts\HttpClient\ResponseRecorderInterface;
+
+/**
+ * Provides a way to record & replay responses.
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class RecordAndReplayCallback
+{
+    const MODE_REPLAY = 'replay';
+    const MODE_RECORD = 'record';
+    const MODE_REPLAY_OR_RECORD = 'replay_or_record';
+
+    /**
+     * @var HttpClientInterface
+     */
+    private $client;
+
+    /**
+     * @var ResponseNamingStrategyInterface
+     */
+    private $strategy;
+
+    /**
+     * @var ResponseRecorderInterface
+     */
+    private $recorder;
+
+    /**
+     * @var string
+     */
+    private $mode;
+
+    public function __construct(ResponseNamingStrategyInterface $strategy, ResponseRecorderInterface $recorder, string $mode, ?HttpClientInterface $client = null)
+    {
+        $this->strategy = $strategy;
+        $this->recorder = $recorder;
+        $this->setMode($mode);
+        $this->client = $client ?? HttpClient::create();
+    }
+
+    public function __invoke(string $method, string $url, array $options): ResponseInterface
+    {
+        $response = null;
+        $name = $this->strategy->name($method, $url, $options);
+
+        if (static::MODE_RECORD !== $this->mode) {
+            $response = $this->recorder->replay($name);
+        }
+
+        if (static::MODE_RECORD === $this->mode || (!$response && $this->mode === static::MODE_REPLAY_OR_RECORD)) {
+            $response = $this->client->request($method, $url, $options);
+
+            $this->recorder->record($name, $response);
+        }
+
+        if (null === $response) {
+            throw new TransportException("Unable to retrieve the response \"$name\".");
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setMode(string $mode)
+    {
+        $modes = static::getModes();
+
+        if (!\in_array($mode, $modes, true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid provided mode "%s", available choices are: %s', $mode, implode(', ', $modes)));
+        }
+
+        $this->mode = $mode;
+
+        return $this;
+    }
+
+    public static function getModes(): array
+    {
+        $modes = [];
+        $ref = new \ReflectionClass(__CLASS__);
+
+        foreach ($ref->getConstants() as $constant => $value) {
+            if (0 === strpos($constant, 'MODE_')) {
+                $modes[] = $value;
+            }
+        }
+
+        return $modes;
+    }
+}

--- a/src/Symfony/Component/HttpClient/RecordAndReplayCallback.php
+++ b/src/Symfony/Component/HttpClient/RecordAndReplayCallback.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\HttpClient;
 
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/HttpClient/ResponseRecorder/FilesystemResponseRecorder.php
+++ b/src/Symfony/Component/HttpClient/ResponseRecorder/FilesystemResponseRecorder.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\ResponseRecorder;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseRecorderInterface;
+
+/**
+ * Saves responses in a defined directory.
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class FilesystemResponseRecorder implements ResponseRecorderInterface
+{
+    /**
+     * @var string
+     */
+    private $directory;
+
+    /**
+     * @var Filesystem
+     */
+    private $fs;
+
+    public function __construct(string $directory, ?Filesystem $fs = null)
+    {
+        $this->fs = $fs ?? new Filesystem();
+
+        if (!$this->fs->exists($directory)) {
+            $this->fs->mkdir($directory);
+        }
+
+        $this->directory = realpath($directory);
+    }
+
+    public function record(string $name, ResponseInterface $response): void
+    {
+        $this->fs->dumpFile($this->getFilename($name), serialize(new MockResponse($response->getContent(), $response->getInfo())));
+    }
+
+    public function replay(string $name): ?ResponseInterface
+    {
+        $filename = $this->getFilename($name);
+
+        if (!$this->fs->exists($filename)) {
+            return null;
+        }
+
+        return unserialize(file_get_contents($filename));
+    }
+
+    private function getFilename(string $name): string
+    {
+        $sep = \DIRECTORY_SEPARATOR;
+
+        return "{$this->directory}{$sep}{$name}.txt";
+    }
+}

--- a/src/Symfony/Component/HttpClient/ResponseRecorder/InMemoryRecorder.php
+++ b/src/Symfony/Component/HttpClient/ResponseRecorder/InMemoryRecorder.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\ResponseRecorder;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseRecorderInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Saves responses in memory. Responses will be lost at the end of the PHP process.
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class InMemoryRecorder implements ResponseRecorderInterface, ResetInterface
+{
+    /**
+     * @var ResponseInterface[]
+     */
+    private $responses = [];
+
+    public function record(string $name, ResponseInterface $response): void
+    {
+        $this->responses[$name] = $response;
+    }
+
+    public function replay(string $name): ?ResponseInterface
+    {
+        return $this->responses[$name] ?? null;
+    }
+
+    public function reset()
+    {
+        $this->responses = [];
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/RecordAndReplayCallbackTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RecordAndReplayCallbackTest.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\RecordAndReplayCallback;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseNamingStrategyInterface;
+use Symfony\Contracts\HttpClient\ResponseRecorderInterface;
+
+class RecordAndReplayCallbackTest extends TestCase
+{
+    /**
+     * @var ResponseNamingStrategyInterface
+     */
+    private $strategy;
+
+    /**
+     * @var ResponseRecorderInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $recorder;
+
+    /**
+     * @var RecordAndReplayCallback
+     */
+    private $responseFactory;
+
+    /**
+     * @var HttpClientInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $backupClient;
+
+    /**
+     * @var MockHttpClient
+     */
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->backupClient = $this->createMock(HttpClientInterface::class);
+        $this->recorder = $this->createMock(ResponseRecorderInterface::class);
+        $this->strategy = $this->createMock(ResponseNamingStrategyInterface::class);
+        $this->strategy->expects($this->any())->method('name')->willReturn('a_unique_name');
+        $this->responseFactory = new RecordAndReplayCallback($this->strategy, $this->recorder, RecordAndReplayCallback::MODE_REPLAY, $this->backupClient);
+        $this->client = new MockHttpClient($this->responseFactory);
+    }
+
+    public function testReplayOrRecord()
+    {
+        $this->responseFactory->setMode(RecordAndReplayCallback::MODE_REPLAY_OR_RECORD);
+        $this->recorder->expects($this->once())->method('record');
+        $this->recorder->expects($this->exactly(2))
+            ->method('replay')
+            ->willReturnOnConsecutiveCalls(null, new MockResponse('I\'m a replayed response.'));
+        $this->backupClient->expects($this->once())
+            ->method('request')
+            ->willReturn(new MockResponse('I\'m a "live" response.'));
+
+        $this->assertSame('I\'m a "live" response.', $this->client->request('GET', 'https://example.org/whatever')->getContent());
+        $this->assertSame('I\'m a replayed response.', $this->client->request('GET', 'https://example.org/whatever')->getContent());
+    }
+
+    public function testReplay()
+    {
+        $this->recorder->expects($this->once())->method('replay')->willReturn(new MockResponse('I\'m a replayed response.'));
+        $this->backupClient->expects($this->never())->method('request');
+
+        $this->assertSame('I\'m a replayed response.', $this->client->request('GET', 'https://example.org/whatever')->getContent());
+    }
+
+    public function testRecord()
+    {
+        $this->responseFactory->setMode(RecordAndReplayCallback::MODE_RECORD);
+        $this->recorder->expects($this->never())->method('replay');
+        $this->backupClient->expects($this->once())->method('request')->willReturn(new MockResponse('I\'m a "live" response.'));
+
+        $this->assertSame('I\'m a "live" response.', $this->client->request('GET', 'https://example.org/whatever')->getContent());
+    }
+
+    public function testReplayThrows()
+    {
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Unable to retrieve the response "a_unique_name".');
+
+        $this->client->request('POST', 'https://example.org/whatever');
+    }
+
+    public function testInvalidMode()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid provided mode "Coucou", available choices are: replay, record, replay_or_record');
+
+        $this->responseFactory->setMode('Coucou');
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/ResponseRecorder/FilesystemResponseRecorderTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/ResponseRecorder/FilesystemResponseRecorderTest.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\ResponseRecorder;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\ResponseRecorder\FilesystemResponseRecorder;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class FilesystemResponseRecorderTest extends FilesystemTestCase
+{
+    /**
+     * @var FilesystemResponseRecorder
+     */
+    private $recorder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->recorder = new FilesystemResponseRecorder($this->workspace, $this->filesystem);
+    }
+
+    public function testReplay(): void
+    {
+        /** @var ResponseInterface|MockObject $mock */
+        $mock = $this->createMock(ResponseInterface::class);
+        $mock->method('getContent')->willReturn('Some nice content');
+        $mock->method('getInfo')->willReturn(['foo' => 'bar']);
+
+        $this->recorder->record('whatever', $mock);
+
+        $this->assertFileExists($this->workspace.\DIRECTORY_SEPARATOR.'whatever.txt', 'A file should be created');
+
+        $response = $this->recorder->replay('whatever');
+        $this->assertNotNull($response, 'Response should be retrieved');
+        $this->assertInstanceOf(MockResponse::class, $response, 'Replay should return a MockResponse');
+
+        // MockResponse instances must be issued by MockHttpClient before processing, so content is not yet accessible.
+        $ref = new \ReflectionClass($response);
+        $body = $ref->getProperty('body');
+        $body->setAccessible(true);
+
+        $this->assertSame('Some nice content', $body->getValue($response));
+        $this->assertSame('bar', $response->getInfo('foo'));
+
+        $this->assertNull($this->recorder->replay('something_else'), 'Replay should return null here.');
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/ResponseRecorder/InMemoryRecorderTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/ResponseRecorder/InMemoryRecorderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\ResponseRecorder;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\ResponseRecorder\InMemoryRecorder;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class InMemoryRecorderTest extends TestCase
+{
+    public function testReplay()
+    {
+        /** @var ResponseInterface $response */
+        $response = $this->createMock(ResponseInterface::class);
+        $recorder = new InMemoryRecorder();
+
+        $this->assertNull($recorder->replay('foo'), 'Should return NULL when not pre-recorded');
+
+        $recorder->record('foo', $response);
+        $this->assertSame($response, $recorder->replay('foo'), 'Should return the same response');
+
+        $recorder->reset();
+        $this->assertNull($recorder->replay('foo'), 'Should return NULL after reset');
+    }
+}

--- a/src/Symfony/Contracts/HttpClient/ResponseNamingStrategyInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ResponseNamingStrategyInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\HttpClient;
+
+/**
+ * Given the parameters of the request, give a unique name to identify a response.
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface ResponseNamingStrategyInterface
+{
+    public function name(string $method, string $url, array $options): string;
+}

--- a/src/Symfony/Contracts/HttpClient/ResponseRecorderInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ResponseRecorderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\HttpClient;
+
+/**
+ * In charge of saving (file system, database, ...) and retrieving a `ResponseInterface` object.
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface ResponseRecorderInterface
+{
+    public function record(string $name, ResponseInterface $response): void;
+
+    public function replay(string $name): ?ResponseInterface;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | partially #30502
| License       | MIT
| Doc PR        | TODO

Allow to record & replay responses for test / dev purpose:
```php
<?php

$recorder = new FilesystemResponseRecorder('var/fixtures/http');
$callback = new RecordAndReplayCallback($myNamingStrategy, $recorder, RecordAndReplayCallback::MODE_REPLAY_OR_RECORD, $httpClient)

$mockClient = new MockHttpClient($callback);

// Will make an actual HTTP request
$client->request('POST', 'https://example.org/whatever');

// Will replay the previous response
$client->request('POST', 'https://example.org/whatever');
```

### TODO:
- [ ] Provide a default naming strategy
- [ ] Create the PR for the documentation
- [ ] Integrate with Framework bundle for easy config
