### PR TITLE
Fix type hints for email attachments

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -372,7 +372,7 @@ class Email extends Message
     /**
      * @return $this
      */
-    public function attachPart(AbstractPart $part)
+    public function attachPart(DataPart $part)
     {
         $this->attachments[] = ['part' => $part];
 
@@ -380,7 +380,7 @@ class Email extends Message
     }
 
     /**
-     * @return AbstractPart[]
+     * @return DataPart[]
      */
     public function getAttachments(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

`createDataPart()` must return a `DataPart` instance, so `attachPart()` must only accept `DataPart` instances and `getAttachments()` is guaranteed to return an array of `DataPart` instances.

