### PR TITLE
Fix Thai translation in validators.th.xlf

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
@@ -152,7 +152,7 @@
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>
-                <target>Tค่านี้ถูกใช้งานไปแล้ว</target>
+                <target>ค่านี้ถูกใช้งานไปแล้ว</target>
             </trans-unit>
             <trans-unit id="42">
                 <source>The size of the image could not be detected.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master?
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

The translated message is wrongly prefixed with a "T" character. The correct translation should read as "ค่านี้ถูกใช้งานไปแล้ว".