### PR TITLE
Release v3.4.26

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -7,6 +7,16 @@ in 3.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.4.0...v3.4.1
 
+* 3.4.26 (2019-04-17)
+
+ * bug #31084 [HttpFoundation] Make MimeTypeExtensionGuesser case insensitive (vermeirentony)
+ * bug #31142 Revert "bug #30423 [Security] Rework firewall's access denied rule (dimabory)" (chalasr)
+ * security #cve-2019-10910 [DI] Check service IDs are valid (nicolas-grekas)
+ * security #cve-2019-10909 [FrameworkBundle][Form] Fix XSS issues in the form theme of the PHP templating engine (stof)
+ * security #cve-2019-10912 [Cache][PHPUnit Bridge] Prevent destructors with side-effects from being unserialized (nicolas-grekas)
+ * security #cve-2019-10911 [Security] Add a separator in the remember me cookie hash (pborreli)
+ * security #cve-2019-10913 [HttpFoundation] reject invalid method override (nicolas-grekas)
+
 * 3.4.25 (2019-04-16)
 
  * bug #29944 [DI] Overriding services autowired by name under _defaults bind not working (przemyslaw-bogusz, renanbr)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -67,12 +67,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '3.4.26-DEV';
+    const VERSION = '3.4.26';
     const VERSION_ID = 30426;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 4;
     const RELEASE_VERSION = 26;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2020';
     const END_OF_LIFE = '11/2021';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.4.25...v3.4.26)

 * bug #31084 [HttpFoundation] Make MimeTypeExtensionGuesser case insensitive (@vermeirentony)
 * bug #31142 Revert "bug #30423 [Security] Rework firewall's access denied rule (dimabory)" (@chalasr)
 * security #cve-2019-10910 [DI] Check service IDs are valid (@nicolas-grekas)
 * security #cve-2019-10909 [FrameworkBundle][Form] Fix XSS issues in the form theme of the PHP templating engine (@stof)
 * security #cve-2019-10912 [Cache][PHPUnit Bridge] Prevent destructors with side-effects from being unserialized (@nicolas-grekas)
 * security #cve-2019-10911 [Security] Add a separator in the remember me cookie hash (@pborreli)
 * security #cve-2019-10913 [HttpFoundation] reject invalid method override (@nicolas-grekas)
