### PR TITLE
SCA: added missing deprecation annotations

### DIFF
--- a/src/Symfony/Component/HttpKernel/CacheClearer/Psr6CacheClearer.php
+++ b/src/Symfony/Component/HttpKernel/CacheClearer/Psr6CacheClearer.php
@@ -25,6 +25,9 @@ class Psr6CacheClearer implements CacheClearerInterface
         $this->pools = $pools;
     }
 
+    /**
+     * @deprecated since version 3.3 and will be removed in 4.0
+     */
     public function addPool(CacheItemPoolInterface $pool)
     {
         @trigger_error(sprintf('The %s() method is deprecated since Symfony 3.3 and will be removed in 4.0. Pass an array of pools indexed by name to the constructor instead.', __METHOD__), E_USER_DEPRECATED);

--- a/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 abstract class AbstractGuardAuthenticator implements AuthenticatorInterface
 {
     /**
-     * {@inheritdoc}
+     * @deprecated since version 3.4, to be removed in 4.0
      */
     public function supports(Request $request)
     {

--- a/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
@@ -60,6 +60,8 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
      * @param string         $providerKey
      *
      * @return RedirectResponse
+     *
+     * @deprecated since version 3.1, to be removed in 4.0
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no new deprecations
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This time with the right branch =)
The PR brings missing `@deprecated` annotations to methods emitting deprecation warnings.