### PR TITLE
[Framework] ProxyController to fetch a remote URL using the HttpClient

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -28,6 +28,7 @@ CHANGELOG
  * Added support for PHP files with translations in translation commands.
  * Added support for boolean container parameters within routes.
  * Added the `messenger:setup-transports` command to setup messenger transports
+ * Added `ProxyController` to fetch content from a remote URL
 
 4.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ProxyController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ProxyController.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -43,18 +43,25 @@ class ProxyController
      * @param array   $options         Options passed to the HttpClient
      * @param array   $responseHeaders HTTP headers added to the response
      *
-     * @throws HttpException In case the route name is empty
+     * @throws \InvalidArgumentException In case of invalid HTTP client options
      */
     public function __invoke(Request $request, string $url, string $method = 'GET', $options = [], $responseHeaders = []): Response
     {
+        $options = array_replace([
+            'buffer' => false,
+        ], $options);
+
         try {
             $remoteResponse = $this->httpClient->request($method, $url, $options);
         } catch (InvalidArgumentException $e) {
-            throw new \InvalidArgumentException(sprintf('Invalid proxy configuration for route "%s"', $request->attributes->get('_route')), 0, $e);
+            throw new \InvalidArgumentException(sprintf('Invalid proxy configuration for route "%s": %s', $request->attributes->get('_route'), $e->getMessage()), 0, $e);
         }
 
-        $response = new Response();
-        $response->setContent($remoteResponse->getContent());
+        $response = new StreamedResponse(function () use ($remoteResponse) {
+            foreach ($this->httpClient->stream([$remoteResponse]) as $chunk) {
+                echo $chunk->getContent();
+            }
+        });
         $response->setStatusCode($remoteResponse->getStatusCode());
         $response->headers->add($responseHeaders);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ProxyController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ProxyController.php
@@ -45,7 +45,7 @@ class ProxyController
      *
      * @throws \InvalidArgumentException In case of invalid HTTP client options
      */
-    public function __invoke(Request $request, string $url, string $method = 'GET', $options = [], $responseHeaders = []): Response
+    public function __invoke(Request $request, string $url, string $method = 'GET', $options = [], $extraResponseHeaders = []): Response
     {
         $options = array_replace([
             'buffer' => false,
@@ -63,7 +63,13 @@ class ProxyController
             }
         });
         $response->setStatusCode($remoteResponse->getStatusCode());
+
+        $responseHeaders = $remoteResponse->getHeaders();
+        unset($responseHeaders['content-encoding']);
+        unset($responseHeaders['content-transfer-encoding']);
         $response->headers->add($responseHeaders);
+
+        $response->headers->add($extraResponseHeaders);
 
         return $response;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ProxyController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ProxyController.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Proxies a request to a remote URL.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ *
+ * @final
+ */
+class ProxyController
+{
+    /** @var HttpClientInterface */
+    private $httpClient;
+
+    public function __construct(HttpClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * Creates a response by fetching the content from a remote URL.
+     *
+     * @param Request $request         The request instance
+     * @param string  $url             The URL to fetch
+     * @param string  $method          The HTTP method to use
+     * @param array   $options         Options passed to the HttpClient
+     * @param array   $responseHeaders HTTP headers added to the response
+     *
+     * @throws HttpException In case the route name is empty
+     */
+    public function proxyAction(Request $request, string $url, string $method = 'GET', $options = [], $responseHeaders = []): Response
+    {
+        try {
+            $httpResponse = $this->httpClient->request($method, $url, $options);
+        } catch (InvalidArgumentException $e) {
+            throw new \InvalidArgumentException(sprintf('Invalid proxy configuration for route "%s"', $request->attributes->get('_route')), 0, $e);
+        }
+        // @todo How to handle runtime errors ?
+
+        $response = new Response();
+        $response->setContent($httpResponse->getContent());
+        $response->setStatusCode($httpResponse->getStatusCode());
+        $response->headers->add($responseHeaders);
+
+        return $response;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ProxyController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ProxyController.php
@@ -45,18 +45,17 @@ class ProxyController
      *
      * @throws HttpException In case the route name is empty
      */
-    public function proxyAction(Request $request, string $url, string $method = 'GET', $options = [], $responseHeaders = []): Response
+    public function __invoke(Request $request, string $url, string $method = 'GET', $options = [], $responseHeaders = []): Response
     {
         try {
-            $httpResponse = $this->httpClient->request($method, $url, $options);
+            $remoteResponse = $this->httpClient->request($method, $url, $options);
         } catch (InvalidArgumentException $e) {
             throw new \InvalidArgumentException(sprintf('Invalid proxy configuration for route "%s"', $request->attributes->get('_route')), 0, $e);
         }
-        // @todo How to handle runtime errors ?
 
         $response = new Response();
-        $response->setContent($httpResponse->getContent());
-        $response->setStatusCode($httpResponse->getStatusCode());
+        $response->setContent($remoteResponse->getContent());
+        $response->setStatusCode($remoteResponse->getStatusCode());
         $response->headers->add($responseHeaders);
 
         return $response;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.xml
@@ -16,5 +16,9 @@
             <argument type="service" id="http_client" />
         </service>
         <service id="Psr\Http\Client\ClientInterface" alias="psr18.http_client" />
+
+        <service id="Symfony\Bundle\FrameworkBundle\Controller\ProxyController" public="true">
+            <argument type="service" id="http_client" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -111,10 +111,6 @@
             <argument>%request_listener.https_port%</argument>
         </service>
 
-        <service id="Symfony\Bundle\FrameworkBundle\Controller\ProxyController" public="true">
-            <argument type="service" id="http_client" />
-        </service>
-
         <service id="Symfony\Bundle\FrameworkBundle\Controller\TemplateController" public="true">
             <argument type="service" id="twig" on-invalid="ignore" />
             <argument type="service" id="templating" on-invalid="ignore" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -111,6 +111,10 @@
             <argument>%request_listener.https_port%</argument>
         </service>
 
+        <service id="Symfony\Bundle\FrameworkBundle\Controller\ProxyController" public="true">
+            <argument type="service" id="http_client" />
+        </service>
+
         <service id="Symfony\Bundle\FrameworkBundle\Controller\TemplateController" public="true">
             <argument type="service" id="twig" on-invalid="ignore" />
             <argument type="service" id="templating" on-invalid="ignore" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ProxyControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ProxyControllerTest.php
@@ -39,7 +39,7 @@ class ProxyControllerTest extends TestCase
         });
         $controller = new ProxyController($httpClient);
 
-        $response = $controller->proxyAction($request, $expectedUrl, 'GET', ['timeout' => 10], ['custom-header' => 'myheadervalue']);
+        $response = $controller($request, $expectedUrl, 'GET', ['timeout' => 10], ['custom-header' => 'myheadervalue']);
 
         $this->assertEquals($expectedBody, $response->getContent());
         $this->assertEquals('myheadervalue', $response->headers->get('custom-header'));
@@ -64,6 +64,6 @@ class ProxyControllerTest extends TestCase
         });
         $controller = new ProxyController($httpClient);
 
-        $controller->proxyAction($request, '');
+        $controller($request, '');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ProxyControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ProxyControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\ProxyController;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+class ProxyControllerTest extends TestCase
+{
+    public function testRoute()
+    {
+        $request = new Request();
+
+        $expectedBody = '<html><body>Page body</body></html>';
+        $expectedUrl = 'https://www.example.com/success';
+
+        $httpClient = new MockHttpClient(function ($method, $url, $options) use ($expectedUrl, $expectedBody) {
+            $this->assertEquals('GET', $method);
+            $this->assertEquals($expectedUrl, $url);
+
+            return new MockResponse($expectedBody, [
+                'http_code' => 200,
+            ]);
+        });
+        $controller = new ProxyController($httpClient);
+
+        $response = $controller->proxyAction($request, $expectedUrl, 'GET', ['timeout' => 10], ['custom-header' => 'myheadervalue']);
+
+        $this->assertEquals($expectedBody, $response->getContent());
+        $this->assertEquals('myheadervalue', $response->headers->get('custom-header'));
+    }
+
+    public function testInvalidRoute()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid proxy configuration for route "myproxy"');
+
+        $request = new Request();
+        $request->attributes->set('_route', 'myproxy');
+
+        $expectedBody = '<html><body>Page body</body></html>';
+
+        $httpClient = new MockHttpClient(function ($method, $url, $options) use ($expectedBody) {
+            $this->assertEquals('GET', $method);
+
+            return new MockResponse($expectedBody, [
+                'http_code' => 200,
+            ]);
+        });
+        $controller = new ProxyController($httpClient);
+
+        $controller->proxyAction($request, '');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ProxyControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ProxyControllerTest.php
@@ -33,15 +33,17 @@ class ProxyControllerTest extends TestCase
             $this->assertEquals('GET', $method);
             $this->assertEquals($expectedUrl, $url);
 
-            return new MockResponse($expectedBody, [
-                'http_code' => 200,
-            ]);
+            return new MockResponse($expectedBody);
         });
         $controller = new ProxyController($httpClient);
 
         $response = $controller($request, $expectedUrl, 'GET', ['timeout' => 10], ['custom-header' => 'myheadervalue']);
 
