### PR TITLE
Release v3.4.24

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -7,6 +7,34 @@ in 3.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.4.0...v3.4.1
 
+* 3.4.24 (2019-04-02)
+
+ * bug #30660 [Bridge][Twig] DebugCommand - fix escaping and filter (SpacePossum)
+ * bug #30720 Fix getSetMethodNormalizer to correctly ignore the attributes specified in "ignored_attributes" (Emmanuel BORGES)
+ * bug #30749 [Serializer] Added check of constuctor modifiers to AbstractNormalizer (NekaKawaii)
+ * bug #30776 [Routing] Fix routes annotation loading with glob pattern (snoob)
+ * bug #30773 [DependencyInjection] Fix hardcoded hotPathTagName (jderusse)
+ * bug #30737 [Validator] Improve constraint default option check (vudaltsov)
+ * bug #30736 [Validator] Fix annotation default for @Count and @Length (vudaltsov)
+ * bug #30620 [FrameworkBundle][HttpFoundation] make session service resettable (dmaicher)
+ * bug #30640 [Phpunit] fixed support for PHP 5.3 (fabpot)
+ * bug #30595 Do not validate child constraints if form has no validation groups (maryo)
+ * bug #30479 Check if Client exists when test.client does not exist, to provide clearer exception message (SerkanYildiz)
+ * feature #30584 [Intl] Add compile binary (ro0NL)
+ * bug #30487 Fix Cache error while using anonymous class (Emmanuel BORGES)
+ * bug #30548 Correct language code for ukrainian language (stanleyk)
+ * bug #30518 [Cache] Fix perf when using RedisCluster by reducing roundtrips to the servers (nicolas-grekas)
+ * bug #30515 [Cache] Only delete one key at a time when on Predis + Cluster (andrerom)
+ * bug #30507 [Routing] Fixed XML options resolution (Jules Pietri)
+ * bug #30506 [TwigBridge] remove deprecation triggered when using Twig 2.7 (nicolas-grekas)
+ * bug #30496 [PHPUnit-Bridge] override some Composer environment variables (nicoweb)
+ * bug #30505 [TwigBridge] Remove usages of the spaceless tag (nicolas-grekas)
+ * bug #30474 compatibility with phpunit8 (garak)
+ * bug #30497 [HttpKernel] Change default log level for output streams (yceruto)
+ * bug #30498 [translation] Update defaut format from yml to yaml (GaryPEGEOT)
+ * bug #30437 [Debug] detect annotations before blank docblock lines (xabbuh)
+ * bug #30392 [PropertyAccess] Fixed PropertyPathBuilder remove that fails to reset internal indexes (GregOriol)
+
 * 3.4.23 (2019-03-03)
 
  * bug #26532 [HttpKernel] Correctly merging cache directives in HttpCache/ResponseCacheStrategy (aschempp)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,21 +15,21 @@ Symfony is the result of the work of many people who made the code better
  - Victor Berchet (victor)
  - Kévin Dunglas (dunglas)
  - Maxime Steinhausser (ogizanagi)
+ - Ryan Weaver (weaverryan)
  - Jakub Zalas (jakubzalas)
  - Johannes S (johannes)
  - Javier Eguiluz (javier.eguiluz)
- - Ryan Weaver (weaverryan)
  - Kris Wallsmith (kriswallsmith)
- - Roland Franssen (ro0)
  - Grégoire Pineau (lyrixx)
+ - Roland Franssen (ro0)
  - Hugo Hamon (hhamon)
  - Abdellatif Ait boudad (aitboudad)
  - Romain Neutron (romain)
  - Pascal Borreli (pborreli)
  - Wouter De Jong (wouterj)
+ - Samuel ROZE (sroze)
  - Joseph Bielawski (stloyd)
  - Karma Dordrak (drak)
- - Samuel ROZE (sroze)
  - Lukas Kahwe Smith (lsmith)
  - Martin Hasoň (hason)
  - Jeremy Mikola (jmikola)
@@ -42,8 +42,8 @@ Symfony is the result of the work of many people who made the code better
  - Guilhem Niot (energetick)
  - Sarah Khalil (saro0h)
  - Jonathan Wage (jwage)
- - Hamza Amrouche (simperfit)
  - Tobias Nyholm (tobias)
+ - Hamza Amrouche (simperfit)
  - Diego Saint Esteben (dosten)
  - Iltar van der Berg (kjarli)
  - Alexandre Salomé (alexandresalome)
@@ -54,8 +54,8 @@ Symfony is the result of the work of many people who made the code better
  - stealth35 ‏ (stealth35)
  - Alexander Mols (asm89)
  - Bulat Shakirzyanov (avalanche123)
- - Matthias Pigulla (mpdude)
  - Jérémy DERUSSÉ (jderusse)
