### PR TITLE
[HttpClient] Document the state object that is passed around by the HttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/ClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/ClientState.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+/**
+ * Internal representation of the client state.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ *
+ * @internal
+ */
+class ClientState
+{
+    public $handlesActivity = [];
+    public $openHandles = [];
+}

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+/**
+ * Internal representation of the cURL client's state.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ *
+ * @internal
+ */
+final class CurlClientState extends ClientState
+{
+    /** @var resource */
+    public $handle;
+    /** @var PushedResponse[] */
+    public $pushedResponses = [];
+    /** @var DnsCache */
+    public $dnsCache;
+
+    public function __construct()
+    {
+        $this->handle = curl_multi_init();
+        $this->dnsCache = new DnsCache();
+    }
+}

--- a/src/Symfony/Component/HttpClient/Internal/DnsCache.php
+++ b/src/Symfony/Component/HttpClient/Internal/DnsCache.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+/**
+ * Cache for resolved DNS queries.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ *
+ * @internal
+ */
+final class DnsCache
+{
+    /**
+     * Resolved hostnames (hostname => IP address).
+     *
+     * @var string[]
+     */
+    public $hostnames = [];
+
+    /**
+     * @var string[]
+     */
+    public $removals = [];
+
+    /**
+     * @var string[]
+     */
+    public $evictions = [];
+}

--- a/src/Symfony/Component/HttpClient/Internal/NativeClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/NativeClientState.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Symfony\Component\HttpClient\Response\NativeResponse;
+
+/**
+ * Internal representation of the native client's state.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ *
+ * @internal
+ */
+final class NativeClientState extends ClientState
+{
+    /** @var int */
+    public $id;
+    /** @var NativeResponse[] */
+    public $pendingResponses = [];
+    /** @var int */
+    public $maxHostConnections = PHP_INT_MAX;
+    /** @var int */
+    public $responseCount = 0;
+    /** @var string[] */
+    public $dnsCache = [];
+    /** @var resource[] */
+    public $handles = [];
+    /** @var bool */
+    public $sleep = false;
+
+    public function __construct()
+    {
+        $this->id = random_int(PHP_INT_MIN, PHP_INT_MAX);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Internal/PushedResponse.php
+++ b/src/Symfony/Component/HttpClient/Internal/PushedResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Symfony\Component\HttpClient\Response\CurlResponse;
+
+/**
+ * A pushed response with headers.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ *
+ * @internal
+ */
+final class PushedResponse
+{
+    /** @var CurlResponse */
+    public $response;
+
+    /** @var string[] */
+    public $headers;
+
+    public function __construct(CurlResponse $response, array $headers)
+    {
+        $this->response = $response;
+        $this->headers = $headers;
+    }
+}

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\ClientState;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -130,10 +131,7 @@ class MockResponse implements ResponseInterface
             throw new InvalidArgumentException('MockResponse instances must be issued by MockHttpClient before processing.');
         }
 
-        $multi = self::$mainMulti ?? self::$mainMulti = (object) [
-            'handlesActivity' => [],
-            'openHandles' => [],
-        ];
+        $multi = self::$mainMulti ?? self::$mainMulti = new ClientState();
 
         if (!isset($runningResponses[0])) {
             $runningResponses[0] = [$multi, []];
@@ -145,7 +143,7 @@ class MockResponse implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    protected static function perform(\stdClass $multi, array &$responses): void
+    protected static function perform(ClientState $multi, array &$responses): void
     {
         foreach ($responses as $response) {
             $id = $response->id;
@@ -185,7 +183,7 @@ class MockResponse implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    protected static function select(\stdClass $multi, float $timeout): int
+    protected static function select(ClientState $multi, float $timeout): int
     {
         return 42;
     }

--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\ClientState;
 
 /**
  * Implements the common logic for response classes.
@@ -49,7 +50,7 @@ trait ResponseTrait
         'error' => null,
     ];
 
-    private $multi;
+    /** @var resource */
     private $handle;
     private $id;
     private $timeout;
@@ -181,12 +182,12 @@ trait ResponseTrait
     /**
      * Performs all pending non-blocking operations.
      */
-    abstract protected static function perform(\stdClass $multi, array &$responses): void;
+    abstract protected static function perform(ClientState $multi, array &$responses): void;
 
     /**
      * Waits for network activity.
      */
-    abstract protected static function select(\stdClass $multi, float $timeout): int;
+    abstract protected static function select(ClientState $multi, float $timeout): int;
 
     private static function addResponseHeaders(array $responseHeaders, array &$info, array &$headers): void
     {
@@ -254,6 +255,7 @@ trait ResponseTrait
             $timeoutMax = 0;
             $timeoutMin = $timeout ?? INF;
 
+            /** @var ClientState $multi */
             foreach ($runningResponses as $i => [$multi]) {
                 $responses = &$runningResponses[$i][1];
                 self::perform($multi, $responses);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

In an attempt to make the code of the new HttpClient component more understandable, I've introduced internal classes that document the `$multi` object that is being passed around between *Client and *Response classes.

My goal is to make the code more accessible to potential contributors and static code analyzers.