### PR TITLE
 [Security] add password rehashing capabilities 

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Security\User;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -25,7 +26,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class EntityUserProvider implements UserProviderInterface
+class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInterface
 {
     private $registry;
     private $managerName;
@@ -105,6 +106,22 @@ class EntityUserProvider implements UserProviderInterface
     public function supportsClass($class)
     {
         return $class === $this->getClass() || is_subclass_of($class, $this->getClass());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    {
+        $class = $this->getClass();
+        if (!$user instanceof $class) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
+        }
+
+        $repository = $this->getRepository();
+        if ($repository instanceof PasswordUpgraderInterface) {
+            $repository->upgradePassword($user, $newEncodedPassword);
+        }
     }
 
     private function getObjectManager()

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -32,7 +32,7 @@
         "symfony/property-access": "~3.4|~4.0",
         "symfony/property-info": "~3.4|~4.0",
         "symfony/proxy-manager-bridge": "~3.4|~4.0",
-        "symfony/security": "~3.4|~4.0",
+        "symfony/security": "^4.4",
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/validator": "~3.4|~4.0",
         "symfony/translation": "~3.4|~4.0",
@@ -48,7 +48,8 @@
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/dependency-injection": "<3.4",
         "symfony/form": "<4.3",
-        "symfony/messenger": "<4.2"
+        "symfony/messenger": "<4.2",
+        "symfony/security-core": "<4.4"
     },
     "suggest": {
         "symfony/form": "",

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * Added `MigratingPasswordEncoder`
+ * Added methods `PasswordEncoderInterface::needsRehash()` and `UserPasswordEncoderInterface::needsRehash()`
+ * Added and implemented `PasswordUpgraderInterface`
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -54,8 +55,14 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
                 throw new BadCredentialsException('The presented password cannot be empty.');
             }
 
-            if (!$this->encoderFactory->getEncoder($user)->isPasswordValid($user->getPassword(), $presentedPassword, $user->getSalt())) {
+            $encoder = $this->encoderFactory->getEncoder($user);
+
+            if (!$encoder->isPasswordValid($user->getPassword(), $presentedPassword, $user->getSalt())) {
                 throw new BadCredentialsException('The presented password is invalid.');
+            }
+
+            if ($this->userProvider instanceof PasswordUpgraderInterface && method_exists($encoder, 'needsRehash') && $encoder->needsRehash($user->getPassword())) {
+                $this->userProvider->upgradePassword($user, $encoder->encodePassword($presentedPassword, $user->getSalt()));
             }
         }
     }

--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -21,6 +21,14 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
     const MAX_PASSWORD_LENGTH = 4096;
 
     /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(string $encoded): bool
+    {
+        return false;
+    }
+
+    /**
      * Demerges a merge password and salt string.
      *
      * @param string $mergedPasswordSalt The merged password and salt string

--- a/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
@@ -65,6 +65,6 @@ class MessageDigestPasswordEncoder extends BasePasswordEncoder
      */
     public function isPasswordValid($encoded, $raw, $salt)
     {
-        return !$this->isPasswordTooLong($raw) && $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
+        return '$' !== substr($encoded, 0, 1) && !$this->isPasswordTooLong($raw) && $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
     }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/MigratingPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MigratingPasswordEncoder.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Encoder;
+
+/**
+ * Hashes passwords using the best available encoder.
+ * Validates them using a chain of encoders.
+ *
+ * /!\ Don't put a PlaintextPasswordEncoder in the list as that'd mean a leaked hash
+ * could be used to authenticate successfully without knowing the cleartext password.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class MigratingPasswordEncoder extends BasePasswordEncoder implements SelfSaltingEncoderInterface
+{
+    private $bestEncoder;
+    private $extraEncoders;
+
+    public function __construct(PasswordEncoderInterface $bestEncoder, PasswordEncoderInterface ...$extraEncoders)
+    {
+        $this->bestEncoder = $bestEncoder;
+        $this->extraEncoders = $extraEncoders;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encodePassword($raw, $salt)
+    {
+        return $this->bestEncoder->encodePassword($raw, $salt);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPasswordValid($encoded, $raw, $salt)
+    {
+        if ($this->bestEncoder->isPasswordValid($encoded, $raw, $salt)) {
+            return true;
+        }
+
+        if (!$this->bestEncoder->needsRehash($encoded)) {
+            return false;
+        }
+
+        foreach ($this->extraEncoders as $encoder) {
+            if ($encoder->isPasswordValid($encoded, $raw, $salt)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(string $encoded): bool
+    {
+        return $this->bestEncoder->needsRehash($encoded);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -87,4 +87,12 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
 
         return \strlen($raw) <= self::MAX_PASSWORD_LENGTH && password_verify($raw, $encoded);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(string $encoded): bool
+    {
+        return password_needs_rehash($encoded, $this->algo, $this->options);
+    }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
  * PasswordEncoderInterface is the interface for all encoders.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method bool needsRehash(string $encoded)
  */
 interface PasswordEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
