### PR TITLE
[Mailer] allow user/pass on dsn while using failover/roundrobin

### DIFF
--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -171,7 +171,17 @@ class Transport
                 throw new LogicException(sprintf('The "%s" scheme is not supported for mailer "%s".', $parsedDsn['scheme'], $parsedDsn['host']));
             default:
                 if ('smtp' === $parsedDsn['scheme']) {
-                    return new Transport\Smtp\EsmtpTransport($parsedDsn['host'], $parsedDsn['port'] ?? 25, $query['encryption'] ?? null, $query['auth_mode'] ?? null, $dispatcher, $logger);
+                    $transport = new Transport\Smtp\EsmtpTransport($parsedDsn['host'], $parsedDsn['port'] ?? 25, $query['encryption'] ?? null, $query['auth_mode'] ?? null, $dispatcher, $logger);
+
+                    if ($user) {
+                        $transport->setUsername($user);
+                    }
+
+                    if ($pass) {
+                        $transport->setPassword($pass);
+                    }
+
+                    return $transport;
                 }
 
                 throw new LogicException(sprintf('The "%s" mailer is not supported.', $parsedDsn['host']));

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -29,8 +29,8 @@ use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
 class EsmtpTransport extends SmtpTransport
 {
     private $authenticators = [];
-    private $username;
-    private $password;
+    private $username = '';
+    private $password = '';
     private $authMode;
 
     public function __construct(string $host = 'localhost', int $port = 25, string $encryption = null, string $authMode = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

this PR provides two things:
1. It is possible now to user `username` and `password` in a failover or round robin transport when using smtp
2. Fixed a type problem with `username` and `password` for the smtp transport as `getUsername()` cannot return `null` because of its signature but if no `username` is provided then the property would have been `null`. Fixed with setting an empty string as default. Same for `password`. (This was discovered by adding a test - yeah!)