-        $this->assertEquals($expectedBody, $response->getContent());
+        ob_start();
+        $response->sendContent();
+        $body = ob_get_clean();
+
+        $this->assertEquals($expectedBody, $body);
         $this->assertEquals('myheadervalue', $response->headers->get('custom-header'));
     }
 
@@ -58,9 +60,7 @@ class ProxyControllerTest extends TestCase
         $httpClient = new MockHttpClient(function ($method, $url, $options) use ($expectedBody) {
             $this->assertEquals('GET', $method);
 
-            return new MockResponse($expectedBody, [
-                'http_code' => 200,
-            ]);
+            return new MockResponse($expectedBody);
         });
         $controller = new ProxyController($httpClient);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | symfony/symfony-docs#... (todo)

Reverse proxy is a convenient feature of most web servers ([Apache](https://httpd.apache.org/docs/2.4/en/howto/reverse_proxy.html), [nginx](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/)). While these solutions are very powerful and stable, it can be easier to configure the rules in the PHP code directly.
This is identical to ["Redirection without custom controller"](https://symfony.com/doc/current/routing/redirect_in_config.html) except that instead of returning a redirect response, the contents is directly fetched.
If necessary, HTTP cache can be specified in the `http_client` configuration.

Use cases:
- Exposing a file from a remote server (`robots.txt`, `ads.txt`)
- Loading an ESI/SSI from a remote server

Usage:
```yaml
# config/routes/proxy.yaml

humans:
    path: /humans.txt
    controller: Symfony\Bundle\FrameworkBundle\Controller\ProxyController
    methods: [GET]
    defaults:
        url: https://robots-txt.org/humans.txt
        options:
            timeout: 1
        extraResponseHeaders:
            Cache-Control: max-age=3600, public
```
Example in symfony-demo : https://github.com/symfony/demo/compare/master...GromNaN:proxycontroller

Feature not supported yet:
- Error handling : what happens when the remote server does not return a 200 or timeouts ?
- Pass headers from the request to the remote request and from the remote response to the response (Auth, Cookies).
- Allow dynamic url using path placeholders.
- The `responseHeaders` option could be a more generic feature on routing to add cache control config to any route.