### PR TITLE
[Messenger] base64_encoding inside PhpSerializer to avoid null characters

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -58,7 +58,7 @@ class PhpSerializerTest extends TestCase
         $serializer = new PhpSerializer();
 
         $serializer->decode([
-            'body' => 'O:13:"ReceivedSt0mp":0:{}',
+            'body' => base64_encode('O:13:"ReceivedSt0mp":0:{}'),
         ]);
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -30,7 +30,13 @@ class PhpSerializer implements SerializerInterface
             throw new MessageDecodingFailedException('Encoded envelope should have at least a "body".');
         }
 
-        return $this->safelyUnserialize($encodedEnvelope['body']);
+        $serializeEnvelope = base64_decode($encodedEnvelope['body']);
+
+        if (false === $serializeEnvelope) {
+            throw new MessageDecodingFailedException('The "body" key could not be base64 decoded.');
+        }
+
+        return $this->safelyUnserialize($serializeEnvelope);
     }
 
     /**
@@ -39,7 +45,7 @@ class PhpSerializer implements SerializerInterface
     public function encode(Envelope $envelope): array
     {
         return [
-            'body' => serialize($envelope),
+            'body' => base64_encode(serialize($envelope)),
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30805
| License       | MIT
| Doc PR        | not needed

Hi!

As pointed out in #30805, the `PhpSerializer` creates strings with null bytes. This apparently causes problems on at least some database systems (I didn't notice, but @vincenttouzet did). I also read that, for example, SQS doesn't like null characters. And, in general, because we're sending this data over a transport, `base64_encoding` data is pretty standard.

Does anyone see any downsides?

Cheers!