### PR TITLE
[WebserverBundle] Deprecate the bundle in favor of symfony local server

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
@@ -24,6 +24,8 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
  */
 class ServerLogCommand extends Command
 {
@@ -77,6 +79,8 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error('Using the WebserverBundle is deprecated since 4.4. The new Symfony local server has more features, you can use it instead.', E_USER_DEPRECATED);
+
         $filter = $input->getOption('filter');
         if ($filter) {
             if (!class_exists(ExpressionLanguage::class)) {

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -26,6 +26,8 @@ use Symfony\Component\Process\Process;
  * Runs Symfony application using a local web server.
  *
  * @author Michał Pipa <michal.pipa.xsolve@gmail.com>
+ *
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
  */
 class ServerRunCommand extends Command
 {
@@ -90,6 +92,8 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error('Using the WebserverBundle is deprecated since 4.4. The new Symfony local server has more features, you can use it instead.', E_USER_DEPRECATED);
+
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
 
         if (null === $documentRoot = $input->getOption('docroot')) {

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -26,6 +26,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  * Runs a local web server in a background process.
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
  */
 class ServerStartCommand extends Command
 {
@@ -90,6 +92,8 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error('Using the WebserverBundle is deprecated since 4.4. The new Symfony local server has more features, you can use it instead.', E_USER_DEPRECATED);
+
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
 
         if (!\extension_loaded('pcntl')) {

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStatusCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStatusCommand.php
@@ -25,6 +25,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * the background.
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
  */
 class ServerStatusCommand extends Command
 {
@@ -72,6 +74,8 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error('Using the WebserverBundle is deprecated since 4.4. The new Symfony local server has more features, you can use it instead.', E_USER_DEPRECATED);
+
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
         $server = new WebServer($this->pidFileDirectory);
         if ($filter = $input->getOption('filter')) {

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStopCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStopCommand.php
@@ -23,6 +23,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * Stops a background process running a local web server.
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
  */
 class ServerStopCommand extends Command
 {
@@ -61,6 +63,8 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error('Using the WebserverBundle is deprecated since 4.4. The new Symfony local server has more features, you can use it instead.', E_USER_DEPRECATED);
+
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
 
         try {

--- a/src/Symfony/Bundle/WebServerBundle/DependencyInjection/WebServerExtension.php
+++ b/src/Symfony/Bundle/WebServerBundle/DependencyInjection/WebServerExtension.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
  */
 class WebServerExtension extends Extension
 {
@@ -40,6 +42,8 @@ class WebServerExtension extends Extension
         if (!class_exists(ConsoleFormatter::class)) {
             $container->removeDefinition('web_server.command.server_log');
         }
+
+        @trigger_error('Using the WebserverBundle is deprecated since 4.3, the new symfony local server has more feature, you should use it instead.');
     }
 
     private function getPublicDirectory(ContainerBuilder $container)

--- a/src/Symfony/Bundle/WebServerBundle/Tests/DependencyInjection/WebServerExtensionTest.php
+++ b/src/Symfony/Bundle/WebServerBundle/Tests/DependencyInjection/WebServerExtensionTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class WebServerExtensionTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testLoad()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Bundle/WebServerBundle/WebServer.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Process\Process;
  * Manages a local HTTP web server.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
  */
 class WebServer
 {

--- a/src/Symfony/Bundle/WebServerBundle/WebServerBundle.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerBundle.php
@@ -13,6 +13,13 @@ namespace Symfony\Bundle\WebServerBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
+ */
 class WebServerBundle extends Bundle
 {
+    public function boot()
+    {
+        @trigger_error('Using the WebserverBundle is deprecated since 4.4. The new Symfony local server has more features, you can use it instead.', E_USER_DEPRECATED);
+    }
 }

--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\WebServerBundle;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 4.4, to be removed in 5.0; the new Symfony local server has more features, you can use it instead.
  */
 class WebServerConfig
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | to do <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

Since most of the feature added to the symfony local server (using php-fpm) will be handy for all developers and as said in https://github.com/symfony/symfony/issues/25748#issuecomment-485740082, I agree that we should deprecate the WebserverBundle in favor of the [Symfony Local Server](https://symfony.com/doc/current/setup/symfony_server.html) cc @stof @fabpot 
