### PR TITLE
[Serializer] Also validate callbacks when given in the normalizer context

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -99,10 +99,14 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         $this->nameConverter = $nameConverter;
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
 
-        if (\is_array($this->defaultContext[self::CALLBACKS] ?? null)) {
+        if (isset($this->defaultContext[self::CALLBACKS])) {
+            if (!\is_array($this->defaultContext[self::CALLBACKS])) {
+                throw new InvalidArgumentException(sprintf('The "%s" default context option must be an array of callables.', self::CALLBACKS));
+            }
+
             foreach ($this->defaultContext[self::CALLBACKS] as $attribute => $callback) {
                 if (!\is_callable($callback)) {
-                    throw new InvalidArgumentException(sprintf('The given callback for attribute "%s" is not callable.', $attribute));
+                    throw new InvalidArgumentException(sprintf('Invalid callback found for attribute "%s" in the "%s" default context option.', $attribute, self::CALLBACKS));
                 }
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -815,7 +815,11 @@ class ObjectNormalizerTest extends TestCase
                 $this->normalizer->setMaxDepthHandler($handler);
             }
         } else {
-            $this->createNormalizer([ObjectNormalizer::MAX_DEPTH_HANDLER => $handler], $classMetadataFactory);
+            $context = [];
+            if (null !== $handler) {
+                $context[ObjectNormalizer::MAX_DEPTH_HANDLER] = $handler;
+            }
+            $this->createNormalizer($context, $classMetadataFactory);
         }
         $this->serializer = new Serializer([$this->normalizer]);
         $this->normalizer->setSerializer($this->serializer);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 (callbacks are handled differently in 3.4)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (unless somebody relied on this bug ignoring `null` as callback 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Related to #30888
| License       | MIT
| Doc PR        | -

callbacks configuration for the normalizer is validated to be valid callbacks when using setCallbacks or using the callbacks field in the default options. however, it was not validated when using the callbacks field in a context passed to `normalize()`