### PR TITLE
[Intl] Rename Regions to Countries

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -108,7 +108,7 @@ Intl
  * Deprecated `Intl::getCurrencyBundle()`, use `Currencies` instead
  * Deprecated `Intl::getLanguageBundle()`, use `Languages` or `Scripts` instead
  * Deprecated `Intl::getLocaleBundle()`, use `Locales` instead
- * Deprecated `Intl::getRegionBundle()`, use `Regions` instead
+ * Deprecated `Intl::getRegionBundle()`, use `Countries` instead
 
 Messenger
 ---------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -250,7 +250,7 @@ Intl
  * Removed `Intl::getLanguageBundle()`, use `Languages` or `Scripts` instead
  * Removed `Intl::getCurrencyBundle()`, use `Currencies` instead
  * Removed `Intl::getLocaleBundle()`, use `Locales` instead
- * Removed `Intl::getRegionBundle()`, use `Regions` instead
+ * Removed `Intl::getRegionBundle()`, use `Countries` instead
 
 Messenger
 ---------

--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
-use Symfony\Component\Intl\Regions;
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -44,7 +44,7 @@ class CountryType extends AbstractType implements ChoiceLoaderInterface
                 $choiceTranslationLocale = $options['choice_translation_locale'];
 
                 return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale) {
-                    return array_flip(Regions::getNames($choiceTranslationLocale));
+                    return array_flip(Countries::getNames($choiceTranslationLocale));
                 });
             },
             'choice_translation_domain' => false,
@@ -83,7 +83,7 @@ class CountryType extends AbstractType implements ChoiceLoaderInterface
             return $this->choiceList;
         }
 
-        return $this->choiceList = new ArrayChoiceList(array_flip(Regions::getNames()), $value);
+        return $this->choiceList = new ArrayChoiceList(array_flip(Countries::getNames()), $value);
     }
 
     /**

--- a/src/Symfony/Component/Intl/CHANGELOG.md
+++ b/src/Symfony/Component/Intl/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
  * added `Currencies` in favor of `Intl::getCurrencyBundle()`
  * added `Languages` and `Scripts` in favor of `Intl::getLanguageBundle()`
  * added `Locales` in favor of `Intl::getLocaleBundle()`
- * added `Regions` in favor of `Intl::getRegionBundle()`
+ * added `Countries` in favor of `Intl::getRegionBundle()`
  * added `Timezones`
 
 4.2.0

--- a/src/Symfony/Component/Intl/Countries.php
+++ b/src/Symfony/Component/Intl/Countries.php
@@ -19,20 +19,20 @@ use Symfony\Component\Intl\Exception\MissingResourceException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Roland Franssen <franssen.roland@gmail.com>
  */
