### PR TITLE
CS Fixes: Not double split with one array argument

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -126,14 +126,12 @@ class UserPasswordEncoderCommandTest extends WebTestCase
 
     public function testEncodePasswordEmptySaltOutput()
     {
-        $this->passwordEncoderCommandTester->execute(
-            [
-                'command' => 'security:encode-password',
-                'password' => 'p@ssw0rd',
-                'user-class' => 'Symfony\Component\Security\Core\User\User',
-                '--empty-salt' => true,
-            ]
-        );
+        $this->passwordEncoderCommandTester->execute([
+            'command' => 'security:encode-password',
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Symfony\Component\Security\Core\User\User',
+            '--empty-salt' => true,
+        ]);
 
         $this->assertContains('Password encoding succeeded', $this->passwordEncoderCommandTester->getDisplay());
         $this->assertContains(' Encoded password   p@ssw0rd', $this->passwordEncoderCommandTester->getDisplay());

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
@@ -205,38 +205,36 @@ class DateIntervalType extends AbstractType
             }));
         };
 
-        $resolver->setDefaults(
-            [
-                'with_years' => true,
-                'with_months' => true,
-                'with_days' => true,
-                'with_weeks' => false,
-                'with_hours' => false,
-                'with_minutes' => false,
-                'with_seconds' => false,
-                'with_invert' => false,
-                'years' => range(0, 100),
-                'months' => range(0, 12),
-                'weeks' => range(0, 52),
-                'days' => range(0, 31),
-                'hours' => range(0, 24),
-                'minutes' => range(0, 60),
-                'seconds' => range(0, 60),
-                'widget' => 'choice',
-                'input' => 'dateinterval',
-                'placeholder' => $placeholderDefault,
-                'by_reference' => true,
-                'error_bubbling' => false,
-                // If initialized with a \DateInterval object, FormType initializes
-                // this option to "\DateInterval". Since the internal, normalized
-                // representation is not \DateInterval, but an array, we need to unset
-                // this option.
-                'data_class' => null,
-                'compound' => $compound,
-                'empty_data' => $emptyData,
-                'labels' => [],
-            ]
-        );
+        $resolver->setDefaults([
+            'with_years' => true,
+            'with_months' => true,
+            'with_days' => true,
+            'with_weeks' => false,
+            'with_hours' => false,
+            'with_minutes' => false,
+            'with_seconds' => false,
+            'with_invert' => false,
+            'years' => range(0, 100),
+            'months' => range(0, 12),
+            'weeks' => range(0, 52),
+            'days' => range(0, 31),
+            'hours' => range(0, 24),
+            'minutes' => range(0, 60),
+            'seconds' => range(0, 60),
+            'widget' => 'choice',
+            'input' => 'dateinterval',
+            'placeholder' => $placeholderDefault,
+            'by_reference' => true,
+            'error_bubbling' => false,
+            // If initialized with a \DateInterval object, FormType initializes
+            // this option to "\DateInterval". Since the internal, normalized
+            // representation is not \DateInterval, but an array, we need to unset
+            // this option.
+            'data_class' => null,
+            'compound' => $compound,
+            'empty_data' => $emptyData,
+            'labels' => [],
+        ]);
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);
         $resolver->setNormalizer('labels', $labelsNormalizer);
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -144,12 +144,10 @@ class DefaultChoiceListFactoryTest extends TestCase
 
     public function testCreateFromChoicesGrouped()
     {
-        $list = $this->factory->createListFromChoices(
-            [
-                'Group 1' => ['A' => $this->obj1, 'B' => $this->obj2],
-                'Group 2' => ['C' => $this->obj3, 'D' => $this->obj4],
-            ]
-        );
+        $list = $this->factory->createListFromChoices([
+            'Group 1' => ['A' => $this->obj1, 'B' => $this->obj2],
+            'Group 2' => ['C' => $this->obj3, 'D' => $this->obj4],
+        ]);
 
         $this->assertObjectListWithGeneratedValues($list);
     }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -531,13 +531,11 @@ class OptionsResolverTest extends TestCase
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[][]');
 
-        $this->resolver->resolve(
-            [
-                'foo' => [
-                    [1.2],
-                ],
-            ]
-        );
+        $this->resolver->resolve([
+            'foo' => [
+                [1.2],
+            ],
+        ]);
     }
 
     /**
@@ -1598,13 +1596,11 @@ class OptionsResolverTest extends TestCase
                     1, 2,
                 ],
             ],
-        ], $this->resolver->resolve(
-            [
-                'foo' => [
-                    [1, 2],
-                ],
-            ]
-        ));
+        ], $this->resolver->resolve([
+            'foo' => [
+                [1, 2],
+            ],
+        ]));
     }
 
     public function testNested2Arrays()
@@ -1644,17 +1640,15 @@ class OptionsResolverTest extends TestCase
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'float[][][][]');
 
-        $this->resolver->resolve(
-            [
-                'foo' => [
+        $this->resolver->resolve([
+            'foo' => [
+                [
                     [
-                        [
-                            [1, 2],
-                        ],
+                        [1, 2],
                     ],
                 ],
-            ]
-        );
+            ],
+        ]);
     }
 
     /**

--- a/src/Symfony/Component/Translation/Tests/Dumper/YamlFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/YamlFileDumperTest.php
@@ -20,11 +20,10 @@ class YamlFileDumperTest extends TestCase
     public function testTreeFormatCatalogue()
     {
         $catalogue = new MessageCatalogue('en');
-        $catalogue->add(
-            [
-                'foo.bar1' => 'value1',
-                'foo.bar2' => 'value2',
-            ]);
+        $catalogue->add([
+            'foo.bar1' => 'value1',
+            'foo.bar2' => 'value2',
+        ]);
 
         $dumper = new YamlFileDumper();
 
@@ -34,11 +33,10 @@ class YamlFileDumperTest extends TestCase
     public function testLinearFormatCatalogue()
     {
         $catalogue = new MessageCatalogue('en');
-        $catalogue->add(
-            [
-                'foo.bar1' => 'value1',
-                'foo.bar2' => 'value2',
-            ]);
+        $catalogue->add([
+            'foo.bar1' => 'value1',
+            'foo.bar2' => 'value2',
+        ]);
 
         $dumper = new YamlFileDumper();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -55,12 +55,10 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
     {
         $this->validator->validate(
             null,
-            new Choice(
-                [
-                    'choices' => ['foo', 'bar'],
-                    'strict' => true,
-                ]
-            )
+            new Choice([
+                'choices' => ['foo', 'bar'],
+                'strict' => true,
+            ])
         );
 
         $this->assertNoViolation();
@@ -102,14 +100,12 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidChoiceCallbackClosure()
     {
-        $constraint = new Choice(
-            [
-                'strict' => true,
-                'callback' => function () {
-                    return ['foo', 'bar'];
-                },
-            ]
-        );
+        $constraint = new Choice([
+            'strict' => true,
+            'callback' => function () {
+                return ['foo', 'bar'];
+            },
+        ]);
 
         $this->validator->validate('bar', $constraint);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  3.4  (master from #31063)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | None
| License       | MIT
| Doc PR        | None

Keep to use the same CS in all the Symfony code base.

Use:
```php
$resolver->setDefaults([
    'compound' => false
]);
```

Instead of:
```php
$resolver->setDefaults(
    [
        'compound' => false,
    ]
);
```

Keep the double split when the method has two or more arguments.

I miss a PSR with this rule.

