### PR TITLE
[Messenger] rename `auto-setup` amqp option into `auto_setup`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -49,7 +49,7 @@ CHANGELOG
    both no longer have `$isDebug` arguments.
  * [BC BREAK] The Amqp Transport now automatically sets up the exchanges
    and queues by default. Previously, this was done when in "debug" mode
-   only. Pass the `auto-setup` connection option to control this.
+   only. Pass the `auto_setup` connection option to control this.
 
 4.2.0
 -----

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
@@ -228,13 +228,13 @@ class ConnectionTest extends TestCase
         $amqpQueue->expects($this->never())->method('declareQueue');
         $amqpQueue->expects($this->never())->method('bind');
 
-        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key', ['auto-setup' => 'false'], $factory);
+        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key', ['auto_setup' => 'false'], $factory);
         $connection->publish('body');
 
-        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key', ['auto-setup' => false], $factory);
+        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key', ['auto_setup' => false], $factory);
         $connection->publish('body');
 
-        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key&auto-setup=false', [], $factory);
+        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key&auto_setup=false', [], $factory);
         $connection->publish('body');
     }
 

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -82,7 +82,7 @@ class Connection
      *     * routing_key_pattern: The pattern of the routing key (Default: "delay_%delay%")
      *     * queue_name_pattern: Pattern to use to create the queues (Default: "delay_queue_%delay%")
      *     * exchange_name: Name of the exchange to be used for the retried messages (Default: "retry")
-     *   * auto-setup: Enable or not the auto-setup of queues and exchanges (Default: true)
+     *   * auto_setup: Enable or not the auto-setup of queues and exchanges (Default: true)
      *   * loop_sleep: Amount of micro-seconds to wait if no message are available (Default: 200000)
      */
     public function __construct(array $connectionConfiguration, array $exchangeConfiguration, array $queueConfiguration, AmqpFactory $amqpFactory = null)
@@ -373,11 +373,11 @@ class Connection
 
     private function shouldSetup(): bool
     {
-        if (!\array_key_exists('auto-setup', $this->connectionConfiguration)) {
+        if (!\array_key_exists('auto_setup', $this->connectionConfiguration)) {
             return true;
         }
 
-        if (\in_array($this->connectionConfiguration['auto-setup'], [false, 'false'], true)) {
+        if (\in_array($this->connectionConfiguration['auto_setup'], [false, 'false'], true)) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

See https://github.com/symfony/symfony/pull/30671#discussion_r268524032