-final class Regions extends ResourceBundle
+final class Countries extends ResourceBundle
 {
     /**
      * @return string[]
      */
-    public static function getRegionCodes(): array
+    public static function getCountryCodes(): array
     {
         return self::readEntry(['Regions'], 'meta');
     }
 
-    public static function exists(string $region): bool
+    public static function exists(string $country): bool
     {
         try {
-            self::readEntry(['Names', $region]);
+            self::readEntry(['Names', $country]);
 
             return true;
         } catch (MissingResourceException $e) {
@@ -41,11 +41,11 @@ final class Regions extends ResourceBundle
     }
 
     /**
-     * @throws MissingResourceException if the region code does not exists
+     * @throws MissingResourceException if the country code does not exists
      */
-    public static function getName(string $region, string $displayLocale = null): string
+    public static function getName(string $country, string $displayLocale = null): string
     {
-        return self::readEntry(['Names', $region], $displayLocale);
+        return self::readEntry(['Names', $country], $displayLocale);
     }
 
     /**

--- a/src/Symfony/Component/Intl/Intl.php
+++ b/src/Symfony/Component/Intl/Intl.php
@@ -188,11 +188,11 @@ final class Intl
      *
      * @return RegionBundleInterface The region resource bundle
      *
-     * @deprecated since Symfony 4.3, to be removed in 5.0. Use {@see Regions} instead.
+     * @deprecated since Symfony 4.3, to be removed in 5.0. Use {@see Countries} instead.
      */
     public static function getRegionBundle()
     {
-        @trigger_error(sprintf('The method "%s()" is deprecated since Symfony 4.3, use "%s" instead.', __METHOD__, Regions::class), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The method "%s()" is deprecated since Symfony 4.3, use "%s" instead.', __METHOD__, Countries::class), E_USER_DEPRECATED);
 
         if (null === self::$regionBundle) {
             self::$regionBundle = new RegionBundle(

--- a/src/Symfony/Component/Intl/Tests/CountriesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CountriesTest.php
@@ -11,17 +11,16 @@
 
 namespace Symfony\Component\Intl\Tests;
 
-use Symfony\Component\Intl\Locale;
-use Symfony\Component\Intl\Regions;
+use Symfony\Component\Intl\Countries;
 
 /**
  * @group intl-data
  */
-class RegionsTest extends ResourceBundleTestCase
+class CountriesTest extends ResourceBundleTestCase
 {
     // The below arrays document the state of the ICU data bundled with this package.
 
-    private static $territories = [
+    private static $countries = [
         'AC',
         'AD',
         'AE',
@@ -279,9 +278,9 @@ class RegionsTest extends ResourceBundleTestCase
         'ZW',
     ];
 
-    public function testGetRegions()
+    public function testGetCountryCodes()
     {
-        $this->assertSame(self::$territories, Regions::getRegionCodes());
+        $this->assertSame(self::$countries, Countries::getCountryCodes());
     }
 
     /**
@@ -289,18 +288,18 @@ class RegionsTest extends ResourceBundleTestCase
      */
     public function testGetNames($displayLocale)
     {
-        $countries = array_keys(Regions::getNames($displayLocale));
+        $countries = array_keys(Countries::getNames($displayLocale));
 
         sort($countries);
 
-        $this->assertSame(self::$territories, $countries);
+        $this->assertSame(self::$countries, $countries);
     }
 
     public function testGetNamesDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
-        $this->assertSame(Regions::getNames('de_AT'), Regions::getNames());
+        $this->assertSame(Countries::getNames('de_AT'), Countries::getNames());
     }
 
     /**
@@ -311,7 +310,7 @@ class RegionsTest extends ResourceBundleTestCase
         // Can't use assertSame(), because some aliases contain scripts with
         // different collation (=order of output) than their aliased locale
         // e.g. sr_Latn_ME => sr_ME
-        $this->assertEquals(Regions::getNames($ofLocale), Regions::getNames($alias));
+        $this->assertEquals(Countries::getNames($ofLocale), Countries::getNames($alias));
     }
 
     /**
@@ -319,10 +318,10 @@ class RegionsTest extends ResourceBundleTestCase
      */
     public function testGetName($displayLocale)
     {
-        $names = Regions::getNames($displayLocale);
+        $names = Countries::getNames($displayLocale);
 
         foreach ($names as $country => $name) {
-            $this->assertSame($name, Regions::getName($country, $displayLocale));
+            $this->assertSame($name, Countries::getName($country, $displayLocale));
         }
     }
 
@@ -332,13 +331,13 @@ class RegionsTest extends ResourceBundleTestCase
     public function testLocaleAliasesAreLoaded()
     {
         \Locale::setDefault('zh_TW');
-        $countryNameZhTw = Regions::getName('AD');
+        $countryNameZhTw = Countries::getName('AD');
 
         \Locale::setDefault('zh_Hant_TW');
-        $countryNameHantZhTw = Regions::getName('AD');
+        $countryNameHantZhTw = Countries::getName('AD');
 
         \Locale::setDefault('zh');
-        $countryNameZh = Regions::getName('AD');
+        $countryNameZh = Countries::getName('AD');
 
         $this->assertSame($countryNameZhTw, $countryNameHantZhTw, 'zh_TW is an alias to zh_Hant_TW');
         $this->assertNotSame($countryNameZh, $countryNameZhTw, 'zh_TW does not fall back to zh');
@@ -347,14 +346,14 @@ class RegionsTest extends ResourceBundleTestCase
     /**
      * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
      */
-    public function testGetNameWithInvalidRegionCode()
+    public function testGetNameWithInvalidCountryCode()
     {
-        Regions::getName('foo');
+        Countries::getName('foo');
     }
 
     public function testExists()
     {
-        $this->assertTrue(Regions::exists('NL'));
-        $this->assertFalse(Regions::exists('ZZ'));
+        $this->assertTrue(Countries::exists('NL'));
+        $this->assertFalse(Countries::exists('ZZ'));
     }
 }

--- a/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Intl\Tests;
 
 use Symfony\Component\Intl\Currencies;
-use Symfony\Component\Intl\Locale;
 
 /**
  * @group intl-data
@@ -585,7 +584,7 @@ class CurrenciesTest extends ResourceBundleTestCase
         'USS' => 998,
     ];
 
-    public function testGetCurrencies()
+    public function testGetCurrencyCodes()
     {
         $this->assertSame(self::$currencies, Currencies::getCurrencyCodes());
     }
@@ -613,7 +612,7 @@ class CurrenciesTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
         $this->assertSame(Currencies::getNames('de_AT'), Currencies::getNames());
     }
@@ -646,7 +645,7 @@ class CurrenciesTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
         $expected = Currencies::getNames('de_AT');
         $actual = [];

--- a/src/Symfony/Component/Intl/Tests/LanguagesTest.php
+++ b/src/Symfony/Component/Intl/Tests/LanguagesTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Intl\Tests;
 
 use Symfony\Component\Intl\Languages;
-use Symfony\Component\Intl\Locale;
 
 /**
  * @group intl-data
@@ -824,7 +823,7 @@ class LanguagesTest extends ResourceBundleTestCase
         'zu' => 'zul',
     ];
 
-    public function testGetLanguages()
+    public function testGetLanguageCodes()
     {
         $this->assertEquals(self::$languages, Languages::getLanguageCodes());
     }
@@ -844,7 +843,7 @@ class LanguagesTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
         $this->assertSame(Languages::getNames('de_AT'), Languages::getNames());
     }
@@ -874,7 +873,7 @@ class LanguagesTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
         $names = Languages::getNames('de_AT');
 

--- a/src/Symfony/Component/Intl/Tests/LocalesTest.php
+++ b/src/Symfony/Component/Intl/Tests/LocalesTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Intl\Tests;
 
-use Symfony\Component\Intl\Locale;
 use Symfony\Component\Intl\Locales;
 
 /**
@@ -24,7 +23,7 @@ class LocalesTest extends ResourceBundleTestCase
         $this->assertSame($this->getLocales(), Locales::getLocales());
     }
 
-    public function testGetLocaleAliases()
+    public function testGetAliases()
     {
         $this->assertSame($this->getLocaleAliases(), Locales::getAliases());
     }
@@ -46,7 +45,7 @@ class LocalesTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
         $this->assertSame(Locales::getNames('de_AT'), Locales::getNames());
     }
@@ -76,7 +75,7 @@ class LocalesTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
         $names = Locales::getNames('de_AT');
 

--- a/src/Symfony/Component/Intl/Tests/ScriptsTest.php
+++ b/src/Symfony/Component/Intl/Tests/ScriptsTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Intl\Tests;
 
-use Symfony\Component\Intl\Locale;
 use Symfony\Component\Intl\Scripts;
 
 /**
@@ -214,7 +213,7 @@ class ScriptsTest extends ResourceBundleTestCase
         'Zzzz',
     ];
 
-    public function testGetScripts()
+    public function testGetScriptCodes()
     {
         $this->assertSame(self::$scripts, Scripts::getScriptCodes());
     }
@@ -236,7 +235,7 @@ class ScriptsTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
         $this->assertSame(Scripts::getNames('de_AT'), Scripts::getNames());
     }
@@ -266,7 +265,7 @@ class ScriptsTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
-        Locale::setDefault('de_AT');
+        \Locale::setDefault('de_AT');
 
         $names = Scripts::getNames('de_AT');
 

--- a/src/Symfony/Component/Intl/Tests/TimezonesTest.php
+++ b/src/Symfony/Component/Intl/Tests/TimezonesTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Intl\Tests;
 
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Exception\MissingResourceException;
-use Symfony\Component\Intl\Regions;
 use Symfony\Component\Intl\Timezones;
 
 /**
@@ -468,7 +468,7 @@ class TimezonesTest extends ResourceBundleTestCase
         'Etc/UTC',
     ];
 
-    public function testGetTimezones()
+    public function testGetIds()
     {
         $this->assertEquals(self::$zones, Timezones::getIds());
     }
@@ -652,6 +652,6 @@ class TimezonesTest extends ResourceBundleTestCase
     {
         return array_map(function ($country) {
             return [$country];
-        }, Regions::getRegionCodes());
+        }, Countries::getCountryCodes());
     }
 }

--- a/src/Symfony/Component/Intl/Timezones.php
+++ b/src/Symfony/Component/Intl/Timezones.php
@@ -99,7 +99,7 @@ final class Timezones extends ResourceBundle
         try {
             return self::readEntry(['CountryToZone', $country], 'meta');
         } catch (MissingResourceException $e) {
-            if (Regions::exists($country)) {
+            if (Countries::exists($country)) {
                 return [];
             }
 

--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Intl\Regions;
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
@@ -47,7 +47,7 @@ class Bic extends Constraint
 
     public function __construct($options = null)
     {
-        if (!class_exists(Regions::class)) {
+        if (!class_exists(Countries::class)) {
             // throw new LogicException(sprintf('The "symfony/intl" component is required to use the "%s" constraint.', __CLASS__));
             @trigger_error(sprintf('Using the "%s" constraint without the "symfony/intl" component installed is deprecated since Symfony 4.2.', __CLASS__), E_USER_DEPRECATED);
         }

--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Intl\Regions;
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -105,8 +105,8 @@ class BicValidator extends ConstraintValidator
         }
 
         // @deprecated since Symfony 4.2, will throw in 5.0
-        if (class_exists(Regions::class)) {
-            $validCountryCode = Regions::exists(substr($canonicalize, 4, 2));
+        if (class_exists(Countries::class)) {
+            $validCountryCode = Countries::exists(substr($canonicalize, 4, 2));
         } else {
             $validCountryCode = ctype_alpha(substr($canonicalize, 4, 2));
             // throw new LogicException('The "symfony/intl" component is required to use the Bic constraint.');

--- a/src/Symfony/Component/Validator/Constraints/Country.php
+++ b/src/Symfony/Component/Validator/Constraints/Country.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Intl\Regions;
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\LogicException;
 
@@ -33,7 +33,7 @@ class Country extends Constraint
 
     public function __construct($options = null)
     {
-        if (!class_exists(Regions::class)) {
+        if (!class_exists(Countries::class)) {
             // throw new LogicException(sprintf('The "symfony/intl" component is required to use the "%s" constraint.', __CLASS__));
             @trigger_error(sprintf('Using the "%s" constraint without the "symfony/intl" component installed is deprecated since Symfony 4.2.', __CLASS__), E_USER_DEPRECATED);
         }

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Intl\Regions;
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\LogicException;
@@ -42,13 +42,13 @@ class CountryValidator extends ConstraintValidator
             throw new UnexpectedValueException($value, 'string');
         }
 
-        if (!class_exists(Regions::class)) {
+        if (!class_exists(Countries::class)) {
             throw new LogicException('The "symfony/intl" component is required to use the Country constraint.');
         }
 
         $value = (string) $value;
 
-        if (!Regions::exists($value)) {
+        if (!Countries::exists($value)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Country::NO_SUCH_COUNTRY_ERROR)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes  (including intl-data group)
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Because that's what the current region data is about; country codes.

This makes things consistent across the board; i.e. CountryType, CountryValidator

This allows a possible other region subset (e.g "continents") to distinct. Thus having `Countries::class` + `Continents::class` both reading from the `region` data. By then data should be compiled under different keys.

Current class is master only, so now or never :)

The alternative approach would be `Regions::getCountryNames [,getContinentNames, etc.]`, which is harder to scale, and should also be decided for 4.3 ideally.