### PR TITLE
[Messenger] DoctrineTransport - Use InvalidArgumentException instead of TransportException during configuration checks

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -213,7 +213,7 @@ class ConnectionTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Messenger\Exception\TransportException
+     * @expectedException \Symfony\Component\Messenger\Exception\InvalidArgumentException
      */
     public function testItThrowsAnExceptionIfAnExtraOptionsInDefined()
     {
@@ -221,7 +221,7 @@ class ConnectionTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Messenger\Exception\TransportException
+     * @expectedException \Symfony\Component\Messenger\Exception\InvalidArgumentException
      */
     public function testItThrowsAnExceptionIfAnExtraOptionsInDefinedInDSN()
     {

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -87,13 +87,13 @@ class Connection
         // check for extra keys in options
         $optionsExtraKeys = array_diff(array_keys($options), array_keys($configuration));
         if (0 < \count($optionsExtraKeys)) {
-            throw new TransportException(sprintf('Unknown option found : [%s]. Allowed options are [%s]', implode(', ', $optionsExtraKeys), implode(', ', self::DEFAULT_OPTIONS)));
+            throw new InvalidArgumentException(sprintf('Unknown option found : [%s]. Allowed options are [%s]', implode(', ', $optionsExtraKeys), implode(', ', self::DEFAULT_OPTIONS)));
         }
 
         // check for extra keys in options
         $queryExtraKeys = array_diff(array_keys($query), array_keys($configuration));
         if (0 < \count($queryExtraKeys)) {
-            throw new TransportException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s]', implode(', ', $queryExtraKeys), implode(', ', self::DEFAULT_OPTIONS)));
+            throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s]', implode(', ', $queryExtraKeys), implode(', ', self::DEFAULT_OPTIONS)));
         }
 
         return $configuration;


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | 

As discussed with @weaverryan the exceptions thrown during the check of the configuration must be InvalidArgumentException instead of TransportException.
