### PR TITLE
[Translator] Add sources when dumping qt files

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/QtFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/QtFileDumper.php
@@ -33,6 +33,17 @@ class QtFileDumper extends FileDumper
 
         foreach ($messages->all($domain) as $source => $target) {
             $message = $context->appendChild($dom->createElement('message'));
+            $metadata = $messages->getMetadata($source, $domain);
+            if (isset($metadata['sources'])) {
+                foreach ((array) $metadata['sources'] as $location) {
+                    $loc = explode(':', $location, 2);
+                    $location = $message->appendChild($dom->createElement('location'));
+                    $location->setAttribute('filename', $loc[0]);
+                    if (isset($loc[1])) {
+                        $location->setAttribute('line', $loc[1]);
+                    }
+                }
+            }
             $message->appendChild($dom->createElement('source', $source));
             $message->appendChild($dom->createElement('translation', $target));
         }

--- a/src/Symfony/Component/Translation/Tests/Dumper/QtFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/QtFileDumperTest.php
@@ -20,7 +20,26 @@ class QtFileDumperTest extends TestCase
     public function testFormatCatalogue()
     {
         $catalogue = new MessageCatalogue('en');
-        $catalogue->add(['foo' => 'bar'], 'resources');
+        $catalogue->add(['foo' => 'bar', 'foo_bar' => 'foobar', 'bar_foo' => 'barfoo'], 'resources');
+        $catalogue->setMetadata('foo_bar', [
+            'comments' => [
+                'Comment 1',
+                'Comment 2',
+            ],
+            'flags' => [
+                'fuzzy',
+                'another',
+            ],
+            'sources' => [
+                'src/file_1',
+                'src/file_2:50',
+            ],
+        ], 'resources');
+        $catalogue->setMetadata('bar_foo', [
+            'comments' => 'Comment',
+            'flags' => 'fuzzy',
+            'sources' => 'src/file_1',
+        ], 'resources');
 
         $dumper = new QtFileDumper();
 

--- a/src/Symfony/Component/Translation/Tests/Loader/QtFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/QtFileLoaderTest.php
@@ -23,7 +23,11 @@ class QtFileLoaderTest extends TestCase
         $resource = __DIR__.'/../fixtures/resources.ts';
         $catalogue = $loader->load($resource, 'en', 'resources');
 
-        $this->assertEquals(['foo' => 'bar'], $catalogue->all('resources'));
+        $this->assertEquals([
+            'foo' => 'bar',
+            'foo_bar' => 'foobar',
+            'bar_foo' => 'barfoo',
+        ], $catalogue->all('resources'));
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources.ts
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources.ts
@@ -6,5 +6,16 @@
       <source>foo</source>
       <translation>bar</translation>
     </message>
+    <message>
+      <location filename="src/file_1"/>
+      <location filename="src/file_2" line="50"/>
+      <source>foo_bar</source>
+      <translation>foobar</translation>
+    </message>
+    <message>
+      <location filename="src/file_1"/>
+      <source>bar_foo</source>
+      <translation>barfoo</translation>
+    </message>
   </context>
 </TS>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR implements similar functionality as #30909, but for Qt files. Currently, only the Qt element `location` is supported, so only `sources` metadata is included in the dump.