### PR TITLE
Release v2.7.51

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,13 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.51 (2019-04-17)
+
+ * security #cve-2019-10910 [DI] Check service IDs are valid (nicolas-grekas)
+ * security #cve-2019-10909 [FrameworkBundle][Form] Fix XSS issues in the form theme of the PHP templating engine - CVE-2019-10909 (stof)
+ * security #cve-2019-10911 [Security] Add a separator in the remember me cookie hash (pborreli)
+ * security #cve-2019-10913 [HttpFoundation] reject invalid method override (nicolas-grekas)
+
 * 2.7.50 (2018-12-06)
 
  * security #cve-2018-19790 [Security\Http] detect bad redirect targets using backslashes (xabbuh)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,11 +58,11 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.50';
-    const VERSION_ID = 20750;
+    const VERSION = '2.7.51';
+    const VERSION_ID = 2.7.51;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
-    const RELEASE_VERSION = 50;
+    const RELEASE_VERSION = 51;
     const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.7.50...v2.7.51)

 * security #cve-2019-10910 [DI] Check service IDs are valid (@nicolas-grekas)
 * security #cve-2019-10909 [FrameworkBundle][Form] Fix XSS issues in the form theme of the PHP templating engine - CVE-2019-10909 (@stof)
 * security #cve-2019-10911 [Security] Add a separator in the remember me cookie hash (@pborreli)
 * security #cve-2019-10913 [HttpFoundation] reject invalid method override (@nicolas-grekas)
