### PR TITLE
Remove redundant animation prefixes

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -363,20 +363,7 @@ div.sf-toolbar .sf-toolbar-block a:hover {
     text-align: right;
 }
 .sf-ajax-request-loading {
-    -webkit-animation: sf-blink .5s ease-in-out infinite;
-    -o-animation: sf-blink .5s ease-in-out infinite;
-    -moz-animation: sf-blink .5s ease-in-out infinite;
     animation: sf-blink .5s ease-in-out infinite;
-}
-@-webkit-keyframes sf-blink {
-    0% { background: #222; }
-    50% { background: #444; }
-    100% { background: #222; }
-}
-@-moz-keyframes sf-blink {
-    0% { background: #222; }
-    50% { background: #444; }
-    100% { background: #222; }
 }
 @keyframes sf-blink {
     0% { background: #222; }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | /   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | / <!-- required for new features -->

Like https://github.com/symfony/symfony/pull/31055, a small cleanup of CSS. CSS animations can be used safely without any prefixes.
