### PR TITLE
[Serializer] Deprecate calling createChildContext without the format parameter

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -555,8 +555,12 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      *
      * @internal
      */
-    protected function createChildContext(array $parentContext, $attribute/*, string $format = null */)
+    protected function createChildContext(array $parentContext, $attribute/*, ?string $format */)
     {
+        if (\func_num_args() < 3) {
+            @trigger_error(sprintf('Method "%s::%s()" will have a third "?string $format" argument in version 5.0; not defining it is deprecated since Symfony 4.3.', \get_class($this), __FUNCTION__), E_USER_DEPRECATED);
+            $format = null;
+        }
         if (isset($parentContext[self::ATTRIBUTES][$attribute])) {
             $parentContext[self::ATTRIBUTES] = $parentContext[self::ATTRIBUTES][$attribute];
         } else {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -559,18 +559,19 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      * We must not mix up the attribute cache between parent and children.
      *
      * {@inheritdoc}
+     *
+     * @param string|null $format
      */
-    protected function createChildContext(array $parentContext, $attribute/*, string $format = null */)
+    protected function createChildContext(array $parentContext, $attribute/*, ?string $format */)
     {
         if (\func_num_args() >= 3) {
             $format = \func_get_arg(2);
         } else {
-            // will be deprecated in version 4
+            @trigger_error(sprintf('Method "%s::%s()" will have a third "?string $format" argument in version 5.0; not defining it is deprecated since Symfony 4.3.', \get_class($this), __FUNCTION__), E_USER_DEPRECATED);
             $format = null;
         }
 
         $context = parent::createChildContext($parentContext, $attribute, $format);
-        // format is already included in the cache_key of the parent.
         $context['cache_key'] = $this->getCacheKey($format, $context);
 
         return $context;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

as discussed in #30907 deprecate omitting the format parameter when extending the AbstractNormalizer.