@@ -72,6 +72,6 @@ class Pbkdf2PasswordEncoder extends BasePasswordEncoder
      */
     public function isPasswordValid($encoded, $raw, $salt)
     {
-        return !$this->isPasswordTooLong($raw) && $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
+        return '$' !== substr($encoded, 0, 1) && !$this->isPasswordTooLong($raw) && $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
     }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -94,4 +94,20 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
 
         throw new LogicException('Libsodium is not available. You should either install the sodium extension, upgrade to PHP 7.2+ or use a different encoder.');
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(string $encoded): bool
+    {
+        if (\function_exists('sodium_crypto_pwhash_str_needs_rehash')) {
+            return \sodium_crypto_pwhash_str_needs_rehash($encoded, $this->opsLimit, $this->memLimit);
+        }
+
+        if (\extension_loaded('libsodium')) {
+            return \Sodium\crypto_pwhash_str_needs_rehash($encoded, $this->opsLimit, $this->memLimit);
+        }
+
+        throw new LogicException('Libsodium is not available. You should either install the sodium extension, upgrade to PHP 7.2+ or use a different encoder.');
+    }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
@@ -46,4 +46,14 @@ class UserPasswordEncoder implements UserPasswordEncoderInterface
 
         return $encoder->isPasswordValid($user->getPassword(), $raw, $user->getSalt());
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(UserInterface $user, string $encoded): bool
+    {
+        $encoder = $this->encoderFactory->getEncoder($user);
+
+        return method_exists($encoder, 'needsRehash') && $encoder->needsRehash($encoded);
+    }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * UserPasswordEncoderInterface is the interface for the password encoder service.
  *
  * @author Ariel Ferrandini <arielferrandini@gmail.com>
+ *
+ * @method bool needsRehash(UserInterface $user, string $encoded)
  */
 interface UserPasswordEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class ChainUserProvider implements UserProviderInterface
+class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterface
 {
     private $providers;
 
@@ -103,5 +103,21 @@ class ChainUserProvider implements UserProviderInterface
         }
 
         return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider instanceof PasswordUpgraderInterface) {
+                try {
+                    $provider->upgradePassword($user, $newEncodedPassword);
+                } catch (UnsupportedUserException $e) {
+                    // ignore: password upgrades are opportunistic
+                }
+            }
+        }
     }
 }

--- a/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\User;
 
 use Symfony\Component\Ldap\Entry;
 use Symfony\Component\Ldap\Exception\ConnectionException;
+use Symfony\Component\Ldap\Exception\ExceptionInterface;
 use Symfony\Component\Ldap\LdapInterface;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -24,7 +25,7 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Charles Sarrazin <charles@sarraz.in>
  */
-class LdapUserProvider implements UserProviderInterface
+class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterface
 {
     private $ldap;
     private $baseDn;
@@ -34,6 +35,7 @@ class LdapUserProvider implements UserProviderInterface
     private $uidKey;
     private $defaultSearch;
     private $passwordAttribute;
+    private $entry;
 
     public function __construct(LdapInterface $ldap, string $baseDn, string $searchDn = null, string $searchPassword = null, array $defaultRoles = [], string $uidKey = null, string $filter = null, string $passwordAttribute = null)
     {
@@ -89,6 +91,11 @@ class LdapUserProvider implements UserProviderInterface
         } catch (InvalidArgumentException $e) {
         }
 
+        if (null !== $this->entry) {
+            // Keep $entry around when called from upgradePassword()
+            $this->entry = $entry;
+        }
+
         return $this->loadUser($username, $entry);
     }
 
