### PR TITLE
[Messenger] Adding MessageCountAwareInterface to get transport message count

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 4.3.0
 -----
 
+ * Added optional `MessageCountAwareInterface` that receivers can implement
+   to give information about how many messages are waiting to be processed.
  * [BC BREAK] The `Envelope::__construct()` signature changed:
    you can no longer pass an unlimited number of stamps as the second,
    third, fourth, arguments etc: stamps are now an array passed to the

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -37,6 +37,9 @@ class ConnectionTest extends TestCase
         $queryBuilder
             ->method('getSQL')
             ->willReturn('');
+        $queryBuilder
+            ->method('getParameters')
+            ->willReturn([]);
         $driverConnection
             ->method('prepare')
             ->willReturn($stmt);
@@ -54,6 +57,9 @@ class ConnectionTest extends TestCase
         $driverConnection = $this->getDBALConnectionMock();
         $stmt = $this->getStatementMock(false);
 
+        $queryBuilder
+            ->method('getParameters')
+            ->willReturn([]);
         $driverConnection->expects($this->once())
             ->method('createQueryBuilder')
             ->willReturn($queryBuilder);
@@ -119,6 +125,7 @@ class ConnectionTest extends TestCase
         $queryBuilder->method('orderBy')->willReturn($queryBuilder);
         $queryBuilder->method('setMaxResults')->willReturn($queryBuilder);
         $queryBuilder->method('setParameter')->willReturn($queryBuilder);
+        $queryBuilder->method('setParameters')->willReturn($queryBuilder);
 
         return $queryBuilder;
     }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -15,6 +15,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -26,7 +27,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  *
  * @experimental in 4.2
  */
-class AmqpReceiver implements ReceiverInterface
+class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
 {
     private $serializer;
     private $connection;
@@ -85,6 +86,14 @@ class AmqpReceiver implements ReceiverInterface
     public function reject(Envelope $envelope): void
     {
         $this->rejectAmqpEnvelope($this->findAmqpEnvelope($envelope));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageCount(): int
+    {
+        return $this->connection->countMessagesInQueue();
     }
 
     private function rejectAmqpEnvelope(\AMQPEnvelope $amqpEnvelope): void

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  *
  * @experimental in 4.2
  */
-class AmqpTransport implements TransportInterface, SetupableTransportInterface
+class AmqpTransport implements TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
 {
     private $serializer;
     private $connection;
@@ -73,6 +74,14 @@ class AmqpTransport implements TransportInterface, SetupableTransportInterface
     public function setup(): void
     {
         $this->connection->setup();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageCount(): int
+    {
+        return ($this->receiver ?? $this->getReceiver())->getMessageCount();
     }
 
     private function getReceiver()

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -185,6 +185,14 @@ class Connection
     }
 
     /**
+     * Returns an approximate count of the messages in a queue.
+     */
+    public function countMessagesInQueue(): int
+    {
+        return $this->queue()->declareQueue();
+    }
+
+    /**
      * @throws \AMQPException
      */
     private function publishWithDelay(string $body, array $headers = [], int $delay)

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/DoctrineReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/DoctrineReceiver.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -25,7 +26,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  *
  * @experimental in 4.3
  */
-class DoctrineReceiver implements ReceiverInterface
+class DoctrineReceiver implements ReceiverInterface, MessageCountAwareInterface
 {
     private $connection;
     private $serializer;
@@ -79,6 +80,14 @@ class DoctrineReceiver implements ReceiverInterface
     public function reject(Envelope $envelope): void
     {
         $this->connection->reject($this->findDoctrineReceivedStamp($envelope)->getId());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageCount(): int
+    {
+        return $this->connection->getMessageCount();
     }
 
     private function findDoctrineReceivedStamp(Envelope $envelope): DoctrineReceivedStamp

--- a/src/Symfony/Component/Messenger/Transport/Receiver/MessageCountAwareInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/MessageCountAwareInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Receiver;
+
+/**
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @experimental in 4.3
+ */
+interface MessageCountAwareInterface
+{
+    /**
+     * Returns the number of messages waiting to be handled.
+     *
+     * In some systems, this may be an approximate number.
+     */
+    public function getMessageCount(): int;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#11236

This adds a new optional interface that receivers should implement to give an approximate number of the messages "waiting" to be handled. Why? Because, with this, you could design a system that dynamically adds/removes worker processes if a specific transport is getting slammed and needs help. Creating that system could be something we discuss for core later, but this at least makes it possible - and means it could be implemented by the user or in a bundle... which I might do if we don't get it in core ;).
