### PR TITLE
[Validator] Fix annotation default for @Count and @Length

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -43,6 +43,9 @@ class Count extends Constraint
                 'min' => $options,
                 'max' => $options,
             ];
+        } elseif (\is_array($options) && isset($options['value']) && !isset($options['min']) && !isset($options['max'])) {
+            $options['min'] = $options['max'] = $options['value'];
+            unset($options['value']);
         }
 
         parent::__construct($options);

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -47,6 +47,9 @@ class Length extends Constraint
                 'min' => $options,
                 'max' => $options,
             ];
+        } elseif (\is_array($options) && isset($options['value']) && !isset($options['min']) && !isset($options['max'])) {
+            $options['min'] = $options['max'] = $options['value'];
+            unset($options['value']);
         }
 
         parent::__construct($options);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -195,4 +195,13 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
         $this->assertEquals(5, $constraint->min);
         $this->assertEquals(5, $constraint->max);
     }
+
+    public function testConstraintAnnotationDefaultOption()
+    {
+        $constraint = new Count(['value' => 5, 'exactMessage' => 'message']);
+
+        $this->assertEquals(5, $constraint->min);
+        $this->assertEquals(5, $constraint->max);
+        $this->assertEquals('message', $constraint->exactMessage);
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -237,11 +237,20 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
         }
     }
 
-    public function testConstraintGetDefaultOption()
+    public function testConstraintDefaultOption()
     {
         $constraint = new Length(5);
 
         $this->assertEquals(5, $constraint->min);
         $this->assertEquals(5, $constraint->max);
+    }
+
+    public function testConstraintAnnotationDefaultOption()
+    {
+        $constraint = new Length(['value' => 5, 'exactMessage' => 'message']);
+
+        $this->assertEquals(5, $constraint->min);
+        $this->assertEquals(5, $constraint->max);
+        $this->assertEquals('message', $constraint->exactMessage);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | is it worth mentioning?

`Count` and `Length` constraints allow to pass the exact value as the constructor argument when used in code.

```php
new Length(5);
// is same as
new Length(['min' => 5, 'max' => 5]);
```

At the same time when using them as annotations, `@Assert\Length(5)` throws `The options "" do not exist in constraint Symfony\\Component\\Validator\\Constraints\\Length` (fix for ugly exception is proposed in https://github.com/symfony/symfony/pull/30737). This happens because annotation's default value is passed as `value`. Since `Length` does not have a default option, `value` is replaced with `''`.

This PR fixes this inconsistency.