### PR TITLE
Fix the configurability of CoreExtension deps in standalone usage

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -69,7 +69,7 @@ class CoreExtension extends AbstractExtension
             new Type\TimeType(),
             new Type\TimezoneType(),
             new Type\UrlType(),
-            new Type\FileType(),
+            new Type\FileType($this->translator),
             new Type\ButtonType(),
             new Type\SubmitType(),
             new Type\ResetType(),

--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\Extension\Core\CoreExtension;
+
 /**
  * The default implementation of FormFactoryBuilderInterface.
  *
@@ -18,6 +20,8 @@ namespace Symfony\Component\Form;
  */
 class FormFactoryBuilder implements FormFactoryBuilderInterface
 {
+    private $forceCoreExtension;
+
     /**
      * @var ResolvedFormTypeFactoryInterface
      */
@@ -42,6 +46,14 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
      * @var FormTypeGuesserInterface[]
      */
     private $typeGuessers = [];
+
+    /**
+     * @param bool $forceCoreExtension
+     */
+    public function __construct($forceCoreExtension = false)
+    {
+        $this->forceCoreExtension = $forceCoreExtension;
+    }
 
     /**
      * {@inheritdoc}
@@ -143,6 +155,21 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
     public function getFormFactory()
     {
         $extensions = $this->extensions;
+
+        if ($this->forceCoreExtension) {
+            $hasCoreExtension = false;
+
+            foreach ($extensions as $extension) {
+                if ($extension instanceof CoreExtension) {
+                    $hasCoreExtension = true;
+                    break;
+                }
+            }
+
+            if (!$hasCoreExtension) {
+                array_unshift($extensions, new CoreExtension());
+            }
+        }
 
         if (\count($this->types) > 0 || \count($this->typeExtensions) > 0 || \count($this->typeGuessers) > 0) {
             if (\count($this->typeGuessers) > 1) {

--- a/src/Symfony/Component/Form/Forms.php
+++ b/src/Symfony/Component/Form/Forms.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Extension\Core\CoreExtension;
-
 /**
  * Entry point of the Form component.
  *
@@ -105,10 +103,7 @@ final class Forms
      */
     public static function createFormFactoryBuilder()
     {
-        $builder = new FormFactoryBuilder();
-        $builder->addExtension(new CoreExtension());
-
-        return $builder;
+        return new FormFactoryBuilder(true);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not yet, but will allow fixing them
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When using the Forms entrypoint to configure the component, there was no chance to configure dependencies of the CoreExtension, as the one registered without argument was first and would win.
The builder now delays the prepending of the CoreExtension to do it only if the CoreExtension is not registered explicitly.

We discovered that when trying to fix tests for the FileType, where we wanted to pass a Translator to it.
