### PR TITLE
[Messenger] Ensure that a TransportException is thrown on redis error

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Messenger\Tests\Transport\RedisExt;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\RedisExt\Connection;
 
 /**
@@ -103,7 +103,7 @@ class ConnectionTest extends TestCase
 
     public function testUnexpectedRedisError()
     {
-        $this->expectException(LogicException::class);
+        $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Redis error happens');
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();
         $redis->expects($this->once())->method('xreadgroup')->willReturn(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
