### PR TITLE
[Routing][ObjectRouteLoader] Allow invokable route loader services

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * deprecated implementing `Serializable` for `Route` and `CompiledRoute`; if you serialize them, please
    ensure your unserialization logic can recover from a failure related to an updated serialization format
  * exposed `utf8` Route option, defaults "locale" and "format" in configuration loaders and configurators
+ * added support for invokable route loader services
 
 4.2.0
 -----

--- a/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
@@ -37,25 +37,25 @@ abstract class ObjectRouteLoader extends Loader
     /**
      * Calls the service that will load the routes.
      *
-     * @param mixed       $resource Some value that will resolve to a callable
+     * @param string      $resource Some value that will resolve to a callable
      * @param string|null $type     The resource type
      *
      * @return RouteCollection
      */
     public function load($resource, $type = null)
     {
+        if (!preg_match('/^[^\:]+(?:::?(?:[^\:]+))?$/', $resource)) {
+            throw new \InvalidArgumentException(sprintf('Invalid resource "%s" passed to the "service" route loader: use the format "service::method" or "service" if your service has an "__invoke" method.', $resource));
+        }
+
         if (1 === substr_count($resource, ':')) {
             $resource = str_replace(':', '::', $resource);
             @trigger_error(sprintf('Referencing service route loaders with a single colon is deprecated since Symfony 4.1. Use %s instead.', $resource), E_USER_DEPRECATED);
         }
 
         $parts = explode('::', $resource);
-        if (2 != \count($parts)) {
-            throw new \InvalidArgumentException(sprintf('Invalid resource "%s" passed to the "service" route loader: use the format "service::method"', $resource));
-        }
-
         $serviceString = $parts[0];
-        $method = $parts[1];
+        $method = $parts[1] ?? '__invoke';
 
         $loaderObject = $this->getServiceObject($serviceString);
 

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
@@ -70,7 +70,7 @@ class ObjectRouteLoaderTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @dataProvider getBadResourceStrings
      */
-    public function testExceptionWithoutSyntax($resourceString)
+    public function testExceptionWithoutSyntax(string $resourceString): void
     {
         $loader = new ObjectRouteLoaderForTest();
         $loader->load($resourceString);
@@ -79,8 +79,12 @@ class ObjectRouteLoaderTest extends TestCase
     public function getBadResourceStrings()
     {
         return [
-            ['Foo'],
             ['Foo:Bar:baz'],
+            ['Foo::Bar::baz'],
+            ['Foo:'],
+            ['Foo::'],
+            [':Foo'],
+            ['::Foo'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11333

#eufossa

Fall back by default on the `__invoke` method when it is not configured.

Using a regex is easier to check that the format is valid, at least for the time we have to supports the single column notation.

TODO :
- [x] Changelog entry
- [x] Doc PR