### PR TITLE
[Dotenv] Deprecate useage of "putenv"

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -45,6 +45,12 @@ Doctrine Bridge
  * Passing an `IdReader` to the `DoctrineChoiceLoader` when the query cannot be optimized with single id field has been deprecated, pass `null` instead
  * Not passing an `IdReader` to the `DoctrineChoiceLoader` when the query can be optimized with single id field has been deprecated
 
+Dotenv
+------
+
+ * First parameter of `Dontenv::__construct()` will change from `true` to `false` in Symfony 5.0. A deprecation warning
+   will be triggered if no parameter is used. Use `$usePutenv=true` to upgrade without breaking changes.  
+
 EventDispatcher
 ---------------
 

--- a/src/Symfony/Component/Dotenv/CHANGELOG.md
+++ b/src/Symfony/Component/Dotenv/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * deprecated use of `putenv()` but default. This feature will be opted-in with a constructor argument to `Dotenv`. 
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Dotenv/README.md
+++ b/src/Symfony/Component/Dotenv/README.md
@@ -2,7 +2,7 @@ Dotenv Component
 ================
 
 Symfony Dotenv parses `.env` files to make environment variables stored in them
-accessible via `getenv()`, `$_ENV`, or `$_SERVER`.
+accessible via `$_ENV`, `$_SERVER` and optionally `getenv()`.
 
 Resources
 ---------

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -22,7 +22,7 @@ class DotenvTest extends TestCase
      */
     public function testParseWithFormatError($data, $error)
     {
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
 
         try {
             $dotenv->parse($data);
@@ -62,7 +62,7 @@ class DotenvTest extends TestCase
      */
     public function testParse($data, $expected)
     {
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $this->assertSame($expected, $dotenv->parse($data));
     }
 
@@ -193,7 +193,7 @@ class DotenvTest extends TestCase
         file_put_contents($path1, 'FOO=BAR');
         file_put_contents($path2, 'BAR=BAZ');
 
-        (new Dotenv())->load($path1, $path2);
+        (new Dotenv(true))->load($path1, $path2);
 
         $foo = getenv('FOO');
         $bar = getenv('BAR');
@@ -224,7 +224,7 @@ class DotenvTest extends TestCase
         // .env
 
         file_put_contents($path, 'FOO=BAR');
-        (new DotEnv())->loadEnv($path, 'TEST_APP_ENV');
+        (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('BAR', getenv('FOO'));
         $this->assertSame('dev', getenv('TEST_APP_ENV'));
 
@@ -232,33 +232,33 @@ class DotenvTest extends TestCase
 
         $_SERVER['TEST_APP_ENV'] = 'local';
         file_put_contents("$path.local", 'FOO=localBAR');
-        (new DotEnv())->loadEnv($path, 'TEST_APP_ENV');
+        (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('localBAR', getenv('FOO'));
 
         // special case for test
 
         $_SERVER['TEST_APP_ENV'] = 'test';
-        (new DotEnv())->loadEnv($path, 'TEST_APP_ENV');
+        (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('BAR', getenv('FOO'));
 
         // .env.dev
 
         unset($_SERVER['TEST_APP_ENV']);
         file_put_contents("$path.dev", 'FOO=devBAR');
-        (new DotEnv())->loadEnv($path, 'TEST_APP_ENV');
+        (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('devBAR', getenv('FOO'));
 
         // .env.dev.local
 
         file_put_contents("$path.dev.local", 'FOO=devlocalBAR');
-        (new DotEnv())->loadEnv($path, 'TEST_APP_ENV');
+        (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('devlocalBAR', getenv('FOO'));
 
         // .env.dist
 
         unlink($path);
         file_put_contents("$path.dist", 'BAR=distBAR');
-        (new DotEnv())->loadEnv($path, 'TEST_APP_ENV');
+        (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('distBAR', getenv('BAR'));
 
         putenv('FOO');
@@ -290,7 +290,7 @@ class DotenvTest extends TestCase
         file_put_contents($path1, 'FOO=BAR');
         file_put_contents($path2, 'BAR=BAZ');
 
-        (new Dotenv())->overload($path1, $path2);
+        (new Dotenv(true))->overload($path1, $path2);
 
         $foo = getenv('FOO');
         $bar = getenv('BAR');
@@ -310,7 +310,7 @@ class DotenvTest extends TestCase
      */
     public function testLoadDirectory()
     {
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->load(__DIR__);
     }
 
@@ -318,7 +318,7 @@ class DotenvTest extends TestCase
     {
         $originalValue = $_SERVER['argc'];
 
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->populate(['argc' => 'new_value']);
 
         $this->assertSame($originalValue, $_SERVER['argc']);
@@ -329,7 +329,7 @@ class DotenvTest extends TestCase
         putenv('TEST_ENV_VAR=original_value');
         $_SERVER['TEST_ENV_VAR'] = 'original_value';
 
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->populate(['TEST_ENV_VAR' => 'new_value']);
 
         $this->assertSame('original_value', getenv('TEST_ENV_VAR'));
@@ -339,7 +339,7 @@ class DotenvTest extends TestCase
     {
         $_SERVER['HTTP_TEST_ENV_VAR'] = 'http_value';
 
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->populate(['HTTP_TEST_ENV_VAR' => 'env_value']);
 
         $this->assertSame('env_value', getenv('HTTP_TEST_ENV_VAR'));
@@ -351,7 +351,7 @@ class DotenvTest extends TestCase
     {
         putenv('TEST_ENV_VAR_OVERRIDEN=original_value');
 
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->populate(['TEST_ENV_VAR_OVERRIDEN' => 'new_value'], true);
 
         $this->assertSame('new_value', getenv('TEST_ENV_VAR_OVERRIDEN'));
@@ -373,7 +373,7 @@ class DotenvTest extends TestCase
         unset($_SERVER['DATABASE_URL']);
         putenv('DATABASE_URL');
 
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->populate(['APP_DEBUG' => '1', 'DATABASE_URL' => 'mysql://root@localhost/db']);
 
         $this->assertSame('APP_DEBUG,DATABASE_URL', getenv('SYMFONY_DOTENV_VARS'));
@@ -390,7 +390,7 @@ class DotenvTest extends TestCase
         unset($_SERVER['DATABASE_URL']);
         putenv('DATABASE_URL');
 
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->populate(['APP_DEBUG' => '0', 'DATABASE_URL' => 'mysql://root@localhost/db']);
         $dotenv->populate(['DATABASE_URL' => 'sqlite:///somedb.sqlite']);
 
@@ -406,12 +406,29 @@ class DotenvTest extends TestCase
         putenv('BAZ=baz');
         putenv('DOCUMENT_ROOT=/var/www');
 
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->populate(['FOO' => 'foo1', 'BAR' => 'bar1', 'BAZ' => 'baz1', 'DOCUMENT_ROOT' => '/boot']);
 
         $this->assertSame('foo1', getenv('FOO'));
         $this->assertSame('bar1', getenv('BAR'));
         $this->assertSame('baz1', getenv('BAZ'));
         $this->assertSame('/var/www', getenv('DOCUMENT_ROOT'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The default value of "$usePutenv" argument of "%s's constructor will change from "true" to "false" in Symfony 5.0, you should define its value explicitly.
+     */
+    public function testDeprecationWarning()
+    {
+        new Dotenv();
+    }
+
+    public function testNoDeprecationWarning()
+    {
+        $dotenv = new Dotenv(true);
+        $this->assertInstanceOf(Dotenv::class, $dotenv);
+        $dotenv = new Dotenv(false);
+        $this->assertInstanceOf(Dotenv::class, $dotenv);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | n/a

From discussions on https://github.com/symfony/recipes/pull/571, I think it is a good idea to make people opt-in to using `putenv`. 

In Symfony 5.0 we will just change the value of the constructor. As an alternative, we could decide we want to remove `putenv` in Symfony 5.0. If so, I would also deprecate `$usePutenv=true`. 