### PR TITLE
[Mailer] Remove unneeded catch in ping()

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -219,10 +219,7 @@ class SmtpTransport extends AbstractTransport
         try {
             $this->executeCommand("NOOP\r\n", [250]);
         } catch (TransportExceptionInterface $e) {
-            try {
-                $this->stop();
-            } catch (TransportExceptionInterface $e) {
-            }
+            $this->stop();
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes?
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The stop() method doesn't throw.
