### PR TITLE
Reword VarDumper description

### DIFF
--- a/src/Symfony/Component/VarDumper/README.md
+++ b/src/Symfony/Component/VarDumper/README.md
@@ -2,8 +2,8 @@ VarDumper Component
 ===================
 
 The VarDumper component provides mechanisms for walking through any arbitrary
-PHP variable. Built on top, it provides a better `dump()` function that you
-can use instead of `var_dump`.
+PHP variable. It provides a better `dump()` function that you can use instead
+of `var_dump`.
 
 Resources
 ---------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

It is hard to understand what "Built on top" refers to, and even when
knowing, the sentence looks weird.
![Untitled](https://user-images.githubusercontent.com/657779/57011659-15ebfe00-6c03-11e9-9b85-5c00cfc15026.png)

The description of [the Github repository](https://github.com/symfony/var-dumper) has the same issue and should be changed.