### PR TITLE
[Messenger] Changing message handling log levels to higher levels

### DIFF
--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -99,7 +99,7 @@ class Worker
 
                     $retryCount = $this->getRetryCount($envelope) + 1;
                     if (null !== $this->logger) {
-                        $this->logger->info('Retrying {class} - retry #{retryCount}.', $context + ['retryCount' => $retryCount, 'error' => $throwable]);
+                        $this->logger->error('Retrying {class} - retry #{retryCount}.', $context + ['retryCount' => $retryCount, 'error' => $throwable]);
                     }
 
                     // add the delay and retry stamp info + remove ReceivedStamp
@@ -113,7 +113,7 @@ class Worker
                     $this->receiver->ack($envelope);
                 } else {
                     if (null !== $this->logger) {
-                        $this->logger->info('Rejecting {class} (removing from transport).', $context + ['error' => $throwable]);
+                        $this->logger->critical('Rejecting {class} (removing from transport).', $context + ['error' => $throwable]);
                     }
 
                     $this->receiver->reject($envelope);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

Update log levels so that the user can configure the logger to be notified of errors. This was really an oversight when I originally added the logging.

Cheers!