### PR TITLE
[Lock][TestSuite]Ensure the parent process is always killed

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -74,8 +74,8 @@ trait BlockingStoreTestTrait
             // Block SIGHUP signal
             pcntl_sigprocmask(SIG_BLOCK, [SIGHUP]);
 
-            $store = $this->getStore();
             try {
+                $store = $this->getStore();
                 $store->save($key);
                 // send the ready signal to the parent
                 posix_kill($parentPID, SIGHUP);
@@ -87,7 +87,8 @@ trait BlockingStoreTestTrait
                 usleep($clockDelay);
                 $store->delete($key);
                 exit(0);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
+                posix_kill($parentPID, SIGHUP);
                 exit(1);
             }
         }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes, but for the test suite
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | n/a


If you try to run the test suite but do not have a redis instance
running, the parent process that was supposed to be killed will never be
as the test is marked as skipped and the store never returned.
This results in the test suite hanging forever at the end.
In this patch, the exception is thrown again, and then caught in the trait, and
the parent gets killed as it should.