### PR TITLE
[HttpKernel] change $previous argument for HttpException to \Throwable

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
@@ -19,11 +19,11 @@ class AccessDeniedHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(403, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
@@ -18,11 +18,11 @@ class BadRequestHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(400, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
@@ -18,11 +18,11 @@ class ConflictHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(409, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
@@ -18,11 +18,11 @@ class GoneHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(410, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -21,7 +21,7 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
     private $statusCode;
     private $headers;
 
-    public function __construct(int $statusCode, string $message = null, \Exception $previous = null, array $headers = [], ?int $code = 0)
+    public function __construct(int $statusCode, string $message = null, \Throwable $previous = null, array $headers = [], ?int $code = 0)
     {
         $this->statusCode = $statusCode;
         $this->headers = $headers;

--- a/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
@@ -18,11 +18,11 @@ class LengthRequiredHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(411, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
@@ -19,11 +19,11 @@ class MethodNotAllowedHttpException extends HttpException
     /**
      * @param array      $allow    An array of allowed methods
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(array $allow, string $message = null, \Exception $previous = null, ?int $code = 0, array $headers = [])
+    public function __construct(array $allow, string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
         $headers['Allow'] = strtoupper(implode(', ', $allow));
 

--- a/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
@@ -18,11 +18,11 @@ class NotAcceptableHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(406, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
@@ -18,11 +18,11 @@ class NotFoundHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(404, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
@@ -18,11 +18,11 @@ class PreconditionFailedHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(412, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
@@ -20,11 +20,11 @@ class PreconditionRequiredHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(428, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
@@ -19,11 +19,11 @@ class ServiceUnavailableHttpException extends HttpException
     /**
      * @param int|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
      * @param string     $message    The internal exception message
-     * @param \Exception $previous   The previous exception
+     * @param \Throwable $previous   The previous exception
      * @param int        $code       The internal exception code
      * @param array      $headers
      */
-    public function __construct($retryAfter = null, string $message = null, \Exception $previous = null, ?int $code = 0, array $headers = [])
+    public function __construct($retryAfter = null, string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
         if ($retryAfter) {
             $headers['Retry-After'] = $retryAfter;

--- a/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
@@ -21,11 +21,11 @@ class TooManyRequestsHttpException extends HttpException
     /**
      * @param int|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
      * @param string     $message    The internal exception message
-     * @param \Exception $previous   The previous exception
+     * @param \Throwable $previous   The previous exception
      * @param int        $code       The internal exception code
      * @param array      $headers
      */
-    public function __construct($retryAfter = null, string $message = null, \Exception $previous = null, ?int $code = 0, array $headers = [])
+    public function __construct($retryAfter = null, string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
         if ($retryAfter) {
             $headers['Retry-After'] = $retryAfter;

--- a/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
@@ -19,11 +19,11 @@ class UnauthorizedHttpException extends HttpException
     /**
      * @param string     $challenge WWW-Authenticate challenge string
      * @param string     $message   The internal exception message
-     * @param \Exception $previous  The previous exception
+     * @param \Throwable $previous  The previous exception
      * @param int        $code      The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $challenge, string $message = null, \Exception $previous = null, ?int $code = 0, array $headers = [])
+    public function __construct(string $challenge, string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
         $headers['WWW-Authenticate'] = $challenge;
 

--- a/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
@@ -18,11 +18,11 @@ class UnprocessableEntityHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(422, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
@@ -18,11 +18,11 @@ class UnsupportedMediaTypeHttpException extends HttpException
 {
     /**
      * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
+     * @param \Throwable $previous The previous exception
      * @param int        $code     The internal exception code
      * @param array      $headers
      */
-    public function __construct(string $message = null, \Exception $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(415, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/AccessDeniedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/AccessDeniedHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class AccessDeniedHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new AccessDeniedHttpException();
+        return new AccessDeniedHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/BadRequestHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/BadRequestHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class BadRequestHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new BadRequestHttpException();
+        return new BadRequestHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ConflictHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ConflictHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 
 class ConflictHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new ConflictHttpException();
+        return new ConflictHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/GoneHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/GoneHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 
 class GoneHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new GoneHttpException();
+        return new GoneHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/HttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/HttpExceptionTest.php
@@ -46,8 +46,16 @@ class HttpExceptionTest extends TestCase
         $this->assertSame($headers, $exception->getHeaders());
     }
 
-    protected function createException()
+    public function testThrowableIsAllowedForPrevious()
     {
-        return new HttpException(200);
+        $previous = new class('Error of PHP 7+') extends \Error {
+        };
+        $exception = $this->createException(null, $previous);
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    {
+        return new HttpException(200, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/LengthRequiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/LengthRequiredHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\LengthRequiredHttpException;
 
 class LengthRequiredHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new LengthRequiredHttpException();
+        return new LengthRequiredHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
@@ -34,4 +34,9 @@ class MethodNotAllowedHttpExceptionTest extends HttpExceptionTest
         $exception->setHeaders($headers);
         $this->assertSame($headers, $exception->getHeaders());
     }
+
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    {
+        return new MethodNotAllowedHttpException(['get'], $message, $previous, $code, $headers);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/NotAcceptableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/NotAcceptableHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 
 class NotAcceptableHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new NotAcceptableHttpException();
+        return new NotAcceptableHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/NotFoundHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/NotFoundHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class NotFoundHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new NotFoundHttpException();
+        return new NotFoundHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionFailedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionFailedHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
 
 class PreconditionFailedHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new PreconditionFailedHttpException();
+        return new PreconditionFailedHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionRequiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionRequiredHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
 
 class PreconditionRequiredHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new PreconditionRequiredHttpException();
+        return new PreconditionRequiredHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
@@ -35,8 +35,8 @@ class ServiceUnavailableHttpExceptionTest extends HttpExceptionTest
         $this->assertSame($headers, $exception->getHeaders());
     }
 
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new ServiceUnavailableHttpException();
+        return new ServiceUnavailableHttpException(null, $message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
@@ -35,8 +35,8 @@ class TooManyRequestsHttpExceptionTest extends HttpExceptionTest
         $this->assertSame($headers, $exception->getHeaders());
     }
 
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new TooManyRequestsHttpException();
+        return new TooManyRequestsHttpException(null, $message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
@@ -34,4 +34,9 @@ class UnauthorizedHttpExceptionTest extends HttpExceptionTest
         $exception->setHeaders($headers);
         $this->assertSame($headers, $exception->getHeaders());
     }
+
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    {
+        return new UnauthorizedHttpException('Challenge', $message, $previous, $code, $headers);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnprocessableEntityHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnprocessableEntityHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class UnprocessableEntityHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new UnprocessableEntityHttpException();
+        return new UnprocessableEntityHttpException($message, $previous, $code, $headers);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnsupportedMediaTypeHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnsupportedMediaTypeHttpExceptionTest.php
@@ -6,8 +6,8 @@ use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 
 class UnsupportedMediaTypeHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException()
+    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
-        return new UnsupportedMediaTypeHttpException();
+        return new UnsupportedMediaTypeHttpException($message, $previous, $code, $headers);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #30728
| License       | MIT

This will fix #30728 with the suggested solution to change the signature of `HttpException` and all its descendants from `\Exception` to `\Throwable`.
