### PR TITLE
Bug #31232 {Serializer] Ensure context timezone is correctly used in …

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -114,7 +114,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         try {
             $datetime = new \DateTime($data, $timezone);
             /**
-             * PHP docs say when created a new DateTime object:
+             * PHP docs say when created a new DateTime object:.
              *
              * The $timezone parameter and the current timezone are ignored when the $time parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone (e.g. 2010-01-28T15:00:00+02:00).
              *
@@ -122,8 +122,10 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
              *
              * If you specify the timezone when denormalizing, you'd expect all datetimes to come out in that timezone, regardless of (user) input.
              */
-            if ($timezone instanceof \DateTimeZone)
+            if ($timezone instanceof \DateTimeZone) {
                 $datetime->setTimezone($timezone);
+            }
+
             return \DateTime::class === $class ? $datetime : new \DateTimeImmutable($datetime->format(\DATE_RFC3339), $timezone);
         } catch (\Exception $e) {
             throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -112,7 +112,19 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         }
 
         try {
-            return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
+            $datetime = new \DateTime($data, $timezone);
+            /**
+             * PHP docs say when created a new DateTime object:
+             *
+             * The $timezone parameter and the current timezone are ignored when the $time parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone (e.g. 2010-01-28T15:00:00+02:00).
+             *
+             * This means the behaviour in this normalizer is different when the timezone is applied in the constructor or later with setTimezone.
+             *
+             * If you specify the timezone when denormalizing, you'd expect all datetimes to come out in that timezone, regardless of (user) input.
+             */
+            if ($timezone instanceof \DateTimeZone)
+                $datetime->setTimezone($timezone);
+            return \DateTime::class === $class ? $datetime : new \DateTimeImmutable($datetime->format(\DATE_RFC3339), $timezone);
         } catch (\Exception $e) {
             throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -187,6 +187,19 @@ class DateTimeNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->denormalize('2016.12.01 17:35:00', \DateTime::class, null, [
             DateTimeNormalizer::FORMAT_KEY => 'Y.m.d H:i:s',
         ]));
+
+        // Test correction of Timezone when timezone information is added in both the date string and the context of the normalizer.
+        $normalizer = new DateTimeNormalizer(
+            [
+                // This is different from Europe times and has NO daylight saving, so tests always pass.
+                DateTimeNormalizer::TIMEZONE_KEY => 'Australia/Brisbane',
+            ]
+        );
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('2016-01-27T16:39:26+01:00', \DateTimeInterface::class)->format(\DATE_RFC3339)); //Non UTC
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('2016-01-27T15:39:26+00:00', \DateTime::class)->format(\DATE_RFC3339)); //UTC
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('2016-01-28 01:39:26', \DateTime::class)->format(\DATE_RFC3339)); //No timezone in string
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('2016-01-28T01:39:26+10:00', \DateTimeInterface::class)->format(\DATE_RFC3339)); //same tz as constructor
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('@1453909166', \DateTimeImmutable::class)->format(\DATE_RFC3339)); //timestamp assumes UTC
     }
 
     public function testDenormalizeUsingFormatPassedInContext()


### PR DESCRIPTION
…denormalizer of DateTimeNormalizer

| Q             | A
| ------------- | ---
| Branch?       |  3.4 up to 4.2 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes   
| Fixed tickets | #31232 
| License       | MIT
| Doc PR        | n/a

<!--
This PR ensures DateTimeNormalizer::denormalizer correctly applies context timezone. 
-->
