### PR TITLE
fix: Response status code from start() of GuardAuthenticator is ignored

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -129,6 +129,7 @@ class ExceptionListener
                 $insufficientAuthenticationException = new InsufficientAuthenticationException('Full authentication is required to access this resource.', 0, $exception);
                 $insufficientAuthenticationException->setToken($token);
 
+		$event->allowCustomResponseCode();
                 $event->setResponse($this->startAuthentication($event->getRequest(), $insufficientAuthenticationException));
             } catch (\Exception $e) {
                 $event->setException($e);

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -129,7 +129,7 @@ class ExceptionListener
                 $insufficientAuthenticationException = new InsufficientAuthenticationException('Full authentication is required to access this resource.', 0, $exception);
                 $insufficientAuthenticationException->setToken($token);
 
-		$event->allowCustomResponseCode();
+                $event->allowCustomResponseCode();
                 $event->setResponse($this->startAuthentication($event->getRequest(), $insufficientAuthenticationException));
             } catch (\Exception $e) {
                 $event->setException($e);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | to be confirmed
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29657 
| License       | MIT
| Doc PR        | -