### PR TITLE
[Form] Add label_raw attribute to form theme

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -232,7 +232,16 @@
             {% set label = name|humanize %}
         {%- endif -%}
     {%- endif -%}
-    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ translation_domain is same as(false) ? label : label|trans(label_translation_parameters, translation_domain) }}</button>
+    {%- if translation_domain is not same as(false) -%}
+        {%- set label = label|trans(label_translation_parameters, translation_domain) -%}
+    {%- endif -%}
+    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>
+        {%- if label_raw|default(false) -%}
+            {{- label|raw -}}
+        {%- else -%}
+            {{- label -}}
+        {%- endif -%}
+    </button>
 {%- endblock button_widget -%}
 
 {%- block submit_widget -%}
@@ -275,11 +284,14 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
+        {%- if translation_domain is not same as(false) -%}
+            {%- set label = label|trans(label_translation_parameters, translation_domain) -%}
+        {%- endif -%}
         <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>
-            {%- if translation_domain is same as(false) -%}
-                {{- label -}}
+            {%- if label_raw|default(false) -%}
+                {{- label|raw -}}
             {%- else -%}
-                {{- label|trans(label_translation_parameters, translation_domain) -}}
+                {{- label -}}
             {%- endif -%}
         </{{ element|default('label') }}>
     {%- endif -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #... 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11513

There are some usecases where you want to render a label as raw (e.g. checkbox with a link in it). This change should make it easier todo this without copying the whole form_label block logic.

Example:

```twig
{% block _my_label %}
    {%- set label_raw = true -%}
    {{- block('form_label') -}}
{% endblock %}
```

Should we add this also to the FormExtension as attribute? Or is it a theming only thing like #30320. 