### PR TITLE
[Serializer] Fix tests

### DIFF
--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -25,7 +25,7 @@
         "symfony/property-access": "~2.8|~3.0|~4.0",
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
         "symfony/cache": "~3.1|~4.0",
-        "symfony/property-info": "~3.1|~4.0",
+        "symfony/property-info": "^3.4.13|~4.0",
         "doctrine/annotations": "~1.0",
         "symfony/dependency-injection": "~3.2|~4.0",
         "doctrine/cache": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | n/a
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

#30888 added some tests on master which fail when `property-info <3.4.13` is installed. 
This bumps the constraint on 3.4 which will fix the low-deps build once merged up to master.