### PR TITLE
[DI] Improve exception message on missing $ of named argument

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -53,6 +53,10 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
                     $parameters = $r->getParameters();
                 }
 
+                if (isset($key[0]) && '$' !== $key[0] && !class_exists($key)) {
+                    throw new InvalidArgumentException(sprintf('Invalid service "%s": did you forget to add the "$" prefix to argument "%s"?', $this->currentId, $key));
+                }
+
                 if (isset($key[0]) && '$' === $key[0]) {
                     foreach ($parameters as $j => $p) {
                         if ($key === '$'.$p->name) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -149,6 +149,21 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $this->assertEquals([new Reference('foo'), '123'], $definition->getArguments());
     }
 
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy": did you forget to add the "$" prefix to argument "apiKey"?
+     */
+    public function testTypedArgumentWithMissingDollar()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
+        $definition->setArgument('apiKey', '123');
+
+        $pass = new ResolveNamedArgumentsPass();
+        $pass->process($container);
+    }
+
     public function testResolvesMultipleArgumentsOfTheSameType()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | -
| New feature?  | -
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31265   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | not related
<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

### Description

As described in #31265, missing the prefix `$` in an argument name:

```
    App\Word\WordChecker:
        arguments:
            checkers:
                - '@App\Word\Checker\StaticWordChecker'
                - '@App\Word\Checker\BannedWorldListChecker'
```

led to the following error:

`Invalid service "App\Word\WordChecker": the value of argument "checkers" of method "__construct()" must be null, an instance of Symfony\Component\DependencyInjection\Reference or an instance of Symfony\Component\DependencyInjection\Definition, array given.`

As this error message is quite confusing I changed it to:

`Invalid service "App\Word\WordChecker":  Did you forget to add the "$" prefix to argument checkers`

### Todo

- [x] add a unit test