### PR TITLE
[WIP][Messenger] Multiple queue support + prioritization

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.3.0
 -----
 
+ * [BC BREAK]: The `Connection::exchange()` method for Amqp was made private.
  * New classes: `RoutableMessageBus`, `AddBusNameStampMiddleware`
    and `BusNameStamp` were added, which allow you to add a bus identifier
    to the `Envelope` then find the correct bus when receiving from

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -75,6 +75,7 @@ class ConsumeMessagesCommand extends Command
                 new InputOption('memory-limit', 'm', InputOption::VALUE_REQUIRED, 'The memory limit the worker can consume'),
                 new InputOption('time-limit', 't', InputOption::VALUE_REQUIRED, 'The time limit in seconds the worker can run'),
                 new InputOption('bus', 'b', InputOption::VALUE_REQUIRED, 'Name of the bus to which received messages should be dispatched (if not passed, bus is determined automatically.'),
+                new InputOption('queues', null, InputOption::VALUE_REQUIRED, 'comma-separated list of queue names in order of priority'),
             ])
             ->setDescription('Consumes messages')
             ->setHelp(<<<'EOF'
@@ -183,7 +184,15 @@ EOF
             $io->comment('Re-run the command with a -vv option to see logs about consumed messages.');
         }
 
-        $worker = new Worker($receiver, $bus, $receiverName, $retryStrategy, $this->eventDispatcher, $this->logger);
+        // TODO - make "default" equal to null?
+        $queues = [];
+        if (null !== $input->getOption('queues')) {
+            $queues = array_map(function ($queue) {
+                return trim($queue);
+            }, explode(',', $input->getOption('queues')));
+        }
+
+        $worker = new Worker($receiver, $bus, $queues, $receiverName, $retryStrategy, $this->eventDispatcher, $this->logger);
         $worker->run();
     }
 

--- a/src/Symfony/Component/Messenger/Stamp/QueueNameStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/QueueNameStamp.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class QueueNameStamp implements StampInterface
+{
+    private $queueName;
+
+    public function __construct(string $queueName)
+    {
+        $this->queueName = $queueName;
+    }
+
+    public function getQueueName(): string
+    {
+        return $this->queueName;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
@@ -37,9 +37,9 @@ class AmqpTransport implements TransportInterface
     /**
      * {@inheritdoc}
      */
-    public function receive(callable $handler): void
+    public function receive(callable $handler, array $queues = null): void
     {
-        ($this->receiver ?? $this->getReceiver())->receive($handler);
+        ($this->receiver ?? $this->getReceiver())->receive($handler, $queues);
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -343,7 +343,12 @@ class Connection
         return $this->amqpQueue;
     }
 
-    public function exchange(): \AMQPExchange
+    public function getConnectionConfiguration(): array
+    {
+        return $this->connectionConfiguration;
+    }
+
+    private function exchange(): \AMQPExchange
     {
         if (null === $this->amqpExchange) {
             $this->amqpExchange = $this->amqpFactory->createExchange($this->channel());
@@ -357,11 +362,6 @@ class Connection
         }
 
         return $this->amqpExchange;
-    }
-
-    public function getConnectionConfiguration(): array
-    {
-        return $this->connectionConfiguration;
     }
 
     private function clear(): void

--- a/src/Symfony/Component/Messenger/Transport/Receiver/ReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/ReceiverInterface.php
@@ -34,7 +34,7 @@ interface ReceiverInterface
      *
      * @throws TransportException If there is an issue communicating with the transport
      */
-    public function receive(callable $handler): void;
+    public function receive(callable $handler, array $queues = []): void;
 
     /**
      * Stop receiving some messages.

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -37,15 +37,17 @@ class Worker
 {
     private $receiver;
     private $bus;
+    private $queues;
     private $receiverName;
     private $retryStrategy;
     private $eventDispatcher;
     private $logger;
 
-    public function __construct(ReceiverInterface $receiver, MessageBusInterface $bus, string $receiverName = null, RetryStrategyInterface $retryStrategy = null, EventDispatcherInterface $eventDispatcher = null, LoggerInterface $logger = null)
+    public function __construct(ReceiverInterface $receiver, MessageBusInterface $bus, array $queues, string $receiverName = null, RetryStrategyInterface $retryStrategy = null, EventDispatcherInterface $eventDispatcher = null, LoggerInterface $logger = null)
     {
         $this->receiver = $receiver;
         $this->bus = $bus;
+        $this->queues = $queues;
         if (null === $receiverName) {
             @trigger_error(sprintf('Instantiating the "%s" class without passing a third argument is deprecated since Symfony 4.3.', __CLASS__), E_USER_DEPRECATED);
 
@@ -138,7 +140,7 @@ class Worker
             if (\function_exists('pcntl_signal_dispatch')) {
                 pcntl_signal_dispatch();
             }
-        });
+        }, $this->queues);
     }
 
     private function dispatchEvent(Event $event)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | WIP
| Deprecations? | no
| Tests pass?   | not yet
| Fixed tickets | Part of #30558
| License       | MIT
| Doc PR        | TODO

Messenger is currently missing an idea of "prioritizing" messages on the queue. Inspired by Laravel, this adds the ability to add different messages to different "queues" and then process those queues in order.

First, put your messages into whatever "queues" you want, which sort of act like "categories":

```php
$bus->dispatch(new Envelope($message), new QueueNameStamp('low')));
$bus->dispatch(new Envelope($message), new QueueNameStamp('high')));
```

And when consuming, say which queues you want to consume and in which order:

```php
./bin/console messenger:consume -vv --queues=high,low
```

All messages will be processed from `high` before going to `low`. I chose this approach, versus just putting everything in one queue with a priority (also possible) because it allows you to create multiple workers, each which work on only 1 (or several) queues. For example, you could have 5 workers working on the `high` queue and one working on `low`.

TODO:

* Tests
* Implementation in Worker & Receiver is a mess
