### PR TITLE
[WIP] [Yaml] [DX] Add a better error message when passing a quoted string with multiple lines

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -167,10 +167,15 @@ class Parser
         $this->currentLine = '';
         $value = $this->cleanup($value);
         $this->lines = explode("\n", $value);
-        $this->locallySkippedLineNumbers = [];
 
+        $this->locallySkippedLineNumbers = [];
         if (null === $this->totalNumberOfLines) {
             $this->totalNumberOfLines = \count($this->lines);
+        }
+
+        // This a quoted string that spans multiple lines
+        if (false !== $pos = strpos($value, "'\n")) {
+            throw new ParseException(sprintf('A quoted string that spans multiple cannot be parsed at position %s', $pos), -1, $value);
         }
 
         if (!$this->moveToNextLine()) {
@@ -265,7 +270,6 @@ class Parser
                     if (isset($values['key'][0]) && '!' === $values['key'][0] && Yaml::PARSE_CONSTANT & $flags) {
                         $evaluateKey = true;
                     }
-
                     $key = Inline::parseScalar($values['key'], 0, null, $i, $evaluateKey);
                 } catch (ParseException $e) {
                     $e->setParsedLine($this->getRealCurrentLineNb() + 1);

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -172,10 +172,10 @@ class Parser
         if (null === $this->totalNumberOfLines) {
             $this->totalNumberOfLines = \count($this->lines);
         }
-
         // This a quoted string that spans multiple lines
-        if (false !== $pos = strpos($value, "'\n")) {
-            throw new ParseException(sprintf('A quoted string that spans multiple cannot be parsed at position %s', $pos), -1, $value);
+        $pos = strpos($value, "''\n");
+        if (false !== $pos && 1 === preg_match("/\s*[A-Za-z0-9]*/", substr($value, $pos))) {
+            throw new ParseException(sprintf('A quoted string that spans multiple lines is not supported at position %s', $pos), -1, $value);
         }
 
         if (!$this->moveToNextLine()) {

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2167,11 +2167,11 @@ YAML;
 
     /**
      * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage A quoted string that spans multiple cannot be parsed at position 44 (near "key:
+     * @expectedExceptionMessage A quoted string that spans multiple lines is not supported at position 44 (near "key:
     fields:
     title: 'bla. Users''
     Guide'
-    ")
+    ")'
      */
     public function testQuotedStringMutlipleLines()
     {
@@ -2182,8 +2182,7 @@ key:
             Guide'
 
 YAML;
-        $parsed = Yaml::parse($data);
-        var_dump($parsed);
+       Yaml::parse($data);
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2167,6 +2167,27 @@ YAML;
 
     /**
      * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage A quoted string that spans multiple cannot be parsed at position 44 (near "key:
+    fields:
+    title: 'bla. Users''
+    Guide'
+    ")
+     */
+    public function testQuotedStringMutlipleLines()
+    {
+        $data = <<<YAML
+key:
+    fields:
+        title: 'bla. Users''
+            Guide'
+
+YAML;
+        $parsed = Yaml::parse($data);
+        var_dump($parsed);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      * @expectedExceptionMessage Reference "foo" does not exist
      */
     public function testEvalRefException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yesish
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #25379   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->


As said in the issue, I tried to find a way to parse this, but I don't have enough knowledge of the YAML component, so as a first thing to do as @xabbuh mentioned is to improve the message we give the users about this error.