### PR TITLE
use behavior instead of behaviour

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -102,7 +102,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * bug #22900 [FrameworkBundle][Console] Fix the override of a command registered by the kernel (aaa2000)
  * bug #22910 [Filesystem] improve error handling in lock() (xabbuh)
  * bug #22924 [Cache] Dont use pipelining with RedisCluster (nicolas-grekas)
- * bug #22718 [Console] Fixed different behaviour of key and value user inputs in multiple choice question (borNfreee)
+ * bug #22718 [Console] Fixed different behavior of key and value user inputs in multiple choice question (borNfreee)
  * bug #22829 [Yaml] fix colon without space deprecation (xabbuh)
  * bug #22901 Fix missing abstract key in XmlDumper (weaverryan)
  * bug #22912 [DI] Avoid private call to Container::has() (ro0NL)

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -425,7 +425,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * bug #22928 [WebProfilerBundle] Fixed options stub values display in form profiler (HeahDude)
  * feature #22838 Make the simple exception pages match the new style (javiereguiluz)
  * bug #22925 [PhpUnitBridge] Adjust PHPUnit class_alias check to also check for namespaced class (GawainLynch)
- * bug #22718 [Console] Fixed different behaviour of key and value user inputs in multiple choice question (borNfreee)
+ * bug #22718 [Console] Fixed different behavior of key and value user inputs in multiple choice question (borNfreee)
  * bug #22921 [FrameworkBundle] Only override getProjectDir if it exists in the kernel (aschempp)
  * feature #22905 [FrameworkBundle][Validator] Move the PSR-11 factory to the component (ogizanagi)
  * bug #22728 [HttpKernel] Fix kernel.project_dir extensibility (chalasr)

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1063,7 +1063,7 @@ UPGRADE FROM 2.x to 3.0
    ```
 
  * The `ApacheMatcherDumper` and `ApacheUrlMatcher` were removed since
-   the performance gains were minimal and it's hard to replicate the behaviour
+   the performance gains were minimal and it's hard to replicate the behavior
    of PHP implementation.
 
  * The `getMatcherDumperInstance()` and `getGeneratorDumperInstance()` methods in the

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -290,12 +290,12 @@ class XmlDumper extends Dumper
             } elseif ($value instanceof Reference) {
                 $element->setAttribute('type', 'service');
                 $element->setAttribute('id', (string) $value);
-                $behaviour = $value->getInvalidBehavior();
-                if (ContainerInterface::NULL_ON_INVALID_REFERENCE == $behaviour) {
+                $behavior = $value->getInvalidBehavior();
+                if (ContainerInterface::NULL_ON_INVALID_REFERENCE == $behavior) {
                     $element->setAttribute('on-invalid', 'null');
-                } elseif (ContainerInterface::IGNORE_ON_INVALID_REFERENCE == $behaviour) {
+                } elseif (ContainerInterface::IGNORE_ON_INVALID_REFERENCE == $behavior) {
                     $element->setAttribute('on-invalid', 'ignore');
-                } elseif (ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE == $behaviour) {
+                } elseif (ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE == $behavior) {
                     $element->setAttribute('on-invalid', 'ignore_uninitialized');
                 }
             } elseif ($value instanceof Definition) {

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -144,10 +144,10 @@ CHANGELOG
  * Added `FlashBag`. Flashes expire when retrieved by `get()` or `all()`. This
    implementation is ESI compatible.
  * Added `AutoExpireFlashBag` (default) to replicate Symfony 2.0.x auto expire
-   behaviour of messages auto expiring after one page page load.  Messages must
+   behavior of messages auto expiring after one page page load.  Messages must
    be retrieved by `get()` or `all()`.
  * Added `Symfony\Component\HttpFoundation\Attribute\AttributeBag` to replicate
-   attributes storage behaviour from 2.0.x (default).
+   attributes storage behavior from 2.0.x (default).
  * Added `Symfony\Component\HttpFoundation\Attribute\NamespacedAttributeBag` for
    namespace session attributes.
  * Flash API can stores messages in an array so there may be multiple messages

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -57,7 +57,7 @@ CHANGELOG
 
  * [DEPRECATION] The `ApacheMatcherDumper` and `ApacheUrlMatcher` were deprecated and
    will be removed in Symfony 3.0, since the performance gains were minimal and
-   it's hard to replicate the behaviour of PHP implementation.
+   it's hard to replicate the behavior of PHP implementation.
 
 2.3.0
 -----

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\ParameterBagUtils;
 /**
  * Class with the default authentication failure handling logic.
  *
- * Can be optionally be extended from by the developer to alter the behaviour
- * while keeping the default behaviour.
+ * Can be optionally be extended from by the developer to alter the behavior
+ * while keeping the default behavior.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -198,7 +198,7 @@ class TranslatorCacheTest extends TestCase
          * messages provided by the loader. This must also be the case when these catalogues
          * are (internally) read from a cache.
          *
-         * Optimizations inside the translator must not change this behaviour.
+         * Optimizations inside the translator must not change this behavior.
          */
 
         /*

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -256,7 +256,7 @@ abstract class Constraint
      *
      * By default, this is the fully qualified name of the constraint class
      * suffixed with "Validator". You can override this method to change that
-     * behaviour.
+     * behavior.
      *
      * @return string
      */

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -72,7 +72,7 @@ yaml: |
       - 2001-07-23
 perl-busted: >
     YAML.pm will be able to emulate this behavior soon. In this regard
-    it may be somewhat more correct than Python's native behaviour which
+    it may be somewhat more correct than Python's native behavior which
     can only use tuples as mapping keys. PyYAML will also need to figure
     out some clever way to roundtrip structured keys.
 python: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

We use American English in the docs and this should be the same in the code base.

Refs https://github.com/symfony/symfony-docs/pull/11196 

This could be checked by fabbot.io continously