### PR TITLE
fix/serializer_42

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -289,7 +289,38 @@ TXT
         $this->assertContains('[OK]', $tester->getDisplay());
     }
 
-    private function createCommandTester(array $paths = [], array $bundleMetadata = [], string $defaultPath = null, string $rootDir = null, bool $useChainLoader = false): CommandTester
+    public function testWithGlobals()
+    {
+        $message = '<error>foo</error>';
+        $tester = $this->createCommandTester([], [], null, null, false, ['message' => $message]);
+        $tester->execute([], ['decorated' => true]);
+        $display = $tester->getDisplay();
+        $this->assertContains(\json_encode($message), $display);
+    }
+
+    public function testWithGlobalsJson()
+    {
+        $globals = ['message' => '<error>foo</error>'];
+        $tester = $this->createCommandTester([], [], null, null, false, $globals);
+        $tester->execute(['--format' => 'json'], ['decorated' => true]);
+        $display = $tester->getDisplay();
+        $display = \json_decode($display, true);
+        $this->assertSame($globals, $display['globals']);
+    }
+
+    public function testWithFilter()
+    {
+        $tester = $this->createCommandTester();
+        $tester->execute(['--format' => 'json'], ['decorated' => false]);
+        $display = $tester->getDisplay();
+        $display1 = \json_decode($display, true);
+        $tester->execute(['--filter' => 'date', '--format' => 'json'], ['decorated' => false]);
+        $display = $tester->getDisplay();
+        $display2 = \json_decode($display, true);
+        $this->assertNotSame($display1, $display2);
+    }
+
+    private function createCommandTester(array $paths = [], array $bundleMetadata = [], string $defaultPath = null, string $rootDir = null, bool $useChainLoader = false, array $globals = []): CommandTester
     {
         $projectDir = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Fixtures';
         $loader = new FilesystemLoader([], $projectDir);
@@ -305,8 +336,13 @@ TXT
             $loader = new ChainLoader([$loader]);
         }
 
+        $environment = new Environment($loader);
+        foreach ($globals as $name => $value) {
+            $environment->addGlobal($name, $value);
+        }
+
         $application = new Application();
-        $application->add(new DebugCommand(new Environment($loader), $projectDir, $bundleMetadata, $defaultPath, $rootDir));
+        $application->add(new DebugCommand($environment, $projectDir, $bundleMetadata, $defaultPath, $rootDir));
         $command = $application->find('debug:twig');
 
         return new CommandTester($command);

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -51,6 +51,9 @@ class TreeBuilder implements NodeParentInterface
         return $this->root = $builder->node($name, $type)->setParent($this);
     }
 
+    /**
+     * @return NodeDefinition|ArrayNodeDefinition The root node (as an ArrayNodeDefinition when the type is 'array')
+     */
     public function getRootNode(): NodeDefinition
     {
         if (null === $this->root) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -51,7 +51,6 @@ class LanguageTypeTest extends BaseTypeTest
 
         // Don't check objects for identity
         $this->assertContains(new ChoiceView('en', 'en', 'англійська'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'British English'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('en_US', 'en_US', 'англійська (США)'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('fr', 'fr', 'французька'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('my', 'my', 'бірманська'), $choices, '', false, false);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
@@ -99,7 +100,6 @@ class GetSetMethodNormalizerTest extends TestCase
     public function testIgnoredAttributesInContext()
     {
         $ignoredAttributes = ['foo', 'bar', 'baz', 'object'];
-        $this->normalizer->setIgnoredAttributes($ignoredAttributes);
         $obj = new GetSetDummy();
         $obj->setFoo('foo');
         $obj->setBar('bar');
@@ -109,7 +109,7 @@ class GetSetMethodNormalizerTest extends TestCase
                 'fooBar' => 'foobar',
                 'camelCase' => true,
             ],
-            $this->normalizer->normalize($obj, 'any')
+            $this->normalizer->normalize($obj, 'any', [AbstractNormalizer::IGNORED_ATTRIBUTES => $ignoredAttributes])
         );
     }
 

--- a/src/Symfony/Component/Translation/Resources/data/parents.json
+++ b/src/Symfony/Component/Translation/Resources/data/parents.json
@@ -7,7 +7,7 @@
     "en_AT": "en_150",
     "en_AU": "en_001",
     "en_BB": "en_001",
-    "en_BE": "en_001",
+    "en_BE": "en_150",
     "en_BM": "en_001",
     "en_BS": "en_001",
     "en_BW": "en_001",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | fix/serializer_42 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no   
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | no fix test in CI
| License       | MIT
| Doc PR        | no

<!--
Fix Test GetSetMethodNormalizerTest::testIgnoredAttributesInContext
method is deprecated since Symfony 4.2, params are set with "ignored_attributes" key of the context instead
-->
