### PR TITLE
[HttpClient] fix too high timeout in test

### DIFF
--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -541,7 +541,7 @@ abstract class HttpClientTestCase extends TestCase
 
         $response = null;
         $this->expectException(TransportExceptionInterface::class);
-        $client->request('GET', 'http://symfony.com:8057/');
+        $client->request('GET', 'http://symfony.com:8057/', ['timeout' => 3]);
     }
 
     public function testTimeoutOnAccess()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This makes tests pass without waiting for no reasons.