### PR TITLE
Not render Bootstrap radio label when false

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -248,10 +248,12 @@
         {%- endif -%}
 
         {{ widget|raw }}
-        <label{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
-            {{- label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) -}}
-            {{- form_errors(form) -}}
-        </label>
+        {% if label is not same as(false) %}
+            <label{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
+                {{- translation_domain is same as(false) ? label : label|trans({}, translation_domain) -}}
+                {{- form_errors(form) -}}
+            </label>
+        {% endif %}
     {%- endif -%}
 {%- endblock checkbox_radio_label %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 up to 4.2
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Bootstrap form theme does still render the `<label>`, even when label is set to `false`. The whole label should be wrapped in the check for `false`.
