### PR TITLE
[DIC] Add a `require` env var processor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * added ability to define an index for services in an injected service locator argument
  * made `ServiceLocator` implement `ServiceProviderInterface`
  * deprecated support for non-string default env() parameters
+ * added `%env(require:...)%` processor to `require()` a PHP file and use the value returned from it
 
 4.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -47,6 +47,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             'default' => 'bool|int|float|string|array',
             'string' => 'string',
             'trim' => 'string',
+            'require' => 'bool|int|float|string|array',
         ];
     }
 
@@ -102,7 +103,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             return '' === $default ? null : $this->container->getParameter($default);
         }
 
-        if ('file' === $prefix) {
+        if ('file' === $prefix || 'require' === $prefix) {
             if (!is_scalar($file = $getEnv($name))) {
                 throw new RuntimeException(sprintf('Invalid file name: env var "%s" is non-scalar.', $name));
             }
@@ -110,7 +111,11 @@ class EnvVarProcessor implements EnvVarProcessorInterface
                 throw new EnvNotFoundException(sprintf('File "%s" not found (resolved from "%s").', $file, $name));
             }
 
-            return file_get_contents($file);
+            if ('file' === $prefix) {
+                return file_get_contents($file);
+            } else {
+                return require $file;
+            }
         }
 
         if (false !== $i || 'string' !== $prefix) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -45,6 +45,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'default' => ['bool', 'int', 'float', 'string', 'array'],
             'string' => ['string'],
             'trim' => ['string'],
+            'require' => ['bool', 'int', 'float', 'string', 'array'],
         ];
 
         $this->assertSame($expected, $container->getParameterBag()->getProvidedTypes());

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -458,4 +458,32 @@ class EnvVarProcessorTest extends TestCase
             ['NULL', 'NULL'],
          ];
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvNotFoundException
+     * @expectedExceptionMessage missing-file
+     */
+    public function testRequireMissingFile()
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $processor->getEnv('require', '/missing-file', function ($name) {
+            return $name;
+        });
+    }
+
+    public function testRequireFile()
+    {
+        $path = __DIR__.'/Fixtures/php/return_foo_string.php';
+
+        $processor = new EnvVarProcessor(new Container());
+
+        $result = $processor->getEnv('require', $path, function ($name) use ($path) {
+            $this->assertSame($path, $name);
+
+            return $path;
+        });
+
+        $this->assertEquals('foo', $result);
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/return_foo_string.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/return_foo_string.php
@@ -1,0 +1,2 @@
+<?php
+    return 'foo';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#11313

This adds a new `require` processor that will `require()` the PHP file given as input value and return the value `return`ed from that file. Leverages opcaching (yay!).

#EUFOSSA