### PR TITLE
[DependencyInjection] non-shared services seems to be not found

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
@@ -83,6 +83,10 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
             }
         }
 
+        if (false === $this->container->has((string) $value) && $graph->hasNode($currentId)) {
+            return $value;
+        }
+
         throw new ServiceNotFoundException($id, $currentId);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |4.2
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29628 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->


Is this the right fix ? It seems to work properly, if it's not in the container (since it's shared and needs to be reinstanciate at each time) and it is in the graph, then we should return it.

cc @nicolas-grekas 