### PR TITLE
[Security] Cleanup "Digest nonce has expired." translation

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nn.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nn.xlf
@@ -30,10 +30,6 @@
                 <source>Invalid CSRF token.</source>
                 <target>Ugyldig CSRF-teikn.</target>
             </trans-unit>
-            <trans-unit id="8">
-                <source>Digest nonce has expired.</source>
-                <target>Digest nonce er ikkje lenger gyldig.</target>
-            </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
                 <target>Fann ingen innloggingstilbydar som støttar dette innloggingsteiknet.</target>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.tl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.tl.xlf
@@ -30,10 +30,6 @@
                 <source>Invalid CSRF token.</source>
                 <target>Hindi balidong mga token ng CSRF.</target>
             </trans-unit>
-             <trans-unit id="8">
-                <source>Digest nonce has expired.</source>
-                <target>Na-expire na ang Digest nonce.</target>
-            </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
                 <target>Walang nakitang nagbibibagay ng suporta sa token ng pagpapatunay.</target>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Running `php src/Symfony/Component/Translation/Resources/bin/translation-status.php` i see:

```
| Locale: nn      | Translated: 16/15
| Locale: tl      | Translated: 16/15
```

Here's the cleanup.

(ref #24336)