### PR TITLE
Made `debug:container` and `debug:autowiring` ignore starting backslash in service id

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -220,6 +220,8 @@ EOF
 
     private function findProperServiceName(InputInterface $input, SymfonyStyle $io, ContainerBuilder $builder, string $name, bool $showHidden)
     {
+        $name = ltrim($name, '\\');
+
         if ($builder->has($name) || !$input->isInteractive()) {
             return $name;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -85,6 +85,7 @@ class ContainerDebugCommandTest extends WebTestCase
         return [
             [BackslashClass::class],
             ['FixturesBackslashClass'],
+            ['\\'.BackslashClass::class],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When you copy a reference to a class from PHPStorm it always start the FQCN with a backslash. 

When you now try to search the container for this class using `bin/console debug:container "\My\Class"` it cannot find it.

This PR always removes the starting backslash before searching the container to avoid this issue.