### PR TITLE
[Routing] Fix routes annotation loading with glob pattern

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -56,6 +56,11 @@ class AnnotationFileLoader extends FileLoader
 
         $collection = new RouteCollection();
         if ($class = $this->findClass($path)) {
+            $refl = new \ReflectionClass($class);
+            if ($refl->isAbstract()) {
+                return;
+            }
+
             $collection->addResource(new FileResource($path));
             $collection->addCollection($this->loader->load($class, $type));
         }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/AbstractClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/AbstractClass.php
@@ -13,4 +13,9 @@ namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
 
 abstract class AbstractClass
 {
+    abstract public function abstractRouteAction();
+
+    public function routeAction($arg1, $arg2 = 'defaultValue2', $arg3 = 'defaultValue3')
+    {
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -78,6 +78,14 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
         $this->loader->load(__DIR__.'/../Fixtures/OtherAnnotatedClasses/AnonymousClassInTrait.php');
     }
 
+    public function testLoadAbstractClass()
+    {
+        $this->reader->expects($this->never())->method('getClassAnnotation');
+        $this->reader->expects($this->never())->method('getMethodAnnotations');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/AbstractClass.php');
+    }
+
     public function testSupports()
     {
         $fixture = __DIR__.'/../Fixtures/annotated.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | #29747
| License       | MIT
| Doc PR        | n/a

Loading routes annotation loading with glob pattern triggers an error if one of the targetted directory contains an abstract class. This fixes it