### PR TITLE
[Form] Improve invalid messages for form types

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -189,6 +189,18 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('field_name')->defaultValue('_token')->end()
                             ->end()
                         ->end()
+                        // to be set to false in Symfony 6.0
+                        ->booleanNode('legacy_error_messages')
+                            ->defaultTrue()
+                            ->validate()
+                                ->ifTrue()
+                                ->then(function ($v) {
+                                    @trigger_error('Since symfony/framework-bundle 5.2: Setting the "framework.form.legacy_error_messages" option to "true" is deprecated. It will have no effect as of Symfony 6.0.', E_USER_DEPRECATED);
+
+                                    return $v;
+                                })
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -514,6 +514,8 @@ class FrameworkExtension extends Extension
     {
         $loader->load('form.php');
 
+        $container->getDefinition('form.type_extension.form.validator')->setArgument(1, $config['form']['legacy_error_messages']);
+
         if (null === $config['form']['csrf_protection']['enabled']) {
             $config['form']['csrf_protection']['enabled'] = $config['csrf_protection']['enabled'];
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -52,6 +52,7 @@
             <xsd:element name="csrf-protection" type="form_csrf_protection" minOccurs="0" maxOccurs="1" />
         </xsd:all>
         <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="legacy-error-messages" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="form_csrf_protection">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -354,6 +354,7 @@ class ConfigurationTest extends TestCase
                     'enabled' => null, // defaults to csrf_protection.enabled
                     'field_name' => '_token',
                 ],
+                'legacy_error_messages' => true,
             ],
             'esi' => ['enabled' => false],
             'ssi' => ['enabled' => false],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf.php
