### PR TITLE
Revert "bug #30620 [FrameworkBundle][HttpFoundation] make session service resettable (dmaicher)"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -15,7 +15,6 @@
             <argument type="service" id="session.storage" />
             <argument type="service" id="session.attribute_bag" />
             <argument type="service" id="session.flash_bag" />
-            <tag name="kernel.reset" method="save" />
         </service>
 
         <service id="Symfony\Component\HttpFoundation\Session\SessionInterface" alias="session" />

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/dependency-injection": "^3.4.24|^4.2.5",
         "symfony/config": "~3.4|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
-        "symfony/http-foundation": "^3.4.24|^4.2.5",
+        "symfony/http-foundation": "^3.3.11|~4.0",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~2.8|~3.0|~4.0",

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -193,9 +193,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function save()
     {
-        if ($this->isStarted()) {
-            $this->storage->save();
-        }
+        $this->storage->save();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -260,14 +260,4 @@ class SessionTest extends TestCase
         $flash->get('hello');
         $this->assertTrue($this->session->isEmpty());
     }
-
-    public function testSaveIfNotStarted()
-    {
-        $storage = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface')->getMock();
-        $session = new Session($storage);
-
-        $storage->expects($this->once())->method('isStarted')->willReturn(false);
-        $storage->expects($this->never())->method('save');
-        $session->save();
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This reverts commit 029fb2e7e36b7cdf29e27d4bfa54dd11adc5d457, reversing
changes made to 9dad29d61c5605b589493efe34012fdb1218b92b.

Reverts #30620
Replaces #31215 

We don't need to solve this in 3.4
Making the session resettable should be done on master, by implementing `ResetInterface`.
On 3.4 apps, one should write a dedicated `SessionResetter` that would implement the reverted logic.