### PR TITLE
[Console] Show commands list when we run bin/console [namespace]

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\NamespaceNotFoundException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\DebugFormatterHelper;
+use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -237,6 +238,12 @@ class Application
             $command = $this->find($name);
         } catch (\Throwable $e) {
             if (!($e instanceof CommandNotFoundException && !$e instanceof NamespaceNotFoundException) || 1 !== \count($alternatives = $e->getAlternatives()) || !$input->isInteractive()) {
+                if ($e->getAlternatives()) {
+                    (new DescriptorHelper())->describe($output, $this, ['raw_text' => true, 'namespace' => $name]);
+
+                    return 0;
+                }
+
                 if (null !== $this->dispatcher) {
                     $event = new ConsoleErrorEvent($input, $output, $e);
                     $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -467,14 +467,24 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foos:bar1'], ['decorated' => false]);
         $this->assertSame('
-                                                          
-  There are no commands defined in the "foos" namespace.  
-                                                          
-  Did you mean this?                                      
-      foo                                                 
-                                                          
+                                                               
+  There are no commands defined in the "foos:bar1" namespace.  
+                                                               
+  Did you mean this?                                           
+      foo                                                      
+                                                               
 
 ', $tester->getDisplay(true));
+    }
+
+    public function testRunNamespace()
+    {
+        $application = new Application();
+        $application->add(new \Foo1Command());
+        $application->setAutoExit(false);
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'foo'], ['decorated' => false]);
+        $this->assertSame("foo:bar1   The foo:bar1 command\n", $tester->getDisplay(true));
     }
 
     public function testCanRunAlternativeCommandName()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/27473
| License       | MIT
| Doc PR        | /

before:
![Screenshot from 2019-04-07 13-24-34](https://user-images.githubusercontent.com/4578773/55682821-b0c12780-5938-11e9-8a85-5384dda465a7.png)

after:
![Screenshot from 2019-04-07 13-25-17](https://user-images.githubusercontent.com/4578773/55682817-a99a1980-5938-11e9-8b7f-22d22c4ba2d0.png)

#EUFOSSA