### PR TITLE
[HttpKernel] Added kernel exception listener interface for explicit exception handling with auto-registration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -66,6 +66,8 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\EventListener\ExceptionListenerInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\LockInterface;
@@ -356,6 +358,8 @@ class FrameworkExtension extends Extension
             ->addTag('kernel.cache_warmer');
         $container->registerForAutoconfiguration(EventSubscriberInterface::class)
             ->addTag('kernel.event_subscriber');
+        $container->registerForAutoconfiguration(ExceptionListenerInterface::class)
+            ->addTag('kernel.event_listener', ['event' => KernelEvents::EXCEPTION]);
         $container->registerForAutoconfiguration(LocaleAwareInterface::class)
             ->addTag('kernel.locale_aware');
         $container->registerForAutoconfiguration(ResetInterface::class)

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListenerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+
+/**
+ * ExceptionListenerInterface handles kernel exception event.
+ */
+interface ExceptionListenerInterface
+{
+    /**
+     * Handle some type of exception and create an appropriate Response to return for the exception.
+     *
+     * @param ExceptionEvent $event
+     *
+     * @return mixed
+     */
+    public function onKernelException(ExceptionEvent $event);
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
+use Symfony\Component\HttpKernel\EventListener\ExceptionListenerInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
@@ -154,6 +155,24 @@ class ExceptionListenerTest extends TestCase
 
         $this->assertFalse($response->headers->has('content-security-policy'), 'CSP header has been removed');
         $this->assertFalse($dispatcher->hasListeners(KernelEvents::RESPONSE), 'CSP removal listener has been removed');
+    }
+
+    public function testExceptionListener()
+    {
+        $request = new Request();
+        $exception = new \Exception('foo');
+        $event = new ExceptionEvent(new TestKernel(), $request, HttpKernelInterface::MASTER_REQUEST, $exception);
+        $listener = new TestExceptionListener();
+        $listener->onKernelException($event);
+        $this->assertEquals(new Response('foo'), $event->getResponse());
+    }
+}
+
+class TestExceptionListener implements ExceptionListenerInterface
+{
+    public function onKernelException(ExceptionEvent $event)
+    {
+        $event->setResponse(new Response('foo'));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Added kernel exception listener interface to implement for explicit exception handling with auto-registration of event-listener tag.
