### PR TITLE
[FrameworkBundle] Added a keep-in-memory option for cache adapters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -995,6 +995,7 @@ class Configuration implements ConfigurationInterface
                                         ->info('Overwrite the setting from the default provider for this adapter.')
                                     ->end()
                                     ->scalarNode('clearer')->end()
+                                    ->booleanNode('keep_in_memory')->defaultFalse()->end()
                                 ->end()
                             ->end()
                             ->validate()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no (option is false by default)
| Deprecations? | no 
| Tests pass?   | need tests 
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

Adding a `keep-in-memory` option for cache adapters which is basically a shortcut using ChainAdapter with ArrayCache as first adapter. 