### PR TITLE
[PropertyInfo] Add possibility to extract private and protected properties in reflection extractor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended2;
@@ -292,6 +293,27 @@ class ReflectionExtractorTest extends TestCase
         $this->assertTrue($this->extractor->isWritable(AdderRemoverDummy::class, 'analyses'));
         $this->assertTrue($this->extractor->isWritable(AdderRemoverDummy::class, 'feet'));
         $this->assertEquals(['analyses', 'feet'], $this->extractor->getProperties(AdderRemoverDummy::class));
+    }
+
+    public function testPrivatePropertyExtractor()
+    {
+        $privateExtractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PRIVATE | ReflectionExtractor::ALLOW_PROTECTED);
+        $properties = $privateExtractor->getProperties(Dummy::class);
+
+        $this->assertContains('bar', $properties);
+        $this->assertContains('baz', $properties);
+
+        $this->assertTrue($privateExtractor->isReadable(Dummy::class, 'bar'));
+        $this->assertTrue($privateExtractor->isReadable(Dummy::class, 'baz'));
+
+        $protectedExtractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED);
+        $properties = $protectedExtractor->getProperties(Dummy::class);
+
+        $this->assertNotContains('bar', $properties);
+        $this->assertContains('baz', $properties);
+
+        $this->assertFalse($protectedExtractor->isReadable(Dummy::class, 'bar'));
+        $this->assertTrue($protectedExtractor->isReadable(Dummy::class, 'baz'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30248 
| License       | MIT
| Doc PR        | TODO

This PR add the possibility to extract private and protected properties from a class by passing a new argument to the `ReflectionExtractor`

This new argument consist of flag that filters properties, so someone will also be able to use the `ReflectionExtractor` only for private property

```php
new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PRIVATE | ReflectionExtractor::ALLOW_PROTECTED)
```

Flags method was prefered over a list of bool to avoid too many parameters and also be close to the reflection API of PHP