### PR TITLE
[Form] Workaround for \DateInterval::createFromDateString()

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
@@ -442,7 +442,7 @@ class DateIntervalTypeTest extends BaseTypeTest
 
     public function provideEmptyData()
     {
-        $expectedData = \DateInterval::createFromDateString('6 years and 4 months');
+        $expectedData = new \DateInterval('P6Y4M');
 
         return [
             'Simple field' => ['single_text', 'P6Y4M0D', $expectedData],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This patch makes test `Symfony\Component\Form\Tests\Extension\Core\Type\DateIntervalTypeTest::testSubmitNullUsesDateEmptyData()` pass in PHP 7.2.17 and 7.3.4

PHP bug reference : https://bugs.php.net/bug.php?id=77896

See also : https://3v4l.org/sQjh2