### PR TITLE
[DependencyInjection] Add test asserting service with factory is not tagged

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class BarFactory
+{
+    /**
+     * @var iterable
+     */
+    private $bars;
+
+    public function __construct(iterable $bars)
+    {
+        $this->bars = \iterator_to_array($bars);
+    }
+
+    public function getDefaultBar(): BarInterface
+    {
+        return reset($this->bars);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/service_instanceof_factory.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/service_instanceof_factory.yml
@@ -1,0 +1,14 @@
+services:
+    _instanceof:
+        Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface:
+            tags:
+                - { name: bar }
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Bar:
+        public: true
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory:
+        arguments: [!tagged 'bar']
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface:
+        factory: ['@Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory', 'getDefaultBar']

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -770,4 +770,15 @@ class YamlFileLoaderTest extends TestCase
         $definition = $container->getDefinition('foo');
         $this->assertSame([['interface' => 'SomeInterface']], $definition->getTag('proxy'));
     }
+
+    public function testServiceWithSameNameAsInterfaceAndFactoryIsNotTagged()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('service_instanceof_factory.yml');
+        $container->compile();
+
+        $tagged = $container->findTaggedServiceIds('bar');
+        $this->assertCount(1, $tagged);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I wrote a test for a scenario that was failing for me on `4.1` branch to find out it's already fixed in 4.2 (which is awesome). Since I already had a test written and couldn't really find a PR in the changelog that could have fixed my issue I figured I'll PR a test, so the behaviour I was expecting won't get broken :)

EDIT: For the record, the issue in 4.1 is: `Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface` gets tagged due to `_instanceof` which results in it being handed to `Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory` via `!tagged`. In the end this results in a recursion which is not handled.