### PR TITLE
[Cache] fix using ProxyAdapter inside TagAwareAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -48,7 +48,6 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
                 $item->value = $value;
                 $item->defaultLifetime = $protoItem->defaultLifetime;
                 $item->expiry = $protoItem->expiry;
-                $item->innerItem = $protoItem->innerItem;
                 $item->poolHash = $protoItem->poolHash;
 
                 return $item;

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAndProxyAdapterIntegrationTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAndProxyAdapterIntegrationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
+
+class TagAwareAndProxyAdapterIntegrationTest extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testIntegrationUsingProxiedAdapter(CacheItemPoolInterface $proxiedAdapter)
+    {
+        $cache = new TagAwareAdapter(new ProxyAdapter($proxiedAdapter));
+
+        $item = $cache->getItem('foo');
+        $item->tag(['tag1', 'tag2']);
+        $item->set('bar');
+        $cache->save($item);
+
+        $this->assertSame('bar', $cache->getItem('foo')->get());
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [new ArrayAdapter()],
+            // also testing with a non-AdapterInterface implementation
+            // because the ProxyAdapter behaves slightly different for those
+            [new ExternalAdapter()],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | #30400 
| License       | MIT
| Doc PR        | -

EUFOSSA

After some debugging this is my first attempt to fix this issue @nicolas-grekas :blush: Let's discuss it.

without the fix the test fails like this:

```
Testing Symfony\Component\Cache\Tests\Adapter\TagAwareAndProxyAdapterIntegrationTest
F                                                                   1 / 1 (100%)

Time: 28 ms, Memory: 4.00MB

There was 1 failure:

1) Symfony\Component\Cache\Tests\Adapter\TagAwareAndProxyAdapterIntegrationTest::testIntegration
Failed asserting that Array &0 (
    'tag1' => 0
    'tag2' => 0
) is identical to 'bar'.

/var/www/symfony/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAndProxyAdapterIntegrationTest.php:26

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.

