### PR TITLE
[Messenger] Remove the mention of handler in the `ReceiverInterface::get` phpdoc.

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Receiver/ReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/ReceiverInterface.php
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\Exception\TransportException;
 interface ReceiverInterface
 {
     /**
-     * Receives some messages to the given handler.
+     * Receives some messages.
      *
      * While this method could return an unlimited number of messages,
      * the intention is that it returns only one, or a "small number"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/30708#pullrequestreview-220830730
| License       | MIT
| Doc PR        | ø

As spotted by @Tobion, we don't have an handler as an argument anymore.