### PR TITLE
[Twig] Remove TemplatedEmail::template()

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
+++ b/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
@@ -50,10 +50,6 @@ final class BodyRenderer implements BodyRendererInterface
             'email' => new WrappedTemplatedEmail($this->twig, $message),
         ]);
 
-        if ($template = $message->getTemplate()) {
-            $this->renderFull($message, $template, $vars);
-        }
-
         if ($template = $message->getTextTemplate()) {
             $message->text($this->twig->render($template, $vars));
         }
@@ -65,29 +61,6 @@ final class BodyRenderer implements BodyRendererInterface
         // if text body is empty, compute one from the HTML body
         if (!$message->getTextBody() && null !== $html = $message->getHtmlBody()) {
             $message->text($this->convertHtmlToText(\is_resource($html) ? stream_get_contents($html) : $html));
-        }
-    }
-
-    private function renderFull(TemplatedEmail $message, string $template, array $vars): void
-    {
-        $template = $this->twig->load($template);
-
-        if ($template->hasBlock('subject', $vars)) {
-            $message->subject($template->renderBlock('subject', $vars));
-        }
-
-        if ($template->hasBlock('text', $vars)) {
-            $message->text($template->renderBlock('text', $vars));
-        }
-
-        if ($template->hasBlock('html', $vars)) {
-            $message->html($template->renderBlock('html', $vars));
-        }
-
-        if ($template->hasBlock('config', $vars)) {
-            // we discard the output as we're only interested
-            // in the side effect of calling email methods
-            $template->renderBlock('config', $vars);
         }
     }
 