+ - Matthias Pigulla (mpdude)
  - Saša Stamenković (umpirsky)
  - Peter Rehm (rpet)
  - Kevin Bond (kbond)
@@ -69,23 +69,24 @@ Symfony is the result of the work of many people who made the code better
  - Mathieu Piot (mpiot)
  - Florin Patan (florinpatan)
  - Gábor Egyed (1ed)
+ - Gabriel Ostrolucký (gadelat)
  - Titouan Galopin (tgalopin)
  - Vladimir Reznichenko (kalessil)
  - Jáchym Toušek (enumag)
+ - David Maicher (dmaicher)
  - Michel Weimerskirch (mweimerskirch)
  - Andrej Hudec (pulzarraider)
  - Konstantin Myakshin (koc)
  - Eric Clemmons (ericclemmons)
  - Charles Sarrazin (csarrazi)
- - David Maicher (dmaicher)
  - Christian Raue
  - Issei Murasawa (issei_m)
+ - Valentin Udaltsov (vudaltsov)
  - Arnout Boks (aboks)
  - Deni
  - Grégoire Paris (greg0ire)
  - Henrik Westphal (snc)
  - Dariusz Górecki (canni)
- - Valentin Udaltsov (vudaltsov)
  - Douglas Greenshields (shieldo)
  - Dariusz Ruminski
  - Lee McDermott
@@ -99,7 +100,6 @@ Symfony is the result of the work of many people who made the code better
  - Jérôme Tamarelle (gromnan)
  - John Wards (johnwards)
  - Fran Moreno (franmomu)
- - gadelat (gadelat)
  - Antoine Hérault (herzult)
  - Paráda József (paradajozsef)
  - Arnaud Le Blanc (arnaud-lb)
@@ -108,13 +108,14 @@ Symfony is the result of the work of many people who made the code better
  - Tim Nagel (merk)
  - Brice BERNARD (brikou)
  - Baptiste Clavié (talus)
+ - Chris Wilkinson (thewilkybarkid)
  - marc.weistroff
  - Tomáš Votruba (tomas_votruba)
  - David Buchmann (dbu)
  - lenar
  - Alexander Schwenn (xelaris)
  - Włodzimierz Gajda (gajdaw)
- - Chris Wilkinson (thewilkybarkid)
+ - Thomas Calvet (fancyweb)
  - Jérôme Vasseur (jvasseur)
  - Peter Kokot (maastermedia)
  - Jacob Dreesen (jdreesen)
@@ -125,11 +126,10 @@ Symfony is the result of the work of many people who made the code better
  - Daniel Wehner (dawehner)
  - excelwebzone
  - Gordon Franke (gimler)
- - Thomas Calvet (fancyweb)
+ - Sebastiaan Stok (sstok)
  - Javier Spagnoletti (phansys)
  - Fabien Pennequin (fabienpennequin)
  - Eric GELOEN (gelo)
- - Sebastiaan Stok (sstok)
  - Lars Strojny (lstrojny)
  - Tugdual Saunier (tucksaun)
  - Théo FIDRY (theofidry)
@@ -140,14 +140,18 @@ Symfony is the result of the work of many people who made the code better
  - Alex Pott
  - Vincent AUBERT (vincent)
  - Juti Noppornpitak (shiroyuki)
+ - Anthony MARTIN (xurudragon)
+ - Oskar Stark (oskarstark)
  - Tigran Azatyan (tigranazatyan)
  - Sebastian Hörl (blogsh)
  - Daniel Gomes (danielcsgomes)
+ - Joel Wurtz (brouznouf)
  - Gabriel Caruso
  - Hidenori Goto (hidenorigoto)
  - Arnaud Kleinpeter (nanocom)
  - Jannik Zschiesche (apfelbox)
  - Guilherme Blanco (guilhermeblanco)
+ - Teoh Han Hui (teohhanhui)
  - Pablo Godel (pgodel)
  - Jérémie Augustin (jaugustin)
  - Andréia Bohner (andreia)
@@ -155,9 +159,7 @@ Symfony is the result of the work of many people who made the code better
  - Julien Falque (julienfalque)
  - Rafael Dohms (rdohms)
  - jwdeitch
- - Teoh Han Hui (teohhanhui)
  - Mikael Pajunen
- - Joel Wurtz (brouznouf)
  - Oleg Voronkovich
  - Vyacheslav Pavlov
  - Richard van Laak (rvanlaak)
@@ -172,7 +174,6 @@ Symfony is the result of the work of many people who made the code better
  - Matthieu Ouellette-Vachon (maoueh)
  - Michał Pipa (michal.pipa)
  - Dawid Nowak
- - Gabriel Ostrolucký
  - Amal Raghav (kertz)
  - Jonathan Ingram (jonathaningram)
  - Artur Kotyrba
