### PR TITLE
[Workflow] Fixed initial places when no places are configured

### DIFF
--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -94,7 +94,7 @@ final class Definition
 
     private function setInitialPlaces($places = null)
     {
-        if (null === $places) {
+        if (!$places) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

EUFOSSA

I introduced a BC break in #30468 and this PR fix it.
With the full stack framework, when one does not configure the
initial_place(s) the DIC set `[]` for the initial values.
So it removes the initials values guessed in `Definition::addPlace()`