### PR TITLE
Remove redundant `box-sizing` prefixes

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -5,8 +5,6 @@
     background-color: #222;
     border-top-left-radius: 4px;
     bottom: 0;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
     display: none;
     height: 36px;
@@ -36,8 +34,6 @@
 }
 
 .sf-toolbarreset * {
-    -webkit-box-sizing: content-box;
-    -moz-box-sizing: content-box;
     box-sizing: content-box;
     vertical-align: baseline;
     letter-spacing: normal;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | /    <!-- please add some, will be required by reviewers -->
| Fixed tickets | /   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | / <!-- required for new features -->

The `-webkit-` and `-moz-` prefixes are redundant and Symfony is not prefixing it on other places in the file, eg:
https://github.com/symfony/symfony/blob/2243bf5bc11e3908f975f92551bd869a61211999/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig#L395-L401

Not sure what branch I should target for PRs like these, just let me know if I need to change anything.

Greetings,
Martijn from the [Bootstrap](https://github.com/orgs/twbs/people) team