### PR TITLE
Add a `yaml` env var processor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * added ability to define an index for services in an injected service locator argument
  * made `ServiceLocator` implement `ServiceProviderInterface`
  * deprecated support for non-string default env() parameters
+ * added `%env(yaml:...)%` processor to parse YAML data
 
 4.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -180,6 +182,20 @@ class EnvVarProcessor implements EnvVarProcessorInterface
 
             if (null !== $env && !\is_array($env)) {
                 throw new RuntimeException(sprintf('Invalid JSON env var "%s": array or null expected, %s given.', $name, \gettype($env)));
+            }
+
+            return $env;
+        }
+
+        if ('yaml' === $prefix) {
+            try {
+                $env = Yaml::parse($env);
+            } catch (ParseException $exception) {
+                throw new RuntimeException(sprintf('Unable to parse YAML in env var "%s": '.$exception->getMessage(), $name), 0, $exception);
+            }
+
+            if (null !== $env && !\is_array($env)) {
+                throw new RuntimeException(sprintf('Invalid YAML env var "%s": array or null expected, %s given.', $name, \gettype($env)));
             }
 
             return $env;

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\EnvVarProcessor;
-use Symfony\Component\DependencyInjection\Tests\Dumper\YamlDumperTest;
 use Symfony\Component\Yaml\Yaml;
 
 class EnvVarProcessorTest extends TestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#11321

This adds a new `yaml` processor, just along the lines of the `json` one.

#EUFOSSA