@@ -2,7 +2,9 @@
 
 $container->loadFromExtension('framework', [
     'csrf_protection' => true,
-    'form' => true,
+    'form' => [
+        'legacy_error_messages' => false,
+    ],
     'session' => [
         'handler_id' => null,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_legacy_messages.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_legacy_messages.php
@@ -1,0 +1,7 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'form' => [
+        'legacy_error_messages' => true,
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_no_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/form_no_csrf.php
@@ -5,5 +5,6 @@ $container->loadFromExtension('framework', [
         'csrf_protection' => [
             'enabled' => false,
         ],
+        'legacy_error_messages' => false,
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -8,6 +8,7 @@ $container->loadFromExtension('framework', [
         'csrf_protection' => [
             'field_name' => '_csrf',
         ],
+        'legacy_error_messages' => false,
     ],
     'http_method_override' => false,
     'esi' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
@@ -8,7 +8,7 @@
 
     <framework:config>
         <framework:csrf-protection />
-        <framework:form />
+        <framework:form legacy-error-messages="false" />
         <framework:session />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
@@ -9,6 +9,6 @@
     <framework:config>
         <framework:csrf-protection field-name="_custom" />
         <framework:session />
-        <framework:form />
+        <framework:form legacy-error-messages="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_under_form_sets_field_name.xml
@@ -8,7 +8,7 @@
 
     <framework:config>
         <framework:csrf-protection field-name="_custom_form" />
-        <framework:form />
+        <framework:form legacy-error-messages="false" />
         <framework:session />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_legacy_messages.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_legacy_messages.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:form legacy-error-messages="true" />
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_no_csrf.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:form enabled="true">
+        <framework:form enabled="true" legacy-error-messages="false">
             <framework:csrf-protection enabled="false" />
         </framework:form>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -8,7 +8,7 @@
 
     <framework:config secret="s3cr3t" ide="file%%link%%format" default-locale="fr" http-method-override="false">
         <framework:csrf-protection />
-        <framework:form>
+        <framework:form legacy-error-messages="false">
             <framework:csrf-protection field-name="_csrf"/>
         </framework:form>
         <framework:esi enabled="true" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf.yml
@@ -1,5 +1,6 @@
 framework:
     secret: s3cr3t
     csrf_protection: ~
-    form: ~
+    form:
+        legacy_error_messages: false
     session: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_legacy_messages.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_legacy_messages.yml
@@ -1,0 +1,3 @@
+framework:
+    form:
+        legacy_error_messages: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_no_csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/form_no_csrf.yml
@@ -2,3 +2,4 @@ framework:
     form:
         csrf_protection:
             enabled: false
+        legacy_error_messages: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -5,6 +5,7 @@ framework:
     form:
         csrf_protection:
             field_name: _csrf
+        legacy_error_messages: false
     http_method_override: false
     esi:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
 use Doctrine\Common\Annotations\Annotation;
 use Psr\Log\LoggerAwareInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAnnotationsCachedReaderPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
@@ -57,6 +58,8 @@ use Symfony\Component\Workflow;
 
 abstract class FrameworkExtensionTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private static $containerCache = [];
 
     abstract protected function loadFromFile(ContainerBuilder $container, $file);
@@ -1013,6 +1016,16 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('form_no_csrf');
 
         $this->assertFalse($container->getParameter('form.type_extension.csrf.enabled'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testFormsWithoutImprovedValidationMessages()
+    {
+        $this->expectDeprecation('Since symfony/framework-bundle 5.2: Setting the "framework.form.legacy_error_messages" option to "true" is deprecated. It will have no effect as of Symfony 6.0.');
+
+        $this->createContainerFromFile('form_legacy_messages');
     }
 
     public function testStopwatchEnabledWithDebugModeEnabled()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -3,7 +3,9 @@ framework:
     router:        { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation:    { enabled: true, enable_annotations: true }
     csrf_protection: true
-    form: true
+    form:
+        enabled: true
+        legacy_error_messages: false
     test: true
     default_locale: en
     session:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -3,7 +3,9 @@ framework:
     router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation: { enabled: true, enable_annotations: true }
     csrf_protection: true
-    form: true
+    form:
+        enabled: true
+        legacy_error_messages: false
     test: ~
     default_locale: en
     session:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -4,7 +4,9 @@ framework:
     validation: { enabled: true, enable_annotations: true }
     assets: ~
     csrf_protection: true
-    form: true
+    form:
+        enabled: true
+        legacy_error_messages: false
     test: ~
     default_locale: en
     session:

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -37,7 +37,7 @@
         "symfony/dom-crawler": "^4.4|^5.0",
         "symfony/expression-language": "^4.4|^5.0",
         "symfony/form": "^4.4|^5.0",
-        "symfony/framework-bundle": "^4.4|^5.0",
+        "symfony/framework-bundle": "^5.2",
         "symfony/process": "^4.4|^5.0",
         "symfony/serializer": "^4.4|^5.0",
         "symfony/translation": "^4.4|^5.0",

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/TransformationFailureListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/TransformationFailureListener.php
@@ -51,14 +51,15 @@ class TransformationFailureListener implements EventSubscriberInterface
         }
 
         $clientDataAsString = is_scalar($form->getViewData()) ? (string) $form->getViewData() : get_debug_type($form->getViewData());
-        $messageTemplate = 'The value {{ value }} is not valid.';
+        $messageTemplate = $form->getConfig()->getOption('invalid_message', 'The value {{ value }} is not valid.');
+        $messageParameters = array_replace(['{{ value }}' => $clientDataAsString], $form->getConfig()->getOption('invalid_message_parameters', []));
 
         if (null !== $this->translator) {
-            $message = $this->translator->trans($messageTemplate, ['{{ value }}' => $clientDataAsString]);
+            $message = $this->translator->trans($messageTemplate, $messageParameters);
         } else {
-            $message = strtr($messageTemplate, ['{{ value }}' => $clientDataAsString]);
+            $message = strtr($messageTemplate, $messageParameters);
         }
 
-        $form->addError(new FormError($message, $messageTemplate, ['{{ value }}' => $clientDataAsString], null, $form->getTransformationFailure()));
+        $form->addError(new FormError($message, $messageTemplate, $messageParameters, null, $form->getTransformationFailure()));
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BirthdayType extends AbstractType
@@ -21,7 +22,14 @@ class BirthdayType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefault('years', range((int) date('Y') - 120, date('Y')));
+        $resolver->setDefaults([
+            'years' => range((int) date('Y') - 120, date('Y')),
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a valid birthdate.';
+            },
+        ]);
 
         $resolver->setAllowedTypes('years', 'array');
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransfo
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CheckboxType extends AbstractType
@@ -60,6 +61,11 @@ class CheckboxType extends AbstractType
             'empty_data' => $emptyData,
             'compound' => false,
             'false_values' => [null],
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'The checkbox has an invalid value.';
+            },
             'is_empty_callback' => static function ($modelData): bool {
                 return false === $modelData;
             },

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -338,6 +338,11 @@ class ChoiceType extends AbstractType
             'data_class' => null,
             'choice_translation_domain' => true,
             'trim' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'The selected choice is invalid.';
+            },
         ]);
 
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -121,6 +121,11 @@ class CollectionType extends AbstractType
             'entry_type' => TextType::class,
             'entry_options' => [],
             'delete_empty' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'The collection is invalid.';
+            },
         ]);
 
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);

