### PR TITLE
[Dotenv] Improve Dotenv messages

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -48,8 +48,8 @@ Doctrine Bridge
 Dotenv
 ------
 
- * First parameter of `Dotenv::__construct()` will change from `true` to `false` in Symfony 5.0. A deprecation warning
-   is triggered if no parameter is used. Use `$usePutenv = true` to upgrade without breaking changes.  
+ * First parameter of `Dotenv::__construct()` will be changed from `true` to `false` in Symfony 5.0. A deprecation warning
+   is triggered if no parameter is provided. Use `$usePutenv = true` to upgrade without breaking changes.
 
 EventDispatcher
 ---------------
@@ -170,7 +170,7 @@ SecurityBundle
 TwigBridge
 ----------
 
- * deprecated the `$requestStack` and `$requestContext` arguments of the 
+ * deprecated the `$requestStack` and `$requestContext` arguments of the
    `HttpFoundationExtension`, pass a `Symfony\Component\HttpFoundation\UrlHelper`
    instance as the only argument instead
 

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -45,7 +45,7 @@ final class Dotenv
     public function __construct(bool $usePutenv = true)
     {
         if (!\func_num_args()) {
-            @trigger_error(sprintf('The default value of "$usePutenv" argument of "%s\'s constructor will change from "true" to "false" in Symfony 5.0, you should define its value explicitly.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The default value of "$usePutenv" argument of "%s" will be changed from "true" to "false" in Symfony 5.0. You should define its value explicitly.', __METHOD__), E_USER_DEPRECATED);
         }
 
         $this->usePutenv = $usePutenv;

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -417,7 +417,7 @@ class DotenvTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The default value of "$usePutenv" argument of "%s's constructor will change from "true" to "false" in Symfony 5.0, you should define its value explicitly.
+     * @expectedDeprecation The default value of "$usePutenv" argument of "%s" will be changed from "true" to "false" in Symfony 5.0. You should define its value explicitly.
      */
     public function testDeprecationWarning()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

This PR improves a little bit of some messages from https://github.com/symfony/symfony/pull/31062

The first, passive sentences may be more suitable here because the value couldn't change by itself. It is changed by us - human.

The second, if we use **The default value of $usePutenv" argument of "%s\'s constructor**, we have to pass `__CLASS__` as the second parameter of `sprintf` function instead of `__METHOD__`. So, I suggest using **The default value of $usePutenv" argument of "%s"**.

Finally, the deprecation warning of `Dotenv::__construct()` is very long. Let's separate it into 2 pieces for readable reason.
