### PR TITLE
[Security] deprecate BCryptPasswordEncoder in favor of NativePasswordEncoder

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -168,13 +168,14 @@ Security
    ```
 
  * The `Argon2iPasswordEncoder` class has been deprecated, use `SodiumPasswordEncoder` instead.
+ * The `BCryptPasswordEncoder` class has been deprecated, use `NativePasswordEncoder` instead.
  * Not implementing the methods `__serialize` and `__unserialize` in classes implementing
    the `TokenInterface` is deprecated
 
 SecurityBundle
 --------------
 
- * Configuring encoders using `argon2i` as algorithm has been deprecated, use `auto` instead.
+ * Configuring encoders using `argon2i` or `bcrypt` as algorithm has been deprecated, use `auto` instead.
 
 TwigBridge
 ----------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -342,6 +342,7 @@ Security
    ```
 
  * The `Argon2iPasswordEncoder` class has been removed, use `SodiumPasswordEncoder` instead.
+ * The `BCryptPasswordEncoder` class has been removed, use `NativePasswordEncoder` instead.
  * Classes implementing the `TokenInterface` must implement the two new methods
    `__serialize` and `__unserialize`
 
@@ -364,7 +365,7 @@ SecurityBundle
    changed to underscores.
    Before: `my-cookie` deleted the `my_cookie` cookie (with an underscore).
    After: `my-cookie` deletes the `my-cookie` cookie (with a dash).
- * Configuring encoders using `argon2i` as algorithm is not supported anymore, use `sodium` instead.
+ * Configuring encoders using `argon2i` or `bcrypt` as algorithm is not supported anymore, use `auto` instead.
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -70,7 +70,7 @@ Suppose that you have the following security configuration in your application:
 security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext
-        App\Entity\User: bcrypt
+        App\Entity\User: auto
 </comment>
 
 If you execute the command non-interactively, the first available configured

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -558,6 +558,8 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         // bcrypt encoder
         if ('bcrypt' === $config['algorithm']) {
+            @trigger_error('Configuring an encoder with "bcrypt" as algorithm is deprecated since Symfony 4.3, use "auto" instead.', E_USER_DEPRECATED);
+
             return [
                 'class' => 'Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder',
                 'arguments' => [$config['cost'] ?? 13],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -306,14 +306,10 @@ abstract class CompleteConfigurationTest extends TestCase
                 'arguments' => ['sha1', false, 5, 30],
             ],
             'JMS\FooBundle\Entity\User6' => [
-                'class' => 'Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder',
-                'arguments' => [15],
-            ],
-            'JMS\FooBundle\Entity\User7' => [
                 'class' => 'Symfony\Component\Security\Core\Encoder\NativePasswordEncoder',
                 'arguments' => [8, 102400, 15],
             ],
-            'JMS\FooBundle\Entity\User8' => [
+            'JMS\FooBundle\Entity\User7' => [
                 'algorithm' => 'auto',
                 'hash_algorithm' => 'sha512',
                 'key_length' => 40,
@@ -371,24 +367,12 @@ abstract class CompleteConfigurationTest extends TestCase
                 'arguments' => ['sha1', false, 5, 30],
             ],
             'JMS\FooBundle\Entity\User6' => [
-                'class' => 'Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder',
-                'arguments' => [15],
+                'class' => 'Symfony\Component\Security\Core\Encoder\NativePasswordEncoder',
+                'arguments' => [8, 102400, 15],
             ],
             'JMS\FooBundle\Entity\User7' => [
                 'class' => 'Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder',
                 'arguments' => [8, 128 * 1024 * 1024],
-            ],
-            'JMS\FooBundle\Entity\User8' => [
-                'algorithm' => 'auto',
-                'hash_algorithm' => 'sha512',
-                'key_length' => 40,
-                'ignore_case' => false,
-                'encode_as_base64' => true,
-                'iterations' => 5000,
-                'cost' => null,
-                'memory_cost' => null,
-                'time_cost' => null,
-                'threads' => null,
             ],
         ]], $container->getDefinition('security.encoder_factory.generic')->getArguments());
     }
@@ -441,15 +425,42 @@ abstract class CompleteConfigurationTest extends TestCase
                 'arguments' => ['sha1', false, 5, 30],
             ],
             'JMS\FooBundle\Entity\User6' => [
-                'class' => 'Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder',
-                'arguments' => [15],
+                'class' => 'Symfony\Component\Security\Core\Encoder\NativePasswordEncoder',
+                'arguments' => [8, 102400, 15],
             ],
             'JMS\FooBundle\Entity\User7' => [
                 'class' => 'Symfony\Component\Security\Core\Encoder\Argon2iPasswordEncoder',
                 'arguments' => [256, 1, 2],
             ],