--- a/src/Symfony/Component/Form/Extension/Core/Type/ColorType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ColorType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -69,6 +70,11 @@ class ColorType extends AbstractType
     {
         $resolver->setDefaults([
             'html5' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please select a valid color.';
+            },
         ]);
 
         $resolver->setAllowedTypes('html5', 'bool');

--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -37,6 +37,11 @@ class CountryType extends AbstractType
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
             'alpha3' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please select a valid country.';
+            },
         ]);
 
         $resolver->setAllowedTypes('choice_translation_locale', ['null', 'string']);

--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -35,6 +35,11 @@ class CurrencyType extends AbstractType
             },
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please select a valid currency.';
+            },
         ]);
 
         $resolver->setAllowedTypes('choice_translation_locale', ['null', 'string']);

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
@@ -234,6 +234,11 @@ class DateIntervalType extends AbstractType
             'compound' => $compound,
             'empty_data' => $emptyData,
             'labels' => [],
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please choose a valid date interval.';
+            },
         ]);
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);
         $resolver->setNormalizer('labels', $labelsNormalizer);

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -273,6 +273,11 @@ class DateTimeType extends AbstractType
                 return $options['compound'] ? [] : '';
             },
             'input_format' => 'Y-m-d H:i:s',
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a valid date and time.';
+            },
         ]);
 
         // Don't add some defaults in order to preserve the defaults

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -299,6 +299,11 @@ class DateType extends AbstractType
             },
             'choice_translation_domain' => false,
             'input_format' => 'Y-m-d',
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a valid date.';
+            },
         ]);
 
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);

--- a/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
@@ -12,9 +12,25 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EmailType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a valid email address.';
+            },
+        ));
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -130,6 +130,11 @@ class FileType extends AbstractType
             'empty_data' => $emptyData,
             'multiple' => false,
             'allow_file_upload' => true,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please select a valid file.';
+            },
         ]);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -199,6 +199,8 @@ class FormType extends BaseType
             'help_attr' => [],
             'help_html' => false,
             'help_translation_parameters' => [],
+            'invalid_message' => 'This value is not valid.',
+            'invalid_message_parameters' => [],
             'is_empty_callback' => null,
         ]);
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/HiddenType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/HiddenType.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class HiddenType extends AbstractType
@@ -27,6 +28,11 @@ class HiddenType extends AbstractType
             // Pass errors to the parent
             'error_bubbling' => true,
             'compound' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'The hidden field is invalid.';
+            },
         ]);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\IntegerToLocalizedStri
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class IntegerType extends AbstractType
@@ -48,6 +49,11 @@ class IntegerType extends AbstractType
             // Integer cast rounds towards 0, so do the same when displaying fractions
             'rounding_mode' => \NumberFormatter::ROUND_DOWN,
             'compound' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter an integer.';
+            },
         ]);
 
         $resolver->setAllowedValues('rounding_mode', [

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -54,6 +54,11 @@ class LanguageType extends AbstractType
             'choice_translation_locale' => null,
             'alpha3' => false,
             'choice_self_translation' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please select a valid language.';
+            },
         ]);
 
         $resolver->setAllowedTypes('choice_self_translation', ['bool']);

--- a/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
@@ -35,6 +35,11 @@ class LocaleType extends AbstractType
             },
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please select a valid locale.';
+            },
         ]);
 
         $resolver->setAllowedTypes('choice_translation_locale', ['null', 'string']);

--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedString
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MoneyType extends AbstractType
@@ -57,6 +58,11 @@ class MoneyType extends AbstractType
             'divisor' => 1,
             'currency' => 'EUR',
             'compound' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a valid money amount.';
