### PR TITLE
[Serializer] Add options to JsonDecode and JsonEncode to wrap/unwrap json data

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -18,7 +18,8 @@ namespace Symfony\Component\Serializer\Encoder;
  */
 class JsonEncoder implements EncoderInterface, DecoderInterface
 {
-    const FORMAT = 'json';
+    public const FORMAT = 'json';
+    public const JSON_PROPERTY_PATH = 'json_property_path';
 
     protected $encodingImpl;
     protected $decodingImpl;

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
@@ -49,10 +49,15 @@ class JsonDecodeTest extends TestCase
 
         $assoc = ['foo' => 'bar'];
 
-        return [
-            ['{"foo": "bar"}', $stdClass, []],
-            ['{"foo": "bar"}', $assoc, ['json_decode_associative' => true]],
-        ];
+        return array(
+            array('{"foo": "bar"}', $stdClass, array()),
+            array('{"foo": "bar"}', $assoc, array('json_decode_associative' => true)),
+            array('{"baz": {"foo": "bar"}}', $stdClass, array(JsonEncoder::JSON_PROPERTY_PATH => 'baz')),
+            array('{"baz": {"foo": "bar"}}', null, array(JsonEncoder::JSON_PROPERTY_PATH => 'baz.inner')),
+            array('{"baz": {"foo": "bar"}}', $assoc, array(JsonEncoder::JSON_PROPERTY_PATH => '[baz]', 'json_decode_associative' => true)),
+            array('{"baz": {"foo": "bar"}}', $assoc, array(JsonEncoder::JSON_PROPERTY_PATH => '[baz]', 'json_decode_associative' => true)),
+            array('{"baz": {"foo": "bar", "inner": {"key": "value"}}}', array('key' => 'value'), array(JsonEncoder::JSON_PROPERTY_PATH => '[baz][inner]', 'json_decode_associative' => true)),
+        );
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncodeTest.php
@@ -46,6 +46,7 @@ class JsonEncodeTest extends TestCase
         return [
             [[], '[]', []],
             [[], '{}', ['json_encode_options' => JSON_FORCE_OBJECT]],
+            [['bar' => 'foo'], '{"baz":{"bar":"foo"}}', [JsonEncoder::JSON_PROPERTY_PATH => '[baz]']],
         ];
     }
 


### PR DESCRIPTION
from @nonanerz
> Add options to JsonDecode and JsonEncode to wrap/unwrap json data
> Q 	A
> Branch? 	master
> Bug fix? 	no
> New feature? 	yes
> BC breaks? 	no
> Deprecations? 	no
> Tests pass? 	yes
> Fixed tickets 	n/a
> License 	MIT
> Doc PR 	n/a
> 
> Add options to JsonDecode and JsonEncode to wrap/unwrap json data.
> 
> So you can use:
> 
> `$serialiser->deserialize("{object: {value: 1, other: 2}}", Object::class, ['json_root_key' => 'object'])`



I've just rebase the PR with master without the merge cc @fabpot 
from #28887
 #FOSSHackathons