### PR TITLE
[HttpKernel][Debug] Get exception content according to request format

### DIFF
--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
 * added `Exception\FlattenException::getAsString` and
 `Exception\FlattenException::getTraceAsString` to increase compatibility to php
 exception objects
+* added `ExceptionHandler::getFormattedContent()` to get the exception content 
+according to given format (html, json, xml, txt)
 
 4.0.0
 -----

--- a/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
@@ -139,4 +139,28 @@ content="0;url=data:text/html;base64,PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaXB0Pg"
 
         $handler->handle($exception);
     }
+
+    public function testJsonExceptionContent()
+    {
+        $handler = new ExceptionHandler(true);
+        $content = $handler->getJson(new \RuntimeException('Foo'));
+
+        $this->assertStringMatchesFormat('{"title":"Internal Server Error","status":500,"detail":"Foo","exceptions":[{"message":"Foo","class":"RuntimeException"%S}]}', $content);
+    }
+
+    public function testXmlExceptionContent()
+    {
+        $handler = new ExceptionHandler(true);
+        $content = $handler->getXml(new \RuntimeException('Foo'));
+
+        $this->assertStringMatchesFormat('<?xml version="1.0" encoding="UTF-8" ?>%A<problem xmlns="urn:ietf:rfc:7807">%A<title>Internal Server Error</title>%A<status>500</status>%A<detail>Foo</detail>%A<exceptions><exception class="RuntimeException" message="Foo"><traces><trace>%A', $content);
+    }
+
+    public function testTxtExceptionContent()
+    {
+        $handler = new ExceptionHandler(true);
+        $content = $handler->getTxt(new \RuntimeException('Foo'));
+
+        $this->assertStringMatchesFormat("[title] Internal Server Error\n[status] 500\n[detail] Foo\n[1] RuntimeException: Foo\nin ExceptionHandlerTest.php line %A", $content);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -151,10 +151,10 @@ class ExceptionListener implements EventSubscriberInterface
     {
         $attributes = [
             'exception' => $exception = FlattenException::create($exception),
-            '_controller' => $this->controller ?: function () use ($exception) {
+            '_controller' => $this->controller ?: function () use ($exception, $request) {
                 $handler = new ExceptionHandler($this->debug, $this->charset, $this->fileLinkFormat);
 
-                return new Response($handler->getHtml($exception), $exception->getStatusCode(), $exception->getHeaders());
+                return new Response($handler->getFormattedContent($exception, $request->getRequestFormat()), $exception->getStatusCode(), $exception->getHeaders());
             },
             'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
         ];

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -48,6 +48,7 @@
     "conflict": {
         "symfony/browser-kit": "<4.3",
         "symfony/config": "<3.4",
+        "symfony/debug": "<4.3",
         "symfony/dependency-injection": "<4.2",
         "symfony/translation": "<4.2",
         "symfony/var-dumper": "<4.1.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25905
| License       | MIT

Mainly for API-based apps that don't require TwigBundle to get the correct exception response according to the request format (aka `_format` attribute).

![exception_response](https://user-images.githubusercontent.com/2028198/55509651-713dc700-562a-11e9-8b98-bef3b0229397.gif)

Let me know if this classify as a bugfix for 4.2, but IMHO this was never supported without TwigBundle, hence `master` branch.

- [x] Hide trace info for non-debug mode
- [x] Update according to RFC https://tools.ietf.org/html/rfc7807 (JSON, XML)

```php
throw new NotFoundHttpException('Resource not found.', null, 0, ['Content-Type' => 'application/problem+json']);
```