### PR TITLE
[Serializer] Added check of constuctor modifiers to AbstractNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -333,6 +333,10 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
 
         $constructor = $this->getConstructor($data, $class, $context, $reflectionClass, $allowedAttributes);
         if ($constructor) {
+            if (true !== $constructor->isPublic()) {
+                return $reflectionClass->newInstanceWithoutConstructor();
+            }
+
             $constructorParameters = $constructor->getParameters();
 
             $params = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.2 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30748
| License       | MIT

If constructor is not public, instantiate target object without constructor to prevent errors like `Access to non-public constructor of class Target`
