### PR TITLE
[Messenger] fixing unused variable names

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
@@ -177,9 +177,9 @@ TXT
 
         $sender = new AmqpSender($connection, $serializer);
 
-        $sender->send($first = new Envelope(new DummyMessage('First')));
-        $sender->send($second = new Envelope(new DummyMessage('Second')));
-        $sender->send($second = new Envelope(new DummyMessage('Third')));
+        $sender->send(new Envelope(new DummyMessage('First')));
+        $sender->send(new Envelope(new DummyMessage('Second')));
+        $sender->send(new Envelope(new DummyMessage('Third')));
 
         sleep(1); // give amqp a moment to have the messages ready
         $this->assertSame(3, $connection->countMessagesInQueue());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/30757/files#r272061245
| License       | MIT
| Doc PR        | n/a

Typo on the variable name - variables aren't needed anyways.

Cheers!