### PR TITLE
Handle case where no translations were found

### DIFF
--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -159,6 +159,11 @@ function printTitle($title)
 
 function printTable($translations, $verboseOutput)
 {
+    if (0 === count($translations)) {
+        echo 'No translations found';
+
+        return;
+    }
     $longestLocaleNameLength = max(array_map('strlen', array_keys($translations)));
 
     foreach ($translations as $locale => $translation) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Right now, the program emits a warning when trying to use max() on an
empty array.