### PR TITLE
Make the email validator a hard requirement of mailer

### DIFF
--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "egulias/email-validator": "^2.0",
         "psr/log": "~1.0",
         "symfony/event-dispatcher": "^4.3",
         "symfony/mime": "^4.3"
     },
     "require-dev": {
         "symfony/amazon-mailer": "^4.3",
-        "egulias/email-validator": "^2.0",
         "symfony/google-mailer": "^4.3",
         "symfony/mailgun-mailer": "^4.3",
         "symfony/mailchimp-mailer": "^4.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes-ish
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I think it makes sense to have the email address validator as a hard requirement of Mailer... as I don't see how you can send emails without an email address :)

