### PR TITLE
Restore previous state for libxml option

### DIFF
--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -115,7 +115,7 @@ EOF
             return ['file' => $file, 'valid' => true];
         }
 
-        libxml_use_internal_errors(true);
+        $internal = libxml_use_internal_errors(true);
 
         $document = new \DOMDocument();
         $document->loadXML($content);
@@ -142,6 +142,9 @@ EOF
                 'message' => $xmlError['message'],
             ];
         }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($internal);
 
         return ['file' => $file, 'valid' => 0 === \count($errors), 'messages' => $errors];
     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Whenever libxml_use_internal_errors() is called, the previous value for
it should be restored. This used to be the case in this piece of code,
but it was wrongly removed in e53bf5839b625e5ab92ffc4859331f4f46161bc6 ,
which has the nasty side effect of making the Validator component test
suite break with this message:

Validation failed: No DTD found!