### PR TITLE
Skip testing the phpunit-bridge on not-master branches when $deps is empty

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,6 +63,7 @@ test_script:
     - SET X=0
     - cd c:\php && copy /Y php.ini-min php.ini
     - cd c:\projects\symfony
+    - IF %APPVEYOR_REPO_BRANCH% neq master (rm -Rf src\Symfony\Bridge\PhpUnit)
     - php phpunit src\Symfony --exclude-group benchmark,intl-data || SET X=!errorlevel!
     - cd c:\php && 7z x php-5.5.9-nts-Win32-VC11-x86.zip -y >nul && copy /Y php.ini-min php.ini
     - cd c:\projects\symfony

--- a/.travis.yml
+++ b/.travis.yml
@@ -225,6 +225,12 @@ install:
       fi
 
     - |
+      # Skip the phpunit-bridge on not-master branches when $deps is empty
+      if [[ ! $deps && $TRAVIS_BRANCH != master ]]; then
+          COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -printf '%h\n')
+      fi
+
+    - |
       # Install symfony/flex
       if [[ $deps = low ]]; then
           export SYMFONY_REQUIRE='>=2.3'
@@ -271,6 +277,7 @@ install:
               echo "$COMPONENTS" | parallel --gnu -j10% "tfold {} 'cd {} && ([ -e composer.lock ] && ${COMPOSER_UP/update/install} || $COMPOSER_UP --prefer-lowest --prefer-stable) && $PHPUNIT_X'"
               echo "$COMPONENTS" | xargs -n1 -I{} tar --append -f ~/php-ext/composer-lowest.lock.tar {}/composer.lock
           elif [[ $PHP = hhvm* ]]; then
+              rm src/Symfony/Bridge/PhpUnit -Rf
               $PHPUNIT --exclude-group no-hhvm,benchmark,intl-data
           else
               echo "$COMPONENTS" | parallel --gnu "tfold {} $PHPUNIT_X {}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Tests are not in sync with the autoloaded code on these jobs.
The bridge is still tested on deps=low/high jobs + master