### PR TITLE
[Messenger] Adding the "sync" transport to call handlers synchronously

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -67,6 +67,10 @@
             <argument type="service" id="messenger.transport.serializer" />
         </service>
 
+        <service id="messenger.transport.sync.factory" class="Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory">
+            <tag name="messenger.transport_factory" />
+        </service>
+
         <!-- retry -->
         <service id="messenger.retry_strategy_locator">
             <tag name="container.service_locator" />

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 4.3.0
 -----
 
+ * Added a new `SyncTransport` along with `ForceCallHandlersStamp` to
+   explicitly handle messages asynchronously.
  * Added optional parameter `prefetch_count` in connection configuration, 
    to setup channel prefetch count
  * New classes: `RoutableMessageBus`, `AddBusNameStampMiddleware`

--- a/src/Symfony/Component/Messenger/Stamp/ForceCallHandlersStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ForceCallHandlersStamp.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Stamp marks that the handlers *should* be called immediately.
+ *
+ * This is used by the SyncTransport to indicate to the
+ * SendMessageMiddleware that handlers *should* be called
+ * immediately, even though a transport was set.
+ *
+ * @experimental in 4.3
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class ForceCallHandlersStamp implements StampInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Transport/Sync/SyncTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/Sync/SyncTransport.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Sync;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Stamp\ForceCallHandlersStamp;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * A "fake" transport that marks messages to be handled immediately.
+ *
+ * @experimental in 4.3
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class SyncTransport implements TransportInterface
+{
+    public function receive(callable $handler): void
+    {
+        throw new InvalidArgumentException('You cannot receive messages from the SyncTransport.');
+    }
+
+    public function stop(): void
+    {
+        throw new InvalidArgumentException('You cannot call stop() on the SyncTransport.');
+    }
+
+    public function ack(Envelope $envelope): void
+    {
+        throw new InvalidArgumentException('You cannot call ack() on the SyncTransport.');
+    }
+
+    public function reject(Envelope $envelope): void
+    {
+        throw new InvalidArgumentException('You cannot call reject() on the SyncTransport.');
+    }
+
+    public function send(Envelope $envelope): Envelope
+    {
+        return $envelope->with(new ForceCallHandlersStamp());
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Sync/SyncTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/Sync/SyncTransportFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Sync;
+
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * @experimental in 4.3
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class SyncTransportFactory implements TransportFactoryInterface
+{
+    public function createTransport(string $dsn, array $options): TransportInterface
+    {
+        return new SyncTransport();
+    }
+
+    public function supports(string $dsn, array $options): bool
+    {
+        return 0 === strpos($dsn, 'sync://');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#11236

This adds a `sync://` transport that just calls the handlers immediately. Why? This allows you to route your messages to some "async" transport. But then, when developing locally or running your tests, you can choose to run them synchronously instead:

```yml
# config/packages/messenger.yaml
framework:
    messenger:
        transports:
            async: '%env(MESSENGER_TRANSPORT_DSN)%'
        routing:
            'App\Message\SmsNotification': async
            'App\Message\OtherMessage': async
```

```
# .env
# by default, handle this sync
MESSENGER_TRANSPORT_DSN=sync://
```

```
# .env.local on production (or set this via real env vars)
# on production, use amqp
MESSENGER_TRANSPORT_DSN=amqp://.......
```

Cheers!