### PR TITLE
[FrameworkBundle][Routing] Add a new tag to be able to use a private service as a service route loader

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -123,6 +123,7 @@ Routing
    options have been deprecated.
  * Implementing `Serializable` for `Route` and `CompiledRoute` is deprecated; if you serialize them, please
    ensure your unserialization logic can recover from a failure related to an updated serialization format
+ * Not tagging the router loader services with `routing.router_loader` has been deprecated.
 
 Security
 --------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -284,6 +284,7 @@ Routing
    options have been removed.
  * `Route` and `CompiledRoute` don't implement `Serializable` anymore; if you serialize them, please
    ensure your unserialization logic can recover from a failure related to an updated serialization format
+ * The router loader services must be tagged with `routing.router_loader`.
 
 Security
 --------

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -49,6 +49,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'proxy',
         'routing.expression_language_provider',
         'routing.loader',
+        'routing.router_loader',
         'security.expression_language_provider',
         'security.remember_me_aware',
         'security.voter',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -92,6 +92,7 @@ use Symfony\Component\Routing\Generator\Dumper\PhpGeneratorDumper;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
 use Symfony\Component\Routing\Loader\AnnotationFileLoader;
+use Symfony\Component\Routing\Loader\DependencyInjection\ServiceRouterLoaderInterface;
 use Symfony\Component\Routing\Matcher\CompiledUrlMatcher;
 use Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper;
 use Symfony\Component\Security\Core\Security;
@@ -428,6 +429,9 @@ class FrameworkExtension extends Extension
         if (!$config['disallow_search_engine_index'] ?? false) {
             $container->removeDefinition('disallow_search_engine_index_response_listener');
         }
+
+        $container->registerForAutoconfiguration(ServiceRouterLoaderInterface::class)
+            ->addTag('routing.router_loader');
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -69,12 +69,21 @@ trait MicroKernelTrait
                 ],
             ]);
 
-            if ($this instanceof EventSubscriberInterface) {
+            if (!$container->hasDefinition('kernel')) {
                 $container->register('kernel', static::class)
                     ->setSynthetic(true)
                     ->setPublic(true)
-                    ->addTag('kernel.event_subscriber')
                 ;
+            }
+
+            $kernelDefinition = $container->getDefinition('kernel');
+
+            $kernelDefinition->addTag('routing.router_loader', [
+                'service_id' => 'kernel',
+            ]);
+
+            if ($this instanceof EventSubscriberInterface) {
+                $kernelDefinition->addTag('kernel.event_subscriber');
             }
 
             $this->configureContainer($container, $loader);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -40,9 +40,14 @@
             <argument type="service" id="file_locator" />
         </service>
 
+        <service id="routing.loader.service.container" class="Symfony\Component\Routing\Loader\DependencyInjection\ServiceRouterLoaderContainer">
+            <argument type="service" id="service_container" />
+            <argument type="tagged_locator" tag="routing.router_loader" index-by="service_id" />
+        </service>
+
         <service id="routing.loader.service" class="Symfony\Component\Routing\Loader\DependencyInjection\ServiceRouterLoader">
             <tag name="routing.loader" />
-            <argument type="service" id="service_container" />
+            <argument type="service" id="routing.loader.service.container" />
         </service>
 
         <service id="routing.loader" class="Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader" public="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -12,6 +12,9 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Kernel;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\HttpFoundation\Request;
 
 class MicroKernelTraitTest extends TestCase
@@ -38,5 +41,22 @@ class MicroKernelTraitTest extends TestCase
         $response = $kernel->handle($request);
 
         $this->assertSame('It\'s dangerous to go alone. Take this ⚔', $response->getContent());
+    }
+
+    public function testRoutingRouteLoaderTagIsAdded()
+    {
+        $frameworkExtension = $this->createMock(ExtensionInterface::class);
+        $frameworkExtension
+            ->expects($this->atLeastOnce())
+            ->method('getAlias')
+            ->willReturn('framework');
+
+        $container = new ContainerBuilder();
+        $container->registerExtension($frameworkExtension);
+
+        $kernel = new ConcreteMicroKernel('test', false);
+        $kernel->registerContainerConfiguration(new ClosureLoader($container));
+
+        $this->assertTrue($container->getDefinition('kernel')->hasTag('routing.router_loader'));
     }
 }

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -11,7 +11,7 @@ CHANGELOG
  * deprecated implementing `Serializable` for `Route` and `CompiledRoute`; if you serialize them, please
    ensure your unserialization logic can recover from a failure related to an updated serialization format
  * exposed `utf8` Route option, defaults "locale" and "format" in configuration loaders and configurators
