### PR TITLE
[PropertyAccess] Allow Can Accessor in Property Access

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -455,6 +455,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         $getsetter = lcfirst($camelProp); // jQuery style, e.g. read: last(), write: last($item)
         $isser = 'is'.$camelProp;
         $hasser = 'has'.$camelProp;
+        $canAccessor = 'can'.$camelProp;
 
         if ($reflClass->hasMethod($getter) && $reflClass->getMethod($getter)->isPublic()) {
             $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
@@ -468,6 +469,9 @@ class PropertyAccessor implements PropertyAccessorInterface
         } elseif ($reflClass->hasMethod($hasser) && $reflClass->getMethod($hasser)->isPublic()) {
             $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
             $access[self::ACCESS_NAME] = $hasser;
+        } elseif ($reflClass->hasMethod($canAccessor) && $reflClass->getMethod($canAccessor)->isPublic()) {
+            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
+            $access[self::ACCESS_NAME] = $canAccessor;
         } elseif ($reflClass->hasMethod('__get') && $reflClass->getMethod('__get')->isPublic()) {
             $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
             $access[self::ACCESS_NAME] = $property;

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
@@ -25,6 +25,7 @@ class TestClass
     private $publicAccessorWithMoreRequiredParameters;
     private $publicIsAccessor;
     private $publicHasAccessor;
+    private $publicCanAccessor;
     private $publicGetter;
     private $date;
 
@@ -39,6 +40,7 @@ class TestClass
         $this->publicAccessorWithMoreRequiredParameters = $value;
         $this->publicIsAccessor = $value;
         $this->publicHasAccessor = $value;
+        $this->publicCanAccessor = $value;
         $this->publicGetter = $value;
     }
 
@@ -100,6 +102,16 @@ class TestClass
     public function hasPublicHasAccessor()
     {
         return $this->publicHasAccessor;
+    }
+
+    public function setPublicCanAccessor($value)
+    {
+        $this->publicCanAccessor = $value;
+    }
+
+    public function canPublicCanAccessor()
+    {
+        return $this->publicCanAccessor;
     }
 
     public function publicGetSetter($value = null)

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -450,6 +450,7 @@ class PropertyAccessorTest extends TestCase
             [new TestClass('Bernhard'), 'publicIsAccessor', 'Bernhard'],
             [new TestClass('Bernhard'), 'publicHasAccessor', 'Bernhard'],
             [new TestClass('Bernhard'), 'publicGetSetter', 'Bernhard'],
+            [new TestClass('Bernhard'), 'publicCanAccessor', 'Bernhard'],
 
             // Methods are camelized
             [new TestClass('Bernhard'), 'public_accessor', 'Bernhard'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

- Added ability to support `can` methods in the property access
  in order to be compatible with PropertyInfo component
  which allows for `can` accessors
