### PR TITLE
[BridgeDoctrineMessenger] Doctrine ping connection middleware

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * changed guessing of DECIMAL to set the `input` option of `NumberType` to string
  * deprecated not passing an `IdReader` to the `DoctrineChoiceLoader` when query can be optimized with a single id field
  * deprecated passing an `IdReader` to the `DoctrineChoiceLoader` when entities have a composite id
+ * added `DoctrinePingConnectionMiddleware`
+ * added `DoctrineCloseConnectionMiddleware`
 
 4.2.0
 -----

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+/**
+ * Closes connection and therefore saves number of connections.
+ *
+ * @author Fuong <insidestyles@gmail.com>
+ *
+ * @experimental in 4.3
+ */
+class DoctrineCloseConnectionMiddleware implements MiddlewareInterface
+{
+    private $managerRegistry;
+    private $entityManagerName;
+
+    public function __construct(ManagerRegistry $managerRegistry, string $entityManagerName = null)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->entityManagerName = $entityManagerName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
+
+        if (!$entityManager instanceof EntityManagerInterface) {
+            throw new \InvalidArgumentException(sprintf('The ObjectManager with name "%s" must be an instance of EntityManagerInterface', $this->entityManagerName));
+        }
+
+        try {
+            $connection = $entityManager->getConnection();
+
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            $connection->close();
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+/**
+ * Checks whether the connection is still open or reconnects otherwise.
+ *
+ * @author Fuong <insidestyles@gmail.com>
+ *
+ * @experimental in 4.3
+ */
+class DoctrinePingConnectionMiddleware implements MiddlewareInterface
+{
+    private $managerRegistry;
+    private $entityManagerName;
+
+    public function __construct(ManagerRegistry $managerRegistry, string $entityManagerName = null)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->entityManagerName = $entityManagerName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
+
+        if (!$entityManager instanceof EntityManagerInterface) {
+            throw new \InvalidArgumentException(sprintf('The ObjectManager with name "%s" must be an instance of EntityManagerInterface', $this->entityManagerName));
+        }
+
+        $connection = $entityManager->getConnection();
+
+        if (!$connection->ping()) {
+            $connection->close();
+            $connection->connect();
+        }
+
+        if (!$entityManager->isOpen()) {
+            $this->managerRegistry->resetManager($this->entityManagerName);
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineCloseConnectionMiddleware;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class DoctrineCloseConnectionMiddlewareTest extends MiddlewareTestCase
+{
+    private $connection;
+    private $entityManager;
+    private $managerRegistry;
+    private $middleware;
+    private $entityManagerName = 'default';
+
+    protected function setUp()
+    {
+        $this->connection = $this->createMock(Connection::class);
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager->method('getConnection')->willReturn($this->connection);
+
+        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->managerRegistry->method('getManager')->willReturn($this->entityManager);
+
+        $this->middleware = new DoctrineCloseConnectionMiddleware(
+            $this->managerRegistry,
+            $this->entityManagerName
+        );
+    }
+
+    public function testMiddlewareCloseConnection()
+    {
+        $this->connection->expects($this->once())
+            ->method('close')
+        ;
+
+        $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Doctrine\Messenger\DoctrinePingConnectionMiddleware;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
+{
+    private $connection;
+    private $entityManager;
+    private $managerRegistry;
+    private $middleware;
+    private $entityManagerName = 'default';
+
+    protected function setUp()
+    {
+        $this->connection = $this->createMock(Connection::class);
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager->method('getConnection')->willReturn($this->connection);
+
+        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->managerRegistry->method('getManager')->willReturn($this->entityManager);
+
+        $this->middleware = new DoctrinePingConnectionMiddleware(
+            $this->managerRegistry,
+            $this->entityManagerName
+        );
+    }
+
+    public function testMiddlewarePingOk()
+    {
+        $this->connection->expects($this->once())
+            ->method('ping')
+            ->willReturn(false);
+
+        $this->connection->expects($this->once())
+            ->method('close')
+        ;
+        $this->connection->expects($this->once())
+            ->method('connect')
+        ;
+
+        $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+    }
+
+    public function testMiddlewarePingResetEntityManager()
+    {
+        $this->entityManager->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(false)
+        ;
+        $this->managerRegistry->expects($this->once())
+            ->method('resetManager')
+            ->with($this->entityManagerName)
+        ;
+
+        $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

- Check and reconnect if mysql has gone away:

        <service id="messenger.middleware.doctrine_ping_connection" class="Symfony\Bridge\Doctrine\Messenger\DoctrinePingConnectionMiddleware" public="false">
            <argument type="service" id="doctrine" />
        </service>

- Close and save opened connections (not active worker):

        <service id="messenger.middleware.doctrine_close_connection" class="Symfony\Bridge\Doctrine\Messenger\DoctrineCloseConnectionMiddleware" public="false">
            <argument type="service" id="doctrine" />
        </service>
