### PR TITLE
[WebProfiler] Fix Javascript error when using custom stopwatch categories

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
@@ -252,11 +252,11 @@ class Legend {
     }
 
     get(category) {
-        return this.categories.find(element => element.value === category);
+        return this.categories.find(element => element.value === category) || this.createCategory(category);
     }
 
     getClassname(category) {
-        return this.classnames[category];
+        return this.classnames[category] || '';
     }
 
     getSectionClassname() {


### PR DESCRIPTION
Fixes #30745

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30745
| License       | MIT

Made the getter do lazy creation so it can dynamically adapt to whatever it's given.