### PR TITLE
CS Fixes: Not double split with one array argument

### DIFF
--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -95,9 +95,7 @@ class DefaultChoiceListFactoryTest extends TestCase
         $this->obj2 = (object) ['label' => 'B', 'index' => 'x', 'value' => 'b', 'preferred' => true, 'group' => 'Group 1', 'attr' => ['attr1' => 'value1']];
         $this->obj3 = (object) ['label' => 'C', 'index' => 'y', 'value' => 1, 'preferred' => true, 'group' => 'Group 2', 'attr' => ['attr2' => 'value2']];
         $this->obj4 = (object) ['label' => 'D', 'index' => 'z', 'value' => 2, 'preferred' => false, 'group' => 'Group 2', 'attr' => []];
-        $this->list = new ArrayChoiceList(
-            ['A' => $this->obj1, 'B' => $this->obj2, 'C' => $this->obj3, 'D' => $this->obj4]
-        );
+        $this->list = new ArrayChoiceList(['A' => $this->obj1, 'B' => $this->obj2, 'C' => $this->obj3, 'D' => $this->obj4]);
         $this->factory = new DefaultChoiceListFactory();
     }
 
@@ -111,9 +109,7 @@ class DefaultChoiceListFactoryTest extends TestCase
 
     public function testCreateFromChoicesFlat()
     {
-        $list = $this->factory->createListFromChoices(
-            ['A' => $this->obj1, 'B' => $this->obj2, 'C' => $this->obj3, 'D' => $this->obj4]
-        );
+        $list = $this->factory->createListFromChoices(['A' => $this->obj1, 'B' => $this->obj2, 'C' => $this->obj3, 'D' => $this->obj4]);
 
         $this->assertObjectListWithGeneratedValues($list);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1841,12 +1841,11 @@ class ChoiceTypeTest extends BaseTypeTest
     {
         $builder = $this->factory->createBuilder();
         $builder->add('choice', static::TESTED_TYPE, [
-                'choices' => [
-                    '1' => '1',
-                    '2' => '2',
-                ],
-            ]
-        );
+            'choices' => [
+                '1' => '1',
+                '2' => '2',
+            ],
+        ]);
         $builder->add('subChoice', 'Symfony\Component\Form\Tests\Fixtures\ChoiceSubType');
         $form = $builder->getForm();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | None
| License       | MIT
| Doc PR        | None



Keep to use the same CS in all the Symfony code base.

Use:
```php
$resolver->setDefaults([
    'compound' => false
]);
```

Instead of:
```php
$resolver->setDefaults(
    [
        'compound' => false,
    ]
);
```

Keep the double split when the method has two or more arguments.

I miss a PSR with this rule.

