### PR TITLE
[Serializer] Experimental for ObjectListExtractor

### DIFF
--- a/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
+++ b/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractor.php
@@ -15,8 +15,10 @@ use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 
 /**
  * @author David Maicher <mail@dmaicher.de>
+ *
+ * @experimental in 4.3
  */
-class ObjectPropertyListExtractor implements ObjectPropertyListExtractorInterface
+final class ObjectPropertyListExtractor implements ObjectPropertyListExtractorInterface
 {
     private $propertyListExtractor;
     private $objectClassResolver;

--- a/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractorInterface.php
+++ b/src/Symfony/Component/Serializer/Extractor/ObjectPropertyListExtractorInterface.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Serializer\Extractor;
 
 /**
  * @author David Maicher <mail@dmaicher.de>
+ *
+ * @experimental in 4.3
  */
 interface ObjectPropertyListExtractorInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30904 
| License       | MIT
| Doc PR        | -

Related to #30818 

I want to mark this class as `@expiremental` until we have the full refactoring done of the Serializer, also this would allow change needed if some behavior was not correctly taken into care in 4.3

Mark also `final` for the default implementation as we don't want that to be extendable and user should use composition over inheritance.
