### PR TITLE
[Messenger] Updating SyncTransport for recent changes + tests

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Sync/SyncTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sync/SyncTransportFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\AmqpExt;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\Sync\SyncTransport;
+use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
+
+class SyncTransportFactoryTest extends TestCase
+{
+    public function testCreateTransport()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $factory = new SyncTransportFactory();
+        $transport = $factory->createTransport('sync://', [], $serializer);
+        $this->assertInstanceOf(SyncTransport::class, $transport);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sync/SyncTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sync/SyncTransportTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\AmqpExt;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\ForceCallHandlersStamp;
+use Symfony\Component\Messenger\Transport\Sync\SyncTransport;
+
+class SyncTransportTest extends TestCase
+{
+    public function testSend()
+    {
+        $message = new \stdClass();
+        $envelope = new Envelope($message);
+        $transport = new SyncTransport();
+        $envelope = $transport->send($envelope);
+        $this->assertSame($message, $envelope->getMessage());
+        $this->assertNotNull($envelope->last(ForceCallHandlersStamp::class));
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Sync/SyncTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/Sync/SyncTransport.php
@@ -25,7 +25,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  */
 class SyncTransport implements TransportInterface
 {
-    public function receive(callable $handler): void
+    public function get(): iterable
     {
         throw new InvalidArgumentException('You cannot receive messages from the SyncTransport.');
     }

--- a/src/Symfony/Component/Messenger/Transport/Sync/SyncTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/Sync/SyncTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\Sync;
 
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
@@ -21,7 +22,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  */
 class SyncTransportFactory implements TransportFactoryInterface
 {
-    public function createTransport(string $dsn, array $options): TransportInterface
+    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
         return new SyncTransport();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

When making the `SyncTransport`, I neglected having at least one test in each of these classes, which allowed the test suite to pass, even after some interface changes made these classes fail. Fixed all of that :) 