### PR TITLE
[ErrorHandler][DebugClassLoader] Add deprecations namespaces mapping option to force exposition or mute deprecations

### DIFF
--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 -----
 
  * added the component
+ * added argument `$namespaceRemappings` to `DebugClassLoader::enable()`

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ExtendsDeprecatedClassInTheSameVendor.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ExtendsDeprecatedClassInTheSameVendor.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+class ExtendsDeprecatedClassInTheSameVendor extends DeprecatedClass
+{
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/RootNamespace.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/RootNamespace.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\ErrorHandler\Tests\Fixtures\DeprecatedClass;
+
+class RootNamespace extends DeprecatedClass
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/30221
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11525

#eufossa

This PR adds a new option when you enable the `DebugClassLoader`.

It allows us to control the "same vendor" concept (cf the linked issue for the full explanation).

If your custom code namespace starts like a namespace of vendor code, you can kinda "remap" it to something else, so your code is not considered in the same vendor anymore. The left part is your code original namespace (you can control how deep you wanna go). The right part is the value that will be considered when doing the "same vendor" check. Example : 
```php
DebugClassLoader::enable([
    'Symfony' => 'sf',
])
```
This code will expose all deprecations messages generated by Symfony code extending deprecated / internal Symfony classes, etc.

A side effect (let's call it a feature actually) is that it is possible to remap your code namespace to a vendor one to mute some deprecations messages.

There is no BC break because by default, it is exactly the same behavior than before.

TODO :
- [x] Changelog entry
- [x] Doc PR

