### PR TITLE
[Messenger] Allows to register handlers on a specific transport

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -81,6 +81,12 @@ CHANGELOG
  * Added a Doctrine transport. For example, use the `doctrine://default` DSN (this uses the `default` Doctrine entity manager)
  * [BC BREAK] The `getConnectionConfiguration` method on Amqp's `Connection` has been removed. 
  * [BC BREAK] A `HandlerFailedException` exception will be thrown if one or more handler fails.
+ * [BC BREAK] The `HandlersLocationInterface::getHandlers` method needs to return `HandlerDescriptor`
+   instances instead of callables.
+ * [BC BREAK] The `HandledStamp` stamp has changed: `handlerAlias` has been renamed to `handlerName`,
+   `getCallableName` has been removed and its constructor only has 2 arguments now.
+ * [BC BREAK] The `ReceivedStamp` needs to exposes the name of the transport from which the message
+   has been received.
 
 4.2.0
 -----

--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -84,7 +84,9 @@ EOF
             foreach ($handlersByMessage as $message => $handlers) {
                 $tableRows[] = [sprintf('<fg=cyan>%s</fg=cyan>', $message)];
                 foreach ($handlers as $handler) {
-                    $tableRows[] = [sprintf('    handled by <info>%s</>', $handler)];
+                    $tableRows[] = [
+                        sprintf('    handled by <info>%s</>', $handler[0]).$this->formatConditions($handler[1]),
+                    ];
                 }
             }
 
@@ -96,5 +98,19 @@ EOF
                 $io->warning(sprintf('No handled message found in bus "%s".', $bus));
             }
         }
+    }
+
+    private function formatConditions(array $options): string
+    {
+        if (!$options) {
+            return '';
+        }
+
+        $optionsMapping = [];
+        foreach ($options as $key => $value) {
+            $optionsMapping[] = ' '.$key.'='.$value;
+        }
+
+        return ' (when'.implode(', ', $optionsMapping).')';
     }
 }

