### PR TITLE
[TwigBridge] bootstrap4 file_widget: allow setting label attributes declared in label_attr

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -122,7 +122,8 @@
     <{{ element|default('div') }} class="custom-file">
         {%- set type = type|default('file') -%}
         {{- block('form_widget_simple') -}}
-        <label for="{{ form.vars.id }}" class="custom-file-label">
+        {%- set label_attr = label_attr|merge({ class: (label_attr.class|default('') ~ ' custom-file-label')|trim }) -%}
+        <label for="{{ form.vars.id }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
             {%- if attr.placeholder is defined -%}
                 {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
             {%- endif -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | ...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | ... <!-- required for new features -->

> Bootstrap provides a way to translate the “Browse” text in HTML with the data-browse attribute which can be added to the custom input label.

https://getbootstrap.com/docs/4.3/components/forms/#translating-or-customizing-the-strings-with-html

But currently the attributes declared in label_attr aren't being added.