### PR TITLE
[YAML] Support PHP class magic constant with !php/const

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -592,6 +592,8 @@ class Inline
                             $i = 0;
                             if (\defined($const = self::parseScalar(substr($scalar, 11), 0, null, $i, false))) {
                                 return \constant($const);
+                            } elseif ('::class' === strtolower(substr($const, -7)) && class_exists($class = (string) substr($const, 0, -7))) {
+                                return $class;
                             }
 
                             throw new ParseException(sprintf('The constant "%s" is not defined.', $const), self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -56,6 +56,8 @@ class InlineTest extends TestCase
     {
         return [
             ['!php/const Symfony\Component\Yaml\Yaml::PARSE_CONSTANT', Yaml::PARSE_CONSTANT],
+            ['!php/const Symfony\Component\Yaml\Yaml::class', Yaml::class],
+            ['!php/const Symfony\Component\Yaml\Yaml::CLASS', Yaml::class],
             ['!php/const PHP_INT_MAX', PHP_INT_MAX],
             ['[!php/const PHP_INT_MAX]', [PHP_INT_MAX]],
             ['{ foo: !php/const PHP_INT_MAX }', ['foo' => PHP_INT_MAX]],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Before this, using `!php/const 'MyClass::class'` was triggering an exception:
`The constant "MyClass::class" is not defined at line ...`