### PR TITLE
Allow env processor to resolve `::`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -42,7 +42,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
                     return $placeholder; // return first result
                 }
             }
-            if (!preg_match('/^(?:\w++:)*+\w++$/', $env)) {
+            if (!preg_match('/^(?:\w*+:)*+\w++$/', $env)) {
                 throw new InvalidArgumentException(sprintf('Invalid %s name: only "word" characters are allowed.', $name));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -194,4 +194,11 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $bag->get('env(ARRAY_VAR)');
         $bag->resolve();
     }
+
+    public function testDefaultToNullAllowed()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $bag->resolve();
+        $this->assertNotNull($bag->get('env(default::BAR)'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | N/A

The env processor resolve to null when no fallback are provided. ie. `env(default::NOT_EXISTS)`

Issue is that the regexp does not allow such pattern. thus made the feature unusable.