### PR TITLE
[FrameworkBundle] change the way http clients are configured by leveraging ScopingHttpClient

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -17,12 +17,12 @@ use Doctrine\DBAL\Connection;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\HttpClientTrait;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\Store\SemaphoreStore;
@@ -43,6 +43,8 @@ use Symfony\Component\WebLink\HttpHeaderSerializer;
  */
 class Configuration implements ConfigurationInterface
 {
+    use HttpClientTrait;
+
     private $debug;
 
     /**
@@ -1232,144 +1234,231 @@ class Configuration implements ConfigurationInterface
 
     private function addHttpClientSection(ArrayNodeDefinition $rootNode)
     {
-        $subNode = $rootNode
+        $rootNode
             ->children()
                 ->arrayNode('http_client')
                     ->info('HTTP Client configuration')
                     ->{!class_exists(FullStack::class) && class_exists(HttpClient::class) ? 'canBeDisabled' : 'canBeEnabled'}()
-                    ->fixXmlConfig('client')
-                    ->children();
+                    ->fixXmlConfig('scoped_client')
+                    ->children()
+                        ->integerNode('max_host_connections')
+                            ->info('The maximum number of connections to a single host.')
+                        ->end()
+                        ->arrayNode('default_options')
+                            ->fixXmlConfig('header')
+                            ->children()
+                                ->arrayNode('headers')
+                                    ->info('Associative array: header => value(s).')
+                                    ->useAttributeAsKey('name')
+                                    ->normalizeKeys(false)
+                                    ->variablePrototype()->end()
+                                ->end()
+                                ->integerNode('max_redirects')
+                                    ->info('The maximum number of redirects to follow.')
+                                ->end()
+                                ->scalarNode('http_version')
+                                    ->info('The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.')
+                                ->end()
+                                ->arrayNode('resolve')
+                                    ->info('Associative array: domain => IP.')
+                                    ->useAttributeAsKey('host')
+                                    ->beforeNormalization()
+                                        ->always(function ($config) {
+                                            if (!\is_array($config)) {
+                                                return [];
+                                            }
+                                            if (!isset($config['host'])) {
+                                                return $config;
+                                            }
 
-        $this->addHttpClientOptionsSection($subNode);
-
-        $subNode = $subNode
-                        ->arrayNode('clients')
-                            ->useAttributeAsKey('name')
-                            ->normalizeKeys(false)
-                            ->arrayPrototype()
-                                ->children();
-
-        $this->addHttpClientOptionsSection($subNode);
-
-        $subNode = $subNode
+                                            return [$config['host'] => $config['value']];
+                                        })
+                                    ->end()
+                                    ->normalizeKeys(false)
+                                    ->scalarPrototype()->end()
+                                ->end()
+                                ->scalarNode('proxy')
+                                    ->info('The URL of the proxy to pass requests through or null for automatic detection.')
+                                ->end()
+                                ->scalarNode('no_proxy')
+                                    ->info('A comma separated list of hosts that do not require a proxy to be reached.')
+                                ->end()
+                                ->floatNode('timeout')
+                                    ->info('Defaults to "default_socket_timeout" ini parameter.')
+                                ->end()
+                                ->scalarNode('bindto')
+                                    ->info('A network interface name, IP address, a host name or a UNIX socket to bind to.')
+                                ->end()
+                                ->booleanNode('verify_peer')
+                                    ->info('Indicates if the peer should be verified in a SSL/TLS context.')
+                                ->end()
+                                ->booleanNode('verify_host')
+                                    ->info('Indicates if the host should exist as a certificate common name.')
+                                ->end()
+                                ->scalarNode('cafile')
+                                    ->info('A certificate authority file.')
+                                ->end()
+                                ->scalarNode('capath')
+                                    ->info('A directory that contains multiple certificate authority files.')
+                                ->end()
+                                ->scalarNode('local_cert')
+                                    ->info('A PEM formatted certificate file.')
+                                ->end()
+                                ->scalarNode('local_pk')
+                                    ->info('A private key file.')
+                                ->end()
+                                ->scalarNode('passphrase')
+                                    ->info('The passphrase used to encrypt the "local_pk" file.')
+                                ->end()
+                                ->scalarNode('ciphers')
+                                    ->info('A list of SSL/TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)')
+                                ->end()
+                                ->arrayNode('peer_fingerprint')
+                                    ->info('Associative array: hashing algorithm => hash(es).')
+                                    ->normalizeKeys(false)
+                                    ->children()
+                                        ->variableNode('sha1')->end()
+                                        ->variableNode('pin-sha256')->end()
+                                        ->variableNode('md5')->end()
+                                    ->end()
                                 ->end()
                             ->end()
                         ->end()
-                    ->end()
-                ->end()
-            ->end()
-        ;
-    }
+                        ->arrayNode('scoped_clients')
+                            ->useAttributeAsKey('name')
+                            ->normalizeKeys(false)
+                            ->arrayPrototype()
+                                ->fixXmlConfig('header')
+                                ->beforeNormalization()
+                                    ->always()
+                                    ->then(function ($config) {
+                                        $config = \is_array($config) ? $config : ['base_uri' => $config];
 
-    private function addHttpClientOptionsSection(NodeBuilder $rootNode)
-    {
-        $rootNode
-            ->integerNode('max_host_connections')
-                ->info('The maximum number of connections to a single host.')
-            ->end()
-            ->arrayNode('default_options')
-                ->fixXmlConfig('header')
-                ->children()
-                    ->scalarNode('auth_basic')
-                        ->info('An HTTP Basic authentication "username:password".')
-                    ->end()
-                    ->scalarNode('auth_bearer')
-                        ->info('A token enabling HTTP Bearer authorization.')
-                    ->end()
-                    ->arrayNode('query')
-                        ->info('Associative array of query string values merged with URL parameters.')
-                        ->useAttributeAsKey('key')
-                        ->beforeNormalization()
-                            ->always(function ($config) {
-                                if (!\is_array($config)) {
-                                    return [];
-                                }
-                                if (!isset($config['key'])) {
-                                    return $config;
-                                }
+                                        if (!isset($config['scope']) && isset($config['base_uri'])) {
+                                            $config['scope'] = preg_quote(implode('', self::resolveUrl(self::parseUrl('.'), self::parseUrl($config['base_uri']))));
+                                        }
 
-                                return [$config['key'] => $config['value']];
-                            })
-                        ->end()
-                        ->normalizeKeys(false)
-                        ->scalarPrototype()->end()
-                    ->end()
-                    ->arrayNode('headers')
-                        ->info('Associative array: header => value(s).')
-                        ->useAttributeAsKey('name')
-                        ->normalizeKeys(false)
-                        ->variablePrototype()->end()
-                    ->end()
-                    ->integerNode('max_redirects')
-                        ->info('The maximum number of redirects to follow.')
-                    ->end()
-                    ->scalarNode('http_version')
-                        ->info('The default HTTP version, typically 1.1 or 2.0. Leave to null for the best version.')
-                    ->end()
-                    ->scalarNode('base_uri')
-                        ->info('The URI to resolve relative URLs, following rules in RFC 3986, section 2.')
-                    ->end()
-                    ->arrayNode('resolve')
-                        ->info('Associative array: domain => IP.')
-                        ->useAttributeAsKey('host')
-                        ->beforeNormalization()
-                            ->always(function ($config) {
-                                if (!\is_array($config)) {
-                                    return [];
-                                }
-                                if (!isset($config['host'])) {
-                                    return $config;
-                                }
+                                        return $config;
+                                    })
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(function ($v) { return !isset($v['scope']); })
+                                    ->thenInvalid('either "scope" or "base_uri" should be defined.')
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(function ($v) { return isset($v['query']) && !isset($v['base_uri']); })
+                                    ->thenInvalid('"query" applies to "base_uri" but no base URI is defined.')
+                                ->end()
+                                ->children()
+                                    ->scalarNode('scope')
+                                        ->info('The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.')
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                    ->scalarNode('base_uri')
+                                        ->info('The URI to resolve relative URLs, following rules in RFC 3985, section 2.')
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                    ->scalarNode('auth_basic')
+                                        ->info('An HTTP Basic authentication "username:password".')
+                                    ->end()
+                                    ->scalarNode('auth_bearer')
+                                        ->info('A token enabling HTTP Bearer authorization.')
+                                    ->end()
+                                    ->arrayNode('query')
+                                        ->info('Associative array of query string values merged with the base URI.')
+                                        ->useAttributeAsKey('key')
+                                        ->beforeNormalization()
+                                            ->always(function ($config) {
+                                                if (!\is_array($config)) {
+                                                    return [];
+                                                }
+                                                if (!isset($config['key'])) {
+                                                    return $config;
+                                                }
 
-                                return [$config['host'] => $config['value']];
-                            })
-                        ->end()
-                        ->normalizeKeys(false)
-                        ->scalarPrototype()->end()
-                    ->end()
-                    ->scalarNode('proxy')
-                        ->info('The URL of the proxy to pass requests through or null for automatic detection.')
-                    ->end()
-                    ->scalarNode('no_proxy')
-                        ->info('A comma separated list of hosts that do not require a proxy to be reached.')
-                    ->end()
-                    ->floatNode('timeout')
-                        ->info('Defaults to "default_socket_timeout" ini parameter.')
-                    ->end()
-                    ->scalarNode('bindto')
-                        ->info('A network interface name, IP address, a host name or a UNIX socket to bind to.')
-                    ->end()
-                    ->booleanNode('verify_peer')
-                        ->info('Indicates if the peer should be verified in a SSL/TLS context.')
-                    ->end()
-                    ->booleanNode('verify_host')
-                        ->info('Indicates if the host should exist as a certificate common name.')
-                    ->end()
-                    ->scalarNode('cafile')
-                        ->info('A certificate authority file.')
-                    ->end()
-                    ->scalarNode('capath')
-                        ->info('A directory that contains multiple certificate authority files.')
-                    ->end()
-                    ->scalarNode('local_cert')
-                        ->info('A PEM formatted certificate file.')
-                    ->end()
-                    ->scalarNode('local_pk')
-                        ->info('A private key file.')
-                    ->end()
-                    ->scalarNode('passphrase')
-                        ->info('The passphrase used to encrypt the "local_pk" file.')
-                    ->end()
-                    ->scalarNode('ciphers')
-                        ->info('A list of SSL/TLS ciphers separated by colons, commas or spaces (e.g. "RC4-SHA:TLS13-AES-128-GCM-SHA256"...)')
-                    ->end()
-                    ->arrayNode('peer_fingerprint')
-                        ->info('Associative array: hashing algorithm => hash(es).')
-                        ->normalizeKeys(false)
-                        ->children()
-                            ->variableNode('sha1')->end()
-                            ->variableNode('pin-sha256')->end()
-                            ->variableNode('md5')->end()
+                                                return [$config['key'] => $config['value']];
+                                            })
+                                        ->end()
+                                        ->normalizeKeys(false)
+                                        ->scalarPrototype()->end()
+                                    ->end()
+                                    ->arrayNode('headers')
+                                        ->info('Associative array: header => value(s).')
+                                        ->useAttributeAsKey('name')
+                                        ->normalizeKeys(false)
+                                        ->variablePrototype()->end()
+                                    ->end()
+                                    ->integerNode('max_redirects')
+                                        ->info('The maximum number of redirects to follow.')
+                                    ->end()
+                                    ->scalarNode('http_version')
+                                        ->info('The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.')
+                                    ->end()
+                                    ->arrayNode('resolve')
+                                        ->info('Associative array: domain => IP.')
+                                        ->useAttributeAsKey('host')
+                                        ->beforeNormalization()
+                                            ->always(function ($config) {
+                                                if (!\is_array($config)) {
+                                                    return [];
+                                                }
+                                                if (!isset($config['host'])) {
+                                                    return $config;
+                                                }
+
+                                                return [$config['host'] => $config['value']];
+                                            })
+                                        ->end()
+                                        ->normalizeKeys(false)
+                                        ->scalarPrototype()->end()
+                                    ->end()
+                                    ->scalarNode('proxy')
+                                        ->info('The URL of the proxy to pass requests through or null for automatic detection.')
+                                    ->end()
+                                    ->scalarNode('no_proxy')
+                                        ->info('A comma separated list of hosts that do not require a proxy to be reached.')
+                                    ->end()
+                                    ->floatNode('timeout')
+                                        ->info('Defaults to "default_socket_timeout" ini parameter.')
+                                    ->end()
+                                    ->scalarNode('bindto')
+                                        ->info('A network interface name, IP address, a host name or a UNIX socket to bind to.')
+                                    ->end()
+                                    ->booleanNode('verify_peer')
+                                        ->info('Indicates if the peer should be verified in a SSL/TLS context.')
+                                    ->end()
+                                    ->booleanNode('verify_host')
+                                        ->info('Indicates if the host should exist as a certificate common name.')
+                                    ->end()
+                                    ->scalarNode('cafile')
+                                        ->info('A certificate authority file.')
+                                    ->end()
+                                    ->scalarNode('capath')
+                                        ->info('A directory that contains multiple certificate authority files.')
+                                    ->end()
+                                    ->scalarNode('local_cert')
+                                        ->info('A PEM formatted certificate file.')
+                                    ->end()
+                                    ->scalarNode('local_pk')
+                                        ->info('A private key file.')
+                                    ->end()
+                                    ->scalarNode('passphrase')
+                                        ->info('The passphrase used to encrypt the "local_pk" file.')
+                                    ->end()
+                                    ->scalarNode('ciphers')
+                                        ->info('A list of SSL/TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)')
+                                    ->end()
+                                    ->arrayNode('peer_fingerprint')
+                                        ->info('Associative array: hashing algorithm => hash(es).')
+                                        ->normalizeKeys(false)
+                                        ->children()
+                                            ->variableNode('sha1')->end()
+                                            ->variableNode('pin-sha256')->end()
+                                            ->variableNode('md5')->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -458,30 +458,26 @@
 
     <xsd:complexType name="http_client">
         <xsd:sequence>
-            <xsd:element name="default-options" type="http_client_options" minOccurs="0" />
-            <xsd:element name="client" type="http_client_client" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="default-options" type="http_client_default_options" minOccurs="0" />
+            <xsd:element name="scoped-client" type="http_client_scope_options" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="max-host-connections" type="xsd:integer" />
     </xsd:complexType>
 
-    <xsd:complexType name="http_client_options" mixed="true">
+    <xsd:complexType name="http_client_default_options" mixed="true">
         <xsd:choice maxOccurs="unbounded">
-            <xsd:element name="query" type="http_query" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="resolve" type="http_resolve" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="header" type="http_header" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="peer-fingerprint" type="fingerprint" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>
+        <xsd:attribute name="max-redirects" type="xsd:integer" />
+        <xsd:attribute name="http-version" type="xsd:string" />
         <xsd:attribute name="proxy" type="xsd:string" />
+        <xsd:attribute name="no-proxy" type="xsd:string" />
         <xsd:attribute name="timeout" type="xsd:float" />
         <xsd:attribute name="bindto" type="xsd:string" />
         <xsd:attribute name="verify-peer" type="xsd:boolean" />
-        <xsd:attribute name="auth-basic" type="xsd:string" />
-        <xsd:attribute name="auth-bearer" type="xsd:string" />
-        <xsd:attribute name="max-redirects" type="xsd:integer" />
-        <xsd:attribute name="http-version" type="xsd:string" />
-        <xsd:attribute name="base-uri" type="xsd:string" />
-        <xsd:attribute name="no-proxy" type="xsd:string" />
         <xsd:attribute name="verify-host" type="xsd:boolean" />
         <xsd:attribute name="cafile" type="xsd:string" />
         <xsd:attribute name="capath" type="xsd:string" />
@@ -489,14 +485,35 @@
         <xsd:attribute name="local-pk" type="xsd:string" />
         <xsd:attribute name="passphrase" type="xsd:string" />
         <xsd:attribute name="ciphers" type="xsd:string" />
+
     </xsd:complexType>
 
-    <xsd:complexType name="http_client_client">
-        <xsd:sequence>
-            <xsd:element name="default-options" type="http_client_options" minOccurs="0" />
-        </xsd:sequence>
+    <xsd:complexType name="http_client_scope_options" mixed="true">
+        <xsd:choice maxOccurs="unbounded">
+            <xsd:element name="query" type="http_query" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="resolve" type="http_resolve" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="header" type="http_header" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="peer-fingerprint" type="fingerprint" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:choice>
         <xsd:attribute name="name" type="xsd:string" />
-        <xsd:attribute name="max-host-connections" type="xsd:integer" />
+        <xsd:attribute name="scope" type="xsd:string" />
+        <xsd:attribute name="base-uri" type="xsd:string" />
+        <xsd:attribute name="auth-basic" type="xsd:string" />
+        <xsd:attribute name="auth-bearer" type="xsd:string" />
+        <xsd:attribute name="max-redirects" type="xsd:integer" />
+        <xsd:attribute name="http-version" type="xsd:string" />
+        <xsd:attribute name="proxy" type="xsd:string" />
+        <xsd:attribute name="no-proxy" type="xsd:string" />
+        <xsd:attribute name="timeout" type="xsd:float" />
+        <xsd:attribute name="bindto" type="xsd:string" />
+        <xsd:attribute name="verify-peer" type="xsd:boolean" />
+        <xsd:attribute name="verify-host" type="xsd:boolean" />
+        <xsd:attribute name="cafile" type="xsd:string" />
+        <xsd:attribute name="capath" type="xsd:string" />
+        <xsd:attribute name="local-cert" type="xsd:string" />
+        <xsd:attribute name="local-pk" type="xsd:string" />
+        <xsd:attribute name="passphrase" type="xsd:string" />
+        <xsd:attribute name="ciphers" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="fingerprint">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -336,7 +336,7 @@ class ConfigurationTest extends TestCase
             'disallow_search_engine_index' => true,
             'http_client' => [
                 'enabled' => !class_exists(FullStack::class) && class_exists(HttpClient::class),
-                'clients' => [],
+                'scoped_clients' => [],
             ],
             'mailer' => [
                 'dsn' => 'smtp://null',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_default_options.php
@@ -4,9 +4,9 @@ $container->loadFromExtension('framework', [
     'http_client' => [
         'max_host_connections' => 4,
         'default_options' => null,
-        'clients' => [
+        'scoped_clients' => [
             'foo' => [
-                'default_options' => null,
+                'base_uri' => 'http://example.com',
             ],
         ],
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_full_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_full_default_options.php
@@ -3,12 +3,9 @@
 $container->loadFromExtension('framework', [
     'http_client' => [
         'default_options' => [
-            'auth_basic' => 'foo:bar',
-            'query' => ['foo' => 'bar', 'bar' => 'baz'],
             'headers' => ['X-powered' => 'PHP'],
             'max_redirects' => 2,
             'http_version' => '2.0',
-            'base_uri' => 'http://example.com',
             'resolve' => ['localhost' => '127.0.0.1'],
             'proxy' => 'proxy.org',
             'timeout' => 3.5,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_override_default_options.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_override_default_options.php
@@ -6,12 +6,10 @@ $container->loadFromExtension('framework', [
         'default_options' => [
             'headers' => ['foo' => 'bar'],
         ],
-        'clients' => [
+        'scoped_clients' => [
             'foo' => [
-                'max_host_connections' => 5,
-                'default_options' => [
-                    'headers' => ['bar' => 'baz'],
-                ],
+                'base_uri' => 'http://example.com',
+                'headers' => ['bar' => 'baz'],
             ],
         ],
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_default_options.xml
@@ -8,9 +8,10 @@
     <framework:config>
         <framework:http-client max-host-connections="4">
             <framework:default-options />
-            <framework:client name="foo">
-                <framework:default-options />
-            </framework:client>
+            <framework:scoped-client
+                name="foo"
+                base-uri="http://example.com"
+            />
         </framework:http-client>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_full_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_full_default_options.xml
@@ -12,10 +12,8 @@
                     bindto="127.0.0.1"
                     timeout="3.5"
                     verify-peer="true"
-                    auth-basic="foo:bar"
                     max-redirects="2"
                     http-version="2.0"
-                    base-uri="http://example.com"
                     verify-host="true"
                     cafile="/etc/ssl/cafile"
                     capath="/etc/ssl"
@@ -24,8 +22,6 @@
                     passphrase="password123456"
                     ciphers="RC4-SHA:TLS13-AES-128-GCM-SHA256"
             >
-                <framework:query key="foo">bar</framework:query>
-                <framework:query key="bar">baz</framework:query>
                 <framework:header name="X-powered">PHP</framework:header>
                 <framework:resolve host="localhost">127.0.0.1</framework:resolve>
                 <framework:peer-fingerprint>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_override_default_options.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_override_default_options.xml
@@ -10,11 +10,9 @@
             <framework:default-options>
                 <framework:header name="foo">bar</framework:header>
             </framework:default-options>
-            <framework:client name="foo" max-host-connections="5">
-                <framework:default-options>
-                    <framework:header name="bar">baz</framework:header>
-                </framework:default-options>
-            </framework:client>
+            <framework:scoped-client name="foo" base-uri="http://example.com">
+                <framework:header name="bar">baz</framework:header>
+            </framework:scoped-client>
         </framework:http-client>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_default_options.yml
@@ -2,6 +2,6 @@ framework:
     http_client:
         max_host_connections: 4
         default_options: ~
-        clients:
+        scoped_clients:
             foo:
-                default_options: ~
+                base_uri: http://example.com

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_full_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_full_default_options.yml
@@ -1,13 +1,10 @@
 framework:
     http_client:
         default_options:
-            auth_basic: foo:bar
-            query: {'foo': 'bar', 'bar': 'baz'}
             headers:
                 X-powered: PHP
             max_redirects: 2
             http_version: 2.0
-            base_uri: 'http://example.com'
             resolve: {'localhost': '127.0.0.1'}
             proxy: proxy.org
             timeout: 3.5

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_override_default_options.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_override_default_options.yml
@@ -3,8 +3,7 @@ framework:
         max_host_connections: 4
         default_options:
             headers: {'foo': 'bar'}
-        clients:
+        scoped_clients:
             foo:
-                max_host_connections: 5
-                default_options:
-                    headers: {'bar': 'baz'}
+                base_uri: http://example.com
+                headers: {'bar': 'baz'}

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -240,7 +240,7 @@ class MockResponse implements ResponseInterface
         $info = $mock->getInfo() ?: [];
         $response->info['http_code'] = ($info['http_code'] ?? 0) ?: $mock->getStatusCode(false) ?: 200;
         $response->addResponseHeaders($info['response_headers'] ?? [], $response->info, $response->headers);
-        $dlSize = (int) ($response->headers['content-length'][0] ?? 0);
+        $dlSize = isset($response->headers['content-encoding']) ? 0 : (int) ($response->headers['content-length'][0] ?? 0);
 
         $response->info = [
             'start_time' => $response->info['start_time'],
@@ -282,7 +282,7 @@ class MockResponse implements ResponseInterface
         // "notify" completion
         $onProgress($offset, $dlSize, $response->info);
 
-        if (isset($response->headers['content-length']) && $offset !== $dlSize) {
+        if ($dlSize && $offset !== $dlSize) {
             throw new TransportException(sprintf('Transfer closed with %s bytes remaining to read.', $dlSize - $offset));
         }
     }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -122,8 +122,7 @@ class ResponseHeaderBag extends HeaderBag
         parent::set($key, $values, $replace);
 
         // ensure the cache-control header has sensible defaults
-        if (\in_array($uniqueKey, ['cache-control', 'etag', 'last-modified', 'expires'], true)) {
-            $computed = $this->computeCacheControlValue();
+        if (\in_array($uniqueKey, ['cache-control', 'etag', 'last-modified', 'expires'], true) && '' !== $computed = $this->computeCacheControlValue()) {
             $this->headers['cache-control'] = [$computed];
             $this->headerNames['cache-control'] = 'Cache-Control';
             $this->computedCacheControl = $this->parseCacheControl($computed);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR allows configuring scoped HTTP clients ("scoped_clients" replaces the previous "clients" options):

```yaml
framework:
  http_client:
    max_host_connections: 4
    default_options:
      # ...
    scoped_clients:
      github_client:
        base_uri: https://api.github.com
        headers:
          Authorization: token abc123
          # ...
```

The base URI is turned into a scoping regular expression so that the token will be sent only when the `github_client` service is requesting the corresponding URLs.
When the base URI is too restrictive, the `scope` option can be used explicitly to define the regexp that URLs must match before any other options are applied.

~All defined scopes are passed to a new `scoping_http_client` service, that can be used to hit endpoints with authentication pre-configured for several hosts. Its named autowiring alias is `HttpClientInterface $scopingClient` (this cannot be done with `http_client` as we want safe defaults, e.g. credentials should not be used implicitly when writing webhooks/crawlers.)~