### PR TITLE
Validator requires Translation

### DIFF
--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/contracts": "^1.0.2",
+        "symfony/translation": "^4.2",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0"
     },
@@ -42,7 +43,6 @@
         "symfony/dependency-injection": "<3.4",
         "symfony/http-kernel": "<3.4",
         "symfony/intl": "<4.1",
-        "symfony/translation": "<4.2",
         "symfony/yaml": "<3.4"
     },
     "suggest": {
@@ -51,7 +51,6 @@
         "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
         "symfony/http-foundation": "",
         "symfony/intl": "",
-        "symfony/translation": "For translating validation errors.",
         "symfony/yaml": "",
         "symfony/config": "",
         "egulias/email-validator": "Strict (RFC compliant) email validation",


### PR DESCRIPTION
AS since 4.2.7 some other projects (ex doctrine-bundle) fails with `PHP Fatal error:  Interface 'Symfony\Component\Translation\TranslatorInterface' not found in /usr/share/php/Symfony4/Component/Validator/Util/LegacyTranslatorProxy.php on line 21`
