### PR TITLE
property normalizer should also pass format and context to isAllowedAttribute

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -102,7 +102,7 @@ class PropertyNormalizer extends AbstractObjectNormalizer
 
         do {
             foreach ($reflectionObject->getProperties() as $property) {
-                if (!$this->isAllowedAttribute($reflectionObject->getName(), $property->name)) {
+                if (!$this->isAllowedAttribute($reflectionObject->getName(), $property->name, $format, $context)) {
                     continue;
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | found while working on https://github.com/symfony/symfony/pull/30888
| License       | MIT
| Doc PR        | -

the context and format are optional parameters to `isAllowedAttribute`, but should be forwarded. due to this omission, the PropertyNormalizer was ignoring the 'attributes' context option (and does in version 4 also ignore the 'ignore_attributes' context option - that one is a property on the normalizer class in version 3 and therefore not ignored here)