### PR TITLE
[PhpUnitBridge] ClockMock does not mock gmdate()

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -79,11 +79,20 @@ class ClockMock
         return \date($format, $timestamp);
     }
 
+    public static function gmdate($format, $timestamp = null)
+    {
+        if (null === $timestamp) {
+            $timestamp = self::time();
+        }
+
+        return \gmdate($format, $timestamp);
+    }
+
     public static function register($class)
     {
         $self = \get_called_class();
 
-        $mockedNs = array(substr($class, 0, strrpos($class, '\\')));
+        $mockedNs = [substr($class, 0, strrpos($class, '\\'))];
         if (0 < strpos($class, '\\Tests\\')) {
             $ns = str_replace('\\Tests\\', '\\', $class);
             $mockedNs[] = substr($ns, 0, strrpos($ns, '\\'));
@@ -122,6 +131,10 @@ function date(\$format, \$timestamp = null)
     return \\$self::date(\$format, \$timestamp);
 }
 
+function gmdate(\$format, \$timestamp = null)
+{
+    return \\$self::gmdate(\$format, \$timestamp);
+}
 EOPHP
             );
         }

--- a/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
@@ -62,4 +62,11 @@ class ClockMockTest extends TestCase
     {
         $this->assertSame('1234567890', date('U'));
     }
+
+    public function testGmDate()
+    {
+        ClockMock::withClockMock(1555075769);
+
+        $this->assertSame('1555075769', gmdate('U'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | feature
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30393   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11418 <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
Adding the feature to mock gmdate directly in ClockMock.