### PR TITLE
[Mime] Removed unnecessary strtolower function call

### DIFF
--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -168,7 +168,7 @@ final class Headers
     public function get(string $name): ?HeaderInterface
     {
         $name = strtolower($name);
-        if (!isset($this->headers[strtolower($name)])) {
+        if (!isset($this->headers[$name])) {
             return null;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT