### PR TITLE
[Validator] Translation should be required to make LegacyTranslationProxy work

### DIFF
--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -19,7 +19,8 @@
         "php": "^7.1.3",
         "symfony/contracts": "^1.0.2",
         "symfony/polyfill-ctype": "~1.8",
-        "symfony/polyfill-mbstring": "~1.0"
+        "symfony/polyfill-mbstring": "~1.0",
+        "symfony/translation": "~4.2"
     },
     "require-dev": {
         "symfony/http-foundation": "~4.1",
@@ -32,7 +33,6 @@
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/cache": "~3.4|~4.0",
         "symfony/property-access": "~3.4|~4.0",
-        "symfony/translation": "~4.2",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0",
         "egulias/email-validator": "^1.2.8|~2.0"


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31152  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

Alternative to #31154, I thinks it's enough to just move the translation to required.
