### PR TITLE
[Translator] Preserve default domain when extracting strings from php files

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -226,7 +226,10 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
                     } elseif (self::METHOD_ARGUMENTS_TOKEN === $item) {
                         $this->skipMethodArgument($tokenIterator);
                     } elseif (self::DOMAIN_TOKEN === $item) {
-                        $domain = $this->getValue($tokenIterator);
+                        $domainToken = $this->getValue($tokenIterator);
+                        if ('' !== $domainToken) {
+                            $domain = $domainToken;
+                        }
 
                         break;
                     } else {

--- a/src/Symfony/Component/Translation/Tests/Extractor/PhpExtractorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/PhpExtractorTest.php
@@ -52,6 +52,7 @@ EOF;
                 $expectedNowdoc => 'prefix'.$expectedNowdoc,
                 '{0} There is no apples|{1} There is one apple|]1,Inf[ There are %count% apples' => 'prefix{0} There is no apples|{1} There is one apple|]1,Inf[ There are %count% apples',
                 'concatenated message with heredoc and nowdoc' => 'prefixconcatenated message with heredoc and nowdoc',
+                'default domain' => 'prefixdefault domain',
             ],
             'not_messages' => [
                 'other-domain-test-no-params-short-array' => 'prefixother-domain-test-no-params-short-array',

--- a/src/Symfony/Component/Translation/Tests/fixtures/extractor/translation.html.php
+++ b/src/Symfony/Component/Translation/Tests/fixtures/extractor/translation.html.php
@@ -55,3 +55,5 @@ EOF
 <?php echo $view['translator']->trans('typecast', ['a' => (int) '123'], 'not_messages'); ?>
 <?php echo $view['translator']->transChoice('msg1', 10 + 1, [], 'not_messages'); ?>
 <?php echo $view['translator']->transChoice('msg2', ceil(4.5), [], 'not_messages'); ?>
+
+<?php echo $view['translator']->trans('default domain', [], null); ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Use default domain when extracting translation strings with `null` as domain.