### PR TITLE
[EventSubscriber] Infer subscribed events from listener parameters

### DIFF
--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -149,4 +149,9 @@ class ExtractingEventDispatcher extends EventDispatcher implements EventSubscrib
 
         return $events;
     }
+
+    protected function inferEventName($subscriber, $params): string
+    {
+        return parent::inferEventName($subscriber instanceof self ? self::$subscriber : $subscriber, $params);
+    }
 }

--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -40,6 +40,12 @@ interface EventSubscriberInterface
      *  * ['eventName' => ['methodName', $priority]]
      *  * ['eventName' => [['methodName1', $priority], ['methodName2']]]
      *
+     * Alternatively, the keys can be omitted. In that case, the event name is
+     * inferred from the type hint of the first parameter of the specified method.
+     *
+     *  * ['methodName']
+     *  * [['methodName1', $priority], 'methodName2']
+     *
      * @return array The event names to listen to
      */
     public static function getSubscribedEvents();

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class RegisterListenersPassTest extends TestCase
 {
@@ -57,6 +59,30 @@ class RegisterListenersPassTest extends TestCase
                     'event',
                     [new ServiceClosureArgument(new Reference('my_event_subscriber')), 'onEvent'],
                     0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    MockEvent::class,
+                    [new ServiceClosureArgument(new Reference('my_event_subscriber')), 'onExplicitlyConfiguredEvent'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    MockEvent::class,
+                    [new ServiceClosureArgument(new Reference('my_event_subscriber')), 'onMockEvent'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    MockEvent::class,
+                    [new ServiceClosureArgument(new Reference('my_event_subscriber')), 'onEarlyMockEvent'],
+                    255,
                 ],
             ],
         ];
@@ -110,6 +136,30 @@ class RegisterListenersPassTest extends TestCase
                     'event',
                     [new ServiceClosureArgument(new Reference('foo')), 'onEvent'],
                     0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    MockEvent::class,
+                    [new ServiceClosureArgument(new Reference('foo')), 'onExplicitlyConfiguredEvent'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    MockEvent::class,
+                    [new ServiceClosureArgument(new Reference('foo')), 'onMockEvent'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    MockEvent::class,
+                    [new ServiceClosureArgument(new Reference('foo')), 'onEarlyMockEvent'],
+                    255,
                 ],
             ],
         ];
@@ -184,14 +234,29 @@ class RegisterListenersPassTest extends TestCase
     }
 }
 
-class SubscriberService implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
+class SubscriberService implements EventSubscriberInterface
 {
     public static function getSubscribedEvents()
     {
         return [
             'event' => 'onEvent',
+            MockEvent::class => 'onExplicitlyConfiguredEvent',
+            'onMockEvent',
+            ['onEarlyMockEvent', 255],
         ];
     }
+
+    public function onEarlyMockEvent(MockEvent $event): void
+    {
+    }
+
+    public function onMockEvent(MockEvent $event): void
+    {
+    }
+}
+
+class MockEvent extends Event
+{
 }
 
 class InvokableListenerService


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Since event names are FQCN now, I though maybe we could reduce the verbosity of event subscribers a bit by omitting the keys in the array returned by `getSubscribedEvents()`. This PR allows to rewrite this subscriber …

```php
final class MySubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return [RequestEvent::class => 'onRequest'];
    }

    public function onRequest(RequestEvent $event): void
    {
    }
}
```

… like this …

```php
final class MySubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return ['onRequest'];
    }

    public function onRequest(RequestEvent $event): void
    {
    }
}
```

Drawbacks:
* The referenced method has to be defined on the subscriber. When using the event name as a key, the subscriber could handle the event within the magic `__call()` method.
* This approach does not work on parameter-less listener methods for obvious reasons.
* Reflection usage comes with a small performance penalty. When using the dispatcher standalone, the `addSubscriber()` call will be slightly slower on a subscriber without event names as keys. When using DI, only the container compilation will be slightly slower.