### PR TITLE
[EventDispatcher][DX] Autoconfigure event listeners

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -116,6 +116,7 @@ use Symfony\Component\Workflow\WorkflowInterface;
 use Symfony\Component\Yaml\Command\LintCommand as BaseYamlLintCommand;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\EventDispatcher\EventListenerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
@@ -368,6 +369,8 @@ class FrameworkExtension extends Extension
             ->addTag('kernel.cache_clearer');
         $container->registerForAutoconfiguration(CacheWarmerInterface::class)
             ->addTag('kernel.cache_warmer');
+        $container->registerForAutoconfiguration(EventListenerInterface::class)
+            ->addTag('kernel.event_listener');
         $container->registerForAutoconfiguration(EventSubscriberInterface::class)
             ->addTag('kernel.event_subscriber');
         $container->registerForAutoconfiguration(ResetInterface::class)

--- a/src/Symfony/Contracts/EventDispatcher/EventListenerInterface.php
+++ b/src/Symfony/Contracts/EventDispatcher/EventListenerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\EventDispatcher;
+
+/**
+ * Marker interface for event listeners.
+ *
+ * @method void __invoke(object $event, string $eventName, EventDispatcherInterface $dispatcher)
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface EventListenerInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
| License       | MIT
| Doc PR        | symfony/symfony-docs/pull/11252

Now that event's FQDN could be used a eventName, this PR adds an alternative to EventSubscriberInterface that uses method's typehint to guess the event to subscribe.

usage for developers:
```
class MyListener implements EventListenerInterface {
  public function __invoke(MyEvent $e) {
  }
}
```

That's is. No more services to configure nor `getSubscribedEvents` to implement.

This PR contains 2 parts:
- extends the tag `kernel.event_listener` to automatically register available methods when the tag does not contains the required `name` attribute.
- add a new `EventListenerInterface` (which is empty) that's just use to trigger the `registerForAutoconfiguration`.


Few questionable choices made on that PR.
- reuse the tag `kernel.event_listener` instead of creating a new one
- priority is not configurable: EventSubscriberInterface is here for that

Fixed 2 issues:
- tag `container.hot_path` was harcoded in subscriber logic (instead of using the injected variable)
- dynamic registration of onMyEventName when event name is a FQDN className