### PR TITLE
Make tests independent from each other

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -41,6 +41,13 @@ class ApplicationTest extends TestCase
 {
     protected static $fixturesPath;
 
+    private $colSize;
+
+    protected function setUp()
+    {
+        $this->colSize = getenv('COLUMNS');
+    }
+
     public static function setUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/Fixtures/');
@@ -383,6 +390,7 @@ class ApplicationTest extends TestCase
      */
     public function testFindWithAmbiguousAbbreviations($abbreviation, $expectedExceptionMessage)
     {
+        putenv('COLUMNS=120');
         if (method_exists($this, 'expectException')) {
             $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
             $this->expectExceptionMessage($expectedExceptionMessage);
@@ -468,6 +476,7 @@ class ApplicationTest extends TestCase
 
     public function testFindAlternativeExceptionMessageMultiple()
     {
+        putenv('COLUMNS=120');
         $application = new Application();
         $application->add(new \FooCommand());
         $application->add(new \Foo1Command());
@@ -1692,6 +1701,7 @@ class ApplicationTest extends TestCase
 
     protected function tearDown()
     {
+        putenv($this->colSize ? 'COLUMNS' : 'COLUMNS='.$this->colSize);
         putenv('SHELL_VERBOSITY');
         unset($_ENV['SHELL_VERBOSITY']);
         unset($_SERVER['SHELL_VERBOSITY']);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -21,6 +21,19 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class ProgressBarTest extends TestCase
 {
+    private $colSize;
+
+    protected function setUp()
+    {
+        $this->colSize = getenv('COLUMNS');
+        putenv('COLUMNS=120');
+    }
+
+    protected function tearDown()
+    {
+        putenv($this->colSize ? 'COLUMNS' : 'COLUMNS='.$this->colSize);
+    }
+
     public function testMultipleStart()
     {
         $bar = new ProgressBar($output = $this->getOutputStream());

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -26,9 +26,11 @@ class SymfonyStyleTest extends TestCase
     protected $command;
     /** @var CommandTester */
     protected $tester;
+    private $colSize;
 
     protected function setUp()
     {
+        $this->colSize = getenv('COLUMNS');
         putenv('COLUMNS=121');
         $this->command = new Command('sfstyle');
         $this->tester = new CommandTester($this->command);
@@ -36,7 +38,7 @@ class SymfonyStyleTest extends TestCase
 
     protected function tearDown()
     {
-        putenv('COLUMNS');
+        putenv($this->colSize ? 'COLUMNS' : 'COLUMNS='.$this->colSize);
         $this->command = null;
         $this->tester = null;
     }

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -16,6 +16,15 @@ use Symfony\Component\Console\Terminal;
 
 class TerminalTest extends TestCase
 {
+    private $colSize;
+    private $lineSize;
+
+    protected function setUp()
+    {
+        $this->colSize = getenv('COLUMNS');
+        $this->lineSize = getenv('LINES');
+    }
+
     public function test()
     {
         putenv('COLUMNS=100');
@@ -29,6 +38,12 @@ class TerminalTest extends TestCase
         $terminal = new Terminal();
         $this->assertSame(120, $terminal->getWidth());
         $this->assertSame(60, $terminal->getHeight());
+    }
+
+    protected function tearDown()
+    {
+        putenv($this->colSize ? 'COLUMNS' : 'COLUMNS='.$this->colSize);
+        putenv($this->lineSize ? 'LINES' : 'LINES='.$this->lineSize);
     }
 
     public function test_zero_values()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

Environment variables set in a test need to be restored to their
previous values or unset if we want to be able to run tests
independently.

Credits to @ostrolucky for spotting this issue, I'm available for help when merging this in more recent branch (issues may appear then).

Created during the EU-FOSSA hackathon