@@ -181,12 +182,12 @@ Symfony is the result of the work of many people who made the code better
  - SpacePossum
  - jeremyFreeAgent (Jérémy Romey) (jeremyfreeagent)
  - James Halsall (jaitsu)
- - Anthony MARTIN (xurudragon)
  - Matthieu Napoli (mnapoli)
  - Florent Mata (fmata)
  - Warnar Boekkooi (boekkooi)
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
+ - Marek Štípek (maryo)
  - Daniel Espendiller
  - Possum
  - Dorian Villet (gnutix)
@@ -196,7 +197,7 @@ Symfony is the result of the work of many people who made the code better
  - Mario A. Alvarez Garcia (nomack84)
  - Dennis Benkert (denderello)
  - DQNEO
- - Oskar Stark (oskarstark)
+ - Samuel NELA (snela)
  - Benjamin Dulau (dbenjamin)
  - François-Xavier de Guillebon (de-gui_f)
  - Mathieu Lemoine (lemoinem)
@@ -205,7 +206,6 @@ Symfony is the result of the work of many people who made the code better
  - Tom Van Looy (tvlooy)
  - Noel Guilbert (noel)
  - Yanick Witschi (toflar)
- - Marek Štípek (maryo)
  - Stepan Anchugov (kix)
  - bronze1man
  - sun (sun)
@@ -217,24 +217,28 @@ Symfony is the result of the work of many people who made the code better
  - apetitpa
  - Matthieu Bontemps (mbontemps)
  - apetitpa
- - Samuel NELA (snela)
  - Pierre Minnieur (pminnieur)
  - fivestar
  - Dominique Bongiraud
  - Jeremy Livingston (jeremylivingston)
  - Michael Lee (zerustech)
  - Matthieu Auger (matthieuauger)
+ - Gregor Harlan (gharlan)
  - Leszek Prabucki (l3l0)
  - Fabien Bourigault (fbourigault)
  - François Zaninotto (fzaninotto)
  - Dustin Whittle (dustinwhittle)
  - jeff
  - John Kary (johnkary)
+ - Andreas Schempp (aschempp)
  - Justin Hileman (bobthecow)
  - Blanchon Vincent (blanchonvincent)
  - Michele Orselli (orso)
  - Sven Paulus (subsven)
+ - Maxime Veber (nek-)
+ - Gary PEGEOT (gary-p)
  - Rui Marinho (ruimarinho)
+ - Massimiliano Arione (garak)
  - Eugene Wissner
  - Pascal Montoya
  - Julien Brochet (mewt)
@@ -242,15 +246,17 @@ Symfony is the result of the work of many people who made the code better
  - Tristan Darricau (nicofuma)
  - Marcel Beerta (mazen)
  - Pavel Batanov (scaytrase)
+ - Mantis Development
  - Loïc Faugeron
  - Hidde Wieringa (hiddewie)
  - Marco Pivetta (ocramius)
+ - Jan Schädlich (jschaedl)
  - Rob Frawley 2nd (robfrawley)
  - julien pauli (jpauli)
  - Lorenz Schori
  - Sébastien Lavoie (lavoiesl)
- - Gregor Harlan (gharlan)
  - Dariusz
+ - Michael Babker (mbabker)
  - Francois Zaninotto
  - Alexander Kotynia (olden)
  - Daniel Tschinder
@@ -265,7 +271,6 @@ Symfony is the result of the work of many people who made the code better
  - Roman Marintšenko (inori)
  - Xavier Montaña Carreras (xmontana)
  - Mickaël Andrieu (mickaelandrieu)
- - Maxime Veber (nek-)
  - Xavier Perez
  - Arjen Brouwer (arjenjb)
  - Katsuhiro OGAWA
@@ -277,6 +282,7 @@ Symfony is the result of the work of many people who made the code better
  - Baptiste Lafontaine (magnetik)
  - Jakub Kucharovic (jkucharovic)
  - Edi Modrić (emodric)
+ - Alexander Schranz (alexander-schranz)
  - Uwe Jäger (uwej711)
  - Eugene Leonovich (rybakit)
  - Filippo Tessarotto
@@ -290,10 +296,9 @@ Symfony is the result of the work of many people who made the code better
  - Viktor Bocharskyi (bocharsky_bw)
  - Jhonny Lidfors (jhonne)
  - Diego Agulló (aeoris)
- - Andreas Schempp (aschempp)
  - jdhoek
- - Massimiliano Arione (garak)
  - Bob den Otter (bopp)
+ - Thomas Schulz (king2500)
  - Frank de Jonge (frenkynet)
  - Nikita Konstantinov
  - Wodor Wodorski
