### PR TITLE
Show more accurate message in profiler when missing stopwatch

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -95,7 +95,11 @@
 
     <h2>Execution timeline</h2>
 
-    {% if collector.events is empty %}
+    {% if not collector.isStopwatchInstalled() %}
+        <div class="empty">
+            <p>The Stopwatch component is not installed. If you want to see timing events, run: <code>composer require symfony/stopwatch</code>.</p>
+        </div>
+    {% elseif collector.events is empty %}
         <div class="empty">
             <p>No timing events have been recorded. Are you sure that debugging is enabled in the kernel?</p>
         </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^5.5.9|>=7.0.8",
-        "symfony/http-kernel": "~3.3|~4.0",
+        "symfony/http-kernel": "~3.4.25|^4.2.6",
         "symfony/polyfill-php70": "~1.0",
         "symfony/routing": "~2.8|~3.0|~4.0",
         "symfony/twig-bridge": "~2.8|~3.0|~4.0",

--- a/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
@@ -47,6 +47,7 @@ class TimeDataCollector extends DataCollector implements LateDataCollectorInterf
             'token' => $response->headers->get('X-Debug-Token'),
             'start_time' => $startTime * 1000,
             'events' => [],
+            'stopwatch_installed' => \class_exists(Stopwatch::class, false),
         ];
     }
 
@@ -137,6 +138,14 @@ class TimeDataCollector extends DataCollector implements LateDataCollectorInterf
     public function getStartTime()
     {
         return $this->data['start_time'];
+    }
+
+    /**
+     * @return bool whether or not the stopwatch component is installed
+     */
+    public function isStopwatchInstalled()
+    {
+        return $this->data['stopwatch_installed'];
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
+use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
  * @group time-sensitive
@@ -51,5 +52,6 @@ class TimeDataCollectorTest extends TestCase
 
         $c->collect($request, new Response());
         $this->assertEquals(123456000, $c->getStartTime());
+        $this->assertSame(\class_exists(Stopwatch::class, false), $c->isStopwatchInstalled());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4+
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31056 
| License       | MIT
| Doc PR        | ~

This adds a message to the profiler if the stopwatch component is not installed, instead of suggesting to check if debug is enabled (even if it is enabled).

I had to add a method in the collector to expose the value collected, which in theory adds a feature. Is there perhaps a way to expose this collected data _without_ a "BC break"? I don't think it breaks anything, though it does make the dependencies on the http-kernel a bit strict. The other solution is to ignore if it's null and only act if it's a boolean (feature detection).
