### PR TITLE
[DoctrineBridge] Deprecated implicit optimization in DoctrineChoiceLoader

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * changed guessing of DECIMAL to set the `input` option of `NumberType` to string
+ * deprecated not passing an `IdReader` to the `DoctrineChoiceLoader` when query can be optimized with a single id field
 
 4.2.0
 -----

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -150,7 +150,8 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
                     $options['em'],
                     $options['class'],
                     $options['id_reader'],
-                    $entityLoader
+                    $entityLoader,
+                    false
                 );
 
                 if (null !== $hash) {

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\IdReader;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
 
@@ -392,5 +393,81 @@ class DoctrineChoiceLoaderTest extends TestCase
             ]);
 
         $this->assertSame([$this->obj2], $loader->loadChoicesForValues(['2'], $value));
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Not explicitly passing an instance of "Symfony\Bridge\Doctrine\Form\ChoiceList\IdReader" when it can optimize single id entity "%s" has been deprecated in 4.3 and will not apply any optimization in 5.0.
+     */
+    public function testLoaderWithoutIdReaderCanBeOptimized()
+    {
+        $obj1 = new SingleIntIdEntity('1', 'one');
+        $obj2 = new SingleIntIdEntity('2', 'two');
+
+        $metadata = $this->createMock(ClassMetadata::class);
+        $metadata->expects($this->once())
+            ->method('getIdentifierFieldNames')
+            ->willReturn(['idField'])
+        ;
+        $metadata->expects($this->any())
+            ->method('getIdentifierValues')
+            ->willReturnCallback(function ($obj) use ($obj1, $obj2) {
+                if ($obj === $obj1) {
+                    return ['idField' => '1'];
+                }
+                if ($obj === $obj2) {
+                    return ['idField' => '2'];
+                }
+
+                return null;
+            })
+        ;
+
+        $this->om = $this->createMock(ObjectManager::class);
+        $this->om->expects($this->once())
+            ->method('getClassMetadata')
+            ->with(SingleIntIdEntity::class)
+            ->willReturn($metadata)
+        ;
+        $this->om->expects($this->any())
+            ->method('contains')
+            ->with($this->isInstanceOf(SingleIntIdEntity::class))
+            ->willReturn(true)
+        ;
+
+        $loader = new DoctrineChoiceLoader(
+            $this->om,
+            SingleIntIdEntity::class,
+            null,
+            $this->objectLoader
+        );
+
+        $choices = [$obj1, $obj2];
+
+        $this->idReader->expects($this->any())
+            ->method('isSingleId')
+            ->willReturn(true);
+
+        $this->idReader->expects($this->any())
+            ->method('getIdField')
+            ->willReturn('idField');
+
+        $this->repository->expects($this->never())
+            ->method('findAll');
+
+        $this->objectLoader->expects($this->once())
+            ->method('getEntitiesByIds')
+            ->with('idField', ['1'])
+            ->willReturn($choices);
+
+        $this->idReader->expects($this->any())
+            ->method('getIdValue')
+            ->willReturnMap([
+                [$obj1, '1'],
+                [$obj2, '2'],
+            ]);
+
+        $this->assertSame([$obj1], $loader->loadChoicesForValues(['1']));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

#EUFOSSA

Big thanks to @stof for the help with writing the test!

## Description
It happens that the `IdReader` is created by the `DoctrineType` and cached for each entity class case.
But the type already resolves whether or not it should use it, only when we can optimize query thanks to a single id field when defining the `choice_value` option: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php#L188.

This PR is a first step to optimize the choice loading process.