@@ -301,7 +306,7 @@ Symfony is the result of the work of many people who made the code better
  - mcfedr (mcfedr)
  - Colin O&#039;Dell (colinodell)
  - Giorgio Premi
- - Jan Schädlich (jschaedl)
+ - Alex Rock (pierstoval)
  - Ben Davies (bendavies)
  - Beau Simensen (simensen)
  - Michael Hirschler (mvhirsch)
@@ -309,9 +314,9 @@ Symfony is the result of the work of many people who made the code better
  - Roumen Damianoff (roumen)
  - Antonio J. García Lagar (ajgarlag)
  - Kim Hemsø Rasmussen (kimhemsoe)
+ - Pascal Luna (skalpa)
  - Wouter Van Hecke
  - Jérôme Parmentier (lctrs)
- - Michael Babker (mbabker)
  - Peter Kruithof (pkruithof)
  - Michael Holm (hollo)
  - Remon van de Kamp (rpkamp)
@@ -319,14 +324,13 @@ Symfony is the result of the work of many people who made the code better
  - Marc Weistroff (futurecat)
  - Christian Schmidt
  - MatTheCat
- - Alexander Schranz (alexander-schranz)
  - Chad Sikorra (chadsikorra)
  - Chris Smith (cs278)
  - Florian Klein (docteurklein)
- - Gary PEGEOT (gary-p)
  - Manuel Kiessling (manuelkiessling)
  - Atsuhiro KUBO (iteman)
  - rudy onfroy (ronfroy)
+ - Serkan Yildiz (srknyldz)
  - Andrew Moore (finewolf)
  - Bertrand Zuchuat (garfield-fr)
  - Sullivan SENECHAL (soullivaneuh)
@@ -347,14 +351,16 @@ Symfony is the result of the work of many people who made the code better
  - Hidde Boomsma (hboomsma)
  - John Bafford (jbafford)
  - Raul Fraile (raulfraile)
+ - David Prévot
  - Adrian Rudnik (kreischweide)
  - Francesc Rosàs (frosas)
  - Romain Pierre (romain-pierre)
  - Julien Galenski (ruian)
  - Bongiraud Dominique
  - janschoenherr
- - Thomas Schulz (king2500)
+ - Emanuele Gaspari (inmarelibero)
  - Dariusz Rumiński
+ - Vincent Touzet (vincenttouzet)
  - Berny Cantos (xphere81)
  - Thierry Thuon (lepiaf)
  - Ricard Clau (ricardclau)
@@ -367,8 +373,9 @@ Symfony is the result of the work of many people who made the code better
  - Zan Baldwin (zanderbaldwin)
  - Thomas Royer (cydonia7)
  - alquerci
+ - Mateusz Sip (mateusz_sip)
+ - Andre Rømcke (andrerom)
  - Francesco Levorato
- - Pascal Luna (skalpa)
  - Dmitrii Poddubnyi (karser)
  - Vitaliy Zakharov (zakharovvi)
  - Tobias Sjösten (tobiassjosten)
@@ -384,6 +391,7 @@ Symfony is the result of the work of many people who made the code better
  - Yaroslav Kiliba
  - Terje Bråten
  - Robbert Klarenbeek (robbertkl)
+ - Eric Masoero (eric-masoero)
  - JhonnyL
  - David Badura (davidbadura)
  - hossein zolfi (ocean)
@@ -394,6 +402,7 @@ Symfony is the result of the work of many people who made the code better
  - ShinDarth
  - Stéphane PY (steph_py)
  - Philipp Kräutli (pkraeutli)
+ - Anton Chernikov (anton_ch1989)
  - Grzegorz (Greg) Zdanowski (kiler129)
  - Iker Ibarguren (ikerib)
  - Kirill chEbba Chebunin (chebba)
@@ -414,10 +423,10 @@ Symfony is the result of the work of many people who made the code better
  - Tobias Naumann (tna)
  - Daniel Beyer
  - Shein Alexey
- - Alex Rock Ancelet (pierstoval)
  - Romain Gautier (mykiwi)
  - Joe Lencioni
  - Daniel Tschinder
+ - Emmanuel BORGES (eborges78)
  - vladimir.reznichenko
  - Kai
  - Lee Rowlands
@@ -427,7 +436,6 @@ Symfony is the result of the work of many people who made the code better
  - Karoly Negyesi (chx)
  - Ivan Kurnosov
  - Xavier HAUSHERR
- - David Prévot
  - Albert Jessurum (ajessu)
  - Laszlo Korte
  - Miha Vrhovnik
@@ -440,7 +448,6 @@ Symfony is the result of the work of many people who made the code better
  - Karel Souffriau
  - Christophe L. (christophelau)
  - Anthon Pang (robocoder)
- - Emanuele Gaspari (inmarelibero)
  - Sébastien Santoro (dereckson)
  - Brian King
  - Michel Salib (michelsalib)
