### PR TITLE
[Serializer] Use name converter when normalizing constraint violation list

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -32,6 +32,8 @@
 
         <!-- Normalizer -->
         <service id="serializer.normalizer.constraint_violation_list" class="Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer">
+            <argument type="collection" />
+            <argument type="service" id="serializer.name_converter.metadata_aware" />
             <!-- Run before serializer.normalizer.object -->
             <tag name="serializer.normalizer" priority="-915" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -43,6 +43,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
+use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
 use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -1174,6 +1175,18 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertEquals('Symfony\Component\Serializer\Normalizer\ObjectNormalizer', $definition->getClass());
         $this->assertEquals(-1000, $tag[0]['priority']);
+    }
+
+    public function testConstraintViolationListNormalizerRegistered()
+    {
+        $container = $this->createContainerFromFile('full');
+
+        $definition = $container->getDefinition('serializer.normalizer.constraint_violation_list');
+        $tag = $definition->getTag('serializer.normalizer');
+
+        $this->assertEquals(ConstraintViolationListNormalizer::class, $definition->getClass());
+        $this->assertEquals(-915, $tag[0]['priority']);
+        $this->assertEquals(new Reference('serializer.name_converter.metadata_aware'), $definition->getArgument(1));
     }
 
     public function testSerializerCacheActivated()

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
@@ -30,10 +31,12 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
     const TYPE = 'type';
 
     private $defaultContext;
+    private $nameConverter;
 
-    public function __construct($defaultContext = [])
+    public function __construct($defaultContext = [], NameConverterInterface $nameConverter = null)
     {
         $this->defaultContext = $defaultContext;
+        $this->nameConverter = $nameConverter;
     }
 
     /**
@@ -44,7 +47,7 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
         $violations = [];
         $messages = [];
         foreach ($object as $violation) {
-            $propertyPath = $violation->getPropertyPath();
+            $propertyPath = $this->nameConverter ? $this->nameConverter->normalize($violation->getPropertyPath(), null, $format, $context) : $violation->getPropertyPath();
 
             $violationEntry = [
                 'propertyPath' => $propertyPath,

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -66,5 +67,43 @@ class ConstraintViolationListNormalizerTest extends TestCase
         ];
 
         $this->assertEquals($expected, $this->normalizer->normalize($list));
+    }
+
+    public function testNormalizeWithNameConverter()
+    {
+        $normalizer = new ConstraintViolationListNormalizer([], new CamelCaseToSnakeCaseNameConverter());
+
+        $list = new ConstraintViolationList([
+            new ConstraintViolation('too short', 'a', [], 'c', 'shortDescription', ''),
+            new ConstraintViolation('too long', 'b', [], '3', 'product.shortDescription', 'Lorem ipsum dolor sit amet'),
+            new ConstraintViolation('error', 'b', [], '3', '', ''),
+        ]);
+
+        $expected = [
+            'type' => 'https://symfony.com/errors/validation',
+            'title' => 'Validation Failed',
+            'detail' => 'short_description: too short
+product.short_description: too long
+error',
+            'violations' => [
+                [
+                    'propertyPath' => 'short_description',
+                    'title' => 'too short',
+                    'parameters' => [],
+                ],
+                [
+                    'propertyPath' => 'product.short_description',
+                    'title' => 'too long',
+                    'parameters' => [],
+                ],
+                [
+                    'propertyPath' => '',
+                    'title' => 'error',
+                    'parameters' => [],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $normalizer->normalize($list));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When using name converter with serializer and the default ConstraintViolationListNormalizer, returned propertyPaths was not converted to the same format.

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
