### PR TITLE
[Form] Remove default option grouping in TimezoneType

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -2551,12 +2551,8 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     [@name="name"]
     [@class="my&class form-control"]
     [not(@required)]
-    [./optgroup
-        [@label="Europe"]
-        [./option[@value="Europe/Vienna"][@selected="selected"][.="Vienna"]]
-    ]
-    [count(./optgroup)>10]
-    [count(.//option)>200]
+    [./option[@value="Europe/Vienna"][@selected="selected"][.="Europe / Vienna"]]
+    [count(./option)>200]
 '
         );
     }
@@ -2572,8 +2568,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 '/select
     [@class="my&class form-control"]
     [./option[@value=""][not(@selected)][not(@disabled)][.="[trans]Select&Timezone[/trans]"]]
-    [count(./optgroup)>10]
-    [count(.//option)>201]
+    [count(./option)>201]
 '
         );
     }

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -48,6 +48,7 @@ CHANGELOG
  * dispatch `PreSetDataEvent` on `form.pre_set_data`
  * dispatch `PostSetDataEvent` on `form.post_set_data`
  * added an `input` option to `NumberType`
+ * removed default option grouping in `TimezoneType`, use `group_by` instead
 
 4.2.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -94,22 +94,9 @@ class TimezoneType extends AbstractType
                 continue;
             }
 
-            $parts = explode('/', $timezone);
-
-            if (\count($parts) > 2) {
-                $region = $parts[0];
-                $name = $parts[1].' - '.$parts[2];
-            } elseif (\count($parts) > 1) {
-                $region = $parts[0];
-                $name = $parts[1];
-            } else {
-                $region = 'Other';
-                $name = $parts[0];
-            }
-
-            $timezones[$region][str_replace('_', ' ', $name)] = $timezone;
+            $timezones[str_replace(['/', '_'], [' / ', ' '], $timezone)] = $timezone;
         }
 
-        return 1 === \count($timezones) ? reset($timezones) : $timezones;
+        return $timezones;
     }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2278,12 +2278,8 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 '/select
     [@name="name"]
     [not(@required)]
-    [./optgroup
-        [@label="Europe"]
-        [./option[@value="Europe/Vienna"][@selected="selected"][.="Vienna"]]
-    ]
-    [count(./optgroup)>10]
-    [count(.//option)>200]
+    [./option[@value="Europe/Vienna"][@selected="selected"][.="Europe / Vienna"]]
+    [count(./option)>200]
 '
         );
     }
@@ -2298,8 +2294,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $this->assertWidgetMatchesXpath($form->createView(), [],
 '/select
     [./option[@value=""][not(@selected)][not(@disabled)][.="[trans]Select&Timezone[/trans]"]]
-    [count(./optgroup)>10]
-    [count(.//option)>201]
+    [count(./option)>201]
 '
         );
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -22,11 +22,8 @@ class TimezoneTypeTest extends BaseTypeTest
         $choices = $this->factory->create(static::TESTED_TYPE)
             ->createView()->vars['choices'];
 
-        $this->assertArrayHasKey('Africa', $choices);
-        $this->assertContains(new ChoiceView('Africa/Kinshasa', 'Africa/Kinshasa', 'Kinshasa'), $choices['Africa'], '', false, false);
-
-        $this->assertArrayHasKey('America', $choices);
-        $this->assertContains(new ChoiceView('America/New_York', 'America/New_York', 'New York'), $choices['America'], '', false, false);
+        $this->assertContains(new ChoiceView('Africa/Kinshasa', 'Africa/Kinshasa', 'Africa / Kinshasa'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('America/New_York', 'America/New_York', 'America / New York'), $choices, '', false, false);
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)
@@ -83,7 +80,7 @@ class TimezoneTypeTest extends BaseTypeTest
         $choices = $this->factory->create(static::TESTED_TYPE, null, ['regions' => \DateTimeZone::EUROPE])
             ->createView()->vars['choices'];
 
-        $this->assertContains(new ChoiceView('Europe/Amsterdam', 'Europe/Amsterdam', 'Amsterdam'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('Europe/Amsterdam', 'Europe/Amsterdam', 'Europe / Amsterdam'), $choices, '', false, false);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This removes some complexity from the TimezoneType. The default option grouping is really a simple `group_by`  (+ `choice_label`) configuration for the end-user, i.e.:

```php
'group_by' => function($choice) {
    if (false !== $i = strpos($choice, '/')) {
        return substr($choice, 0, $i);
    }

    return 'Other';
},
```

The grouping labels are not really i18n friendly, so i think SF should opt-out by default.