### PR TITLE
[HttpClient] Fix Notice on HttpClientTestCase::testTimeoutOnStream()

### DIFF
--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -86,7 +86,7 @@ switch ($vars['REQUEST_URI']) {
 
     case '/timeout-body':
         echo '<1>';
-        ob_flush();
+        @ob_flush();
         flush();
         usleep(500000);
         echo '<2>';
@@ -97,7 +97,7 @@ switch ($vars['REQUEST_URI']) {
         sleep(1);
         while (true) {
             echo '<1>';
-            ob_flush();
+            @ob_flush();
             flush();
             usleep(500);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

When I run the test suite for the HTTP Client locally, I run into the following notice:

```
Notice: ob_flush(): failed to flush buffer. No buffer to flush in /path/to/symfony/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php on line 89
```

This PR aims to fix this.

`EUFOSSA`