### PR TITLE
[WIP][Messenger] Handling & Tracking Failed Messages Support

### DIFF
--- a/src/Symfony/Component/Messenger/Failure/DbalFailedMessageStorage.php
+++ b/src/Symfony/Component/Messenger/Failure/DbalFailedMessageStorage.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Failure;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer;
+use Doctrine\DBAL\Types\Type;
+use Symfony\Component\Messenger\Envelope;
+
+class DbalFailedMessageStorage implements FailedMessageStorageInterface
+{
+    private $driverConnection;
+    private $options;
+
+    public function __construct(Connection $driverConnection, array $options)
+    {
+        $this->driverConnection = $driverConnection;
+        $this->options = array_merge([
+            'auto_setup' => true,
+            'table_name' => 'failed_messages',
+        ], $options);
+    }
+
+    public function add(Envelope $envelope, \Throwable $exception, string $transportName, \DateTimeInterface $failedAt): FailedMessage
+    {
+        $queryBuilder = $this->driverConnection->createQueryBuilder()
+            ->insert($this->options['table_name'])
+            ->values([
+                'envelope' => ':envelope',
+                'exception' => ':exception',
+                'transport_name' => ':transport_name',
+                'failed_at' => ':failed_at',
+            ])
+        ;
+
+        $data = [
+            'envelope' => serialize($envelope),
+            'exception' => serialize($exception),
+            'transport_name' => $transportName,
+            'failed_at' => $failedAt->format('Y-m-d H:i:s'),
+        ];
+
+        $this->executeQuery($queryBuilder->getSQL(), $data);
+
+        $data['id'] = $this->driverConnection->lastInsertId();
+
+        return $this->createFailedMessage($data);
+    }
+
+    public function all(): array
+    {
+        $query = $this->driverConnection->createQueryBuilder()
+            ->select('m.*')
+            ->from($this->options['table_name'], 'm')
+            ->orderBy('failed_at', 'ASC')
+        ;
+
+        $rows = $this->executeQuery($query->getSQL())->fetchAll();
+
+        return array_map(function ($row) {
+            return $this->createFailedMessage($row);
+        }, $rows);
+    }
+
+    public function get($id): FailedMessage
+    {
+        $query = $this->driverConnection->createQueryBuilder()
+            ->select('m.*')
+            ->from($this->options['table_name'], 'm')
+            ->where('m.id = :id')
+        ;
+
+        $row = $this->executeQuery($query->getSQL(), ['id' => $id])->fetch();
+
+        return $this->createFailedMessage($row);
+    }
+
+    public function remove(FailedMessage $failedMessage): void
+    {
+        $query = $this->driverConnection->createQueryBuilder()
+            ->delete($this->options['table_name'])
+            ->where('m.id = :id')
+        ;
+
+        $this->executeQuery($query->getSQL(), ['id' => $failedMessage->getId()]);
+    }
+
+    public function removeAll(): void
+    {
+        $query = $this->driverConnection->createQueryBuilder()
+            ->delete($this->options['table_name'])
+        ;
+
+        $this->executeQuery($query->getSQL());
+    }
+
+    private function executeQuery(string $sql, array $parameters = []): Statement
+    {
+        $stmt = null;
+
+        try {
+            $stmt = $this->driverConnection->prepare($sql);
+            $stmt->execute($parameters);
+        } catch (TableNotFoundException $e) {
+            // create table
+            if (!$this->driverConnection->isTransactionActive() && $this->options['auto_setup']) {
+                $this->setup();
+            }
+
+            // statement not prepared ? SQLite throw on exception on prepare if the table does not exist
+            if (null === $stmt) {
+                $stmt = $this->driverConnection->prepare($sql);
+            }
+
+            $stmt->execute($parameters);
+        }
+
+        return $stmt;
+    }
+
+    public function setup(): void
+    {
+        $synchronizer = new SingleDatabaseSynchronizer($this->driverConnection);
+        $synchronizer->updateSchema($this->getSchema(), true);
+    }
+
+    private function getSchema(): Schema
+    {
+        $schema = new Schema();
+        $table = $schema->createTable($this->options['table_name']);
+        $table->addColumn('id', Type::BIGINT)
+            ->setAutoincrement(true)
+            ->setNotnull(true);
+        $table->addColumn('envelope', Type::TEXT)
+            ->setNotnull(true);
+        $table->addColumn('exception', Type::TEXT)
+            ->setNotnull(true);
+        $table->addColumn('transport_name', Type::STRING)
+            ->setLength(255)
+            ->setNotnull(true);
+        $table->addColumn('failed_at', Type::DATETIME_IMMUTABLE)
+            ->setNotnull(true);
+        $table->setPrimaryKey(['id']);
+
+        return $schema;
+    }
+
+    private function createFailedMessage(array $rowData): FailedMessage
+    {
+        return new FailedMessage(
+            $rowData['id'],
+            unserialize($rowData['envelope']),
+            unserialize($rowData['exception']),
+            $rowData['transport_name'],
+            \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $rowData['failed_at'])
+        );
+    }
+}