@@ -461,7 +468,7 @@ Symfony is the result of the work of many people who made the code better
  - Olivier Dolbeau (odolbeau)
  - Jan Rosier (rosier)
  - Alessandro Lai (jean85)
- - Andre Rømcke (andrerom)
+ - Nicolas LEFEVRE (nicoweb)
  - Arturs Vonda
  - Josip Kruslin
  - Asmir Mustafic (goetas)
@@ -473,7 +480,6 @@ Symfony is the result of the work of many people who made the code better
  - Vlad Gregurco (vgregurco)
  - Boris Vujicic (boris.vujicic)
  - Chris Sedlmayr (catchamonkey)
- - Mateusz Sip (mateusz_sip)
  - Kamil Kokot (pamil)
  - Seb Koelen
  - Christoph Mewes (xrstf)
@@ -528,6 +534,7 @@ Symfony is the result of the work of many people who made the code better
  - ondrowan
  - Barry vd. Heuvel (barryvdh)
  - Craig Duncan (duncan3dc)
+ - Patrick Landolt (scube)
  - Sébastien Alfaiate (seb33300)
  - Evan S Kaufman (evanskaufman)
  - mcben
@@ -603,6 +610,7 @@ Symfony is the result of the work of many people who made the code better
  - Jan Behrens
  - Mantas Var (mvar)
  - Sebastian Krebs
+ - Piotr Stankowski
  - Baptiste Leduc (bleduc)
  - Laurent VOULLEMIER (lvo)
  - Jean-Christophe Cuvelier [Artack]
@@ -617,6 +625,7 @@ Symfony is the result of the work of many people who made the code better
  - Renan
  - Ricky Su (ricky)
  - Gildas Quéméner (gquemener)
+ - Kyle Evans (kevans91)
  - Charles-Henri Bruyand
  - Max Rath (drak3)
  - Stéphane Escandell (sescandell)
@@ -625,6 +634,8 @@ Symfony is the result of the work of many people who made the code better
  - Sinan Eldem
  - Alexandre Dupuy (satchette)
  - Malte Blättermann
+ - Kévin THERAGE (kevin_therage)
+ - Simeon Kolev (simeon_kolev9)
  - Nahuel Cuesta (ncuesta)
  - Chris Boden (cboden)
  - Christophe Villeger (seragan)
@@ -649,11 +660,13 @@ Symfony is the result of the work of many people who made the code better
  - Sebastian Marek (proofek)
  - Guilhem N (guilhemn)
  - Erkhembayar Gantulga (erheme318)
+ - zenmate
  - Michal Trojanowski
  - David Fuhr
  - Max Grigorian (maxakawizard)
  - DerManoMann
  - Rostyslav Kinash
+ - Dennis Fridrich (dfridrich)
  - Maciej Malarz (malarzm)
  - Daisuke Ohata
  - Vincent Simonin
@@ -707,6 +720,7 @@ Symfony is the result of the work of many people who made the code better
  - Paweł Wacławczyk (pwc)
  - Oleg Zinchenko (cystbear)
  - Baptiste Meyer (meyerbaptiste)
+ - Tales Santos (tsantos84)
  - Johannes Klauss (cloppy)
  - Evan Villemez
  - fzerorubigd
@@ -720,6 +734,7 @@ Symfony is the result of the work of many people who made the code better
  - flip111
  - Greg Anderson
  - VJ
+ - RJ Garcia
  - Delf Tonder (leberknecht)
  - Mark Sonnabaum
  - Massimiliano Braglia (massimilianobraglia)
@@ -738,15 +753,14 @@ Symfony is the result of the work of many people who made the code better
  - Julien DIDIER (juliendidier)
  - Dominik Ritter (dritter)
  - Sebastian Grodzicki (sgrodzicki)
- - Serkan Yildiz (srknyldz)
  - Jeroen van den Enden (stoefke)
+ - nikos.sotiropoulos
  - Pascal Helfenstein
  - Anthony GRASSIOT (antograssiot)
  - Baldur Rensch (brensch)
  - Pierre Rineau
  - Vladyslav Petrovych
  - Alex Xandra Albert Sim
- - Patrick Landolt (scube)
  - Carson Full
  - Sergey Yastrebov
  - Trent Steel (trsteel88)
@@ -761,6 +775,7 @@ Symfony is the result of the work of many people who made the code better
  - Dave Marshall (davedevelopment)
  - Jakub Kulhan (jakubkulhan)
  - avorobiev
+ - Grégoire Penverne (gpenverne)
  - Venu
  - Lars Vierbergen
  - Jonatan Männchen
@@ -774,6 +789,7 @@ Symfony is the result of the work of many people who made the code better
  - Jordan Deitch
  - Casper Valdemar Poulsen
  - Josiah (josiah)
