### PR TITLE
[HttpFoundation] Fix regression of delegation of Session::save() to Storage::Save()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -193,9 +193,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function save()
     {
-        if ($this->isStarted()) {
-            $this->storage->save();
-        }
+        $this->storage->save();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -219,12 +219,11 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function save()
     {
-        // In PHP <7.2 session_write_close() does not error if the session is
-        // not started.
+        // In PHP <7.2 session_write_close() returns void if the session is not started.
+        // @see https://www.php.net/manual/function.session-write-close.php
         if (!$this->started) {
             return;
         }
-
         $session = $_SESSION;
 
         foreach ($this->bags as $bag) {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -219,6 +219,12 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function save()
     {
+        // In PHP <7.2 session_write_close() does not error if the session is
+        // not started.
+        if (!$this->started) {
+            return;
+        }
+
         $session = $_SESSION;
 
         foreach ($this->bags as $bag) {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -261,13 +261,4 @@ class SessionTest extends TestCase
         $this->assertTrue($this->session->isEmpty());
     }
 
-    public function testSaveIfNotStarted()
-    {
-        $storage = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface')->getMock();
-        $session = new Session($storage);
-
-        $storage->expects($this->once())->method('isStarted')->willReturn(false);
-        $storage->expects($this->never())->method('save');
-        $session->save();
-    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -260,5 +260,4 @@ class SessionTest extends TestCase
         $flash->get('hello');
         $this->assertTrue($this->session->isEmpty());
     }
-
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -105,6 +105,13 @@ class NativeSessionStorageTest extends TestCase
         $this->assertSame($id, $storage->getId(), 'ID stays after saving session');
     }
 
+    public function testSaveIfNotStarted()
+    {
+        $storage = $this->getStorage();
+        $this->assertNull($storage->save(), 'Saving unstarted sessions does not error');
+        $this->assertEmpty(glob($this->savePath.'/*'));
+    }
+
     public function testRegenerate()
     {
         $storage = $this->getStorage();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

https://github.com/symfony/symfony/pull/30620 caused a regression in Drupal because we have the concept of lazy sessions. We tried to address this by patching Drupal core but we're now finding affects on contributed modules and the wider ecosystem. As per https://github.com/symfony/symfony/pull/30620#issuecomment-485870779 this PR implements a slightly different fix which still delegates saving to the storage but allows for the NativeStorage as implemented by Symfony to be resettable.