### PR TITLE
Make UrlTypes render as url types.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UrlType extends AbstractType
@@ -27,17 +25,6 @@ class UrlType extends AbstractType
     {
         if (null !== $options['default_protocol']) {
             $builder->addEventSubscriber(new FixUrlProtocolListener($options['default_protocol']));
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildView(FormView $view, FormInterface $form, array $options)
-    {
-        if ($options['default_protocol']) {
-            $view->vars['attr']['inputmode'] = 'url';
-            $view->vars['type'] = 'text';
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2260,10 +2260,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
 '/input
-    [@type="text"]
+    [@type="url"]
     [@name="name"]
     [@value="http://www.google.com?foo1=bar1&foo2=bar2"]
-    [@inputmode="url"]
 '
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31283 #30635 #29926 #29690   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

Currently you have to declare an explicit option of `["default_protocol" => null]` on every UrlType form element or it renders as a `type="text"`. Seems like 2 merges tried to fix this from different ends with one forcing a default protocol and once changing to a text type if there is no default protocol, thus ensuring that url type are always changed to text types unless the above option is also passed, which is very counter-intuitive.

This PR fixes that by no longer changing to text types if default_protocol is not null since we are always forcing a default now. 
