### PR TITLE
Use env variable to create anytype of lock store

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Traits\RedisProxy;
+use Symfony\Component\Lock\Store\FlockStore;
+use Symfony\Component\Lock\Store\MemcachedStore;
+use Symfony\Component\Lock\Store\RedisStore;
+use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Component\Lock\Store\StoreFactory;
+use Symfony\Component\Lock\Store\ZookeeperStore;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class StoreFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider validConnections
+     */
+    public function testCreateStore($connection, string $expectedStoreClass)
+    {
+        $store = StoreFactory::createStore($connection);
+
+        $this->assertInstanceOf($expectedStoreClass, $store);
+    }
+
+    public function validConnections()
+    {
+        if (\class_exists(\Redis::class)) {
+            yield [$this->createMock(\Redis::class), RedisStore::class];
+        }
+        yield [$this->createMock(RedisProxy::class), RedisStore::class];
+        yield [$this->createMock(\Predis\Client::class), RedisStore::class];
+        if (\class_exists(\Memcached::class)) {
+            yield [$this->createMock(\Memcached::class), MemcachedStore::class];
+        }
+        if (\class_exists(\Zookeeper::class)) {
+            yield [$this->createMock(\Zookeeper::class), ZookeeperStore::class];
+        }
+        yield ['flock', FlockStore::class];
+        yield ['flock:///tmp', FlockStore::class];
+        yield ['semaphore', SemaphoreStore::class];
+        if (\class_exists(\Memcached::class)) {
+            yield ['memcached://server.com', MemcachedStore::class];
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27555
| License       | MIT
| Doc PR        | NA

In lock configuration, at the moment, env variable are only able to resolve DNS which are able to create RedisStore and MemcachedStore.

This PR update the StoreFactory to be able to also create connection at runtime.