### PR TITLE
[Validator] Define null return type for Constraint::getDefaultOption()

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -232,12 +232,13 @@ abstract class Constraint
      *
      * Override this method to define a default option.
      *
-     * @return string
+     * @return string|null
      *
      * @see __construct()
      */
     public function getDefaultOption()
     {
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The `Constraint::getDefaultOption()` method is documented with a return type of `string`, but has no `return` statement. This behaviour is expected, as the return value is compared against `null` elsewhere in the code, but the docblock causes problems with static analysis when extending this class.

This PR corrects the documented return type to `string|null` and adds an explicit `return null`.