### PR TITLE
[PropertyInfo] Add class extractor interface and collection implementation

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.3.0
 -----
 
+* Add `ClassListExtractorInterface` which provide a way to get classes for a specific domain
 * Added the ability to extract property type based on its initial value
 
 4.2.0

--- a/src/Symfony/Component/PropertyInfo/ClassListExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/ClassListExtractorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo;
+
+/**
+ * Extract a list of class for a specific domain.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ */
+interface ClassListExtractorInterface
+{
+    /**
+     * @return iterable An array of FQDN classes
+     */
+    public function getClasses(array $context = []): iterable;
+}

--- a/src/Symfony/Component/PropertyInfo/Extractor/ClassCollectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ClassCollectionExtractor.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Extractor;
+
+use Symfony\Component\PropertyInfo\ClassListExtractorInterface;
+
+/**
+ * Extracts class from a specific collection.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ */
+final class ClassCollectionExtractor implements ClassListExtractorInterface
+{
+    private $classes;
+
+    /**
+     * @param string[] $classes
+     */
+    public function __construct(array $classes = [])
+    {
+        $this->classes = $classes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClasses(array $context = []): iterable
+    {
+        return $this->classes;
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ClassCollectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ClassCollectionExtractorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Extractor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ */
+class ClassCollectionExtractorTest extends TestCase
+{
+    public function testExtractor()
+    {
+        $extractor = new ClassCollectionExtractor([Dummy::class]);
+        $classes = $extractor->getClasses();
+
+        $this->assertContains(Dummy::class, $classes);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This add support for extracting a list of classes given a specific domain.

This is something that is done in ApiPltaform here : https://github.com/api-platform/core/blob/master/src/Metadata/Resource/ResourceNameCollection.php

Also there could be implementation for Doctrine and others domain in their corresponding Bridge / Bundle. 

This is a first step towards restricting property info for specific domain, like each domain would get its own property info extractor configuration (one accept private / protected / public property / one only accept specific annotation / ...) So we can correctly use the correct extractor given a specific domain / class.

This can also be used in the future as a way to warmup / refresh cache of extraction metadatas for a domain. Since we got a registry we can put a specific watcher on each class of this domain and refresh it when it change or warmup on deployment.
