### PR TITLE
[FrameworkBundle] Fix for Controller DEPRECATED  when using composer --optimized 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -14,14 +14,12 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use %s instead.', Controller::class, AbstractController::class), E_USER_DEPRECATED);
-
 /**
  * Controller is a simple implementation of a Controller.
  *
  * It provides methods to common features needed in controllers.
  *
- * @deprecated since Symfony 4.2, use {@see AbstractController} instead.
+ * @deprecated since Symfony 4.2, use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 4.2 |
| Bug fix? | Yes |
| New feature? | No |
| BC breaks? | No |
| Deprecations? | No |
| Tests pass? | Yes |
| Fixed tickets | --- |
| License | MIT |

Using `composer --optimize-autoload` causes `console cache:clear` (without warmup) to give DEPRECATED error, that stays in profiler.

I moved `@trigger_error` from beggining of the file to Controller __consctruct method.