### PR TITLE
[Console] Commands with an alias should not be recognized as ambiguous when using register

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -596,6 +596,15 @@ class Application
         $this->init();
 
         $aliases = [];
+
+        foreach ($this->commands as $command) {
+            foreach ($command->getAliases() as $alias) {
+                if (!$this->has($alias)) {
+                    $this->commands[$alias] = $command;
+                }
+            }
+        }
+
         $allCommands = $this->commandLoader ? array_merge($this->commandLoader->getNames(), array_keys($this->commands)) : array_keys($this->commands);
         $expr = preg_replace_callback('{([^:]+|)}', function ($matches) { return preg_quote($matches[1]).'[^:]*'; }, $name);
         $commands = preg_grep('{^'.$expr.'}', $allCommands);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -72,8 +72,8 @@ class ApplicationTest extends TestCase
         require_once self::$fixturesPath.'/BarBucCommand.php';
         require_once self::$fixturesPath.'/FooSubnamespaced1Command.php';
         require_once self::$fixturesPath.'/FooSubnamespaced2Command.php';
-        require_once self::$fixturesPath.'/TestTiti.php';
-        require_once self::$fixturesPath.'/TestToto.php';
+        require_once self::$fixturesPath.'/TestAmbiguousCommandRegistering.php';
+        require_once self::$fixturesPath.'/TestAmbiguousCommandRegistering2.php';
     }
 
     protected function normalizeLineBreaks($text)
@@ -162,6 +162,27 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $command = $application->register('foo');
         $this->assertEquals('foo', $command->getName(), '->register() registers a new command');
+    }
+
+    public function testRegisterAmbiguous()
+    {
+        $code = function (InputInterface $input, OutputInterface $output) {
+            $output->writeln('It works!');
+        };
+
+        $application = new Application();
+        $application
+            ->register('test-foo')
+            ->setAliases(['test'])
+            ->setCode($code);
+
+        $application
+            ->register('test-bar')
+            ->setCode($code);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['test']);
+        $this->assertContains('It works!', $tester->getDisplay(true));
     }
 
     public function testAdd()
@@ -303,9 +324,9 @@ class ApplicationTest extends TestCase
     public function testFindNonAmbiguous()
     {
         $application = new Application();
-        $application->add(new \TestTiti());
-        $application->add(new \TestToto());
-        $this->assertEquals('test-toto', $application->find('test')->getName());
+        $application->add(new \TestAmbiguousCommandRegistering());
+        $application->add(new \TestAmbiguousCommandRegistering2());
+        $this->assertEquals('test-ambiguous', $application->find('test')->getName());
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Fixtures/TestAmbiguousCommandRegistering.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/TestAmbiguousCommandRegistering.php
@@ -4,18 +4,19 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class TestTiti extends Command
+class TestAmbiguousCommandRegistering extends Command
 {
     protected function configure()
     {
         $this
-            ->setName('test-titi')
-            ->setDescription('The test:titi command')
+            ->setName('test-ambiguous')
+            ->setDescription('The test-ambiguous command')
+            ->setAliases(['test'])
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->write('test-titi');
+        $output->write('test-ambiguous');
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/TestAmbiguousCommandRegistering2.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/TestAmbiguousCommandRegistering2.php
@@ -4,19 +4,18 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class TestToto extends Command
+class TestAmbiguousCommandRegistering2 extends Command
 {
     protected function configure()
     {
         $this
-            ->setName('test-toto')
-            ->setDescription('The test-toto command')
-            ->setAliases(['test'])
+            ->setName('test-ambiguous2')
+            ->setDescription('The test-ambiguous2 command')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->write('test-toto');
+        $output->write('test-ambiguous2');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25355 
| License       | MIT
| Doc PR        | 


I think when passing an alias, it should not be treated as a ambiguous command since it's configured to response to it.

I've [pushed a commit](https://github.com/Simperfit/symfony-reproducer/commit/2f5209a6876101a5f47ed589baa392d37e55aa40) that reproduce the bug and with this patch it does work.