### PR TITLE
[Serializer] provide new ObjectPropertyListExtractorInterface

### DIFF
--- a/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
+++ b/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Extractor;
+
+use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+
+/**
+ * @author David Maicher <mail@dmaicher.de>
+ */
+class ObjectPropertyListExtractor implements ObjectPropertyListExtractorInterface
+{
+    private $propertyListExtractor;
+    private $objectClassResolver;
+
+    public function __construct(PropertyListExtractorInterface $propertyListExtractor, ?callable $objectClassResolver = null)
+    {
+        $this->propertyListExtractor = $propertyListExtractor;
+        $this->objectClassResolver = $objectClassResolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperties($object, array $context = [])
+    {
+        $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
+
+        return $this->propertyListExtractor->getProperties($class, $context);
+    }
+}

--- a/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractorInterface.php
+++ b/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Extractor;
+
+/**
+ * @author David Maicher <mail@dmaicher.de>
+ */
+interface ObjectPropertyListExtractorInterface
+{
+    /**
+     * Gets the list of properties available for the given object.
+     *
+     * @param object $object
+     * @param array  $context
+     *
+     * @return string[]|null
+     */
+    public function getProperties($object, array $context = []);
+}

--- a/src/Symfony/Component/Serializer/Tests/Extractor/ObjectPropertyListExtractorTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Extractor/ObjectPropertyListExtractorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Extractor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\Serializer\Extractor\ObjectPropertyListExtractor;
+
+class ObjectPropertyListExtractorTest extends TestCase
+{
+    public function testGetPropertiesWithoutObjectClassResolver(): void
+    {
+        $object = new \stdClass();
+        $context = ['bar' => true];
+        $properties = ['prop1', 'prop2'];
+
+        $propertyListExtractor = $this->createMock(PropertyListExtractorInterface::class);
+        $propertyListExtractor->expects($this->once())
+            ->method('getProperties')
+            ->with(\get_class($object), $context)
+            ->willReturn($properties);
+
+        $this->assertSame(
+            $properties,
+            (new ObjectPropertyListExtractor($propertyListExtractor))->getProperties($object, $context)
+        );
+    }
+
+    public function testGetPropertiesWithObjectClassResolver(): void
+    {
+        $object = new \stdClass();
+        $classResolver = function ($objectArg) use ($object): string {
+            $this->assertSame($object, $objectArg);
+
+            return 'foo';
+        };
+
+        $context = ['bar' => true];
+        $properties = ['prop1', 'prop2'];
+
+        $propertyListExtractor = $this->createMock(PropertyListExtractorInterface::class);
+        $propertyListExtractor->expects($this->once())
+            ->method('getProperties')
+            ->with('foo', $context)
+            ->willReturn($properties);
+
+        $this->assertSame(
+            $properties,
+            (new ObjectPropertyListExtractor($propertyListExtractor, $classResolver))->getProperties($object, $context)
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | related to https://github.com/symfony/symfony/issues/30818
| License       | MIT
| Doc PR        | -

EUFOSSA Hackathon

As discussed with @joelwurtz this adds a new `ObjectPropertyListExtractorInterface` and a default implementation.

See https://github.com/symfony/symfony/issues/30818

>  A new interface will be provided ObjectPropertyListExtractorInterface (name can change), that allow getting attributes based on an object. A default implementation will be provided that use the PropertyListExtractorInterface and a class resolver, as the latter one only rely on class name, it may be important to have this distinction (this will allow features that rely on a specific value of the object to get the current property list, like exclusion policy)