@@ -110,6 +117,35 @@ class LdapUserProvider implements UserProviderInterface
     public function supportsClass($class)
     {
         return 'Symfony\Component\Security\Core\User\User' === $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    {
+        if (!$user instanceof User) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
+        }
+
+        if (null === $this->passwordAttribute) {
+            return;
+        }
+
+        try {
+            // Tell loadUserByUsername() to keep the $entry around
+            $this->entry = true;
+
+            if ($user->isEqualTo($this->loadUserByUsername($user->getUsername())) && \is_object($this->entry)) {
+                $this->entry->setAttribute($this->passwordAttribute, [$newEncodedPassword]);
+                $this->ldap->getEntryManager()->update($this->entry);
+                $user->setPassword($newEncodedPassword);
+            }
+        } catch (ExceptionInterface $e) {
+            // ignore failed password upgrades
+        } finally {
+            $this->entry = null;
+        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\User;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface PasswordUpgraderInterface
+{
+    /**
+     * Upgrades the encoded password of a user, typically for using a better hash algorithm.
+     *
+     * This method should persist the new password in the user storage and update the $user object accordingly.
+     * Because you don't want your users not being able to log in, this method should be opportunistic:
+     * it's fine if it does nothing or if it fails without throwing any exception.
+     */
+    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void;
+}

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -157,4 +157,9 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
 
         return true;
     }
+
+    public function setPassword(string $password)
+    {
+        $this->password = $password;
+    }
 }

--- a/src/Symfony/Component/Security/Guard/AuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/AuthenticatorInterface.php
@@ -94,14 +94,15 @@ interface AuthenticatorInterface extends AuthenticationEntryPointInterface
      *
      * The *credentials* are the return value from getCredentials()
      *
-     * @param mixed         $credentials
-     * @param UserInterface $user
+     * @param mixed                     $credentials
+     * @param UserInterface             $user
+     * @param PasswordUpgraderInterface $passwordUpgrader
      *
      * @return bool
      *
      * @throws AuthenticationException
      */
-    public function checkCredentials($credentials, UserInterface $user);
+    public function checkCredentials($credentials, UserInterface $user/*, PasswordUpgraderInterface $passwordUpgrader = null*/);
 
     /**
      * Create an authenticated token for the given user.

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\AuthenticationExpiredException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -110,7 +111,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         }
 
         $this->userChecker->checkPreAuth($user);
-        if (true !== $guardAuthenticator->checkCredentials($token->getCredentials(), $user)) {
+        if (true !== $guardAuthenticator->checkCredentials($token->getCredentials(), $user, $this->userProvider instanceof PasswordUpgraderInterface ? $this->userProvider : null)) {
             throw new BadCredentialsException(sprintf('Authentication failed because %s::checkCredentials() did not return true.', \get_class($guardAuthenticator)));
         }
         $this->userChecker->checkPostAuth($user);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31139
| License       | MIT
| Doc PR        | -
| Maker PR | symfony/maker-bundle#389

This PR adds a new `PasswordUpgraderInterface` to migrate passwords to better hash algos when users log in.

The interface is implemented on relevant user-encoder in core. When Users are managed via Doctrine, the interface should be implemented on the app's UserRepository. This means the feature is opt-in. For new projects, symfony/maker-bundle#389 generates user repositories that provide the needed implementation, so that this feature works by default. Existing projects should add [the new method](https://github.com/symfony/maker-bundle/pull/389/files#diff-5abcba85d436f4dc2698f51b2ed99b91) to their repo.

Because it was needed, Guard's `AuthenticatorInterface::checkCredentials()` method now takes a `PasswordUpgraderInterface` as 3rd argument.

On the validation side, a new `MigratingPasswordEncoder` allows validating a hash using several algos.

TL;DR, this should provide state of the art password management, with an authentication layer that can validate old password hashes and turn them into new ones.