### PR TITLE
[Form] Show all option normalizers on debug:form command

### DIFF
--- a/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
@@ -120,7 +120,7 @@ abstract class Descriptor implements DescriptorInterface
             'lazy' => 'getLazyClosures',
             'allowedTypes' => 'getAllowedTypes',
             'allowedValues' => 'getAllowedValues',
-            'normalizer' => 'getNormalizer',
+            'normalizers' => 'getNormalizers',
             'deprecationMessage' => 'getDeprecationMessage',
         ];
 

--- a/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
@@ -87,7 +87,7 @@ class JsonDescriptor extends Descriptor
                 }
             }
         }
-        $data['has_normalizer'] = isset($definition['normalizer']);
+        $data['has_normalizer'] = isset($definition['normalizers']);
 
         $this->writeData($data, $options);
     }

--- a/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
@@ -118,7 +118,7 @@ class TextDescriptor extends Descriptor
             'Default' => 'default',
             'Allowed types' => 'allowedTypes',
             'Allowed values' => 'allowedValues',
-            'Normalizer' => 'normalizer',
+            'Normalizers' => 'normalizers',
         ];
         $rows = [];
         foreach ($map as $label => $name) {

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -164,27 +164,29 @@ TXT
 Symfony\Component\Form\Tests\Command\FooType (foo)
 ==================================================
 
- ---------------- -----------------------------------------------------------%s
-  Required         true                                                      %w
- ---------------- -----------------------------------------------------------%s
-  Default          -                                                         %w
- ---------------- -----------------------------------------------------------%s
-  Allowed types    [                                                         %w
-                     "string"                                                %w
-                   ]                                                         %w
- ---------------- -----------------------------------------------------------%s
-  Allowed values   [                                                         %w
-                     "bar",                                                  %w
-                     "baz"                                                   %w
-                   ]                                                         %w
- ---------------- -----------------------------------------------------------%s
-  Normalizer       Closure(Options $options, $value) {                       %w
-                     class: "Symfony\Component\Form\Tests\Command\FooType"   %w
-                     this: Symfony\Component\Form\Tests\Command\FooType { …} %w
-                     file: "%s"%w
-                     line: "%d to %d"%w
-                   }                                                         %w
- ---------------- -----------------------------------------------------------%s
+ ---------------- -----------%s
+  Required         true      %s
+ ---------------- -----------%s
+  Default          -         %s
+ ---------------- -----------%s
+  Allowed types    [         %s
+                     "string"%s
+                   ]         %s
+ ---------------- -----------%s
+  Allowed values   [         %s
+                     "bar",  %s
+                     "baz"   %s
+                   ]         %s
+ ---------------- -----------%s
+  Normalizers      [         %s
+                     Closure(%s
+                       class:%s
+                       this: %s
+                       file: %s
+                       line: %s
+                     }       %s
+                   ]         %s
+ ---------------- -----------%s
 
 TXT
             , $tester->getDisplay(true));

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
@@ -2,22 +2,26 @@
 Symfony\Component\Form\Extension\Core\Type\ChoiceType (choice_translation_domain)
 =================================================================================
 
- ---------------- --------------------%s 
-  Required         false              %s 
- ---------------- --------------------%s 
-  Default          true               %s 
- ---------------- --------------------%s 
-  Allowed types    [                  %s 
-                     "null",          %s 
-                     "bool",          %s 
-                     "string"         %s 
-                   ]                  %s 
- ---------------- --------------------%s 
-  Allowed values   -                  %s 
- ---------------- --------------------%s 
-  Normalizer       Closure%s{%A
-                     file: "%s%eExtension%eCore%eType%eChoiceType.php"%w
-                     line: %s 
-                   }                  %s 
- ---------------- --------------------%s 
+ ---------------- -----------%s
+  Required         false     %s
+ ---------------- -----------%s
+  Default          true      %s
+ ---------------- -----------%s
+  Allowed types    [         %s
+                     "null", %s
+                     "bool", %s
+                     "string"%s
+                   ]         %s
+ ---------------- -----------%s
+  Allowed values   -         %s
+ ---------------- -----------%s
+  Normalizers      [         %s
+                     Closure(%s
+                       class:%s
+                       this: %s
+                       file: %s
+                       line: %s
+                     }       %s
+                   ]         %s
+ ---------------- -----------%s
 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/deprecated_option.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/deprecated_option.txt
@@ -14,5 +14,5 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (bar)
  --------------------- ----------------------------------- 
   Allowed values        -                                  
  --------------------- ----------------------------------- 
-  Normalizer            -                                  
+  Normalizers           -                                  
  --------------------- -----------------------------------

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
@@ -1,4 +1,3 @@
-
 Symfony\Component\Form\Tests\Console\Descriptor\FooType (empty_data)
 ====================================================================
 
@@ -22,6 +21,6 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (empty_data)
  ---------------- ----------------------%s 
   Allowed values   -                    %s 
  ---------------- ----------------------%s 
-  Normalizer       -                    %s 
+  Normalizers      -                    %s
  ---------------- ----------------------%s 
 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
@@ -2,23 +2,27 @@
 Symfony\Component\Form\Tests\Console\Descriptor\FooType (foo)
 =============================================================
 
- ---------------- --------------------%s 
-  Required         true               %s 
- ---------------- --------------------%s 
-  Default          -                  %s 
- ---------------- --------------------%s 
-  Allowed types    [                  %s 
-                     "string"         %s 
-                   ]                  %s 
- ---------------- --------------------%s 
-  Allowed values   [                  %s 
-                     "bar",           %s 
-                     "baz"            %s 
-                   ]                  %s 
- ---------------- --------------------%s 
-  Normalizer       Closure%s{%A
-                     file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"%w
-                     line: %s 
-                   }                  %s 
- ---------------- --------------------%s 
+ ---------------- -----------%s
+  Required         true      %s
+ ---------------- -----------%s
+  Default          -         %s
+ ---------------- -----------%s
+  Allowed types    [         %s
+                     "string"%s
+                   ]         %s
+ ---------------- -----------%s
+  Allowed values   [         %s
+                     "bar",  %s
+                     "baz"   %s
+                   ]         %s
+ ---------------- -----------%s
+  Normalizers      [         %s
+                     Closure(%s
+                       class:%s
+                       this: %s
+                       file: %s
+                       line: %s
+                     }       %s
+                   ]         %s
+ ---------------- -----------%s
 

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1.3",
         "symfony/event-dispatcher": "^4.3",
         "symfony/intl": "^4.3",
-        "symfony/options-resolver": "~4.2",
+        "symfony/options-resolver": "~4.3",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/property-access": "~3.4|~4.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Follow-up https://github.com/symfony/symfony/pull/30371

![normalizers](https://user-images.githubusercontent.com/2028198/55996454-6667df80-5c85-11e9-94f6-9ee3988833f3.png)
