### PR TITLE
[BrowserKit vs HttpFoundation][TestSuite]Run test in separate process

### DIFF
--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -621,6 +621,9 @@ class ClientTest extends TestCase
         $this->assertEquals([], $client->getCookieJar()->all(), '->restart() clears the cookies');
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testInsulatedRequests()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This test calls code that defines some environment variables, which in
turn trigger the registration of a the deprecation error handler, which
causes unexpected issues when testing other components.