### PR TITLE
[Validator] Improve TypeValidator to handle array of types

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added support for checking an array of types in `TypeValidator`
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -33,22 +33,25 @@ class TypeValidator extends ConstraintValidator
             return;
         }
 
-        $type = strtolower($constraint->type);
-        $type = 'boolean' == $type ? 'bool' : $constraint->type;
-        $isFunction = 'is_'.$type;
-        $ctypeFunction = 'ctype_'.$type;
+        $types = (array) $constraint->type;
 
-        if (\function_exists($isFunction) && $isFunction($value)) {
-            return;
-        } elseif (\function_exists($ctypeFunction) && $ctypeFunction($value)) {
-            return;
-        } elseif ($value instanceof $constraint->type) {
-            return;
+        foreach ($types as $type) {
+            $type = strtolower($type);
+            $type = 'boolean' === $type ? 'bool' : $type;
+            $isFunction = 'is_'.$type;
+            $ctypeFunction = 'ctype_'.$type;
+            if (\function_exists($isFunction) && $isFunction($value)) {
+                return;
+            } elseif (\function_exists($ctypeFunction) && $ctypeFunction($value)) {
+                return;
+            } elseif ($value instanceof $type) {
+                return;
+            }
         }
 
         $this->context->buildViolation($constraint->message)
             ->setParameter('{{ value }}', $this->formatValue($value))
-            ->setParameter('{{ type }}', $constraint->type)
+            ->setParameter('{{ type }}', implode('|', $types))
             ->setCode(Type::INVALID_TYPE_ERROR)
             ->addViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -163,6 +163,52 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
+    /**
+     * @dataProvider getValidValuesMultipleTypes
+     */
+    public function testValidValuesMultipleTypes($value, array $types)
+    {
+        $constraint = new Type(['type' => $types]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidValuesMultipleTypes()
+    {
+        return [
+            ['12345', ['array', 'string']],
+            [[], ['array', 'string']],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidValuesMultipleTypes
+     */
+    public function testInvalidValuesMultipleTypes($value, $types, $valueAsString)
+    {
+        $constraint = new Type([
+            'type' => $types,
+            'message' => 'myMessage',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $valueAsString)
+            ->setParameter('{{ type }}', implode('|', $types))
+            ->setCode(Type::INVALID_TYPE_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidValuesMultipleTypes()
+    {
+        return [
+            ['12345', ['boolean', 'array'], '"12345"'],
+        ];
+    }
+
     protected function createFile()
     {
         if (!static::$file) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31330
| License       | MIT
| Doc PR        | tbd.

The `@Type` constraint is now able to handle multiple types:

```php
/**
 * @var string|array
 * @Assert\Type(type={"string", "array"})
 */
 private $name;
```

and will pass when `$name` is either of type `string` or `array`.
