### PR TITLE
[DependencyInjection] resolve env variables

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -461,7 +461,7 @@ class Container implements ResettableContainerInterface
      *
      * @throws EnvNotFoundException When the environment variable is not found and has no default value
      */
-    protected function getEnv($name)
+    public function getEnv($name)
     {
         if (isset($this->resolving[$envName = "env($name)"])) {
             throw new ParameterCircularReferenceException(array_keys($this->resolving));

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1569,7 +1569,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * {@inheritdoc}
      */
-    protected function getEnv($name)
+    public function getEnv($name)
     {
         $value = parent::getEnv($name);
         $bag = $this->getParameterBag();

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -140,7 +140,17 @@ class EnvVarProcessor implements EnvVarProcessorInterface
                 if (!isset($match[1])) {
                     return '%';
                 }
-                $value = $this->container->getParameter($match[1]);
+
+                $subEnv = $match[1];
+                if ($this->container instanceof Container) {
+                    if (0 === strpos($subEnv, 'env(') && ')' === substr($subEnv, -1) && 'env()' !== $subEnv) {
+                        $subEnv = substr($subEnv, 4, -1);
+                    }
+
+                    $value = $this->container->getEnv($subEnv);
+                } else {
+                    $value = $this->container->getParameter($subEnv);
+                }
                 if (!is_scalar($value)) {
                     throw new RuntimeException(sprintf('Parameter "%s" found when resolving env var "%s" must be scalar, "%s" given.', $match[1], $name, \gettype($value)));
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (change the visibility of a method in a not-final class)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The documentation (https://symfony.com/doc/current/configuration/environment_variables.html#config-env-vars) give the following example:
```yaml
parameters:
    env(HOST): '10.0.0.1'
    env(SENTRY_DSN): 'http://%env(HOST)%/project'
sentry:
    dsn: '%env(resolve:SENTRY_DSN)%'
```

This example works because the parameter `env(HOST)` is literally defined in the parameters sections. Reading the documentation we could think that `env(HOST)` is resolved by trying to read the `HOST` env variable then fallback to the default parameter, but it's not the case.

If I write the following same application using `.env` file I would have the error `The parameter "env(HOST)" must be defined.`
```bash
# .env
HOST="10.0.0.1"
SENTRY_DSN="http://%env(HOST)%/project"
```

This PR fix it. my use case is

```bash
# .env
DATABASE_URL="mysql://root:root@localhost/db_name"

# .env.prod
DATABASE_URL="mysql://my_user:%env(secret:DATABASE_PASSWORD)%@service.com/db_name"
```

note: to access the `getEnv()` which calls the list of env processors, I've to change the visibility of the method. Tell me we have another way to do it.