+            },
         ]);
 
         $resolver->setAllowedValues('rounding_mode', [

--- a/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
@@ -63,6 +63,11 @@ class NumberType extends AbstractType
             'compound' => false,
             'input' => 'number',
             'html5' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a number.';
+            },
         ]);
 
         $resolver->setAllowedValues('rounding_mode', [

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PasswordType extends AbstractType
@@ -36,6 +37,11 @@ class PasswordType extends AbstractType
         $resolver->setDefaults([
             'always_empty' => true,
             'trim' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'The password is invalid.';
+            },
         ]);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
@@ -57,6 +57,11 @@ class PercentType extends AbstractType
             'symbol' => '%',
             'type' => 'fractional',
             'compound' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a percentage value.';
+            },
         ]);
 
         $resolver->setAllowedValues('type', [

--- a/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
@@ -12,9 +12,25 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RadioType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please select a valid option.';
+            },
+        ));
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -12,9 +12,25 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RangeType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please choose a valid range.';
+            },
+        ));
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ValueToDuplicatesTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RepeatedType extends AbstractType
@@ -57,6 +58,11 @@ class RepeatedType extends AbstractType
             'first_name' => 'first',
             'second_name' => 'second',
             'error_bubbling' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'The values do not match.';
+            },
         ]);
 
         $resolver->setAllowedTypes('options', 'array');

--- a/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
@@ -12,9 +12,25 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SearchType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a valid search term.';
+            },
+        ));
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/TelType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TelType.php
@@ -12,9 +12,25 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TelType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please provide a valid phone number.';
+            },
+        ));
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -336,6 +336,11 @@ class TimeType extends AbstractType
             },
             'compound' => $compound,
             'choice_translation_domain' => false,
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a valid time.';
+            },
         ]);
 
         $resolver->setNormalizer('view_timezone', function (Options $options, $viewTimezone): ?string {

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -61,6 +61,12 @@ class TimezoneType extends AbstractType
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
             'input' => 'string',
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please select a valid timezone.';
+            },
+            'regions' => \DateTimeZone::ALL,
         ]);
 
         $resolver->setAllowedTypes('intl', ['bool']);