+ - Greg ORIOL
  - Joschi Kuphal
  - John Bohn (jbohn)
  - Marc Morera (mmoreram)
@@ -922,6 +938,7 @@ Symfony is the result of the work of many people who made the code better
  - Stéphane Delprat
  - Brian Freytag (brianfreytag)
  - Samuele Lilli (doncallisto)
+ - Marko Kaznovac (kaznovac)
  - Brunet Laurent (lbrunet)
  - Florent Viel (luxifer)
  - Mikhail Yurasov (mym)
@@ -937,15 +954,17 @@ Symfony is the result of the work of many people who made the code better
  - Kyle
  - Daniel Alejandro Castro Arellano (lexcast)
  - sensio
+ - Thomas Jarrand
  - Sebastien Morel (plopix)
  - Patrick Kaufmann
- - Piotr Stankowski
  - Anton Dyshkant
  - Reece Fowell (reecefowell)
  - Mátyás Somfai (smatyas)
  - stefan.r
  - Valérian Galliat
  - d-ph
+ - Renan Taranto (renan-taranto)
+ - Thomas Talbot (ioni)
  - Rikijs Murgs
  - Ben Ramsey (ramsey)
  - Amaury Leroux de Lens (amo__)
@@ -954,12 +973,14 @@ Symfony is the result of the work of many people who made the code better
  - The Whole Life to Learn
  - ergiegonzaga
  - Farhad Safarov
+ - Alexis Lefebvre
  - Liverbool (liverbool)
  - Sam Malone
  - Phan Thanh Ha (haphan)
  - Chris Jones (leek)
  - xaav
  - Mahmoud Mostafa (mahmoud)
+ - Ahmed Abdou
  - Pieter
  - Michael Tibben
  - Billie Thompson
@@ -992,21 +1013,23 @@ Symfony is the result of the work of many people who made the code better
  - Irmantas Šiupšinskas (irmantas)
  - Danilo Silva
  - Arnaud PETITPAS (apetitpa)
+ - Ken Stanley
  - Zachary Tong (polyfractal)
  - Ashura
  - Hryhorii Hrebiniuk
  - johnstevenson
- - Dennis Fridrich (dfridrich)
  - hamza
  - dantleech
  - Bastien DURAND (deamon)
  - Xavier Leune
  - Rudy Onfroy
  - Tero Alén (tero)
+ - Stanislav Kocanda
  - DerManoMann
  - Guillaume Royer
  - Artem (digi)
  - boite
+ - Silvio Ginter
  - MGDSoft
  - Vadim Tyukov (vatson)
  - David Wolter (davewww)
@@ -1015,6 +1038,7 @@ Symfony is the result of the work of many people who made the code better
  - Wojciech Sznapka
  - Gavin Staniforth
  - Ariel J. Birnbaum
+ - Danijel Obradović
  - Pablo Borowicz
  - Mathieu Santostefano
  - Arjan Keeman
@@ -1065,7 +1089,6 @@ Symfony is the result of the work of many people who made the code better
  - Jean-Guilhem Rouel (jean-gui)
  - jfcixmedia
  - Dominic Tubach
- - Tales Santos (tsantos84)
  - Nikita Konstantinov
  - Martijn Evers
  - Vitaliy Ryaboy (vitaliy)
@@ -1094,6 +1117,7 @@ Symfony is the result of the work of many people who made the code better
  - Tadas Gliaubicas (tadcka)
  - Thanos Polymeneas (thanos)
  - Benoit Garret
+ - Maximilian Ruta (deltachaos)
  - Jakub Sacha
  - Olaf Klischat
  - orlovv
@@ -1131,7 +1155,6 @@ Symfony is the result of the work of many people who made the code better
  - rpg600
  - Péter Buri (burci)
  - kaiwa
- - RJ Garcia
  - Charles Sanquer (csanquer)
  - Albert Ganiev (helios-ag)
  - Neil Katin
@@ -1148,7 +1171,6 @@ Symfony is the result of the work of many people who made the code better
  - rchoquet
  - gitlost
  - Taras Girnyk
- - nikos.sotiropoulos
  - Eduardo García Sanz (coma)
  - Sergio (deverad)
  - James Gilliland
@@ -1207,7 +1229,6 @@ Symfony is the result of the work of many people who made the code better
  - Mario Young
  - Ilia (aliance)
  - Chris McCafferty (cilefen)
- - Grégoire Penverne (gpenverne)
  - Mo Di (modi)
  - Pablo Schläpfer
  - Gert de Pagter
@@ -1215,6 +1236,7 @@ Symfony is the result of the work of many people who made the code better
  - Quique Porta (quiqueporta)
  - stoccc
  - Tomasz Szymczyk (karion)
