### PR TITLE
[Messenger] Fixed DIC config when the messenger is not installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -280,6 +280,7 @@ class FrameworkExtension extends Extension
         } else {
             $container->removeDefinition('console.command.messenger_consume_messages');
             $container->removeDefinition('console.command.messenger_debug');
+            $container->removeDefinition('console.command.messenger_stop_workers');
             $container->removeDefinition('console.command.messenger_setup_transports');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

EUFOSSA

--- 

Fix: 

```

In getConsole_Command_MessengerStopWorkersService.php line 9:
                                                                                                      
  Attempted to load class "StopWorkersCommand" from namespace "Symfony\Component\Messenger\Command".  
  Did you forget a "use" statement for another namespace?                                             
                                                                                                      

```