### PR TITLE
[Serializer] add return type hints for ObjectPropertyListExtractorInterface

### DIFF
--- a/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
+++ b/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
@@ -30,7 +30,7 @@ class ObjectPropertyListExtractor implements ObjectPropertyListExtractorInterfac
     /**
      * {@inheritdoc}
      */
-    public function getProperties($object, array $context = [])
+    public function getProperties($object, array $context = []): ?array
     {
         $class = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
 

--- a/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractorInterface.php
+++ b/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractorInterface.php
@@ -20,9 +20,8 @@ interface ObjectPropertyListExtractorInterface
      * Gets the list of properties available for the given object.
      *
      * @param object $object
-     * @param array  $context
      *
      * @return string[]|null
      */
-    public function getProperties($object, array $context = []);
+    public function getProperties($object, array $context = []): ?array;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no   
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

@nicolas-grekas as just discussed here the type-hint + phpdoc cleanup as follow-up for https://github.com/symfony/symfony/pull/30904 :wink: 

cc @joelwurtz 