### PR TITLE
[Debug][DebugClassLoader] Discourage using the \Serializable interface

### DIFF
--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -6,8 +6,9 @@ CHANGELOG
 
 * made the `ErrorHandler` and `ExceptionHandler` classes final
 * added `Exception\FlattenException::getAsString` and
-`Exception\FlattenException::getTraceAsString` to increase compatibility to php
-exception objects
+  `Exception\FlattenException::getTraceAsString` to increase compatibility to php exception objects
+* added a deprecation for classes and interfaces that implement or extend the `\Serializable` interface
+  and that are not ready for the new serialization mechanism (currently restricted to Symfony core classes)
 
 4.0.0
 -----

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -392,14 +392,14 @@ class DebugClassLoaderTest extends TestCase
     public function implementsSerializableProvider(): array
     {
         return [
-            [['The "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ImplementsSerializable" class implements the broken "Serializable" interface. You should implement the new "__serialize" and "__unserialize" methods instead.'], ImplementsSerializable::class],
+            [['Implementing "Serializable" without also implementing the "__serialize" and "__unserialize" methods is deprecated in "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ImplementsSerializable".'], ImplementsSerializable::class],
             [[], ImplementsSerializableWithTheNewMechanism::class],
-            [['The "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ImplementsSerializable" class implements the broken "Serializable" interface. You should implement the new "__serialize" and "__unserialize" methods instead.'], ExtendsAClassImplementingSerializable::class],
-            [['The "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ExtendsSerializable" interface extends the broken "Serializable" interface. You should implement the new "__serialize" and "__unserialize" methods instead.'], ImplementsAnInterfaceThatExtendsSerializable::class],
-            [['The "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ExtendsSerializable" interface extends the broken "Serializable" interface. You should implement the new "__serialize" and "__unserialize" methods instead.'], ExtendsSerializable::class],
+            [['Implementing "Serializable" without also implementing the "__serialize" and "__unserialize" methods is deprecated in "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ImplementsSerializable".'], ExtendsAClassImplementingSerializable::class],
+            [['Implementing "Serializable" without also implementing the "__serialize" and "__unserialize" methods is deprecated in "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ExtendsSerializable".'], ImplementsAnInterfaceThatExtendsSerializable::class],
+            [['Implementing "Serializable" without also implementing the "__serialize" and "__unserialize" methods is deprecated in "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ExtendsSerializable".'], ExtendsSerializable::class],
             [[], ExtendsSerializableWithTheNewMechanism::class],
             [[], ExtendsSerializableWithTheNewMechanismThroughVirtualMethods::class],
-            [['The "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ExtendsSerializable" interface extends the broken "Serializable" interface. You should implement the new "__serialize" and "__unserialize" methods instead.'], ExtendsAnInterfaceThatExtendsSerializable::class],
+            [['Implementing "Serializable" without also implementing the "__serialize" and "__unserialize" methods is deprecated in "Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable\ExtendsSerializable".'], ExtendsAnInterfaceThatExtendsSerializable::class],
             [[], 'SymfonyFoo\\'.__NAMESPACE__.'\ImplementsSerializableOutsideOfSymfony'], // We don't trigger if the root namespace is not Symfony
         ];
     }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsAClassImplementingSerializable.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsAClassImplementingSerializable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable;
+
+class ExtendsAClassImplementingSerializable extends ImplementsSerializable
+{
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsAnInterfaceThatExtendsSerializable.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsAnInterfaceThatExtendsSerializable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable;
+
+interface ExtendsAnInterfaceThatExtendsSerializable extends ExtendsSerializable
+{
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsSerializable.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsSerializable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable;
+
+/**
+ * @method void __unserialize(array $data)
+ */
+interface ExtendsSerializable extends \Serializable
+{
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsSerializableWithTheNewMechanism.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsSerializableWithTheNewMechanism.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable;
+
+interface ExtendsSerializableWithTheNewMechanism extends \Serializable
+{
+    public function __serialize(): array;
+
+    public function __unserialize(array $data): void;
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsSerializableWithTheNewMechanismThroughVirtualMethods.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ExtendsSerializableWithTheNewMechanismThroughVirtualMethods.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable;
+
+/**
+ * @method array __serialize(): array
+ * @method void __unserialize(array $data): void
+ */
+interface ExtendsSerializableWithTheNewMechanismThroughVirtualMethods extends \Serializable
+{
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ImplementsAnInterfaceThatExtendsSerializable.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ImplementsAnInterfaceThatExtendsSerializable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable;
+
+class ImplementsAnInterfaceThatExtendsSerializable implements ExtendsSerializable
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return 'foo';
+    }
+
+    public function __unserialize(array $data): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+    }
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ImplementsSerializable.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ImplementsSerializable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable;
+
+class ImplementsSerializable implements \Serializable
+{
+    public function __serialize(): array
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return 'foo';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+    }
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ImplementsSerializableWithTheNewMechanism.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DiscourageSerializable/ImplementsSerializableWithTheNewMechanism.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures\DiscourageSerializable;
+
+class ImplementsSerializableWithTheNewMechanism implements \Serializable
+{
+    public function __serialize(): array
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return 'foo';
+    }
+
+    public function __unserialize(array $data): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/30304
| License       | MIT
| Doc PR        | -

#eufossa

The deprecation is triggered only if the class implementing `\Serializable` does not already implement the future serialization mechanism (with `__serialize` and `__unserialize`).

The case we don't handle (yet) is if your class implements an interface that extends `\Serializable`.

Needs https://github.com/symfony/symfony/pull/30965 and https://github.com/twigphp/Twig/pull/2927 for tests to pass.