--- a/src/Symfony/Component/Messenger/Failure/FailedMessage.php
+++ b/src/Symfony/Component/Messenger/Failure/FailedMessage.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Failure;
+
+use Symfony\Component\Messenger\Envelope;
+
+class FailedMessage
+{
+    private $id;
+    private $envelope;
+    private $exception;
+    private $transportName;
+    private $failedAt;
+
+    public function __construct($id, Envelope $envelope, \Throwable $exception, string $transportName, \DateTimeInterface $failedAt)
+    {
+        $this->id = $id;
+        $this->envelope = $envelope;
+        $this->exception = $exception;
+        $this->transportName = $transportName;
+        $this->failedAt = $failedAt;
+    }
+
+    /**
+     * Some unique identifier for this failed message within the storage.
+     *
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getEnvelope(): Envelope
+    {
+        return $this->envelope;
+    }
+
+    public function getException(): \Throwable
+    {
+        return $this->exception;
+    }
+
+    public function getFailedAt(): \DateTimeInterface
+    {
+        return $this->failedAt;
+    }
+
+    public function getTransportName(): string
+    {
+        return $this->transportName;
+    }
+}

--- a/src/Symfony/Component/Messenger/Failure/FailedMessageStorageInterface.php
+++ b/src/Symfony/Component/Messenger/Failure/FailedMessageStorageInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Failure;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+interface FailedMessageStorageInterface
+{
+    public function add(Envelope $envelope, \Throwable $exception, string $transportName, \DateTimeInterface $failedAt): FailedMessage;
+
+    /**
+     * @return FailedMessage[]
+     */
+    public function all(): array;
+
+    public function get($id): FailedMessage;
+
+    public function remove(FailedMessage $failedMessage): void;
+
+    public function removeAll(): void;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | TODO
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#11236

Hi o/!

This is a proposal to add global "failed messages" handling to Messenger. Messages are already retried a configurable number of times. But what happens if those all fail (e.g. due to a temporary network issue with an external service)? Currently, the messages are rejecting and lost. There is an event the user can hook into, but I think we can do better.

In this system, the envelopes would be "stored" somewhere for later. There would be 3 new commands you could use to handle them:

```
# see all failed messages or one in more detail
bin/console messenger:failed:show
bin/console messenger:failed:show 15

# remove all or just one message
bin/console messenger:failed:remove --all
bin/console messenger:failed:remove 15

# retry all failed message or just one
bin/console messenger:failed:retry --all
bin/console messenger:failed:retry 15
```

The configuration would probably look like this:

```yml
framework:
    messenger:
        # ...

        failure_handler: 'doctrine://default'
```

Most true messaging/queuing systems (AMQP, SQS) already have a concept of a "dead letter queue/exchange", where you can configure failed messages to go to. And this *is* something that we can/should document using if people are interested. However, they have few practical disadvantages. First, since these are normal queues, you can "consume" them, but you can't easily see a full list of them or look at once specific one to decide if you want to retry or remove it. Second, less robust transports like Redis & Doctrine do *not* have dead letter exchanges/queues built in.

Cheers!