### PR TITLE
[Translator] Fix wrong dump for PO files

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -40,7 +40,7 @@ class PoFileDumper extends FileDumper
                 $newLine = true;
             }
             $output .= sprintf('msgid "%s"'."\n", $this->escape($source));
-            $output .= sprintf('msgstr "%s"', $this->escape($target));
+            $output .= sprintf('msgstr "%s"'."\n", $this->escape($target));
         }
 
         return $output;

--- a/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
@@ -20,7 +20,7 @@ class PoFileDumperTest extends TestCase
     public function testFormatCatalogue()
     {
         $catalogue = new MessageCatalogue('en');
-        $catalogue->add(['foo' => 'bar']);
+        $catalogue->add(['foo' => 'bar', 'bar' => 'foo']);
 
         $dumper = new PoFileDumper();
 

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -23,7 +23,7 @@ class PoFileLoaderTest extends TestCase
         $resource = __DIR__.'/../fixtures/resources.po';
         $catalogue = $loader->load($resource, 'en', 'domain1');
 
-        $this->assertEquals(['foo' => 'bar'], $catalogue->all('domain1'));
+        $this->assertEquals(['foo' => 'bar', 'bar' => 'foo'], $catalogue->all('domain1'));
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources.po
@@ -6,3 +6,6 @@ msgstr ""
 
 msgid "foo"
 msgstr "bar"
+
+msgid "bar"
+msgstr "foo"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When working on #30909 I encountered this bug.
Currently the tests were passing, because the po fixture file contained only one translation.
