### PR TITLE
[PropertyAccess] Handle setters with variadic arguments

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -780,4 +780,37 @@ class PropertyAccessorTest extends TestCase
         $object = new TestClassSetValue(0);
         $this->propertyAccessor->setValue($object, 'foo', 1);
     }
+
+    public function generateAnonymousClassWithVariadicSetter()
+    {
+        return eval('return new class() 
+        {
+            private $property;
+
+            public function setProperty(int ...$args) {
+                $this->property = implode(",", $args);
+            }
+
+            public function getProperty() {
+                return $this->property;
+            }
+        };');
+    }
+
+    public function testVariadicSetter()
+    {
+        $object = $this->generateAnonymousClassWithVariadicSetter();
+
+        $this->propertyAccessor->setValue($object, 'property', ...[1, 2, 3]);
+
+        $this->assertEquals('1,2,3', $this->propertyAccessor->getValue($object, 'property'));
+    }
+
+    public function testThrowInvalidArgumentExceptionOfVariadicType()
+    {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidArgumentException');
+
+        $object = $this->generateAnonymousClassWithVariadicSetter();
+        $this->propertyAccessor->setValue($object, 'property', ...[1, 2, new \stdClass()]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #30703 
| License       | MIT
| Doc PR        | not sure if it's required

- [ ] Update `CHANGELOG.md`


## Use case
```php
<?php

include 'vendor/autoload.php';

use Symfony\Component\PropertyAccess\PropertyAccess;

class Foo {
    private $property;

    public function setProperty(...$args) {
        $this->property = implode(',', $args);
    }

    public function getProperty() {
        return $this->property;
    }
}

$foo = new Foo();

$propertyAccessor = PropertyAccess::createPropertyAccessor();

$propertyAccessor->setValue($foo, 'property', 'value', 'value1', 'valueN');
// $propertyAccessor->setValue($foo, 'property', ...['value', 'value1', 'valueN']);

// BEFORE:
echo $foo->getProperty(); // 'value'

// AFTER:
echo $foo->getProperty(); // 'value,value1,valueN'
```