### PR TITLE
[Validator] Improve constraint default option check

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -105,6 +105,7 @@ abstract class Constraint
      */
     public function __construct($options = null)
     {
+        $defaultOption = $this->getDefaultOption();
         $invalidOptions = [];
         $missingOptions = array_flip((array) $this->getRequiredOptions());
         $knownOptions = get_object_vars($this);
@@ -112,8 +113,12 @@ abstract class Constraint
         // The "groups" option is added to the object lazily
         $knownOptions['groups'] = true;
 
-        if (\is_array($options) && \count($options) >= 1 && isset($options['value']) && !property_exists($this, 'value')) {
-            $options[$this->getDefaultOption()] = $options['value'];
+        if (\is_array($options) && isset($options['value']) && !property_exists($this, 'value')) {
+            if (null === $defaultOption) {
+                throw new ConstraintDefinitionException(sprintf('No default option is configured for constraint "%s".', \get_class($this)));
+            }
+
+            $options[$defaultOption] = $options['value'];
             unset($options['value']);
         }
 
@@ -130,26 +135,24 @@ abstract class Constraint
                 }
             }
         } elseif (null !== $options && !(\is_array($options) && 0 === \count($options))) {
-            $option = $this->getDefaultOption();
-
-            if (null === $option) {
-                throw new ConstraintDefinitionException(sprintf('No default option is configured for constraint %s', \get_class($this)));
+            if (null === $defaultOption) {
+                throw new ConstraintDefinitionException(sprintf('No default option is configured for constraint "%s".', \get_class($this)));
             }
 
-            if (\array_key_exists($option, $knownOptions)) {
-                $this->$option = $options;
-                unset($missingOptions[$option]);
+            if (\array_key_exists($defaultOption, $knownOptions)) {
+                $this->$defaultOption = $options;
+                unset($missingOptions[$defaultOption]);
             } else {
-                $invalidOptions[] = $option;
+                $invalidOptions[] = $defaultOption;
             }
         }
 
         if (\count($invalidOptions) > 0) {
-            throw new InvalidOptionsException(sprintf('The options "%s" do not exist in constraint %s', implode('", "', $invalidOptions), \get_class($this)), $invalidOptions);
+            throw new InvalidOptionsException(sprintf('The options "%s" do not exist in constraint "%s".', implode('", "', $invalidOptions), \get_class($this)), $invalidOptions);
         }
 
         if (\count($missingOptions) > 0) {
-            throw new MissingOptionsException(sprintf('The options "%s" must be set for constraint %s', implode('", "', array_keys($missingOptions)), \get_class($this)), array_keys($missingOptions));
+            throw new MissingOptionsException(sprintf('The options "%s" must be set for constraint "%s".', implode('", "', array_keys($missingOptions)), \get_class($this)), array_keys($missingOptions));
         }
     }
 
@@ -173,7 +176,7 @@ abstract class Constraint
             return;
         }
 
-        throw new InvalidOptionsException(sprintf('The option "%s" does not exist in constraint %s', $option, \get_class($this)), [$option]);
+        throw new InvalidOptionsException(sprintf('The option "%s" does not exist in constraint "%s".', $option, \get_class($this)), [$option]);
     }
 
     /**
@@ -199,7 +202,7 @@ abstract class Constraint
             return $this->groups;
         }
 
-        throw new InvalidOptionsException(sprintf('The option "%s" does not exist in constraint %s', $option, \get_class($this)), [$option]);
+        throw new InvalidOptionsException(sprintf('The option "%s" does not exist in constraint "%s".', $option, \get_class($this)), [$option]);
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -225,7 +225,7 @@ class ConstraintTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\Validator\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The options "0", "5" do not exist
+     * @expectedExceptionMessage The options "0", "5" do not exist in constraint "Symfony\Component\Validator\Tests\Fixtures\ConstraintA".
      */
     public function testInvalidOptions()
     {
@@ -241,5 +241,14 @@ class ConstraintTest extends TestCase
         $constraint = new ConstraintA($options);
 
         $this->assertEquals('foo', $constraint->property1);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage No default option is configured for constraint "Symfony\Component\Validator\Tests\Fixtures\ConstraintB".
+     */
+    public function testAnnotationSetUndefinedDefaultOption()
+    {
+        new ConstraintB(['value' => 1]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Any constraint without default option used as annotation with unnamed first argument (for example, `@Assert\Collection(1)`) throws an exception with an ugly message `The options "" do not exist in constraint Collection`.

This PR makes constraint check the default option in the annotation case in the same way it checks it in the "real" code case. So the exception will be `No default option is configured for constraint Collection.`