### PR TITLE
[HttpClient] Add ScopingHttpClient::forBaseUri() + tweak MockHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -111,6 +111,10 @@ class MockResponse implements ResponseInterface
         $response->info['user_data'] = $options['user_data'] ?? null;
         $response->info['url'] = $url;
 
+        if ($mock instanceof self) {
+            $mock->requestOptions = $response->requestOptions;
+        }
+
         self::writeRequest($response, $options, $mock);
         $response->body[] = [$options, $mock];
 

--- a/src/Symfony/Component/HttpClient/ScopingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/ScopingHttpClient.php
@@ -38,6 +38,17 @@ class ScopingHttpClient implements HttpClientInterface
         $this->defaultRegexp = $defaultRegexp;
     }
 
+    public static function forBaseUri(HttpClientInterface $client, string $baseUri, array $defaultOptions = [], $regexp = null): self
+    {
+        if (null === $regexp) {
+            $regexp = preg_quote(implode('', self::resolveUrl(self::parseUrl('.'), self::parseUrl($baseUri))));
+        }
+
+        $defaultOptions['base_uri'] = $baseUri;
+
+        return new self($client, [$regexp => $defaultOptions], $regexp);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This allows creating scoped HTTP clients in one line:

```php
$client = ScopingHttpClient::forBaseUri($client, 'http://example.com');
```

`$client` now resolves relative URLs using the provided base URI.

If one also adds default options as 3rd argument, these will be applied conditionally when a URL matching the base URI is requested.

This PR also tweaks `MockHttpClient` to make it return `MockResponse` on its own when no constructor argument is provided, easing tests a bit.