### PR TITLE
[Validator] Wire NotCompromisedPassword in FrameworkBundle and handle non UTF-8 password

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -61,6 +61,12 @@
             <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator" />
         </service>
 
+        <service id="validator.not_compromised_password" class="Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator">
+            <argument type="service" id="http_client" on-invalid="null" />
+            <argument>%kernel.charset%</argument>
+            <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator" />
+        </service>
+
         <service id="validator.property_info_loader" class="Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader">
             <argument type="service" id="property_info" />
             <argument type="service" id="property_info" />

--- a/src/Symfony/Component/Validator/Constraints/NotCompromisedPasswordValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotCompromisedPasswordValidator.php
@@ -31,14 +31,16 @@ class NotCompromisedPasswordValidator extends ConstraintValidator
     private const RANGE_API = 'https://api.pwnedpasswords.com/range/%s';
 
     private $httpClient;
+    private $charset;
 
-    public function __construct(HttpClientInterface $httpClient = null)
+    public function __construct(HttpClientInterface $httpClient = null, string $charset = 'UTF-8')
     {
         if (null === $httpClient && !class_exists(HttpClient::class)) {
             throw new \LogicException(sprintf('The "%s" class requires the "HttpClient" component. Try running "composer require symfony/http-client".', self::class));
         }
 
         $this->httpClient = $httpClient ?? HttpClient::create();
+        $this->charset = $charset;
     }
 
     /**
@@ -59,6 +61,10 @@ class NotCompromisedPasswordValidator extends ConstraintValidator
         $value = (string) $value;
         if ('' === $value) {
             return;
+        }
+
+        if ('UTF-8' !== $this->charset) {
+            $value = mb_convert_encoding($value, 'UTF-8', $this->charset);
         }
 
         $hash = strtoupper(sha1($value));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/30870
| License       | MIT
| Doc PR        | -

Live from #eu-fossa

Fix https://github.com/symfony/symfony/issues/30870