### PR TITLE
Release v2.8.50

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,14 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.50 (2019-04-17)
+
+ * security #cve-2019-10910 [DI] Check service IDs are valid (nicolas-grekas)
+ * security #cve-2019-10909 [FrameworkBundle][Form] Fix XSS issues in the form theme of the PHP templating engine (stof)
+ * security #cve-2019-10912 [PHPUnit Bridge] Prevent destructors with side-effects from being unserialized (nicolas-grekas)
+ * security #cve-2019-10911 [Security] Add a separator in the remember me cookie hash (pborreli)
+ * security #cve-2019-10913 [HttpFoundation] reject invalid method override (nicolas-grekas)
+
 * 2.8.49 (2018-12-06)
 
  * security #cve-2018-19790 [Security\Http] detect bad redirect targets using backslashes (xabbuh)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,11 +59,11 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.49';
-    const VERSION_ID = 20849;
+    const VERSION = '2.8.50';
+    const VERSION_ID = 2.8.50;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
-    const RELEASE_VERSION = 49;
+    const RELEASE_VERSION = 50;
     const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.8.49...v2.8.50)

 * security #cve-2019-10910 [DI] Check service IDs are valid (@nicolas-grekas)
 * security #cve-2019-10909 [FrameworkBundle][Form] Fix XSS issues in the form theme of the PHP templating engine (@stof)
 * security #cve-2019-10912 [PHPUnit Bridge] Prevent destructors with side-effects from being unserialized (@nicolas-grekas)
 * security #cve-2019-10911 [Security] Add a separator in the remember me cookie hash (@pborreli)
 * security #cve-2019-10913 [HttpFoundation] reject invalid method override (@nicolas-grekas)
