### PR TITLE
[Translator] Load plurals from po files properly

### DIFF
--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -126,23 +126,24 @@ class PoFileLoader extends FileLoader
      */
     private function addMessage(array &$messages, array $item)
     {
-        if (\is_array($item['translated'])) {
-            $messages[stripcslashes($item['ids']['singular'])] = stripcslashes($item['translated'][0]);
+        if (!empty($item['ids']['singular'])) {
+            $id = stripcslashes($item['ids']['singular']);
             if (isset($item['ids']['plural'])) {
-                $plurals = $item['translated'];
-                // PO are by definition indexed so sort by index.
-                ksort($plurals);
-                // Make sure every index is filled.
-                end($plurals);
-                $count = key($plurals);
-                // Fill missing spots with '-'.
-                $empties = array_fill(0, $count + 1, '-');
-                $plurals += $empties;
-                ksort($plurals);
-                $messages[stripcslashes($item['ids']['plural'])] = stripcslashes(implode('|', $plurals));
+                $id .= '|'.stripcslashes($item['ids']['plural']);
             }
-        } elseif (!empty($item['ids']['singular'])) {
-            $messages[stripcslashes($item['ids']['singular'])] = stripcslashes($item['translated']);
+
+            $translated = (array) $item['translated'];
+            // PO are by definition indexed so sort by index.
+            ksort($translated);
+            // Make sure every index is filled.
+            end($translated);
+            $count = key($translated);
+            // Fill missing spots with '-'.
+            $empties = array_fill(0, $count + 1, '-');
+            $translated += $empties;
+            ksort($translated);
+
+            $messages[$id] = stripcslashes(implode('|', $translated));
         }
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -34,7 +34,10 @@ class PoFileLoaderTest extends TestCase
         $resource = __DIR__.'/../fixtures/plurals.po';
         $catalogue = $loader->load($resource, 'en', 'domain1');
 
-        $this->assertEquals(['foo' => 'bar', 'foos' => 'bar|bars'], $catalogue->all('domain1'));
+        $this->assertEquals([
+            'foo|foos' => 'bar|bars',
+            '{0} no foos|one foo|%count% foos' => '{0} no bars|one bar|%count% bars',
+        ], $catalogue->all('domain1'));
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
@@ -89,10 +92,8 @@ class PoFileLoaderTest extends TestCase
         $catalogue = $loader->load($resource, 'en', 'domain1');
 
         $messages = $catalogue->all('domain1');
-        $this->assertArrayHasKey('escaped "foo"', $messages);
-        $this->assertArrayHasKey('escaped "foos"', $messages);
-        $this->assertEquals('escaped "bar"', $messages['escaped "foo"']);
-        $this->assertEquals('escaped "bar"|escaped "bars"', $messages['escaped "foos"']);
+        $this->assertArrayHasKey('escaped "foo"|escaped "foos"', $messages);
+        $this->assertEquals('escaped "bar"|escaped "bars"', $messages['escaped "foo"|escaped "foos"']);
     }
 
     public function testSkipFuzzyTranslations()
@@ -105,5 +106,17 @@ class PoFileLoaderTest extends TestCase
         $this->assertArrayHasKey('foo1', $messages);
         $this->assertArrayNotHasKey('foo2', $messages);
         $this->assertArrayHasKey('foo3', $messages);
+    }
+
+    public function testMissingPlurals()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../fixtures/missing-plurals.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals([
+            'foo|foos' => '-|bar|-|bars',
+        ], $catalogue->all('domain1'));
+        $this->assertEquals('en', $catalogue->getLocale());
     }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/missing-plurals.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/missing-plurals.po
@@ -1,0 +1,4 @@
+msgid "foo"
+msgid_plural "foos"
+msgstr[3] "bars"
+msgstr[1] "bar"

--- a/src/Symfony/Component/Translation/Tests/fixtures/plurals.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/plurals.po
@@ -3,3 +3,5 @@ msgid_plural "foos"
 msgstr[0] "bar"
 msgstr[1] "bars"
 
+msgid "{0} no foos|one foo|%count% foos"
+msgstr "{0} no bars|one bar|%count% bars"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/10152#issuecomment-55522675
| License       | MIT
| Doc PR        | 

Plurals were not handled correctly when loading po files.
```
msgid "foo"
msgid_plural "foos"
msgstr[0] "bar"
msgstr[1] "bars"
```

Before, the po entry above was treated as two entries, which doesn't make sense:
```
'foo' => 'bar'
'foos' => 'bar|bars'
```

With this PR, it is treated as one entry:
```
'foo|foos' => 'bar|bars'
```