### PR TITLE
[Security] Add symfony/polyfill-ctype to dev requirements

### DIFF
--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -33,6 +33,7 @@
     "require-dev": {
         "psr/container": "^1.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
+        "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/routing": "~2.8|~3.0|~4.0",
         "symfony/validator": "^3.2.5|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| License       | MIT

because this [test](https://github.com/symfony/symfony/blob/v3.4.0/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php#L55) uses `ctype_print`