### PR TITLE
[Intl] Fix LocaleDataGenerator

### DIFF
--- a/src/Symfony/Component/Intl/Data/Provider/LanguageDataProvider.php
+++ b/src/Symfony/Component/Intl/Data/Provider/LanguageDataProvider.php
@@ -19,7 +19,7 @@ use Symfony\Component\Intl\Locale;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @internal to be removed in 5.0.
+ * @internal
  */
 class LanguageDataProvider
 {
@@ -38,11 +38,17 @@ class LanguageDataProvider
         $this->reader = $reader;
     }
 
+    /**
+     * @internal to be removed in 5.0.
+     */
     public function getLanguages()
     {
         return $this->reader->readEntry($this->path, 'meta', ['Languages']);
     }
 
+    /**
+     * @internal to be removed in 5.0.
+     */
     public function getAliases()
     {
         return $this->reader->readEntry($this->path, 'root', ['Aliases']);
@@ -57,6 +63,9 @@ class LanguageDataProvider
         return $this->reader->readEntry($this->path, $displayLocale, ['Names', $language]);
     }
 
+    /**
+     * @internal to be removed in 5.0.
+     */
     public function getNames($displayLocale = null)
     {
         if (null === $displayLocale) {
@@ -75,6 +84,9 @@ class LanguageDataProvider
         return $languages;
     }
 
+    /**
+     * @internal to be removed in 5.0.
+     */
     public function getAlpha3Code($language)
     {
         return $this->reader->readEntry($this->path, 'meta', ['Alpha2ToAlpha3', $language]);

--- a/src/Symfony/Component/Intl/Data/Provider/RegionDataProvider.php
+++ b/src/Symfony/Component/Intl/Data/Provider/RegionDataProvider.php
@@ -19,7 +19,7 @@ use Symfony\Component\Intl\Locale;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @internal to be removed in 5.0.
+ * @internal
  */
 class RegionDataProvider
 {
@@ -38,6 +38,9 @@ class RegionDataProvider
         $this->reader = $reader;
     }
 
+    /**
+     * @internal to be removed in 5.0.
+     */
     public function getRegions()
     {
         return $this->reader->readEntry($this->path, 'meta', ['Regions']);
@@ -52,6 +55,9 @@ class RegionDataProvider
         return $this->reader->readEntry($this->path, $displayLocale, ['Names', $region]);
     }
 
+    /**
+     * @internal to be removed in 5.0.
+     */
     public function getNames($displayLocale = null)
     {
         if (null === $displayLocale) {

--- a/src/Symfony/Component/Intl/Data/Provider/ScriptDataProvider.php
+++ b/src/Symfony/Component/Intl/Data/Provider/ScriptDataProvider.php
@@ -19,7 +19,7 @@ use Symfony\Component\Intl\Locale;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @internal to be removed in 5.0.
+ * @internal
  */
 class ScriptDataProvider
 {
@@ -38,6 +38,9 @@ class ScriptDataProvider
         $this->reader = $reader;
     }
 
+    /**
+     * @internal to be removed in 5.0.
+     */
     public function getScripts()
     {
         return $this->reader->readEntry($this->path, 'meta', ['Scripts']);
@@ -52,6 +55,9 @@ class ScriptDataProvider
         return $this->reader->readEntry($this->path, $displayLocale, ['Names', $script]);
     }
 
+    /**
+     * @internal to be removed in 5.0.
+     */
     public function getNames($displayLocale = null)
     {
         if (null === $displayLocale) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Forgotten in #28846 

The `getName()` method for scripts/regions/languages is stilled needed during locale generation.