### PR TITLE
[Messenger] Wrapping the PhpSerializer data in json_encode to avoid null bytes

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -46,7 +46,7 @@ class PhpSerializerTest extends TestCase
         $serializer = new PhpSerializer();
 
         $serializer->decode([
-            'body' => '{"message": "bar"}',
+            'body' => '{"data": "not-serialized"}',
         ]);
     }
 
@@ -58,7 +58,7 @@ class PhpSerializerTest extends TestCase
         $serializer = new PhpSerializer();
 
         $serializer->decode([
-            'body' => base64_encode('O:13:"ReceivedSt0mp":0:{}'),
+            'body' => json_encode(['data' => 'O:13:"ReceivedSt0mp":0:{}']),
         ]);
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -30,13 +30,16 @@ class PhpSerializer implements SerializerInterface
             throw new MessageDecodingFailedException('Encoded envelope should have at least a "body".');
         }
 
-        $serializeEnvelope = base64_decode($encodedEnvelope['body']);
-
-        if (false === $serializeEnvelope) {
-            throw new MessageDecodingFailedException('The "body" key could not be base64 decoded.');
+        $decodedData = \json_decode($encodedEnvelope['body'], true);
+        if (false === $decodedData) {
+            throw new MessageDecodingFailedException('The "body" key could not be JSON decoded.');
         }
 
-        return $this->safelyUnserialize($serializeEnvelope);
+        if (!isset($decodedData['data'])) {
+            throw new MessageDecodingFailedException('Missing the "data" key on the JSON decoded data..');
+        }
+
+        return $this->safelyUnserialize($decodedData['data']);
     }
 
     /**
@@ -45,7 +48,7 @@ class PhpSerializer implements SerializerInterface
     public function encode(Envelope $envelope): array
     {
         return [
-            'body' => base64_encode(serialize($envelope)),
+            'body' => json_encode(['data' => serialize($envelope)]),
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

Hi!

In #30814, we decided to `base64_encode` the serialized messages to avoid null characters, which can cause issues persisting on some databases and I also think Amazon SQS does not like them **(https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html),  for example.

The only downside is that the messages become unreadable. I thought about that more, that's really unfortunate: if I'm using some sort of a 3rd party tool (like RabbitMQ's admin dashboard) to inspect the messages, they are fully unreadable. PHP Serialized messages are ugly, but you can absolutely understand them as a human.

This proposal is to consider using `json_encode()` instead. In both cases, it's a bit awkward: the PhpSerializer is not really a PhpSerializer, but a PhpSerialize that is *then* encoded again to avoid null characters. base64_encode is a really "pure" way to do this, but json_encode (which, unfortunately requires an extra "array") is a lot more readable.

Cheers!