### PR TITLE
Move doctrine/collections to an optional dep in doctrine-bridge

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Form\Type;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader;
@@ -107,7 +108,7 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if ($options['multiple']) {
+        if ($options['multiple'] && interface_exists(Collection::class)) {
             $builder
                 ->addEventSubscriber(new MergeDoctrineCollectionListener())
                 ->addViewTransformer(new CollectionToArrayTransformer(), true)

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "doctrine/collections": "~1.0",
         "doctrine/event-manager": "~1.0",
         "doctrine/persistence": "~1.0",
         "symfony/contracts": "^1.0",
@@ -39,6 +38,7 @@
         "symfony/translation": "~3.4|~4.0",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.6",
+        "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "^2.4.5",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | 

The EntityType does not need to convert the array to a collection if the project does not care about using doctrine/collections. So this can become an optional dependency.
The goal here is to reduce the dependencies of DoctrineBundle when using it in DBAL-only mode.

doctrine/persistence still brings a bunch of unwanted dependencies for a DBAL-only project, but this requires work on the Doctrine side (we discussed it with @alcaeus) as the ConnectionRegistry is part of it. Moving it to an optional dependency in the bridge will probably come in 6 months instead.
And doctrine-cache-bundle also brings some, but that's already in the work of being removed from DoctrineBundle 2.0.