+ - Alex Vasilchenko
  - Xavier Coureau
  - ConneXNL
  - Aharon Perkel
@@ -1232,8 +1254,10 @@ Symfony is the result of the work of many people who made the code better
  - Sebastian Göttschkes (sgoettschkes)
  - Tatsuya Tsuruoka
  - Ross Tuck
+ - Andreas Erhard
  - Kévin Gomez (kevin)
  - Mihai Nica (redecs)
+ - Soufian EZ-ZANTAR (soezz)
  - Andrei Igna
  - azine
  - Dawid Sajdak
@@ -1249,6 +1273,7 @@ Symfony is the result of the work of many people who made the code better
  - Saem Ghani
  - Clément LEFEBVRE
  - Conrad Kleinespel
+ - Matthias Althaus
  - Zacharias Luiten
  - Sebastian Utz
  - Adrien Gallou (agallou)
@@ -1288,6 +1313,7 @@ Symfony is the result of the work of many people who made the code better
  - Markus Fasselt (digilist)
  - Vašek Purchart (vasek-purchart)
  - Janusz Jabłoński (yanoosh)
+ - Fleuv
  - Sandro Hopf
  - Łukasz Makuch
  - George Giannoulopoulos
@@ -1311,11 +1337,11 @@ Symfony is the result of the work of many people who made the code better
  - Daniel Kay (danielkay-cp)
  - Matt Daum (daum)
  - Alberto Pirovano (geezmo)
- - Nicolas LEFEVRE (nicoweb)
  - Pete Mitchell (peterjmit)
  - Tom Corrigan (tomcorrigan)
  - Luis Galeas
  - Martin Pärtel
+ - Frédéric Bouchery (fbouchery)
  - Patrick Daley (padrig)
  - Xavier Briand (xavierbriand)
  - Max Summe
@@ -1336,6 +1362,7 @@ Symfony is the result of the work of many people who made the code better
  - Emmanuel Vella (emmanuel.vella)
  - Guillaume BRETOU (guiguiboy)
  - Jonathan Johnson (jrjohnson)
+ - Dāvis Zālītis (k0d3r1s)
  - Carsten Nielsen (phreaknerd)
  - Roger Guasch (rogerguasch)
  - Mathieu Rochette
@@ -1371,6 +1398,7 @@ Symfony is the result of the work of many people who made the code better
  - mlively
  - Amine Matmati
  - caalholm
+ - Nouhail AL FIDI (alfidi)
  - Fabian Steiner (fabstei)
  - Felipy Tavares Amorim (felipyamorim)
  - Klaus Silveira (klaussilveira)
@@ -1420,7 +1448,6 @@ Symfony is the result of the work of many people who made the code better
  - Hoffmann András
  - LubenZA
  - Olivier
- - Anton Chernikov
  - Cyril PASCAL
  - pscheit
  - Wybren Koelmans
@@ -1432,6 +1459,7 @@ Symfony is the result of the work of many people who made the code better
  - Antonio Peric-Mazar (antonioperic)
  - César Suárez (csuarez)
  - Bjorn Twachtmann (dotbjorn)
+ - Tobias Genberg (lorceroth)
  - Luis Tacón (lutacon)
  - Nicolas Badey (nico-b)
  - Shane Preece (shane)
@@ -1465,10 +1493,9 @@ Symfony is the result of the work of many people who made the code better
  - Przemysław Piechota (kibao)
  - Leonid Terentyev (li0n)
  - Martynas Sudintas (martiis)
- - Gabriel Ostrolucký
  - ryunosuke
- - zenmate
  - victoria
+ - Dmytro Borysovskyi (dmytr0)
  - Francisco Facioni (fran6co)
  - Iwan van Staveren (istaveren)
  - Povilas S. (povilas)
@@ -1488,6 +1515,7 @@ Symfony is the result of the work of many people who made the code better
  - Ikhsan Agustian
  - Arnau González (arnaugm)
  - Simon Bouland (bouland)
+ - Jibé Barth (jibbarth)
  - Matthew Foster (mfoster)
  - Reyo Stallenberg (reyostallenberg)
  - Paul Seiffert (seiffert)
@@ -1531,7 +1559,6 @@ Symfony is the result of the work of many people who made the code better
  - Gunther Konig
  - Mickael GOETZ
  - Maciej Schmidt
- - Greg ORIOL
  - Dennis Væversted
  - nuncanada
  - flack
@@ -1652,6 +1679,7 @@ Symfony is the result of the work of many people who made the code better
  - Trevor Suarez
  - gedrox
  - Alan Bondarchuk
+ - Joe Bennett
  - dropfen
  - Andrey Chernykh
  - Edvinas Klovas
@@ -1671,6 +1699,7 @@ Symfony is the result of the work of many people who made the code better
  - AmsTaFF (amstaff)
  - Simon Müller (boscho)
  - Yannick Bensacq (cibou)