-            'JMS\FooBundle\Entity\User8' => [
-                'algorithm' => 'auto',
+        ]], $container->getDefinition('security.encoder_factory.generic')->getArguments());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testEncodersWithBCrypt()
+    {
+        $container = $this->getContainer('bcrypt_encoder');
+
+        $this->assertEquals([[
+            'JMS\FooBundle\Entity\User1' => [
+                'class' => 'Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder',
+                'arguments' => [false],
+            ],
+            'JMS\FooBundle\Entity\User2' => [
+                'algorithm' => 'sha1',
+                'encode_as_base64' => false,
+                'iterations' => 5,
+                'hash_algorithm' => 'sha512',
+                'key_length' => 40,
+                'ignore_case' => false,
+                'cost' => null,
+                'memory_cost' => null,
+                'time_cost' => null,
+                'threads' => null,
+            ],
+            'JMS\FooBundle\Entity\User3' => [
+                'algorithm' => 'md5',
                 'hash_algorithm' => 'sha512',
                 'key_length' => 40,
                 'ignore_case' => false,
@@ -459,6 +470,19 @@ abstract class CompleteConfigurationTest extends TestCase
                 'memory_cost' => null,
                 'time_cost' => null,
                 'threads' => null,
+            ],
+            'JMS\FooBundle\Entity\User4' => new Reference('security.encoder.foo'),
+            'JMS\FooBundle\Entity\User5' => [
+                'class' => 'Symfony\Component\Security\Core\Encoder\Pbkdf2PasswordEncoder',
+                'arguments' => ['sha1', false, 5, 30],
+            ],
+            'JMS\FooBundle\Entity\User6' => [
+                'class' => 'Symfony\Component\Security\Core\Encoder\NativePasswordEncoder',
+                'arguments' => [8, 102400, 15],
+            ],
+            'JMS\FooBundle\Entity\User7' => [
+                'class' => 'Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder',
+                'arguments' => [15],
             ],
         ]], $container->getDefinition('security.encoder_factory.generic')->getArguments());
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_encoder.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_encoder.php
@@ -1,0 +1,12 @@
+<?php
+
+$this->load('container1.php', $container);
+
+$container->loadFromExtension('security', [
+    'encoders' => [
+        'JMS\FooBundle\Entity\User7' => [
+            'algorithm' => 'bcrypt',
+            'cost' => 15,
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -22,16 +22,12 @@ $container->loadFromExtension('security', [
             'key_length' => 30,
         ],
         'JMS\FooBundle\Entity\User6' => [
-            'algorithm' => 'bcrypt',
-            'cost' => 15,
-        ],
-        'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'native',
             'time_cost' => 8,
             'memory_cost' => 100,
             'cost' => 15,
         ],
-        'JMS\FooBundle\Entity\User8' => [
+        'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'auto',
         ],
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_encoder.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_encoder.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:sec="http://symfony.com/schema/dic/security"
+   xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <imports>
+        <import resource="container1.xml"/>
+    </imports>
+
+    <sec:config>
+        <sec:encoder class="JMS\FooBundle\Entity\User7" algorithm="bcrypt" cost="15" />
+    </sec:config>
+
+</container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -16,11 +16,9 @@
 
         <encoder class="JMS\FooBundle\Entity\User5" algorithm="pbkdf2" hash-algorithm="sha1" encode-as-base64="false" iterations="5" key-length="30" />
 
-        <encoder class="JMS\FooBundle\Entity\User6" algorithm="bcrypt" cost="15" />
+        <encoder class="JMS\FooBundle\Entity\User6" algorithm="native" time-cost="8" memory-cost="100" cost="15" />
 
-        <encoder class="JMS\FooBundle\Entity\User7" algorithm="native" time-cost="8" memory-cost="100" cost="15" />
-
-        <encoder class="JMS\FooBundle\Entity\User8" algorithm="auto" />
+        <encoder class="JMS\FooBundle\Entity\User7" algorithm="auto" />
 
         <provider name="default">
             <memory>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_encoder.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_encoder.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: container1.yml }
+
+security:
+    encoders:
+        JMS\FooBundle\Entity\User7:
+            algorithm: bcrypt
+            cost: 15

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -16,14 +16,11 @@ security:
             iterations: 5
             key_length: 30
         JMS\FooBundle\Entity\User6:
-            algorithm: bcrypt
-            cost: 15
-        JMS\FooBundle\Entity\User7:
             algorithm: native
             time_cost: 8
             memory_cost: 100
             cost: 15
-        JMS\FooBundle\Entity\User8:
+        JMS\FooBundle\Entity\User7:
             algorithm: auto
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordEncode/bcrypt.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordEncode/bcrypt.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: config.yml }
+
+security:
+    encoders:
+        Custom\Class\Bcrypt\User:
+            algorithm: bcrypt

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordEncode/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordEncode/config.yml
@@ -4,8 +4,8 @@ imports:
 security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext
-        Custom\Class\Bcrypt\User:
-            algorithm: bcrypt
+        Custom\Class\Native\User:
+            algorithm: native
             cost:      10
         Custom\Class\Pbkdf2\User:
             algorithm: pbkdf2

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -21,7 +21,8 @@ CHANGELOG
  * Dispatch `AuthenticationFailureEvent` on `security.authentication.failure`
  * Dispatch `InteractiveLoginEvent` on `security.interactive_login`
  * Dispatch `SwitchUserEvent` on `security.switch_user`
- * Deprecated `Argon2iPasswordEncoder`, use `SodiumPasswordEncoder`
+ * Deprecated `Argon2iPasswordEncoder`, use `SodiumPasswordEncoder` instead
+ * Deprecated `BCryptPasswordEncoder`, use `NativePasswordEncoder` instead
 
 4.2.0
 -----

--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.3, use "%s" instead.', BCryptPasswordEncoder::class, NativePasswordEncoder::class), E_USER_DEPRECATED);
+
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
 /**
  * @author Elnur Abdurrakhimov <elnur@elnur.pro>
  * @author Terje Bråten <terje@braten.be>
+ *
+ * @deprecated since Symfony 4.3, use NativePasswordEncoder instead
  */
 class BCryptPasswordEncoder extends BasePasswordEncoder implements SelfSaltingEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
@@ -106,6 +106,7 @@ class EncoderFactory implements EncoderFactoryInterface
                     ],
                 ];
 
+            /* @deprecated since Symfony 4.3 */
             case 'bcrypt':
                 return [
                     'class' => BCryptPasswordEncoder::class,

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
 
 /**
  * @author Elnur Abdurrakhimov <elnur@elnur.pro>
+ *
+ * @group legacy
  */
 class BCryptPasswordEncoderTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Follow up of #31140