### PR TITLE
[PropertyAccess] Improve errors when trying to find a writable property

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestAdderRemoverInvalidArgumentLength.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestAdderRemoverInvalidArgumentLength.php
@@ -11,26 +11,17 @@
 
 namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
 
-class TestClassSetValue
+class TestAdderRemoverInvalidArgumentLength
 {
-    protected $value;
-
-    public function getValue()
+    public function addFoo()
     {
-        return $this->value;
     }
 
-    public function setValue($value)
+    public function removeFoo($var1, $var2)
     {
-        $this->value = $value;
     }
 
-    public function __construct($value)
-    {
-        $this->value = $value;
-    }
-
-    private function setFoo()
+    public function setBar($var1, $var2)
     {
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestAdderRemoverInvalidMethods.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestAdderRemoverInvalidMethods.php
@@ -11,26 +11,13 @@
 
 namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
 
-class TestClassSetValue
+class TestAdderRemoverInvalidMethods
 {
-    protected $value;
-
-    public function getValue()
+    public function addFoo($foo)
     {
-        return $this->value;
     }
 
-    public function setValue($value)
-    {
-        $this->value = $value;
-    }
-
-    public function __construct($value)
-    {
-        $this->value = $value;
-    }
-
-    private function setFoo()
+    public function removeBar($foo)
     {
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -189,7 +189,7 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
     /**
      * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * expectedExceptionMessageRegExp /The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis()", "removeAxis()" but the new value must be an array or an instance of \Traversable, "string" given./
+     * @expectedExceptionMessageRegExp /Could not determine access type for property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*": The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis\(\)", "removeAxis\(\)" but the new value must be an array or an instance of \\Traversable, "string" given./
      */
     public function testSetValueFailsIfAdderAndRemoverExistButValueIsNotTraversable()
     {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\ReturnTyped;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestAdderRemoverInvalidArgumentLength;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestAdderRemoverInvalidMethods;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassIsWritable;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicCall;
@@ -761,5 +763,55 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->setValue($object, 'aircraft', ['aeroplane']);
 
         $this->assertEquals(['aeroplane'], $object->getAircraft());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @expectedExceptionMessageRegExp /.*The add method "addFoo" in class "Symfony\\Component\\PropertyAccess\\Tests\\Fixtures\\TestAdderRemoverInvalidMethods" was found, but the corresponding remove method "removeFoo" was not found\./
+     */
+    public function testAdderWithoutRemover()
+    {
+        $object = new TestAdderRemoverInvalidMethods();
+        $this->propertyAccessor->setValue($object, 'foos', [1, 2]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @expectedExceptionMessageRegExp /.*The remove method "removeBar" in class "Symfony\\Component\\PropertyAccess\\Tests\\Fixtures\\TestAdderRemoverInvalidMethods" was found, but the corresponding add method "addBar" was not found\./
+     */
+    public function testRemoverWithoutAdder()
+    {
+        $object = new TestAdderRemoverInvalidMethods();
+        $this->propertyAccessor->setValue($object, 'bars', [1, 2]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @expectedExceptionMessageRegExp /.*The method "addFoo" in class "Symfony\\Component\\PropertyAccess\\Tests\\Fixtures\\TestAdderRemoverInvalidArgumentLength" requires 0 arguments, but should accept only 1\. The method "removeFoo" in class "Symfony\\Component\\PropertyAccess\\Tests\\Fixtures\\TestAdderRemoverInvalidArgumentLength" requires 2 arguments, but should accept only 1\./
+     */
+    public function testAdderAndRemoveNeedsTheExactParametersDefined()
+    {
+        $object = new TestAdderRemoverInvalidArgumentLength();
+        $this->propertyAccessor->setValue($object, 'foo', [1, 2]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @expectedExceptionMessageRegExp /.*The method "setBar" in class "Symfony\\Component\\PropertyAccess\\Tests\\Fixtures\\TestAdderRemoverInvalidArgumentLength" requires 2 arguments, but should accept only 1\./
+     */
+    public function testSetterNeedsTheExactParametersDefined()
+    {
+        $object = new TestAdderRemoverInvalidArgumentLength();
+        $this->propertyAccessor->setValue($object, 'bar', [1, 2]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @expectedExceptionMessageRegExp /.*The method "setFoo" in class "Symfony\\Component\\PropertyAccess\\Tests\\Fixtures\\TestClassSetValue" was found but does not have public access./
+     */
+    public function testSetterNeedsPublicAccess()
+    {
+        $object = new TestClassSetValue(0);
+        $this->propertyAccessor->setValue($object, 'foo', 1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17907
| License       | MIT
| Doc PR        | N/A

When setting a property using an adder/remove, the error message is very generic if the methods don't fit the exact requirements (both the adder and remover need to be defined and accept at least one argument). This can be confusing when you already have the methods `addFoo()` and `removeFoo()` defined (but without any parameters in the signature), but the error message states that the method doesn't exist or don't have public access.

So this PR tries to improve the error message if a property isn't writable by doing the following:

* If only one of the add/remove methods is implemented, indicate that the other method is needed as well.
* If any of the adder/remover, setter or magic methods (`__call` or `__set`) don't have the required number of parameters,  make it clear that the methods need to define the correct number of parameter.
* The any of the access methods were found, but don't have public access, make it clear that the method needs to be defined as public,

```php
class Foo
{
    public function addBar($value)
    {
    }

    public function removeBar()
    {
    }
}
```

**Before:**
```
Neither the property "bar" nor one of the methods "addBar()/removeBar()", "setBar()", "bar()", "__set()" or "__call()" exist and have public access in class "Foo".
```

**After:**

```
The method "removeBar" requires at least "1" parameters, "0" found.
```

