### PR TITLE
[Form] Add Button type back to Form::getClickedButton docblock

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -89,7 +89,7 @@ class Form implements \IteratorAggregate, FormInterface
     private $submitted = false;
 
     /**
-     * @var ClickableInterface|null The button that was used to submit the form
+     * @var FormInterface|ClickableInterface|null The button that was used to submit the form
      */
     private $clickedButton;
 
@@ -749,7 +749,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns the button that was used to submit the form.
      *
-     * @return ClickableInterface|null
+     * @return FormInterface|ClickableInterface|null
      */
     public function getClickedButton()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In commit 56429a6f082c057880e88ca665910b04d26e76d8 the `Button` type was removed from the return doc block. 

I suspect this was an oversight because, AFAIK, the [recommended way](https://symfony.com/doc/current/form/multiple_buttons.html) to check the name of a clicked button would require a return type of `Button` or `SubmitButton`. 

The effect is that our static analysis checks are failing. 
```
Call to an undefined method                            
Symfony\Component\Form\ClickableInterface::getName(). 
```

