### PR TITLE
Fix getSetMethodNormalizer to correctly ignore the attributes specified in "ignored_attributes"

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -109,7 +109,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
             $attributeName = lcfirst(substr($method->name, 0 === strpos($method->name, 'is') ? 2 : 3));
 
-            if ($this->isAllowedAttribute($object, $attributeName)) {
+            if ($this->isAllowedAttribute($object, $attributeName, $format, $context)) {
                 $attributes[] = $attributeName;
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -91,6 +91,23 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->assertTrue($obj->isBaz());
     }
 
+    public function testIgnoredAttributesInContext()
+    {
+        $ignoredAttributes = ['foo', 'bar', 'baz', 'object'];
+        $this->normalizer->setIgnoredAttributes($ignoredAttributes);
+        $obj = new GetSetDummy();
+        $obj->setFoo('foo');
+        $obj->setBar('bar');
+        $obj->setCamelCase(true);
+        $this->assertEquals(
+            [
+                'fooBar' => 'foobar',
+                'camelCase' => true,
+            ],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
     public function testDenormalizeWithObject()
     {
         $data = new \stdClass();


### PR DESCRIPTION
…ed in "ignored_attributes"

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | #30453
| License       | MIT

The GetSetMethodNormalizer class correctly ignores the attributes specified in "ignored_attributes"