### PR TITLE
use server instead of env

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -37,7 +37,7 @@ $getEnvVar = function ($name, $default = false) {
     }
     if (false !== $phpunitConfig) {
         $var = new DOMXpath($phpunitConfig);
-        foreach ($var->query('//php/env[@name="'.$name.'"]') as $var) {
+        foreach ($var->query('//php/server[@name="'.$name.'"]') as $var) {
             return $var->getAttribute('value');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

This change causes `simple-phpunit` script to look for `server` nodes instead of `env` nodes as introduced in symfony/recipes#561. 
This change is required by symfony/recipes#578