### PR TITLE
[Security] Add authentication success sensitive event to authentication provider manager (rebase #26050)

### DIFF
--- a/src/Symfony/Component/Security/Core/AuthenticationEvents.php
+++ b/src/Symfony/Component/Security/Core/AuthenticationEvents.php
@@ -14,8 +14,31 @@ namespace Symfony\Component\Security\Core;
 final class AuthenticationEvents
 {
     /**
+     * The AUTHENTICATION_SUCCESS_SENSITIVE event occurs after a user is
+     * authenticated by one provider. It is dispatched immediately *prior* to
+     * the companion AUTHENTICATION_SUCCESS event.
+     *
+     * This event *does* contain user credentials and other sensitive data. This
+     * enables rehashing and other credentials-aware actions. Listeners and
+     * subscribers of this event carry the added responsibility of passing
+     * around sensitive data and usage should be limited to cases where this
+     * extra information is explicitly utilized; otherwise, use the
+     * AUTHENTICATION_SUCCESS event instead.
+     *
+     * @Event("Symfony\Component\Security\Core\Event\AuthenticationSensitiveEvent")
+     */
+    const AUTHENTICATION_SUCCESS_SENSITIVE = 'security.authentication.success_sensitive';
+
+    /**
      * The AUTHENTICATION_SUCCESS event occurs after a user is authenticated
-     * by one provider.
+     * by one provider. It is dispatched immediately *after* the companion
+     * AUTHENTICATION_SUCCESS_SENSITIVE event.
+     *
+     * This event does *not* contain user credentials and other sensitive data
+     * by default. Listeners and subscribers of this event are shielded from
+     * the added responsibility of passing around sensitive data and this event
+     * should be used unless such extra information is required; use the
+     * AUTHENTICATION_SUCCESS_SENSITIVE event instead if this is the case.
      *
      * @Event("Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent")
      */

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationEvent.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This is a general purpose authentication event.

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationEvent.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationSensitiveEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationSensitiveEvent.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * This is an authentication event that includes sensitive data.
+ *
+ * @author Rob Frawley 2nd <rmf@src.run>
+ */
+class AuthenticationSensitiveEvent extends Event
+{
+    private $preAuthenticationToken;
+    private $authenticationToken;
+    private $authenticationProviderClassName;
+
+    public function __construct(TokenInterface $preAuthenticationToken, TokenInterface $authenticationToken, ?string $authenticationProviderClassName = null)
+    {
+        $this->preAuthenticationToken = $preAuthenticationToken;
+        $this->authenticationToken = $authenticationToken;
+        $this->authenticationProviderClassName = $authenticationProviderClassName;
+    }
+
+    public function getPreAuthenticationToken(): TokenInterface
+    {
+        return $this->preAuthenticationToken;
+    }
+
+    public function getAuthenticationToken(): TokenInterface
+    {
+        return $this->authenticationToken;
+    }
+
+    public function getAuthenticationProviderClassName(): ?string
+    {
+        return $this->authenticationProviderClassName;
+    }
+
+    /**
+     * Tries to extract the credentials password, first from the post-auth token and second from the pre-auth token.
+     * It uses either a custom extraction closure (optionally passed as its first and only argument) or the default
+     * extraction implementation. The default extractor fetches the token's credentials and directly returns it if
+     * the value is a scalar or object that implements a "__toString()" method. If the credentials val is an array
+     * the first "password", "api_key", "api-key", or "secret" index value (that exists and is non-false after being
+     * cast to a sting using the prior described method) is returned. Lastly, if none of the previous conditions are
+     * met, "null" is returned.
+     *
+     * @param \Closure|null $extractor An optional custom token credentials password extraction \Closure that is
+     *                                 provided an auth token (as an instance of TokenInterface) and an auth event
+     *                                 (as an instance of AuthenticationSensitiveEvent). This closure is called
+     *                                 first with the final-auth token and second with the pre-auth token, returning
+     *                                 early if a non-null/non-empty scalar/castable-object value is returned.
+     *
+     * @return string|null Either a credentials password/secret/auth_key is returned or null on extraction failure
+     */
+    public function getAuthenticationTokenPassword(?\Closure $extractor = null): ?string
+    {
+        $extractor = $extractor ?? function (TokenInterface $token): ?string {
+            return $this->tryCoercibleCredentialsPasswordToString($credentials = $token->getCredentials())
+                ?: $this->tryArrayFindCredentialsPasswordToString($credentials);
+        };
+
+        return ($extractor($this->authenticationToken, $this) ?: null)
+            ?: ($extractor($this->preAuthenticationToken, $this) ?: null);
+    }
+
+    private function tryCoercibleCredentialsPasswordToString($credentials): ?string
+    {
+        return is_scalar($credentials) || method_exists($credentials, '__toString')
+            ? $credentials
+            : null;
+    }
+
+    private function tryArrayFindCredentialsPasswordToString($credentials): ?string
+    {
+        if (\is_array($credentials)) {
+            foreach (['password', 'api_key', 'api-key', 'secret'] as $index) {
+                if ($c = $this->tryCoercibleCredentialsPasswordToString($credentials[$index] ?? null)) {
+                    return $c;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationSensitiveEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationSensitiveEvent.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationSensitiveEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationSensitiveEvent.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This is an authentication event that includes sensitive data.

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Core\Tests\Authentication;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\WrappedEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -192,22 +191,22 @@ class AuthenticationProviderManagerTest extends TestCase
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addListener(AuthenticationEvents::AUTHENTICATION_SUCCESS_SENSITIVE, function ($event) use ($providerCN) {
-            if (\get_class($event) === 'Symfony\Component\EventDispatcher\WrappedEvent') {
+            if ('Symfony\Component\EventDispatcher\WrappedEvent' === \get_class($event)) {
                 $event = $event->getWrappedEvent();
             }
 
-            /** @var AuthenticationSensitiveEvent $event */
+            /* @var AuthenticationSensitiveEvent $event */
             $this->assertSame($providerCN, $event->getAuthenticationProviderClassName());
             $this->assertSame('bar', $event->getAuthenticationTokenPassword());
             $this->assertEquals('bar', $event->getPreAuthenticationToken()->getCredentials());
             $this->assertEquals('bar', $event->getAuthenticationToken()->getCredentials());
         });
         $dispatcher->addListener(AuthenticationEvents::AUTHENTICATION_SUCCESS, function ($event) {
-            if (\get_class($event) === 'Symfony\Component\EventDispatcher\WrappedEvent') {
+            if ('Symfony\Component\EventDispatcher\WrappedEvent' === \get_class($event)) {
                 $event = $event->getWrappedEvent();
             }
 
-            /** @var AuthenticationSuccessEvent $event */
+            /* @var AuthenticationSuccessEvent $event */
             $this->assertEquals('', $event->getAuthenticationToken()->getCredentials());
         });
 

--- a/src/Symfony/Component/Security/Core/Tests/Event/AuthenticationSensitiveEventTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Event/AuthenticationSensitiveEventTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authentication;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Event\AuthenticationSensitiveEvent;
+
+class AuthenticationSensitiveEventTest extends TestCase
+{
+    public static function provideTestAccessorMethodsData(): \Iterator
+    {
+        $createPassExtractorFunc = function ($default = null) {
+            return function ($token, $event) use ($default): ?string {
+                self::assertInstanceOf(TokenInterface::class, $token);
+                self::assertInstanceOf(AuthenticationSensitiveEvent::class, $event);
+
+                $c = $token->getCredentials();
+
+                if (method_exists($c, 'getInnerCredentials')) {
+                    return $c->getInnerCredentials();
+                }
+
+                if ($c instanceof \Closure) {
+                    return ($c)();
+                }
+
+                if (isset($c[$k = sprintf('%s-key', $default)])) {
+                    return $c[$k];
+                }
+
+                return $default;
+            };
+        };
+
+        $createHasStrCastableClass = function (?string $return = null) {
+            return new class($return) {
+                private $return;
+
+                public function __construct(?string $return = null)
+                {
+                    $this->return = $return;
+                }
+
+                public function __toString(): string
+                {
+                    return $this->return ?? '';
+                }
+            };
+        };
+
+        $createNotStrCastableClass = function (?string $return = null) {
+            return new class($return) {
+                private $return;
+
+                public function __construct(?string $return = null)
+                {
+                    $this->return = $return;
+                }
+
+                public function getInnerCredentials(): string
+                {
+                    return $this->return ?? '';
+                }
+            };
+        };
+
+        $createCredentialsAFuncVal = function ($return = null) {
+            return function () use ($return) {
+                return $return;
+            };
+        };
+
+        // expects credential password of "null" type
+        yield [null];
+        yield [null, $createHasStrCastableClass('')];
+        yield [null, $createNotStrCastableClass('foo')];
+        yield [null, ['unknown-index-foo' => 'foo']];
+        yield [null, null, $createHasStrCastableClass('')];
+        yield [null, null, $createNotStrCastableClass('foo')];
+        yield [null, null, ['unknown-index-bar' => 'bar']];
+        yield [null, null, null, $createPassExtractorFunc(null)];
+
+        // expects credential password of "foo" value
+        yield ['foo', 'foo'];
+        yield ['foo', 'foo', 'bar'];
+        yield ['foo', $createHasStrCastableClass('foo')];
+        yield ['foo', $createNotStrCastableClass('foo'), null, $createPassExtractorFunc()];
+        yield ['foo', $createCredentialsAFuncVal('foo'), null, $createPassExtractorFunc()];
+
+        // expects credential password of "bar" value
+        yield ['bar', null, 'bar'];
+        yield ['bar', null, $createHasStrCastableClass('bar')];
+        yield ['bar', null, $createNotStrCastableClass('bar'), $createPassExtractorFunc()];
+        yield ['bar', null, $createCredentialsAFuncVal('bar'), $createPassExtractorFunc()];
+
+        // expects credential password of "baz" value
+        yield ['baz', null, null, $createPassExtractorFunc('baz')];
+
+        // expects array value will be extracted for all supported indexes
+        foreach (['password', 'api_key', 'api-key', 'secret'] as $index) {
+            // expects credential password of "null" type
+            yield [null, [$index => null]];
+            yield [null, null, [$index => '']];
+            yield [null, [$index => ''], [$index => null]];
+
+            // expects credential password of "foo" value
+            yield ['foo', [$index => 'foo']];
+            yield ['foo', [$index => 'foo'], [$index => null]];
+            yield ['foo', [$index => 'foo'], [$index => '']];
+            yield ['foo', [$index => 'foo'], ['unknown-index-bar' => 'bar']];
+            yield ['foo', [$index => 'foo'], [$index => 'bar']];
+
+            // expects credential password of "bar" value
+            yield ['bar', null, [$index => 'bar']];
+            yield ['bar', [$index => null], [$index => 'bar']];
+            yield ['bar', [$index => ''], [$index => 'bar']];
+            yield ['bar', ['unknown-index-foo' => 'foo'], [$index => 'bar']];
+            yield ['bar', [$index => $createNotStrCastableClass], [$index => 'bar']];
+
+            // expects credential password of "{$index}-val" variable
+            yield [
+                sprintf('%s-val', $index),
+                [sprintf('%s-key', $index) => sprintf('%s-val', $index)],
+                null,
+                $createPassExtractorFunc($index),
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider provideTestAccessorMethodsData
+     *
+     * @param string            $expectedPassword
+     * @param string|array|null $finalCredentials
+     * @param string|array|null $priorCredentials
+     * @param \Closure|null     $passwordExtractor
+     */
+    public function testAccessorMethods(string $expectedPassword = null, $finalCredentials = null, $priorCredentials = null, \Closure $passwordExtractor = null): void
+    {
+        $event = new AuthenticationSensitiveEvent(
+            $priorToken = $this->getTokenInterfaceMock($priorCredentials),
+            $finalToken = $this->getTokenInterfaceMock($finalCredentials),
+            AuthenticationProviderInterface::class
+        );
+
+        $this->assertSame($priorToken, $event->getPreAuthenticationToken());
+        $this->assertSame($finalToken, $event->getAuthenticationToken());
+        $this->assertSame(AuthenticationProviderInterface::class, $event->getAuthenticationProviderClassName());
+        $this->assertSame($expectedPassword, $event->getAuthenticationTokenPassword($passwordExtractor));
+    }
+
+    private function getTokenInterfaceMock($credentials = null): TokenInterface
+    {
+        $token = $this
+            ->getMockBuilder(TokenInterface::class)
+            ->getMock();
+
+        $token->expects($this->any())
+            ->method('getCredentials')
+            ->will($this->returnValue($credentials));
+
+        return $token;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26050 #18494
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11334

Rebased #26050 at EUFOSSA 

Thanks @robfrawley for the excellent work!