### PR TITLE
[Messenger] test DoctrineTransport on travis and appveyor

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -103,7 +103,7 @@ class Connection
      */
     public function send(string $body, array $headers, int $delay = 0): void
     {
-        $now = (\DateTime::createFromFormat('U.u', microtime(true)));
+        $now = new \DateTime();
         $availableAt = (clone $now)->modify(sprintf('+%d seconds', $delay / 1000));
 
         $queryBuilder = $this->driverConnection->createQueryBuilder()
@@ -151,7 +151,7 @@ class Connection
                 ->update($this->configuration['table_name'])
                 ->set('delivered_at', ':delivered_at')
                 ->where('id = :id');
-            $now = \DateTime::createFromFormat('U.u', microtime(true));
+            $now = new \DateTime();
             $this->executeQuery($queryBuilder->getSQL(), [
                 ':id' => $doctrineEnvelope['id'],
                 ':delivered_at' => self::formatDateTime($now),
@@ -202,7 +202,7 @@ class Connection
 
     private function createAvailableMessagesQueryBuilder(): QueryBuilder
     {
-        $now = \DateTime::createFromFormat('U.u', microtime(true));
+        $now = new \DateTime();
         $redeliverLimit = (clone $now)->modify(sprintf('-%d seconds', $this->configuration['redeliver_timeout']));
 
         return $this->driverConnection->createQueryBuilder()
@@ -268,6 +268,6 @@ class Connection
 
     public static function formatDateTime(\DateTimeInterface $dateTime)
     {
-        return $dateTime->format('Y-m-d\TH:i:s.uZ');
+        return $dateTime->format('Y-m-d\TH:i:s');
     }
 }

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -20,7 +20,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "doctrine/dbal": "~2.4",
+        "doctrine/dbal": "^2.5",
         "psr/cache": "~1.0",
         "symfony/console": "~3.4|~4.0",
         "symfony/dependency-injection": "~3.4.19|^4.1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes ? WIP
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Currently tests on the `Symfony\Component\Messenger\Tests\Transport\Doctrine\DoctrineIntegrationTest` are skipped because there is no `MESSENGER_DOCTRINE_DSN` environment variable is not defined.

This PR update the travis and AppVeyor configuration to run these tests. 

This is a WIP. I'm not a Travis/AppVeyor user so this clearly need more work