--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -20,20 +20,9 @@ use Symfony\Component\Mime\Email;
  */
 class TemplatedEmail extends Email
 {
-    private $template;
     private $htmlTemplate;
     private $textTemplate;
     private $context = [];
-
-    /**
-     * @return $this
-     */
-    public function template(?string $template)
-    {
-        $this->template = $template;
-
-        return $this;
-    }
 
     /**
      * @return $this
@@ -53,11 +42,6 @@ class TemplatedEmail extends Email
         $this->htmlTemplate = $template;
 
         return $this;
-    }
-
-    public function getTemplate(): ?string
-    {
-        return $this->template;
     }
 
     public function getTextTemplate(): ?string
@@ -90,7 +74,7 @@ class TemplatedEmail extends Email
      */
     public function __serialize(): array
     {
-        return [$this->template, $this->htmlTemplate, $this->textTemplate, $this->context, parent::__serialize()];
+        return [$this->htmlTemplate, $this->textTemplate, $this->context, parent::__serialize()];
     }
 
     /**
@@ -98,7 +82,7 @@ class TemplatedEmail extends Email
      */
     public function __unserialize(array $data): void
     {
-        [$this->template, $this->htmlTemplate, $this->textTemplate, $this->context, $parentData] = $data;
+        [$this->htmlTemplate, $this->textTemplate, $this->context, $parentData] = $data;
 
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Bridge/Twig/Tests/Mime/RendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/RendererTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Mime\BodyRenderer;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
-use Symfony\Component\Mime\Part\Multipart\MixedPart;
-use Symfony\Component\Mime\Part\Multipart\RelatedPart;
-use Symfony\Component\Mime\Part\TextPart;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
@@ -25,13 +22,13 @@ class RendererTest extends TestCase
 {
     public function testRenderTextOnly(): void
     {
-        $email = $this->prepareEmail(null, 'Text', null);
+        $email = $this->prepareEmail('Text', null);
         $this->assertEquals('Text', $email->getBody()->bodyToString());
     }
 
     public function testRenderHtmlOnly(): void
     {
-        $email = $this->prepareEmail(null, null, '<b>HTML</b>');
+        $email = $this->prepareEmail(null, '<b>HTML</b>');
         $body = $email->getBody();
         $this->assertInstanceOf(AlternativePart::class, $body);
         $this->assertEquals('HTML', $body->getParts()[0]->bodyToString());
@@ -40,7 +37,7 @@ class RendererTest extends TestCase
 
     public function testRenderHtmlOnlyWithTextSet(): void
     {
-        $email = $this->prepareEmail(null, null, '<b>HTML</b>');
+        $email = $this->prepareEmail(null, '<b>HTML</b>');
         $email->text('Text');
         $body = $email->getBody();
         $this->assertInstanceOf(AlternativePart::class, $body);
@@ -50,108 +47,16 @@ class RendererTest extends TestCase
 
     public function testRenderTextAndHtml(): void
     {
-        $email = $this->prepareEmail(null, 'Text', '<b>HTML</b>');
+        $email = $this->prepareEmail('Text', '<b>HTML</b>');
         $body = $email->getBody();
         $this->assertInstanceOf(AlternativePart::class, $body);
         $this->assertEquals('Text', $body->getParts()[0]->bodyToString());
         $this->assertEquals('<b>HTML</b>', $body->getParts()[1]->bodyToString());
     }
 
-    public function testRenderFullOnly(): void
-    {
-        $email = $this->prepareEmail(<<<EOF
-{% block subject %}Subject{% endblock %}
-{% block text %}Text{% endblock %}
-{% block html %}<b>HTML</b>{% endblock %}
-EOF
-        , null, null);
-        $body = $email->getBody();
-        $this->assertInstanceOf(AlternativePart::class, $body);
-        $this->assertEquals('Subject', $email->getSubject());
-        $this->assertEquals('Text', $body->getParts()[0]->bodyToString());
-        $this->assertEquals('<b>HTML</b>', $body->getParts()[1]->bodyToString());
-    }
-
-    public function testRenderFullOnlyWithTextOnly(): void
-    {
-        $email = $this->prepareEmail(<<<EOF
-{% block text %}Text{% endblock %}
-EOF
-        , null, null);
-        $body = $email->getBody();
-        $this->assertInstanceOf(TextPart::class, $body);
-        $this->assertEquals('', $email->getSubject());
-        $this->assertEquals('Text', $body->bodyToString());
-    }
-
-    public function testRenderFullOnlyWithHtmlOnly(): void
-    {
-        $email = $this->prepareEmail(<<<EOF
-{% block html %}<b>HTML</b>{% endblock %}
-EOF
-        , null, null);
-        $body = $email->getBody();
-        $this->assertInstanceOf(AlternativePart::class, $body);
-        $this->assertEquals('', $email->getSubject());
-        $this->assertEquals('HTML', $body->getParts()[0]->bodyToString());
-        $this->assertEquals('<b>HTML</b>', $body->getParts()[1]->bodyToString());
-    }
-
-    public function testRenderFullAndText(): void
-    {
-        $email = $this->prepareEmail(<<<EOF
-{% block text %}Text full{% endblock %}
-{% block html %}<b>HTML</b>{% endblock %}
-EOF
-        , 'Text', null);
-        $body = $email->getBody();
-        $this->assertInstanceOf(AlternativePart::class, $body);
-        $this->assertEquals('Text', $body->getParts()[0]->bodyToString());
-        $this->assertEquals('<b>HTML</b>', $body->getParts()[1]->bodyToString());
-    }
-
-    public function testRenderFullAndHtml(): void
-    {
-        $email = $this->prepareEmail(<<<EOF
-{% block text %}Text full{% endblock %}
-{% block html %}<b>HTML</b>{% endblock %}
-EOF
-        , null, '<i>HTML</i>');
-        $body = $email->getBody();
-        $this->assertInstanceOf(AlternativePart::class, $body);
-        $this->assertEquals('Text full', $body->getParts()[0]->bodyToString());
-        $this->assertEquals('<i>HTML</i>', $body->getParts()[1]->bodyToString());
-    }
-
-    public function testRenderHtmlWithEmbeddedImages(): void
-    {
-        $email = $this->prepareEmail(null, null, '<img src="{{ email.image("image.jpg") }}" />');
-        $body = $email->getBody();
-        $this->assertInstanceOf(RelatedPart::class, $body);
-        $this->assertInstanceOf(AlternativePart::class, $body->getParts()[0]);
-        $this->assertStringMatchesFormat('<img src=3D"cid:%s@symfony" />', $body->getParts()[0]->getParts()[1]->bodyToString());
-        $this->assertEquals('Some image data', base64_decode($body->getParts()[1]->bodyToString()));
-    }
-
-    public function testRenderFullWithAttachments(): void
-    {
-        $email = $this->prepareEmail(<<<EOF
-{% block text %}Text{% endblock %}
-{% block config %}
-    {% do email.attach('document.txt') %}
-{% endblock %}
-EOF
-        , null, null);
-        $body = $email->getBody();
-        $this->assertInstanceOf(MixedPart::class, $body);
-        $this->assertEquals('Text', $body->getParts()[0]->bodyToString());
-        $this->assertEquals('Some text document...', base64_decode($body->getParts()[1]->bodyToString()));
-    }
-
-    private function prepareEmail(?string $full, ?string $text, ?string $html): TemplatedEmail
+    private function prepareEmail(?string $text, ?string $html): TemplatedEmail
     {
         $twig = new Environment(new ArrayLoader([
-            'full' => $full,
             'text' => $text,
             'html' => $html,
             'document.txt' => 'Some text document...',
@@ -159,9 +64,6 @@ EOF
         ]));
         $renderer = new BodyRenderer($twig);
         $email = (new TemplatedEmail())->to('fabien@symfony.com')->from('helene@symfony.com');
-        if (null !== $full) {
-            $email->template('full');
-        }
         if (null !== $text) {
             $email->textTemplate('text');
         }

--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -13,9 +13,6 @@ class TemplatedEmailTest extends TestCase
         $email->context($context = ['product' => 'Symfony']);
         $this->assertEquals($context, $email->getContext());
 
-        $email->template($template = 'full');
-        $this->assertEquals($template, $email->getTemplate());
-
         $email->textTemplate($template = 'text');
         $this->assertEquals($template, $email->getTextTemplate());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I propose to remove `TemplatedEmail::template()` for several reasons:

 * There is no real benefit over using `textTemplate` and `htmlTemplate` (ok, you only have one template instead of two... but the text template can only be automatically created based on the HTML one, so...);

 * It means having more than one way to do the same thing (do I set the subject on the object directly or in the template for instance);

 * A major drawback that is not easy to spot: the template is HTML, so the `subject` and `text` block must be carefully crafted to avoid avoid HTML escaping.

