### PR TITLE
[Messenger] RoutableMessageBus route to default bus

### DIFF
--- a/src/Symfony/Component/Messenger/RoutableMessageBus.php
+++ b/src/Symfony/Component/Messenger/RoutableMessageBus.php
@@ -45,14 +45,12 @@ class RoutableMessageBus implements MessageBusInterface
 
         /** @var BusNameStamp $busNameStamp */
         $busNameStamp = $envelope->last(BusNameStamp::class);
-        if (null === $busNameStamp) {
-            throw new InvalidArgumentException('Envelope does not contain a BusNameStamp.');
+        $busName = null !== $busNameStamp ? $busNameStamp->getBusName() : MessageBusInterface::class;
+
+        if (!$this->busLocator->has($busName)) {
+            throw new InvalidArgumentException(sprintf('Bus name "%s" does not exists.', $busName));
         }
 
-        if (!$this->busLocator->has($busNameStamp->getBusName())) {
-            throw new InvalidArgumentException(sprintf('Invalid bus name "%s" on BusNameStamp.', $busNameStamp->getBusName()));
-        }
-
-        return $this->busLocator->get($busNameStamp->getBusName())->dispatch($envelope, $stamps);
+        return $this->busLocator->get($busName)->dispatch($envelope, $stamps);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no   
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | #31200 
| License       | MIT
| Doc PR        | Not needed

Hi! I modified the behaviour of RoutableMessageBus to route message without BusNameStamp to default bus instead of raise an exception.


Made with :heart: by [![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)