--- a/src/Symfony/Component/Messenger/HandleTrait.php
+++ b/src/Symfony/Component/Messenger/HandleTrait.php
@@ -52,7 +52,7 @@ trait HandleTrait
 
         if (\count($handledStamps) > 1) {
             $handlers = implode(', ', array_map(function (HandledStamp $stamp): string {
-                return sprintf('"%s"', $stamp->getHandlerAlias() ?? $stamp->getCallableName());
+                return sprintf('"%s"', $stamp->getHandlerName());
             }, $handledStamps));
 
             throw new LogicException(sprintf('Message of type "%s" was handled multiple times. Only one handler is expected when using "%s::%s()", got %d: %s.', \get_class($envelope->getMessage()), \get_class($this), __FUNCTION__, \count($handledStamps), $handlers));

--- a/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+/**
+ * Describes a handler and the possible associated options, such as `from_transport`, `bus`, etc.
+ *
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ *
+ * @experimental in 4.3
+ */
+final class HandlerDescriptor
+{
+    private $handler;
+    private $options;
+
+    public function __construct(callable $handler, array $options = [])
+    {
+        $this->handler = $handler;
+        $this->options = $options;
+    }
+
+    public function getHandler(): callable
+    {
+        return $this->handler;
+    }
+
+    public function getName(): string
+    {
+        $name = $this->callableName($this->handler);
+        $alias = $this->options['alias'] ?? null;
+
+        if (null !== $alias) {
+            $name .= '@'.$alias;
+        }
+
+        return $name;
+    }
+
+    public function getOption(string $option)
+    {
+        return $this->options[$option] ?? null;
+    }
+
+    private function callableName(callable $handler)
+    {
+        if (\is_array($handler)) {
+            if (\is_object($handler[0])) {
+                return \get_class($handler[0]).'::'.$handler[1];
+            }
+
+            return $handler[0].'::'.$handler[1];
+        }
+
+        if (\is_string($handler)) {
+            return $handler;
+        }
+
+        if ($handler instanceof \Closure) {
+            $r = new \ReflectionFunction($handler);
+            if (false !== strpos($r->name, '{closure}')) {
+                return 'Closure';
+            }
+            if ($class = $r->getClosureScopeClass()) {
+                return $class->name.'::'.$r->name;
+            }
+
+            return $r->name;
+        }
+
+        return \get_class($handler).'::__invoke';
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/HandlersLocatorInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlersLocatorInterface.php
@@ -25,7 +25,7 @@ interface HandlersLocatorInterface
     /**
      * Returns the handlers for the given message name.
      *
-     * @return iterable|callable[] Indexed by handler alias if available
+     * @return iterable|HandlerDescriptor[] Indexed by handler alias if available
      */
     public function getHandlers(Envelope $envelope): iterable;
 }

--- a/src/Symfony/Component/Messenger/Stamp/HandledStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/HandledStamp.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+
 /**
  * Stamp identifying a message handled by the `HandleMessageMiddleware` middleware
  * and storing the handler returned value.
@@ -24,54 +26,23 @@ namespace Symfony\Component\Messenger\Stamp;
 final class HandledStamp implements StampInterface
 {
     private $result;
-    private $callableName;
-    private $handlerAlias;
+    private $handlerName;
 
     /**
      * @param mixed $result The returned value of the message handler
      */
-    public function __construct($result, string $callableName, string $handlerAlias = null)
+    public function __construct($result, string $handlerName)
     {
         $this->result = $result;
-        $this->callableName = $callableName;
-        $this->handlerAlias = $handlerAlias;
+        $this->handlerName = $handlerName;
     }
 
     /**
      * @param mixed $result The returned value of the message handler
      */
-    public static function fromCallable(callable $handler, $result, ?string $handlerAlias = null): self
+    public static function fromDescriptor(HandlerDescriptor $handler, $result): self
     {
-        return new self($result, self::getNameFromCallable($handler), $handlerAlias);
-    }
-
-    public static function getNameFromCallable(callable $handler): string
-    {
-        if (\is_array($handler)) {
-            if (\is_object($handler[0])) {
-                return \get_class($handler[0]).'::'.$handler[1];
-            }
-
-            return $handler[0].'::'.$handler[1];
-        }
-
-        if (\is_string($handler)) {
-            return $handler;
-        }
-
-        if ($handler instanceof \Closure) {
-            $r = new \ReflectionFunction($handler);
-            if (false !== strpos($r->name, '{closure}')) {
-                return 'Closure';
-            }
-            if ($class = $r->getClosureScopeClass()) {
-                return $class->name.'::'.$r->name;
-            }
-
-            return $r->name;
-        }
-
-        return \get_class($handler).'::__invoke';
+        return new self($result, $handler->getName());
     }
 
     /**
@@ -82,13 +53,8 @@ final class HandledStamp implements StampInterface
         return $this->result;
     }
 
-    public function getCallableName(): string
+    public function getHandlerName(): string
     {
-        return $this->callableName;
-    }
-
-    public function getHandlerAlias(): ?string
-    {
-        return $this->handlerAlias;
+        return $this->handlerName;
     }
 }

--- a/src/Symfony/Component/Messenger/Stamp/ReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ReceivedStamp.php
@@ -27,4 +27,15 @@ use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
  */
 final class ReceivedStamp implements StampInterface
 {
+    private $transportName;
+
+    public function __construct(string $transportName)
+    {
+        $this->transportName = $transportName;
+    }
+
+    public function getTransportName(): string
+    {
+        return $this->transportName;
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -40,12 +40,12 @@ class DebugCommandTest extends TestCase
     {
         $command = new DebugCommand([
             'command_bus' => [
-                DummyCommand::class => [DummyCommandHandler::class],
-                MultipleBusesMessage::class => [MultipleBusesMessageHandler::class],
+                DummyCommand::class => [[DummyCommandHandler::class, []]],
+                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, []]],
             ],
             'query_bus' => [
-                DummyQuery::class => [DummyQueryHandler::class],
-                MultipleBusesMessage::class => [MultipleBusesMessageHandler::class],
+                DummyQuery::class => [[DummyQueryHandler::class, []]],
+                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, []]],
             ],
         ]);
 

--- a/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
@@ -25,7 +25,7 @@ class EnvelopeTest extends TestCase
 {
     public function testConstruct()
     {
-        $receivedStamp = new ReceivedStamp();
+        $receivedStamp = new ReceivedStamp('transport');
         $envelope = new Envelope($dummy = new DummyMessage('dummy'), [$receivedStamp]);
 
         $this->assertSame($dummy, $envelope->getMessage());
@@ -37,12 +37,12 @@ class EnvelopeTest extends TestCase
     {
         $envelope = new Envelope(new DummyMessage('dummy'));
 
-        $this->assertNotSame($envelope, $envelope->with(new ReceivedStamp()));
+        $this->assertNotSame($envelope, $envelope->with(new ReceivedStamp('transport')));
     }
 
     public function testWithoutAll()
     {
-        $envelope = new Envelope(new DummyMessage('dummy'), [new ReceivedStamp(), new ReceivedStamp(), new DelayStamp(5000)]);
+        $envelope = new Envelope(new DummyMessage('dummy'), [new ReceivedStamp('transport1'), new ReceivedStamp('transport2'), new DelayStamp(5000)]);
 
         $envelope = $envelope->withoutAll(ReceivedStamp::class);
 
@@ -52,7 +52,7 @@ class EnvelopeTest extends TestCase
 
     public function testLast()
     {
-        $receivedStamp = new ReceivedStamp();
+        $receivedStamp = new ReceivedStamp('transport');
         $envelope = new Envelope($dummy = new DummyMessage('dummy'), [$receivedStamp]);
 
         $this->assertSame($receivedStamp, $envelope->last(ReceivedStamp::class));
@@ -62,7 +62,7 @@ class EnvelopeTest extends TestCase
     public function testAll()
     {
         $envelope = (new Envelope($dummy = new DummyMessage('dummy')))
-            ->with($receivedStamp = new ReceivedStamp())
+            ->with($receivedStamp = new ReceivedStamp('transport'))
             ->with($validationStamp = new ValidationStamp(['foo']))
         ;
 
@@ -76,7 +76,7 @@ class EnvelopeTest extends TestCase
     public function testWrapWithMessage()
     {
         $message = new \stdClass();
-        $stamp = new ReceivedStamp();
+        $stamp = new ReceivedStamp('transport');
         $envelope = Envelope::wrap($message, [$stamp]);
 
         $this->assertSame($message, $envelope->getMessage());
@@ -86,7 +86,7 @@ class EnvelopeTest extends TestCase
     public function testWrapWithEnvelope()
     {
         $envelope = new Envelope(new \stdClass(), [new DelayStamp(5)]);
-        $envelope = Envelope::wrap($envelope, [new ReceivedStamp()]);
+        $envelope = Envelope::wrap($envelope, [new ReceivedStamp('transport')]);
 
         $this->assertCount(1, $envelope->all(DelayStamp::class));
         $this->assertCount(1, $envelope->all(ReceivedStamp::class));

--- a/src/Symfony/Component/Messenger/Tests/HandleTraitTest.php
+++ b/src/Symfony/Component/Messenger/Tests/HandleTraitTest.php
@@ -65,7 +65,7 @@ class HandleTraitTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\Messenger\Exception\LogicException
-     * @expectedExceptionMessage Message of type "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage" was handled multiple times. Only one handler is expected when using "Symfony\Component\Messenger\Tests\TestQueryBus::handle()", got 2: "FirstDummyHandler::__invoke", "dummy_2".
+     * @expectedExceptionMessage Message of type "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage" was handled multiple times. Only one handler is expected when using "Symfony\Component\Messenger\Tests\TestQueryBus::handle()", got 2: "FirstDummyHandler::__invoke", "SecondDummyHandler::__invoke".
      */
     public function testHandleThrowsOnMultipleHandledStamps()
     {
@@ -74,7 +74,7 @@ class HandleTraitTest extends TestCase
 
         $query = new DummyMessage('Hello');
         $bus->expects($this->once())->method('dispatch')->willReturn(
-            new Envelope($query, [new HandledStamp('first_result', 'FirstDummyHandler::__invoke'), new HandledStamp('second_result', 'SecondDummyHandler::__invoke', 'dummy_2')])
+            new Envelope($query, [new HandledStamp('first_result', 'FirstDummyHandler::__invoke'), new HandledStamp('second_result', 'SecondDummyHandler::__invoke')])
         );
 
         $queryBus->query($query);

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandleDescriptorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandleDescriptorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
+
+class HandleDescriptorTest extends TestCase
+{
+    /**
+     * @dataProvider provideHandlers
+     */
+    public function testDescriptorNames(callable $handler, ?string $expectedHandlerString)
+    {
+        $descriptor = new HandlerDescriptor($handler);
+
+        $this->assertStringMatchesFormat($expectedHandlerString, $descriptor->getName());
+    }
+
+    public function provideHandlers()
+    {
+        yield [function () {}, 'Closure'];
+        yield ['var_dump', 'var_dump'];
+        yield [new DummyCommandHandler(), DummyCommandHandler::class.'::__invoke'];
+        yield [
+            [new DummyCommandHandlerWithSpecificMethod(), 'handle'],
+            DummyCommandHandlerWithSpecificMethod::class.'::handle',
+        ];
+        yield [\Closure::fromCallable(function () {}), 'Closure'];
+        yield [\Closure::fromCallable(new DummyCommandHandler()), DummyCommandHandler::class.'::__invoke'];
+        yield [\Closure::bind(\Closure::fromCallable(function () {}), new \stdClass()), 'Closure'];
+        yield [new class() {
+            public function __invoke()
+            {
+            }
+        }, 'class@anonymous%sHandleDescriptorTest.php%s::__invoke'];
+    }
+}
+
+class DummyCommandHandlerWithSpecificMethod
+{
+    public function handle(): void
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
@@ -13,18 +13,41 @@ namespace Symfony\Component\Messenger\Tests\Handler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
 class HandlersLocatorTest extends TestCase
 {
-    public function testItYieldsProvidedAliasAsKey()
+    public function testItYieldsHandlerDescriptors()
     {
         $handler = $this->createPartialMock(\stdClass::class, ['__invoke']);
         $locator = new HandlersLocator([
-            DummyMessage::class => ['dummy' => $handler],
+            DummyMessage::class => [$handler],
         ]);
 
-        $this->assertSame(['dummy' => $handler], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
+        $this->assertEquals([new HandlerDescriptor($handler)], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
+    }
+
+    public function testItReturnsOnlyHandlersMatchingTransport()
+    {
+        $firstHandler = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $secondHandler = $this->createPartialMock(\stdClass::class, ['__invoke']);
+
+        $locator = new HandlersLocator([
+            DummyMessage::class => [
+                $first = new HandlerDescriptor($firstHandler, ['alias' => 'one']),
+                new HandlerDescriptor($this->createPartialMock(\stdClass::class, ['__invoke']), ['from_transport' => 'ignored', 'alias' => 'two']),
+                $second = new HandlerDescriptor($secondHandler, ['from_transport' => 'transportName', 'alias' => 'three']),
+            ],
+        ]);
+
+        $this->assertEquals([
+            $first,
+            $second,
+        ], iterator_to_array($locator->getHandlers(
+            new Envelope(new DummyMessage('Body'), [new ReceivedStamp('transportName')])
+        )));
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/MessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/MessageBusTest.php
@@ -71,7 +71,7 @@ class MessageBusTest extends TestCase
     public function testThatAMiddlewareCanAddSomeStampsToTheEnvelope()
     {
         $message = new DummyMessage('Hello');
-        $envelope = new Envelope($message, [new ReceivedStamp()]);
+        $envelope = new Envelope($message, [new ReceivedStamp('transport')]);
         $envelopeWithAnotherStamp = $envelope->with(new AnEnvelopeStamp());
 
         $firstMiddleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
@@ -109,7 +109,7 @@ class MessageBusTest extends TestCase
     public function testThatAMiddlewareCanUpdateTheMessageWhileKeepingTheEnvelopeStamps()
     {
         $message = new DummyMessage('Hello');
-        $envelope = new Envelope($message, $stamps = [new ReceivedStamp()]);
+        $envelope = new Envelope($message, $stamps = [new ReceivedStamp('transport')]);
 
         $changedMessage = new DummyMessage('Changed');
         $expectedEnvelope = new Envelope($changedMessage, $stamps);

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\StackMiddleware;
@@ -79,28 +80,26 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         ];
 
         yield 'A stamp is added per handler' => [
-            ['first' => $first, 'second' => $second],
             [
-                new HandledStamp('first result', $firstClass.'::__invoke', 'first'),
-                new HandledStamp(null, $secondClass.'::__invoke', 'second'),
+                new HandlerDescriptor($first, ['alias' => 'first']),
+                new HandlerDescriptor($second, ['alias' => 'second']),
             ],
-            true,
-        ];
-
-        yield 'Yielded locator alias is used' => [
-            ['first_alias' => $first, $second],
             [
-                new HandledStamp('first result', $firstClass.'::__invoke', 'first_alias'),
-                new HandledStamp(null, $secondClass.'::__invoke'),
+                new HandledStamp('first result', $firstClass.'::__invoke@first'),
+                new HandledStamp(null, $secondClass.'::__invoke@second'),
             ],
             true,
         ];
 
         yield 'It tries all handlers' => [
-            ['first' => $first, 'failing' => $failing, 'second' => $second],
             [
-                new HandledStamp('first result', $firstClass.'::__invoke', 'first'),
-                new HandledStamp(null, $secondClass.'::__invoke', 'second'),
+                new HandlerDescriptor($first, ['alias' => 'first']),
+                new HandlerDescriptor($failing, ['alias' => 'failing']),
+                new HandlerDescriptor($second, ['alias' => 'second']),
+            ],
+            [
+                new HandledStamp('first result', $firstClass.'::__invoke@first'),
+                new HandledStamp(null, $secondClass.'::__invoke@second'),
             ],
             false,
         ];

--- a/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
@@ -195,7 +195,7 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
 
     public function testItSkipsReceivedMessages()
     {
-        $envelope = (new Envelope(new DummyMessage('Hey')))->with(new ReceivedStamp());
+        $envelope = (new Envelope(new DummyMessage('Hey')))->with(new ReceivedStamp('transport'));
 
         $sender = $this->getMockBuilder(SenderInterface::class)->getMock();
 

--- a/src/Symfony/Component/Messenger/Tests/RetryIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/RetryIntegrationTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
@@ -45,8 +46,8 @@ class RetryIntegrationTest extends TestCase
         $throwingHandler = new DummyMessageHandlerFailingFirstTimes(1);
         $handlerLocator = new HandlersLocator([
             DummyMessage::class => [
-                'handler' => $handler,
-                'throwing' => $throwingHandler,
+                new HandlerDescriptor($handler, ['alias' => 'first']),
+                new HandlerDescriptor($throwingHandler, ['alias' => 'throwing']),
             ],
         ]);
 

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -44,10 +44,15 @@ class WorkerTest extends TestCase
 
         $bus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
 
-        $bus->expects($this->at(0))->method('dispatch')->with($envelope = new Envelope($apiMessage, [new ReceivedStamp()]))->willReturn($envelope);
-        $bus->expects($this->at(1))->method('dispatch')->with($envelope = new Envelope($ipaMessage, [new ReceivedStamp()]))->willReturn($envelope);
+        $bus->expects($this->at(0))->method('dispatch')->with(
+            $envelope = new Envelope($apiMessage, [new ReceivedStamp('transport')])
+        )->willReturn($envelope);
 
-        $worker = new Worker([$receiver], $bus);
+        $bus->expects($this->at(1))->method('dispatch')->with(
+            $envelope = new Envelope($ipaMessage, [new ReceivedStamp('transport')])
+        )->willReturn($envelope);
+
+        $worker = new Worker(['transport' => $receiver], $bus);
         $worker->run([], function (?Envelope $envelope) use ($worker) {
             // stop after the messages finish
             if (null === $envelope) {
@@ -62,12 +67,12 @@ class WorkerTest extends TestCase
     {
         $envelope = new Envelope(new DummyMessage('API'));
         $receiver = new DummyReceiver([[$envelope]]);
-        $envelope = $envelope->with(new ReceivedStamp());
+        $envelope = $envelope->with(new ReceivedStamp('transport'));
 
         $bus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
         $bus->expects($this->at(0))->method('dispatch')->with($envelope)->willReturn($envelope);
 
-        $worker = new Worker([$receiver], $bus, []);
+        $worker = new Worker(['transport' => $receiver], $bus, []);
         $worker->run([], function (?Envelope $envelope) use ($worker) {
             // stop after the messages finish
             if (null === $envelope) {

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -44,7 +44,7 @@ class Worker implements WorkerInterface
     private $shouldStop = false;
 
     /**
-     * @param ReceiverInterface[]      $receivers       Where the key will be used as the string "identifier"
+     * @param ReceiverInterface[]      $receivers       Where the key is the transport name
      * @param RetryStrategyInterface[] $retryStrategies Retry strategies for each receiver (array keys must match)
      */
     public function __construct(array $receivers, MessageBusInterface $bus, $retryStrategies = [], EventDispatcherInterface $eventDispatcher = null, LoggerInterface $logger = null)
@@ -86,13 +86,13 @@ class Worker implements WorkerInterface
 
         while (false === $this->shouldStop) {
             $envelopeHandled = false;
-            foreach ($this->receivers as $receiverName => $receiver) {
+            foreach ($this->receivers as $transportName => $receiver) {
                 $envelopes = $receiver->get();
 
                 foreach ($envelopes as $envelope) {
                     $envelopeHandled = true;
 
-                    $this->handleMessage($envelope, $receiver, $receiverName, $this->retryStrategies[$receiverName] ?? null);
+                    $this->handleMessage($envelope, $receiver, $transportName, $this->retryStrategies[$transportName] ?? null);
                     $onHandled($envelope);
                 }
 
@@ -114,9 +114,9 @@ class Worker implements WorkerInterface
         $this->dispatchEvent(new WorkerStoppedEvent());
     }
 
-    private function handleMessage(Envelope $envelope, ReceiverInterface $receiver, string $receiverName, ?RetryStrategyInterface $retryStrategy)
+    private function handleMessage(Envelope $envelope, ReceiverInterface $receiver, string $transportName, ?RetryStrategyInterface $retryStrategy)
     {
-        $this->dispatchEvent(new WorkerMessageReceivedEvent($envelope, $receiverName));
+        $this->dispatchEvent(new WorkerMessageReceivedEvent($envelope, $transportName));
 
         $message = $envelope->getMessage();
         $context = [
@@ -125,7 +125,7 @@ class Worker implements WorkerInterface
         ];
 
         try {
-            $envelope = $this->bus->dispatch($envelope->with(new ReceivedStamp()));
+            $envelope = $this->bus->dispatch($envelope->with(new ReceivedStamp($transportName)));
         } catch (\Throwable $throwable) {
             if ($throwable instanceof HandlerFailedException) {
                 $envelope = $throwable->getEnvelope();
@@ -133,7 +133,7 @@ class Worker implements WorkerInterface
 
             $shouldRetry = $this->shouldRetry($throwable, $envelope, $retryStrategy);
 
-            $this->dispatchEvent(new WorkerMessageFailedEvent($envelope, $receiverName, $throwable, $shouldRetry));
+            $this->dispatchEvent(new WorkerMessageFailedEvent($envelope, $transportName, $throwable, $shouldRetry));
 
             if ($shouldRetry) {
                 if (null === $retryStrategy) {
@@ -166,7 +166,7 @@ class Worker implements WorkerInterface
             return;
         }
 
-        $this->dispatchEvent(new WorkerMessageHandledEvent($envelope, $receiverName));
+        $this->dispatchEvent(new WorkerMessageHandledEvent($envelope, $transportName));
 
         if (null !== $this->logger) {
             $this->logger->info('{class} was handled successfully (acknowledging to transport).', $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30110
| License       | MIT
| Doc PR        | symfony/symfony-docs#11236

With the #30008 pull-request in, we can now do the following:
```yaml
framework:
    messenger:
        transports:
            events:
                dsn: amqp://guest:guest@127.0.0.1/%2f/events
                options:
                    queues:
                        3rdparty:
                            binding_keys: [ 3rdparty ]
                        projection:
                            binding_keys: [ projection ]

            events_3rdparty: amqp://guest:guest@127.0.0.1/%2f/events?queues[3rdparty]
            events_projection: amqp://guest:guest@127.0.0.1/%2f/events?queues[projection]

        routing:
            'App\Message\RegisterBet': events
``` 

This will bind two queues to the `events` exchange, fantastic:
<img width="325" alt="Screenshot 2019-04-07 at 10 26 27" src="https://user-images.githubusercontent.com/804625/55680861-af373580-591f-11e9-8f1e-2d3b6ddba2fd.png">

---

Now, in this setup, the message will be duplicated within the `3rdparty` & `projection` queues. If you just run the consumer for each transport, it will consume the message and call all the handlers. You can't do different things based on which queue you have consumed the message. **This pull-request adds the following feature:**

```php
class RegisterBetHandler implements MessageSubscriberInterface
{
    public function __invoke(RegisterBet $message)
    {
        // Do something only when the message comes from the `events_projection` transport...
    }

    /**
     * {@inheritdoc}
     */
    public static function getHandledMessages(): iterable
    {
        yield RegisterBet::class => [
            'from_transport' => 'events_projection',
        ];
    }
}
```

---

In the debugger, it looks like this:
<img width="649" alt="Screenshot 2019-04-07 at 10 29 55" src="https://user-images.githubusercontent.com/804625/55680892-1d7bf800-5920-11e9-80f7-853f0201c6d8.png">
