### PR TITLE
Treat undefined env var as strict mode

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -241,6 +241,10 @@ class DeprecationErrorHandler
             return $this->configuration = Configuration::fromNumber($mode);
         }
 
+        if (!$mode) {
+            return $this->configuration = Configuration::fromNumber(0);
+        }
+
         return $this->configuration = Configuration::fromUrlEncodedString((string) $mode);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

An undefined SYMFONY_DEPRECATION_HELPER environment variable translates
to false, and that was previously interpreted as 0, which means strict
mode.
This restores backwards compatibility with the previous behavior, which
got broken in 1c73f9cfedad7fb7eb6ab0b1230d0219685ead0f .