### PR TITLE
[Yaml]  Deal with lines containing whitespace ONLY in multiline parser.

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -436,6 +436,12 @@ class Parser
                     $value = '';
 
                     foreach ($this->lines as $line) {
+                        if ('' === trim($line) && '' !== $line && \in_array($this->currentLine, ['{', '['])) {
+                            continue;
+                        } elseif ('' === trim($line) && '' !== $line) {
+                            $line = '';
+                        }
+
                         // If the indentation is not consistent at offset 0, it is to be considered as a ParseError
                         if (0 === $this->offset && !$deprecatedUsage && isset($line[0]) && ' ' === $line[0]) {
                             throw new ParseException('Unable to parse.', $this->getRealCurrentLineNb() + 1, $this->currentLine, $this->filename);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1757,6 +1757,11 @@ EOF;
 
         $tests[] = [$yaml, $expected, false];
 
+        $yaml = "{\n \n}";
+        $expected = [];
+
+        $tests[] = [$yaml, $expected, false];
+
         return $tests;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #31333 
| License       | MIT
| Doc PR        | n/a

This PR ignores lines in a YAML file that contain whitespace ONLY, effectively an empty line as far as the parser is concerned.


Speed:
Over 100 iterations compared to libYaml in PHP 7.3.4 on WAMP64 installation the average speed ratio is approx. 3.5:1  (SymfonyParser:libYaml) for data = "{\n \n}"