### PR TITLE
[Serializer] Do not throw exception in the DateTimeNormalizer if its not a date

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -114,7 +114,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
-            throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
+            // let the validator show the error and do not throw 500.
         }
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -235,12 +235,9 @@ class DateTimeNormalizerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
-    public function testDenormalizeInvalidDataThrowsException()
+    public function testDenormalizeInvalidDataDoesNotThrowsException()
     {
-        $this->normalizer->denormalize('invalid date', \DateTimeInterface::class);
+        $this->assertEmpty($this->normalizer->denormalize('invalid date', \DateTimeInterface::class));
     }
 
     /**


### PR DESCRIPTION
…a date

| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27824   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

It's a bug that we have seen in API-Platform too, that would fix API very easily and not getting 500 errors on this kind of errors. 