### PR TITLE
[DependencyInjection] [WIP] Disallow using an existing class name as id for a service that declares the "class" option

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -400,6 +400,9 @@ class YamlFileLoader extends FileLoader
         }
 
         if (isset($service['class'])) {
+            if ($service['class'] !== $id && class_exists($id)) {
+                throw new InvalidArgumentException(sprintf('Using the class "%s" as id for a service which have defined "%s" as "class" option is not allowed.', $id, $service['class']));
+            }
             $definition->setClass($service['class']);
         }
 


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Branch       |4.2|
|Bug fix?     |no |
|New feature? |no |
|BC breaks?   |no |
|Deprecations?|no |
|Tests pass?  |yes|
|Fixed tickets|n/a|
|License      |MIT|
|Doc PR       |n/a|

This PR should be taken as a RFC by now.

**TODO**:
- [ ] Validate the changes with other collaborators;
- [ ] Check if this must trigger a `E_USER_DEPRECATED` notice in the last stable branch in order to avoid BC breaks; moving the exception for the next major release;
- [ ] Implement the same checks for other loaders;
- [ ] Add tests;