--- a/src/Symfony/Component/Form/Extension/Core/Type/TransformationFailureExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TransformationFailureExtension.php
@@ -30,7 +30,7 @@ class TransformationFailureExtension extends AbstractTypeExtension
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (!isset($options['invalid_message']) && !isset($options['invalid_message_parameters'])) {
+        if (!isset($options['constraints'])) {
             $builder->addEventSubscriber(new TransformationFailureListener($this->translator));
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UrlType extends AbstractType
@@ -46,7 +47,14 @@ class UrlType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefault('default_protocol', 'http');
+        $resolver->setDefaults([
+            'default_protocol' => 'http',
+            'invalid_message' => function (Options $options, $previousValue) {
+                return ($options['legacy_error_messages'] ?? true)
+                    ? $previousValue
+                    : 'Please enter a valid URL.';
+            },
+        ]);
 
         $resolver->setAllowedTypes('default_protocol', ['null', 'string']);
     }

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -26,11 +26,13 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
 {
     private $validator;
     private $violationMapper;
+    private $legacyErrorMessages;
 
-    public function __construct(ValidatorInterface $validator)
+    public function __construct(ValidatorInterface $validator, bool $legacyErrorMessages = true)
     {
         $this->validator = $validator;
         $this->violationMapper = new ViolationMapper();
+        $this->legacyErrorMessages = $legacyErrorMessages;
     }
 
     /**
@@ -58,9 +60,18 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
             'constraints' => [],
             'invalid_message' => 'This value is not valid.',
             'invalid_message_parameters' => [],
+            'legacy_error_messages' => $this->legacyErrorMessages,
             'allow_extra_fields' => false,
             'extra_fields_message' => 'This form should not contain extra fields.',
         ]);
+        $resolver->setAllowedTypes('legacy_error_messages', 'bool');
+        $resolver->setDeprecated('legacy_error_messages', 'symfony/form', '5.2', function (Options $options, $value) {
+            if ($value === true) {
+                return 'Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.';
+            }
+
+            return '';
+        });
 
         $resolver->setNormalizer('constraints', $constraintsNormalizer);
     }

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -25,9 +25,12 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class ValidatorExtension extends AbstractExtension
 {
     private $validator;
+    private $legacyErrorMessages;
 
-    public function __construct(ValidatorInterface $validator)
+    public function __construct(ValidatorInterface $validator, bool $legacyErrorMessages = true)
     {
+        $this->legacyErrorMessages = $legacyErrorMessages;
+
         $metadata = $validator->getMetadataFor('Symfony\Component\Form\Form');
 
         // Register the form constraints in the validator programmatically.
@@ -50,7 +53,7 @@ class ValidatorExtension extends AbstractExtension
     protected function loadTypeExtensions()
     {
         return [
-            new Type\FormTypeValidatorExtension($this->validator),
+            new Type\FormTypeValidatorExtension($this->validator, $this->legacyErrorMessages),
             new Type\RepeatedTypeValidatorExtension(),
             new Type\SubmitTypeValidatorExtension(),
         ];

--- a/src/Symfony/Component/Form/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.en.xlf
@@ -18,6 +18,102 @@
                 <source>This value is not a valid HTML5 color.</source>
                 <target>This value is not a valid HTML5 color.</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Please enter a valid birthdate.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>The selected choice is invalid.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>The collection is invalid.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Please select a valid color.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Please select a valid country.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Please select a valid currency.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Please choose a valid date interval.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Please enter a valid date and time.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Please enter a valid date.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Please select a valid file.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>The hidden field is invalid.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Please enter an integer.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Please select a valid language.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Please select a valid locale.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Please enter a valid money amount.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Please enter a number.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>The password is invalid.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Please enter a percentage value.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>The values do not match.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Please enter a valid time.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Please select a valid timezone.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Please enter a valid URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Please enter a valid search term.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Please provide a valid phone number.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -39,6 +39,6 @@ trait ValidatorExtensionTrait
         $this->validator->expects($this->any())->method('getMetadataFor')->will($this->returnValue($metadata));
         $this->validator->expects($this->any())->method('validate')->will($this->returnValue(new ConstraintViolationList()));
 
-        return new ValidatorExtension($this->validator);
+        return new ValidatorExtension($this->validator, false);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
@@ -23,7 +23,7 @@ class FormValidatorPerformanceTest extends FormPerformanceTestCase
     protected function getExtensions()
     {
         return [
-            new ValidatorExtension(Validation::createValidator()),
+            new ValidatorExtension(Validation::createValidator(), false),
         ];
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BirthdayTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BirthdayTypeValidatorExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class BirthdayTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(BirthdayType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a valid birthdate.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CheckboxTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CheckboxTypeValidatorExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class CheckboxTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(CheckboxType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('The checkbox has an invalid value.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ChoiceTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ChoiceTypeValidatorExtensionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class ChoiceTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(ChoiceType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('The selected choice is invalid.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CollectionTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CollectionTypeValidatorExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class CollectionTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(CollectionType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('The collection is invalid.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ColorTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ColorTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\ColorType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class ColorTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(ColorType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please select a valid color.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CountryTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CountryTypeValidatorExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CountryType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class CountryTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(CountryType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please select a valid country.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CurrencyTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CurrencyTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class CurrencyTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(CurrencyType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please select a valid currency.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateIntervalTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateIntervalTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class DateIntervalTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(DateIntervalType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please choose a valid date interval.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTimeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTimeTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class DateTimeTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(DateTimeType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a valid date and time.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class DateTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(DateType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a valid date.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/EmailTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/EmailTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class EmailTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(EmailType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a valid email address.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FileTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FileTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class FileTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(FileType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please select a valid file.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Forms;
@@ -29,6 +30,7 @@ use Symfony\Component\Validator\Validation;
 
 class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 {
+    use ExpectDeprecationTrait;
     use ValidatorExtensionTrait;
 
     public function testSubmitValidatesData()
@@ -62,7 +64,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
     public function testGroupSequenceWithConstraintsOption()
     {
         $form = Forms::createFormFactoryBuilder()
-            ->addExtension(new ValidatorExtension(Validation::createValidator()))
+            ->addExtension(new ValidatorExtension(Validation::createValidator(), false))
             ->getFormFactory()
             ->create(FormTypeTest::TESTED_TYPE, null, (['validation_groups' => new GroupSequence(['First', 'Second'])]))
             ->add('field', TextTypeTest::TESTED_TYPE, [
@@ -131,6 +133,25 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
         $this->assertCount(1, $errors);
         $this->assertInstanceOf(Length::class, $errors[0]->getCause()->getConstraint());
         $this->assertSame('children[lastName].data', $errors[0]->getCause()->getPropertyPath());
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertEquals('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array('legacy_error_messages' => true));
+
+        $this->assertEquals('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
     }
 
     protected function createForm(array $options = [])

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/HiddenTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/HiddenTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class HiddenTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(HiddenType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('The hidden field is invalid.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/IntegerTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/IntegerTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class IntegerTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(IntegerType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter an integer.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LanguageTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LanguageTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\LanguageType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class LanguageTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(LanguageType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please select a valid language.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LocaleTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LocaleTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class LocaleTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(LocaleType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please select a valid locale.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/MoneyTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/MoneyTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class MoneyTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(MoneyType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a valid money amount.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/NumberTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/NumberTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class NumberTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(NumberType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a number.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PasswordTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PasswordTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class PasswordTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(PasswordType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('The password is invalid.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PercentTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PercentTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\PercentType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class PercentTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(PercentType::class, null, $options + ['rounding_mode' => \NumberFormatter::ROUND_CEILING]);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a percentage value.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RadioTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RadioTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\RadioType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class RadioTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(RadioType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please select a valid option.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RangeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RangeTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\RangeType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class RangeTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(RangeType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please choose a valid range.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RepeatedTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RepeatedTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class RepeatedTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(RepeatedType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('The values do not match.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SearchTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SearchTypeValidatorExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\SearchType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class SearchTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(SearchType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a valid search term.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TelTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TelTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TelType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class TelTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(TelType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please provide a valid phone number.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimeTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class TimeTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(TimeType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a valid time.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimezoneTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimezoneTypeValidatorExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class TimezoneTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(TimezoneType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please select a valid timezone.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+
+class UrlTypeValidatorExtensionTest extends BaseValidatorExtensionTest
+{
+    use ExpectDeprecationTrait;
+    use ValidatorExtensionTrait;
+
+    protected function createForm(array $options = array())
+    {
+        return $this->factory->create(UrlType::class, null, $options);
+    }
+
+    public function testInvalidMessage()
+    {
+        $form = $this->createForm();
+
+        $this->assertSame('Please enter a valid URL.', $form->getConfig()->getOption('invalid_message'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidMessage()
+    {
+        $this->expectDeprecation('Since symfony/form 5.2: Setting the "legacy_error_messages" option to "true" is deprecated. It will be disabled in Symfony 6.0.');
+
+        $form = $this->createForm(array(
+            'legacy_error_messages' => true,
+        ));
+
+        $this->assertSame('This value is not valid.', $form->getConfig()->getOption('invalid_message'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -35,7 +35,7 @@ class ValidatorExtensionTest extends TestCase
             ->setMetadataFactory($metadataFactory)
             ->getValidator();
 
-        $extension = new ValidatorExtension($validator);
+        $extension = new ValidatorExtension($validator, false);
 
         $this->assertInstanceOf(ValidatorTypeGuesser::class, $extension->loadTypeGuesser());
 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -23,6 +23,7 @@
                 "data_class",
                 "empty_data",
                 "error_bubbling",
+                "invalid_message",
                 "trim"
             ]
         },
@@ -43,6 +44,7 @@
                 "help_html",
                 "help_translation_parameters",
                 "inherit_data",
+                "invalid_message_parameters",
                 "is_empty_callback",
                 "label",
                 "label_attr",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -11,8 +11,8 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   choice_loader               data_class           allow_file_upload              csrf_message           
   choice_name                 empty_data           attr                           csrf_protection        
   choice_translation_domain   error_bubbling       attr_translation_parameters    csrf_token_id          
-  choice_value                trim                 auto_initialize                csrf_token_manager     
-  choices                                          block_name                                            
+  choice_value                invalid_message      auto_initialize                csrf_token_manager     
+  choices                     trim                 block_name                                            
   expanded                                         block_prefix                                          
   group_by                                         by_reference                                          
   multiple                                         data                                                  
@@ -22,6 +22,7 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
                                                    help_html                                             
                                                    help_translation_parameters                           
                                                    inherit_data                                          
+                                                   invalid_message_parameters                            
                                                    is_empty_callback                                     
                                                    label                                                 
                                                    label_attr                                            

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
@@ -22,6 +22,8 @@
             "help_html",
             "help_translation_parameters",
             "inherit_data",
+            "invalid_message",
+            "invalid_message_parameters",
             "is_empty_callback",
             "label",
             "label_attr",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
@@ -24,6 +24,8 @@ Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")
   help_html                     
   help_translation_parameters   
   inherit_data                  
+  invalid_message               
+  invalid_message_parameters    
   is_empty_callback             
   label                         
   label_attr                    


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #27142, #5946
| License       | MIT
| Doc PR        | TODO

This merge request is a continuation of https://github.com/symfony/symfony/pull/27142.

Changes done here:

* rebased on master
* made the error messages friendlier