### PR TITLE
[Routing] UrlHelper to get absolute URL for a path

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -145,6 +145,13 @@ Security
    }
    ```
 
+TwigBridge
+==========
+
+ * deprecated the `$requestStack` and `$requestContext` arguments of the 
+   `HttpFoundationExtension`, pass a `Symfony\Component\HttpFoundation\UrlHelper`
+   instance as the only argument instead
+
 Workflow
 --------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -364,6 +364,13 @@ TwigBundle
  * The default value (`false`) of the `twig.strict_variables` configuration option has been changed to `%kernel.debug%`.
  * The `transchoice` tag and filter have been removed, use the `trans` ones instead with a `%count%` parameter.
  * Removed support for legacy templates directories `src/Resources/views/` and `src/Resources/<BundleName>/views/`, use `templates/` and `templates/bundles/<BundleName>/` instead.
+ 
+TwigBridge
+----------
+
+ * removed the `$requestStack` and `$requestContext` arguments of the 
+   `HttpFoundationExtension`, pass a `Symfony\Component\HttpFoundation\UrlHelper`
+   instance as the only argument instead
 
 Validator
 --------

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 
  * added the `form_parent()` function that allows to reliably retrieve the parent form in Twig templates
  * added the `workflow_transition_blockers()` function
+ * deprecated the `$requestStack` and `$requestContext` arguments of the 
+   `HttpFoundationExtension`, pass a `Symfony\Component\HttpFoundation\UrlHelper`
+   instance as the only argument instead
 
 4.2.0
 -----

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -26,7 +26,7 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",
         "symfony/form": "^4.3",
-        "symfony/http-foundation": "~3.4|~4.0",
+        "symfony/http-foundation": "~4.3",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/mime": "~4.3",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -46,6 +46,7 @@
     "conflict": {
         "symfony/console": "<3.4",
         "symfony/form": "<4.3",
+        "symfony/http-foundation": "<4.3",
         "symfony/translation": "<4.2",
         "symfony/workflow": "<4.3"
     },

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -63,6 +63,12 @@
         <service id="request_stack" class="Symfony\Component\HttpFoundation\RequestStack" public="true" />
         <service id="Symfony\Component\HttpFoundation\RequestStack" alias="request_stack" />
 
+        <service id="url_helper" class="Symfony\Component\HttpFoundation\UrlHelper">
+            <argument type="service" id="request_stack" />
+            <argument type="service" id="router.request_context" on-invalid="ignore" />
+        </service>
+        <service id="Symfony\Component\HttpFoundation\UrlHelper" alias="url_helper" />
+
         <service id="cache_warmer" class="Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate" public="true">
             <argument type="tagged" tag="kernel.cache_warmer" />
             <argument>%kernel.debug%</argument>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -108,8 +108,7 @@
         </service>
 
         <service id="twig.extension.httpfoundation" class="Symfony\Bridge\Twig\Extension\HttpFoundationExtension">
-            <argument type="service" id="request_stack" />
-            <argument type="service" id="router.request_context" on-invalid="ignore" />
+            <argument type="service" id="url_helper" />
         </service>
 
         <service id="twig.extension.debug" class="Twig\Extension\DebugExtension" />

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": "^7.1.3",
         "symfony/config": "~4.2",
-        "symfony/twig-bridge": "^4.2",
-        "symfony/http-foundation": "~4.1",
+        "symfony/twig-bridge": "^4.3",
+        "symfony/http-foundation": "~4.3",
         "symfony/http-kernel": "~4.1",
         "symfony/polyfill-ctype": "~1.8",
         "twig/twig": "~1.34|~2.4"

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * deprecated `MimeType` and `MimeTypeExtensionGuesser` in favor of `Symfony\Component\Mime\MimeTypes`.
  * deprecated `FileBinaryMimeTypeGuesser` in favor of `Symfony\Component\Mime\FileBinaryMimeTypeGuesser`.
  * deprecated `FileinfoMimeTypeGuesser` in favor of `Symfony\Component\Mime\FileinfoMimeTypeGuesser`.
+ * added `UrlHelper` that allows to get an absolute URL and a relative path for a given path
 
 4.2.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Tests/UrlHelperTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UrlHelperTest.php
@@ -9,18 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bridge\Twig\Tests\Extension;
+namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Twig\Extension\HttpFoundationExtension;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\UrlHelper;
 use Symfony\Component\Routing\RequestContext;
 
-/**
- * @group legacy
- */
-class HttpFoundationExtensionTest extends TestCase
+class UrlHelperTest extends TestCase
 {
     /**
      * @dataProvider getGenerateAbsoluteUrlData()
@@ -29,9 +26,9 @@ class HttpFoundationExtensionTest extends TestCase
     {
         $stack = new RequestStack();
         $stack->push(Request::create($pathinfo));
-        $extension = new HttpFoundationExtension($stack);
+        $helper = new UrlHelper($stack);
 
-        $this->assertEquals($expected, $extension->generateAbsoluteUrl($path));
+        $this->assertEquals($expected, $helper->getAbsoluteUrl($path));
     }
 
     public function getGenerateAbsoluteUrlData()
@@ -67,9 +64,9 @@ class HttpFoundationExtensionTest extends TestCase
         }
 
         $requestContext = new RequestContext($baseUrl, 'GET', $host, $scheme, $httpPort, $httpsPort, $path);
-        $extension = new HttpFoundationExtension(new RequestStack(), $requestContext);
+        $helper = new UrlHelper(new RequestStack(), $requestContext);
 
-        $this->assertEquals($expected, $extension->generateAbsoluteUrl($path));
+        $this->assertEquals($expected, $helper->getAbsoluteUrl($path));
     }
 
     /**
@@ -81,9 +78,9 @@ class HttpFoundationExtensionTest extends TestCase
             $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
         }
 
-        $extension = new HttpFoundationExtension(new RequestStack());
+        $helper = new UrlHelper(new RequestStack());
 
-        $this->assertEquals($path, $extension->generateAbsoluteUrl($path));
+        $this->assertEquals($path, $helper->getAbsoluteUrl($path));
     }
 
     public function getGenerateAbsoluteUrlRequestContextData()
@@ -107,11 +104,11 @@ class HttpFoundationExtensionTest extends TestCase
 
         $stack = new RequestStack();
         $stack->push($request);
-        $extension = new HttpFoundationExtension($stack);
+        $helper = new UrlHelper($stack);
 
         $this->assertEquals(
             'http://localhost/app/web/bundles/framework/css/structure.css',
-            $extension->generateAbsoluteUrl('/app/web/bundles/framework/css/structure.css')
+            $helper->getAbsoluteUrl('/app/web/bundles/framework/css/structure.css')
         );
     }
 
@@ -126,9 +123,9 @@ class HttpFoundationExtensionTest extends TestCase
 
         $stack = new RequestStack();
         $stack->push(Request::create($pathinfo));
-        $extension = new HttpFoundationExtension($stack);
+        $urlHelper = new UrlHelper($stack);
 
-        $this->assertEquals($expected, $extension->generateRelativePath($path));
+        $this->assertEquals($expected, $urlHelper->getRelativePath($path));
     }
 
     public function getGenerateRelativePathData()

--- a/src/Symfony/Component/HttpFoundation/UrlHelper.php
+++ b/src/Symfony/Component/HttpFoundation/UrlHelper.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * A helper service for manipulating URLs within and outside the request scope.
+ *
+ * @author Valentin Udaltsov <udaltsov.valentin@gmail.com>
+ */
+final class UrlHelper
+{
+    private $requestStack;
+    private $requestContext;
+
+    public function __construct(RequestStack $requestStack, ?RequestContext $requestContext = null)
+    {
+        $this->requestStack = $requestStack;
+        $this->requestContext = $requestContext;
+    }
+
+    public function getAbsoluteUrl(string $path): string
+    {
+        if (false !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
+            return $path;
+        }
+
+        if (null === $request = $this->requestStack->getMasterRequest()) {
+            return $this->getAbsoluteUrlFromContext($path);
+        }
+
+        if ('#' === $path[0]) {
+            $path = $request->getRequestUri().$path;
+        } elseif ('?' === $path[0]) {
+            $path = $request->getPathInfo().$path;
+        }
+
+        if (!$path || '/' !== $path[0]) {
+            $prefix = $request->getPathInfo();
+            $last = \strlen($prefix) - 1;
+            if ($last !== $pos = strrpos($prefix, '/')) {
+                $prefix = substr($prefix, 0, $pos).'/';
+            }
+
+            return $request->getUriForPath($prefix.$path);
+        }
+
+        return $request->getSchemeAndHttpHost().$path;
+    }
+
+    public function getRelativePath(string $path): string
+    {
+        if (false !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
+            return $path;
+        }
+
+        if (null === $request = $this->requestStack->getMasterRequest()) {
+            return $path;
+        }
+
+        return $request->getRelativeUriForPath($path);
+    }
+
+    private function getAbsoluteUrlFromContext(string $path): string
+    {
+        if (null === $this->requestContext || '' === $host = $this->requestContext->getHost()) {
+            return $path;
+        }
+
+        $scheme = $this->requestContext->getScheme();
+        $port = '';
+
+        if ('http' === $scheme && 80 !== $this->requestContext->getHttpPort()) {
+            $port = ':'.$this->requestContext->getHttpPort();
+        } elseif ('https' === $scheme && 443 !== $this->requestContext->getHttpsPort()) {
+            $port = ':'.$this->requestContext->getHttpsPort();
+        }
+
+        if ('#' === $path[0]) {
+            $queryString = $this->requestContext->getQueryString();
+            $path = $this->requestContext->getPathInfo().($queryString ? '?'.$queryString : '').$path;
+        } elseif ('?' === $path[0]) {
+            $path = $this->requestContext->getPathInfo().$path;
+        }
+
+        if ('/' !== $path[0]) {
+            $path = rtrim($this->requestContext->getBaseUrl(), '/').'/'.$path;
+        }
+
+        return $scheme.'://'.$host.$port.$path;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

I noticed that I need to generate absolute urls quite often. For example when normalizing uploads in API. I found Twig's `absolute_url()` really helpful, but obviously `Symfony\Bridge\Twig\Extension\HttpFoundationExtension` cannot be used as a normalizer's argument service.

In this PR I propose to extract `HttpFoundationExtension::generateAbsoluteUrl` and `HttpFoundationExtension::generateRelativePath` to separate interfaces which could be used on their own. Although this could be just a final class helper, I thought that we might leave a possibility for decoration here. That's why I created interfaces.

- [x] Split `HttpFoundationExtension` into two interfaces
- [x] Deprecate `HttpFoundationExtension::generateAbsoluteUrl` and `HttpFoundationExtension::generateRelativePath`
- [x] Add service definitions
- [x] Fix tests
- [ ] Add docs