### PR TITLE
Avoid dispatching SendMessageToTransportsEvent on redeliver

### DIFF
--- a/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
+++ b/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
@@ -20,6 +20,8 @@ use Symfony\Component\Messenger\Envelope;
  * The event is *only* dispatched if the message will actually
  * be sent to at least one transport. If the message is sent
  * to multiple transports, the message is dispatched only one time.
+ * This message is only dispatched the first time a message
+ * is sent to a transport, not also if it is retried.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes - I think so
| New feature?  | no
| BC breaks?    | no (feature only on master)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | a lot, soon :)

This purpose of this event is to be a hook when a message is sent to a transport.
If that message is redelivered later, that's not the purpose of this hook (there
are Worker events for that) and could cause problems if the user unknowingly
tries to modify the Envelope in some way, not thinking about how this might
be a redelivery message.