- * added support for invokable route loader services
+ * added support for invokable router loader services
 
 4.2.0
 -----

--- a/src/Symfony/Component/Routing/Loader/DependencyInjection/ServiceRouterLoaderContainer.php
+++ b/src/Symfony/Component/Routing/Loader/DependencyInjection/ServiceRouterLoaderContainer.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\DependencyInjection;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * @internal
+ *
+ * @deprecated since Symfony 4.3, to be removed in 5.0
+ */
+class ServiceRouterLoaderContainer implements ContainerInterface
+{
+    private $container;
+    private $serviceLocator;
+
+    public function __construct(ContainerInterface $container, ContainerInterface $serviceLocator)
+    {
+        $this->container = $container;
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        if ($this->serviceLocator->has($id)) {
+            return $this->serviceLocator->get($id);
+        }
+
+        @trigger_error(sprintf('Registering the routing loader "%s" without tagging it with the "routing.router_loader" tag is deprecated since Symfony 4.3 and will be required in Symfony 5.0.', $id), E_USER_DEPRECATED);
+
+        return $this->container->get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return $this->serviceLocator->has($id) || $this->container->has($id);
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/DependencyInjection/ServiceRouterLoaderInterface.php
+++ b/src/Symfony/Component/Routing/Loader/DependencyInjection/ServiceRouterLoaderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\DependencyInjection;
+
+/**
+ * Marker interface for router loader services.
+ */
+interface ServiceRouterLoaderInterface
+{
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/DependencyInjection/ServiceRouterLoaderContainerTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/DependencyInjection/ServiceRouterLoaderContainerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Routing\Loader\DependencyInjection\ServiceRouterLoaderContainer;
+
+class ServiceRouterLoaderContainerTest extends TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $serviceLocator;
+
+    /**
+     * @var ServiceRouterLoaderContainer
+     */
+    private $serviceRouterLoaderContainer;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->container = new Container();
+        $this->container->set('foo', new \stdClass());
+
+        $this->serviceLocator = new Container();
+        $this->serviceLocator->set('bar', new \stdClass());
+
+        $this->serviceRouterLoaderContainer = new ServiceRouterLoaderContainer($this->container, $this->serviceLocator);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Registering the routing loader "foo" without tagging it with the "routing.router_loader" tag is deprecated since Symfony 4.3 and will be required in Symfony 5.0.
+     */
+    public function testGet()
+    {
+        $this->assertSame($this->container->get('foo'), $this->serviceRouterLoaderContainer->get('foo'));
+        $this->assertSame($this->serviceLocator->get('bar'), $this->serviceRouterLoaderContainer->get('bar'));
+    }
+
+    public function testHas()
+    {
+        $this->assertTrue($this->serviceRouterLoaderContainer->has('foo'));
+        $this->assertTrue($this->serviceRouterLoaderContainer->has('bar'));
+        $this->assertFalse($this->serviceRouterLoaderContainer->has('ccc'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/30402
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11337

#eufossa

This PR adds a new tag `routing.route_loader` autoconfigured thanks to a new `ServiceRouterLoader` interface to be able to use private route loader services.

The deprecation layer is done through a temporary container that will be removed in 5.0.

TODO :
- [x] Changelog and upgrade entry
- [x] Doc PR