### PR TITLE
[Validator] BIC remove unused sprintf and parameter

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -53,7 +53,7 @@ class Bic extends Constraint
         }
 
         if (isset($options['iban']) && isset($options['ibanPropertyPath'])) {
-            throw new ConstraintDefinitionException(sprintf('The "iban" and "ibanPropertyPath" options of the Iban constraint cannot be used at the same time.', self::class));
+            throw new ConstraintDefinitionException('The "iban" and "ibanPropertyPath" options of the Iban constraint cannot be used at the same time.');
         }
 
         if (isset($options['ibanPropertyPath']) && !class_exists(PropertyAccess::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

removed surplus parameter and sprintf as there are no placeholders in message template
