### PR TITLE
[Routing] Fix: annotation loader ignores method's default values

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -196,7 +196,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
                 continue;
             }
             foreach ($paths as $locale => $path) {
-                if (false !== strpos($path, sprintf('{%s}', $param->name))) {
+                if (preg_match(sprintf('/\{%s(?:<.*?>)?\}/', preg_quote($param->name)), $path)) {
                     $defaults[$param->name] = $param->getDefaultValue();
                     break;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/DefaultValueController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/DefaultValueController.php
@@ -12,4 +12,12 @@ class DefaultValueController
     public function action($default = 'value')
     {
     }
+
+    /**
+     * @Route("/hello/{name<\w+>}", name="hello_without_default")
+     * @Route("/hello/{name<\w+>?Symfony}", name="hello_with_default")
+     */
+    public function hello(string $name = 'World')
+    {
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -136,9 +136,11 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     public function testDefaultValuesForMethods()
     {
         $routes = $this->loader->load(DefaultValueController::class);
-        $this->assertCount(1, $routes);
+        $this->assertCount(3, $routes);
         $this->assertEquals('/{default}/path', $routes->get('action')->getPath());
         $this->assertEquals('value', $routes->get('action')->getDefault('default'));
+        $this->assertEquals('Symfony', $routes->get('hello_with_default')->getDefault('name'));
+        $this->assertEquals('World', $routes->get('hello_without_default')->getDefault('name'));
     }
 
     public function testMethodActionControllers()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

In some cases annotation loader ignores method param's default values.
For example this code won't work as expected:
```php
/**
 * @Route("/hello/{name<\w++>}", methods="GET", name="hello")
 */
public function hello(Request $request, string $name = 'World'): Response
{
    // If you try to open "/hello" path an exception (No route found for "GET /hello") will be thrown.
    return $this->json([
        'hello' => \sprintf('Hello, %s!', $name),
    ]);
}
```

