### PR TITLE
[Messenger] Setup the doctrine transport when consuming

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\Doctrine\Connection;
@@ -25,6 +26,7 @@ class ConnectionTest extends TestCase
     {
         $queryBuilder = $this->getQueryBuilderMock();
         $driverConnection = $this->getDBALConnectionMock();
+        $schemaSynchronizer = $this->getSchemaSynchronizerMock();
         $stmt = $this->getStatementMock([
             'id' => 1,
             'body' => '{"message":"Hi"}',
@@ -44,7 +46,7 @@ class ConnectionTest extends TestCase
             ->method('prepare')
             ->willReturn($stmt);
 
-        $connection = new Connection([], $driverConnection);
+        $connection = new Connection([], $driverConnection, $schemaSynchronizer);
         $doctrineEnvelope = $connection->get();
         $this->assertEquals(1, $doctrineEnvelope['id']);
         $this->assertEquals('{"message":"Hi"}', $doctrineEnvelope['body']);
@@ -55,6 +57,7 @@ class ConnectionTest extends TestCase
     {
         $queryBuilder = $this->getQueryBuilderMock();
         $driverConnection = $this->getDBALConnectionMock();
+        $schemaSynchronizer = $this->getSchemaSynchronizerMock();
         $stmt = $this->getStatementMock(false);
 
         $queryBuilder
@@ -68,7 +71,7 @@ class ConnectionTest extends TestCase
         $driverConnection->expects($this->never())
             ->method('update');
 
-        $connection = new Connection([], $driverConnection);
+        $connection = new Connection([], $driverConnection, $schemaSynchronizer);
         $doctrineEnvelope = $connection->get();
         $this->assertNull($doctrineEnvelope);
     }
@@ -140,6 +143,12 @@ class ConnectionTest extends TestCase
             ->willReturn($expectedResult);
 
         return $stmt;
+    }
+
+    private function getSchemaSynchronizerMock()
+    {
+        return $this->getMockBuilder(SchemaSynchronizer::class)
+            ->getMock();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
@@ -164,4 +164,17 @@ class DoctrineIntegrationTest extends TestCase
         $this->assertEquals('{"message": "Hi requeued"}', $next['body']);
         $this->connection->reject($next['id']);
     }
+
+    public function testTheTransportIsSetupOnGet()
+    {
+        // If the table does not exist and we call the get (i.e run messenger:consume) the table must be setup
+        // so first delete the tables
+        $this->driverConnection->exec('DROP TABLE messenger_messages');
+
+        $this->assertNull($this->connection->get());
+
+        $this->connection->send('the body', ['my' => 'header']);
+        $envelope = $this->connection->get();
+        $this->assertEquals('the body', $envelope['body']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no     
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Currently there is an error when the table does not exists and we run the `messenger:consume` command.

This is because all queries made in the `get` method of the `Connection` are in a transaction. Therefore the table is not created.

To avoid this error I added a call to the `setup` method before starting the transaction.

I needed to add the SchemaSynchronizer as construct parameter for the tests
