### PR TITLE
[Security] Add IS_IMPERSONATOR, IS_ANONYMOUS and IS_REMEMBERED

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added access decision strategy to override access decisions by voter service priority
+ * Added `IS_ANONYMOUS`, `IS_REMEMBERED`, `IS_IMPERSONATOR`
 
 5.0.0
 -----

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authorization\Voter;
 
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -28,6 +29,9 @@ class AuthenticatedVoter implements VoterInterface
     const IS_AUTHENTICATED_FULLY = 'IS_AUTHENTICATED_FULLY';
     const IS_AUTHENTICATED_REMEMBERED = 'IS_AUTHENTICATED_REMEMBERED';
     const IS_AUTHENTICATED_ANONYMOUSLY = 'IS_AUTHENTICATED_ANONYMOUSLY';
+    const IS_ANONYMOUS = 'IS_ANONYMOUS';
+    const IS_IMPERSONATOR = 'IS_IMPERSONATOR';
+    const IS_REMEMBERED = 'IS_REMEMBERED';
 
     private $authenticationTrustResolver;
 
@@ -45,7 +49,10 @@ class AuthenticatedVoter implements VoterInterface
         foreach ($attributes as $attribute) {
             if (null === $attribute || (self::IS_AUTHENTICATED_FULLY !== $attribute
                     && self::IS_AUTHENTICATED_REMEMBERED !== $attribute
-                    && self::IS_AUTHENTICATED_ANONYMOUSLY !== $attribute)) {
+                    && self::IS_AUTHENTICATED_ANONYMOUSLY !== $attribute
+                    && self::IS_ANONYMOUS !== $attribute
+                    && self::IS_IMPERSONATOR !== $attribute
+                    && self::IS_REMEMBERED !== $attribute)) {
                 continue;
             }
 
@@ -66,6 +73,18 @@ class AuthenticatedVoter implements VoterInterface
                 && ($this->authenticationTrustResolver->isAnonymous($token)
                     || $this->authenticationTrustResolver->isRememberMe($token)
                     || $this->authenticationTrustResolver->isFullFledged($token))) {
+                return VoterInterface::ACCESS_GRANTED;
+            }
+
+            if (self::IS_REMEMBERED === $attribute && $this->authenticationTrustResolver->isRememberMe($token)) {
+                return VoterInterface::ACCESS_GRANTED;
+            }
+
+            if (self::IS_ANONYMOUS === $attribute && $this->authenticationTrustResolver->isAnonymous($token)) {
+                return VoterInterface::ACCESS_GRANTED;
+            }
+
+            if (self::IS_IMPERSONATOR === $attribute && $token instanceof SwitchUserToken) {
                 return VoterInterface::ACCESS_GRANTED;
             }
         }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -49,6 +49,15 @@ class AuthenticatedVoterTest extends TestCase
             ['fully', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_GRANTED],
             ['remembered', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_DENIED],
             ['anonymously', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_DENIED],
+
+            ['fully', ['IS_ANONYMOUS'], VoterInterface::ACCESS_DENIED],
+            ['remembered', ['IS_ANONYMOUS'], VoterInterface::ACCESS_DENIED],
+            ['anonymously', ['IS_ANONYMOUS'], VoterInterface::ACCESS_GRANTED],
+
+            ['fully', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
+            ['remembered', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
+            ['anonymously', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
+            ['impersonated', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_GRANTED],
         ];
     }
 
@@ -58,6 +67,8 @@ class AuthenticatedVoterTest extends TestCase
             return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         } elseif ('remembered' === $authenticated) {
             return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(['setPersistent'])->disableOriginalConstructor()->getMock();
+        } elseif ('impersonated' === $authenticated) {
+            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken')->disableOriginalConstructor()->getMock();
         } else {
             return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setConstructorArgs(['', ''])->getMock();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/29848
| License       | MIT
| Doc PR        | symfony/symfony-docs#11487

This continues work of @HeahDude and finally finishes one of the code PRs I've been working on during the ⭐️ EUFOSSA Hackathon.

Changes
---

The PRs modifies some of the attributes used by the `AuthenticatedVoter`:

* New `IS_IMPERSONATOR`, `IS_ANONYMOUS` and `IS_REMEMBERED` attributes are introduced to indicate the user either impersonated, anonymous or rembered.
* <s>`IS_AUTHENTICATED_ANONYMOUSLY` actually meant "is authenticated, either anonymous or fully". As this is confusing, it is replaced by `IS_AUTHENTICATED`.</s>
* <s>All `is_*()` functions in expressions are deprecated in favor of `is_granted('IS_*')`. It's not worth duplicating the `AuthenticatedVoter` logic in two places now we have shorter `IS_*` attributes</s>

**Before**

```php
if ($authorizationChecker->isGranted('ROLE_PREVIOUS_ADMIN')) {
    // ...
}
```
<s>

```yaml
security:
  # ...

  access_control:
    - { path: ^/protected, roles: 'IS_AUTHENTICATED_ANONYMOUSLY' }
```
</s>

**After**

```php
if ($authorizationChecker->isGranted('IS_IMPERSONATOR')) {
    // ...
}
```
<s>

```yaml
security:
  # ...

  access_control:
    - { path: ^/protected, roles: 'IS_AUTHENTICATED' }
```
</s>

<s>Discussion
---

The only thing I'm wondering is how we combine this with the `is_authenticated()` expression function:

https://github.com/symfony/symfony/blob/98929dc2927c59ba3e36b5547f2eae6316aa4740/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php#L33-L37

As you can see, the `IS_AUTHENTICATED` attribute and `is_authenticated()` expression function do not have the same meaning. Should we somehow deprecate the current behavior of `is_authenticated()` or should we find another name for `IS_AUTHENTICATED` (that would be a shame imo).</s>