### PR TITLE
[Process] Fix missing $extraDirs when open_basedir returns

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -51,7 +51,10 @@ class ExecutableFinder
     public function find($name, $default = null, array $extraDirs = [])
     {
         if (ini_get('open_basedir')) {
-            $searchPath = explode(PATH_SEPARATOR, ini_get('open_basedir'));
+            $searchPath = array_merge(
+                explode(PATH_SEPARATOR, ini_get('open_basedir')),
+                $extraDirs
+            );
             $dirs = [];
             foreach ($searchPath as $path) {
                 // Silencing against https://bugs.php.net/69240


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  |no 
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31010
| License       | MIT

Fix missing $extraDirs when open_basedir returns