### PR TITLE
[Validator] Deprecated interface still required for TranslationInterface in Validator

### DIFF
--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -14,11 +14,12 @@ namespace Symfony\Component\Validator\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Util\LegacyTranslatorProxy;
 use Symfony\Component\Validator\ValidatorBuilder;
+use Symfony\Component\Validator\ValidatorBuilderInterface;
 
 class ValidatorBuilderTest extends TestCase
 {
     /**
-     * @var ValidatorBuilder
+     * @var ValidatorBuilderInterface
      */
     protected $builder;
 

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -14,12 +14,11 @@ namespace Symfony\Component\Validator\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Util\LegacyTranslatorProxy;
 use Symfony\Component\Validator\ValidatorBuilder;
-use Symfony\Component\Validator\ValidatorBuilderInterface;
 
 class ValidatorBuilderTest extends TestCase
 {
     /**
-     * @var ValidatorBuilderInterface
+     * @var ValidatorBuilder
      */
     protected $builder;
 
@@ -102,7 +101,7 @@ class ValidatorBuilderTest extends TestCase
     public function testSetTranslator()
     {
         $this->assertSame($this->builder, $this->builder->setTranslator(
-            $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock())
+            $this->getMockBuilder('Symfony\Contracts\Translation\TranslatorInterface')->getMock())
         );
     }
 

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -256,8 +256,11 @@ class ValidatorBuilder implements ValidatorBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function setTranslator(LegacyTranslatorInterface $translator)
+    public function setTranslator($translator)
     {
+        if (!$translator instanceof LegacyTranslatorInterface && !$translator instanceof TranslatorInterface) {
+            throw new \TypeError(sprintf('Argument 1 passed to %s() must be an instance of %s, %s given.', __METHOD__, TranslatorInterface::class, \is_object($translator) ? \get_class($translator) : \gettype($translator)));
+        }
         $this->translator = $translator instanceof LegacyTranslatorProxy ? $translator->getTranslator() : $translator;
 
         return $this;

--- a/src/Symfony/Component/Validator/ValidatorBuilderInterface.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilderInterface.php
@@ -12,10 +12,11 @@
 namespace Symfony\Component\Validator;
 
 use Doctrine\Common\Annotations\Reader;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Component\Validator\Mapping\Cache\CacheInterface;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * A configurable builder for ValidatorInterface objects.
@@ -134,9 +135,10 @@ interface ValidatorBuilderInterface
     /**
      * Sets the translator used for translating violation messages.
      *
+     * @param TranslatorInterface|LegacyTranslatorInterface $translator
      * @return $this
      */
-    public function setTranslator(TranslatorInterface $translator);
+    public function setTranslator($translator);
 
     /**
      * Sets the default translation domain of violation messages.

--- a/src/Symfony/Component/Validator/ValidatorBuilderInterface.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilderInterface.php
@@ -136,6 +136,7 @@ interface ValidatorBuilderInterface
      * Sets the translator used for translating violation messages.
      *
      * @param TranslatorInterface|LegacyTranslatorInterface $translator
+     *
      * @return $this
      */
     public function setTranslator($translator);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30591 (related)
| License       | MIT

This PR removes the hard requirement for the LegacyValidatorInterface used by replacing the type-hint with a docBlock typehint for either the non-deprecated or deprecated TranslatorInterface.

Also, updated the test to use the new TranslatorInterface contract.