+ - Damien (damien_vauchel)
  - Frédéric G. Marand (fgm)
  - Freek Van der Herten (freekmurze)
  - Luca Genuzio (genuzio)
@@ -1735,6 +1764,7 @@ Symfony is the result of the work of many people who made the code better
  - timaschew
  - Jochen Mandl
  - Marin Nicolae
+ - soyuka
  - Alessandro Loffredo
  - Ian Phillips
  - Marco Lipparini
@@ -1810,6 +1840,7 @@ Symfony is the result of the work of many people who made the code better
  - Kevin Verschaeve (keversc)
  - Kevin Herrera (kherge)
  - Luis Ramón López López (lrlopez)
+ - Mehdi Mabrouk (mehdidev)
  - Bart Reunes (metalarend)
  - Muriel (metalmumu)
  - Michael Pohlers (mick_the_big)
@@ -1861,6 +1892,7 @@ Symfony is the result of the work of many people who made the code better
  - Ramon Henrique Ornelas (ramonornela)
  - Ricardo de Vries (ricknox)
  - Markus S. (staabm)
+ - Thomas Dutrion (theocrite)
  - Till Klampaeckel (till)
  - Tobias Weinert (tweini)
  - Ulf Reimers (ureimers)
@@ -2011,7 +2043,6 @@ Symfony is the result of the work of many people who made the code better
  - phc
  - Дмитрий Пацура
  - ilyes kooli
- - Marko Kaznovac
  - Matthias Althaus
  - Michaël VEROUX
  - Julia
@@ -2073,6 +2104,7 @@ Symfony is the result of the work of many people who made the code better
  - samuel laulhau (lalop)
  - Laurent Bachelier (laurentb)
  - Luís Cobucci (lcobucci)
+ - Marcos Gómez Vilches (markitosgv)
  - Matthieu Mota (matthieumota)
  - Matthieu Moquet (mattketmo)
  - Moritz Borgmann (mborgmann)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -67,12 +67,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '3.4.24-DEV';
+    const VERSION = '3.4.24';
     const VERSION_ID = 30424;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 4;
     const RELEASE_VERSION = 24;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2020';
     const END_OF_LIFE = '11/2021';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.4.23...v3.4.24)

 * bug #30660 [Bridge][Twig] DebugCommand - fix escaping and filter (@SpacePossum)
 * bug #30720 Fix getSetMethodNormalizer to correctly ignore the attributes specified in "ignored_attributes" (@Emmanuel BORGES)
 * bug #30749 [Serializer] Added check of constuctor modifiers to AbstractNormalizer (@NekaKawaii)
 * bug #30776 [Routing] Fix routes annotation loading with glob pattern (@snoob)
 * bug #30773 [DependencyInjection] Fix hardcoded hotPathTagName (@jderusse)
 * bug #30737 [Validator] Improve constraint default option check (@vudaltsov)
 * bug #30736 [Validator] Fix annotation default for @Count and @Length (@vudaltsov)
 * bug #30620 [FrameworkBundle][HttpFoundation] make session service resettable (@dmaicher)
 * bug #30640 [Phpunit] fixed support for PHP 5.3 (@fabpot)
 * bug #30595 Do not validate child constraints if form has no validation groups (@maryo)
 * bug #30479 Check if Client exists when test.client does not exist, to provide clearer exception message (@SerkanYildiz)
 * feature #30584 [Intl] Add compile binary (@ro0NL)
 * bug #30487 Fix Cache error while using anonymous class (@Emmanuel BORGES)
 * bug #30548 Correct language code for ukrainian language (@stanleyk)
 * bug #30518 [Cache] Fix perf when using RedisCluster by reducing roundtrips to the servers (@nicolas-grekas)
 * bug #30515 [Cache] Only delete one key at a time when on Predis + Cluster (@andrerom)
 * bug #30507 [Routing] Fixed XML options resolution (@Jules Pietri)
 * bug #30506 [TwigBridge] remove deprecation triggered when using Twig 2.7 (@nicolas-grekas)
 * bug #30496 [PHPUnit-Bridge] override some Composer environment variables (@nicoweb)
 * bug #30505 [TwigBridge] Remove usages of the spaceless tag (@nicolas-grekas)
 * bug #30474 compatibility with phpunit8 (@garak)
 * bug #30497 [HttpKernel] Change default log level for output streams (@yceruto)
 * bug #30498 [translation] Update defaut format from yml to yaml (@GaryPEGEOT)
 * bug #30437 [Debug] detect annotations before blank docblock lines (@xabbuh)
 * bug #30392 [PropertyAccess] Fixed PropertyPathBuilder remove that fails to reset internal indexes (@GregOriol)
