### PR TITLE
[Security] Dispatch an event when "logout user on change" steps in

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
  * Dispatch `SwitchUserEvent` on `security.switch_user`
  * Deprecated `Argon2iPasswordEncoder`, use `SodiumPasswordEncoder` instead
  * Deprecated `BCryptPasswordEncoder`, use `NativePasswordEncoder` instead
+ * Added `DeauthenticatedEvent` dispatched in case the user has changed when trying to refresh it
 
 4.2.0
 -----

--- a/src/Symfony/Component/Security/Http/Event/DeauthenticatedEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/DeauthenticatedEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Event;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Deauthentication happens in case the user has changed when trying to refresh it.
+ *
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+class DeauthenticatedEvent extends Event
+{
+    private $originalToken;
+    private $refreshedToken;
+
+    public function __construct(TokenInterface $originalToken, TokenInterface $refreshedToken)
+    {
+        $this->originalToken = $originalToken;
+        $this->refreshedToken = $refreshedToken;
+    }
+
+    public function getRefreshedToken(): TokenInterface
+    {
+        return $this->refreshedToken;
+    }
+
+    public function getOriginalToken(): TokenInterface
+    {
+        return $this->originalToken;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -28,6 +28,7 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Role\SwitchUserRole;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Event\DeauthenticatedEvent;
 
 /**
  * ContextListener manages the SecurityContext persistence through a session.
@@ -223,6 +224,10 @@ class ContextListener implements ListenerInterface
         if ($userDeauthenticated) {
             if (null !== $this->logger) {
                 $this->logger->debug('Token was deauthenticated after trying to refresh it.');
+            }
+
+            if (null !== $this->dispatcher) {
+                $this->dispatcher->dispatch(new DeauthenticatedEvent($token, $newToken), DeauthenticatedEvent::class);
             }
 
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26902   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11450 <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

This adds a new event when the user has been changed and has been log out from the apps, it allow someone to register to this event and do something with either to token or the refreshedUser.
