### PR TITLE
[HttpFoundation] Added ParameterBag getArray method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -171,6 +171,19 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Returns the parameter value converted to array.
+     *
+     * @param string $key     The parameter key
+     * @param array  $default The default value if the parameter key does not exist
+     *
+     * @return array The filtered value
+     */
+    public function getArray($key, $default = [])
+    {
+        return (array) $this->get($key, $default);
+    }
+
+    /**
      * Returns the parameter value converted to boolean.
      *
      * @param string $key     The parameter key

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -125,6 +125,20 @@ class ParameterBagTest extends TestCase
         $this->assertEquals(0, $bag->getInt('unknown'), '->getInt() returns zero if a parameter is not defined');
     }
 
+    public function testGetArray()
+    {
+        $bag = new ParameterBag(
+            [
+                'foo' => ['foo', 'bar'],
+                'bar' => 'hello',
+            ]
+        );
+
+        $this->assertEquals(['foo', 'bar'], $bag->getArray('foo'), '->getArray() gets a value of parameter as an array');
+        $this->assertEquals(['hello'], $bag->getArray('bar'), '->getArray() gets a value of parameter as an array');
+        $this->assertEquals([], $bag->getArray('unknown'), '->getArray() returns empty array if a parameter is not defined');
+    }
+
     public function testFilter()
     {
         $bag = new ParameterBag([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11260

This PR adds a new helper for the `ParameterBag` to converts the parameter as array.

_TODO: Update the changelog_
