### PR TITLE
Changing to MessageDecodingFailedException so that invalid messages are rejected

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -28,6 +28,16 @@ class PhpSerializerTest extends TestCase
         $this->assertEquals($envelope, $serializer->decode($serializer->encode($envelope)));
     }
 
+    public function testDecodingFailsWithMissingBodyKey()
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessage('Encoded envelope should have at least a "body".');
+
+        $serializer = new PhpSerializer();
+
+        $serializer->decode([]);
+    }
+
     public function testDecodingFailsWithBadFormat()
     {
         $this->expectException(MessageDecodingFailedException::class);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -108,6 +108,37 @@ class SerializerTest extends TestCase
         ]);
     }
 
+    /**
+     * @dataProvider getMissingKeyTests
+     */
+    public function testDecodingFailsWithMissingKeys(array $data, string $expectedMessage)
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $serializer = new Serializer();
+
+        $serializer->decode($data);
+    }
+
+    public function getMissingKeyTests()
+    {
+        yield 'no_body' => [
+            ['headers' => ['type' => 'bar']],
+            'Encoded envelope should have at least a "body" and some "headers".',
+        ];
+
+        yield 'no_headers' => [
+            ['body' => '{}'],
+            'Encoded envelope should have at least a "body" and some "headers".',
+        ];
+
+        yield 'no_headers_type' => [
+            ['body' => '{}', 'headers' => ['foo' => 'bar']],
+            'Encoded envelope does not have a "type" header.',
+        ];
+    }
+
     public function testDecodingFailsWithBadClass()
     {
         $this->expectException(MessageDecodingFailedException::class);

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Messenger\Transport\Serialization;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 
 /**
@@ -28,7 +27,7 @@ class PhpSerializer implements SerializerInterface
     public function decode(array $encodedEnvelope): Envelope
     {
         if (empty($encodedEnvelope['body'])) {
-            throw new InvalidArgumentException('Encoded envelope should have at least a "body".');
+            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body".');
         }
 
         return $this->safelyUnserialize($encodedEnvelope['body']);

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Messenger\Transport\Serialization;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
@@ -63,11 +62,11 @@ class Serializer implements SerializerInterface
     public function decode(array $encodedEnvelope): Envelope
     {
         if (empty($encodedEnvelope['body']) || empty($encodedEnvelope['headers'])) {
-            throw new InvalidArgumentException('Encoded envelope should have at least a "body" and some "headers".');
+            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body" and some "headers".');
         }
 
         if (empty($encodedEnvelope['headers']['type'])) {
-            throw new InvalidArgumentException('Encoded envelope does not have a "type" header.');
+            throw new MessageDecodingFailedException('Encoded envelope does not have a "type" header.');
         }
 
         $stamps = $this->decodeStamps($encodedEnvelope);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  |  no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30649
| License       | MIT
| Doc PR        | not needed for bug fix

Bug fix if a message body is completely blank. I'm fixing this on master only, because in 4.2 and earlier, there is actually no system in place to fail serialization and cause the messages to be rejected. In 4.3, we just need to throw this exception.

Cheers!
