### PR TITLE
fix tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -160,6 +160,7 @@ abstract class FrameworkExtensionTest extends TestCase
     }
 
     /**
+     * @group legacy
      * @expectedException \LogicException
      */
     public function testAmbiguousWhenBothTemplatingAndFragments()

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -35,14 +35,14 @@
         "symfony/templating": "~3.4|~4.0",
         "symfony/translation": "^4.2",
         "symfony/yaml": "~3.4|~4.0",
-        "symfony/framework-bundle": "~4.1",
+        "symfony/framework-bundle": "~4.3",
         "symfony/web-link": "~3.4|~4.0",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0"
     },
     "conflict": {
         "symfony/dependency-injection": "<4.1",
-        "symfony/framework-bundle": "<4.1",
+        "symfony/framework-bundle": "<4.3",
         "symfony/translation": "<4.2"
     },
     "autoload": {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -30,7 +30,7 @@
         "symfony/config": "~3.4|~4.0",
         "symfony/console": "~3.4|~4.0",
         "symfony/css-selector": "~3.4|~4.0",
-        "symfony/dependency-injection": "^4.2",
+        "symfony/dependency-injection": "^4.3",
         "symfony/dom-crawler": "~3.4|~4.0",
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",
@@ -49,7 +49,7 @@
     "conflict": {
         "symfony/browser-kit": "<4.3",
         "symfony/config": "<3.4",
-        "symfony/dependency-injection": "<4.2",
+        "symfony/dependency-injection": "<4.3",
         "symfony/translation": "<4.2",
         "symfony/var-dumper": "<4.1.1",
         "twig/twig": "<1.34|<2.4,>=2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

* use legacy group when using the deprecated `hinclude_default_template`
  templating config option
* conflict with DependencyInjection 4.2 in the HttpKernel component to
  be able to rely on five values being retrieved from the values of the
  `BoundArgument` class
* let the TwigBundle conflict with versions of FrameworkBundle that do
  not ship the `url_helper` service