### PR TITLE
[Mime][BrowserKit] Add FormUrlEncoded - Fix content-type in HttpBrowserPost

### DIFF
--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\BrowserKit\HttpBrowser;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SpecialHttpResponse extends Response
 {
@@ -111,5 +113,63 @@ class HttpBrowserTest extends AbstractBrowserTest
         $this->assertInstanceOf('Symfony\Component\BrowserKit\Response', $client->getInternalResponse());
         $this->assertNotInstanceOf('Symfony\Component\BrowserKit\Tests\SpecialHttpResponse', $client->getInternalResponse());
         $this->assertInstanceOf('Symfony\Component\BrowserKit\Tests\SpecialHttpResponse', $client->getResponse());
+    }
+
+    /**
+     * @dataProvider validContentTypes
+     */
+    public function testRequestHeaders(array $request, array $exepectedCall)
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client
+            ->expects($this->once())
+            ->method('request')
+            ->with(...$exepectedCall)
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $browser = new HttpBrowser($client);
+        $browser->request(...$request);
+    }
+
+    public function validContentTypes()
+    {
+        $defaultHeaders = ['user-agent' => 'Symfony BrowserKit', 'host' => 'example.com'];
+        yield 'GET/HEAD' => [
+            ['GET', 'http://example.com/', ['key' => 'value']],
+            ['GET', 'http://example.com/', ['headers' => $defaultHeaders, 'body' => '', 'max_redirects' => 0]],
+        ];
+        yield 'empty form' => [
+            ['POST', 'http://example.com/'],
+            ['POST', 'http://example.com/', ['headers' => $defaultHeaders, 'body' => '', 'max_redirects' => 0]],
+        ];
+        yield 'form' => [
+            ['POST', 'http://example.com/', ['key' => 'value', 'key2' => 'value']],
+            ['POST', 'http://example.com/', ['headers' => $defaultHeaders + ['Content-Type' => 'application/x-www-form-urlencoded'], 'body' => 'key=value&key2=value', 'max_redirects' => 0]],
+        ];
+        yield 'content' => [
+            ['POST', 'http://example.com/', [], [], [], 'content'],
+            ['POST', 'http://example.com/', ['headers' => $defaultHeaders + ['Content-Type: text/plain; charset=utf-8', 'Content-Transfer-Encoding: 8bit'], 'body' => 'content', 'max_redirects' => 0]],
+        ];
+    }
+
+    public function testMultiPartRequest()
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client
+            ->expects($this->once())
+            ->method('request')
+            ->with('POST', 'http://example.com/', $this->callback(function ($options) {
+                $this->assertContains('Content-Type: multipart/form-data', implode('', $options['headers']));
+                $this->assertInstanceOf('\Generator', $options['body']);
+                $this->assertContains('my_file', implode('', iterator_to_array($options['body'])));
+
+                return true;
+            }))
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $browser = new HttpBrowser($client);
+        $path = tempnam(sys_get_temp_dir(), 'http');
+        file_put_contents($path, 'my_file');
+        $browser->request('POST', 'http://example.com/', [], ['file' => ['tmp_name' => $path, 'name' => 'foo']]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30867 
| License       | MIT
| Doc PR        | NA

This PR use the content-type `x-www-form-urlencoded` when posting a form with the HttpBrowser.