### PR TITLE
[TwigBundle] Use the apply tag instead of the filter tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "doctrine/common": "~2.4",
         "fig/link-util": "^1.0",
-        "twig/twig": "^1.35|^2.4.4",
+        "twig/twig": "^1.40|^2.9",
         "psr/cache": "~1.0",
         "psr/container": "^1.0",
         "psr/link": "^1.0",

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces_text.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces_text.html.twig
@@ -19,9 +19,9 @@
             <td>
                 {% if exception.trace|length %}
                 <pre class="stacktrace">
-                {%- filter escape('html') -%}
+                {%- apply escape('html') -%}
                     {{- include('@Twig/Exception/traces.txt.twig', { exception: exception, format: 'html' }, with_context = false) }}
-                {% endfilter %}
+                {% endapply %}
                 </pre>
                 {% endif %}
             </td>

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
         "symfony/http-kernel": "^3.3|~4.0",
         "symfony/polyfill-ctype": "~1.8",
-        "twig/twig": "~1.34|~2.4"
+        "twig/twig": "~1.40|~2.9"
     },
     "require-dev": {
         "symfony/asset": "~2.8|~3.0|~4.0",


### PR DESCRIPTION
The filter has been deprecated in favor of the apply tag since Twig 2.9,
see https://twig.symfony.com/doc/2.x/tags/filter.html (apply does not
seem to have its own documentation page yet).

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

⚠ Note: don't merge until Twig 2.9 and 1.40 are released, or this will block symfony releases ⚠