### PR TITLE
[Form] Add intl/choice_translation_locale option to TimezoneType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -13,10 +13,12 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeZoneToStringTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\IntlTimeZoneToStringTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Intl\Timezones;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -40,18 +42,40 @@ class TimezoneType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
+            'intl' => false,
             'choice_loader' => function (Options $options) {
-                $regions = $options->offsetGet('regions', false);
                 $input = $options['input'];
 
+                if ($options['intl']) {
+                    $choiceTranslationLocale = $options['choice_translation_locale'];
+
+                    return new IntlCallbackChoiceLoader(function () use ($input, $choiceTranslationLocale) {
+                        return self::getIntlTimezones($input, $choiceTranslationLocale);
+                    });
+                }
+
+                $regions = $options->offsetGet('regions', false);
+
                 return new CallbackChoiceLoader(function () use ($regions, $input) {
-                    return self::getTimezones($regions, $input);
+                    return self::getPhpTimezones($regions, $input);
                 });
             },
             'choice_translation_domain' => false,
+            'choice_translation_locale' => null,
             'input' => 'string',
             'regions' => \DateTimeZone::ALL,
         ]);
+
+        $resolver->setAllowedTypes('intl', ['bool']);
+
+        $resolver->setAllowedTypes('choice_translation_locale', ['null', 'string']);
+        $resolver->setNormalizer('choice_translation_locale', function (Options $options, $value) {
+            if (null !== $value && !$options['intl']) {
+                throw new LogicException('The "choice_translation_locale" option can only be used if the "intl" option is set to true.');
+            }
+
+            return $value;
+        });
 
         $resolver->setAllowedValues('input', ['string', 'datetimezone', 'intltimezone']);
         $resolver->setNormalizer('input', function (Options $options, $value) {
@@ -64,6 +88,13 @@ class TimezoneType extends AbstractType
 
         $resolver->setAllowedTypes('regions', 'int');
         $resolver->setDeprecated('regions', 'The option "%name%" is deprecated since Symfony 4.2.');
+        $resolver->setNormalizer('regions', function (Options $options, $value) {
+            if ($options['intl'] && \DateTimeZone::ALL !== (\DateTimeZone::ALL & $value)) {
+                throw new LogicException('The "regions" option can only be used if the "intl" option is set to false.');
+            }
+
+            return $value;
+        });
     }
 
     /**
@@ -82,10 +113,7 @@ class TimezoneType extends AbstractType
         return 'timezone';
     }
 
-    /**
-     * Returns a normalized array of timezone choices.
-     */
-    private static function getTimezones(int $regions, string $input): array
+    private static function getPhpTimezones(int $regions, string $input): array
     {
         $timezones = [];
 
@@ -95,6 +123,21 @@ class TimezoneType extends AbstractType
             }
 
             $timezones[str_replace(['/', '_'], [' / ', ' '], $timezone)] = $timezone;
+        }
+
+        return $timezones;
+    }
+
+    private static function getIntlTimezones(string $input, string $locale = null): array
+    {
+        $timezones = array_flip(Timezones::getNames($locale));
+
+        if ('intltimezone' === $input) {
+            foreach ($timezones as $name => $timezone) {
+                if ('Etc/Unknown' === \IntlTimeZone::createTimeZone($timezone)->getID()) {
+                    unset($timezones[$name]);
+                }
+            }
         }
 
         return $timezones;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #28836 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/11503

final step :)

for now i think any form of grouping is a user concern (i.e. by GMT offset or area name); see #31293 + #31295 

having a special built in `group_by' => 'gmt_offset'` util would be nice, and can be done in the future.

includes #31434 