### PR TITLE
[DI] Removes number of elements information in debug mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -137,6 +137,7 @@ EOF
         $options['show_arguments'] = $input->getOption('show-arguments');
         $options['raw_text'] = $input->getOption('raw');
         $options['output'] = $io;
+        $options['is_debug'] = $this->getApplication()->getKernel()->isDebug();
         $helper->describe($io, $object, $options);
 
         if (!$input->getArgument('name') && !$input->getOption('tag') && !$input->getOption('parameter') && $input->isInteractive()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -339,7 +340,11 @@ class TextDescriptor extends Descriptor
                 if ($argument instanceof Reference) {
                     $argumentsInformation[] = sprintf('Service(%s)', (string) $argument);
                 } elseif ($argument instanceof IteratorArgument) {
-                    $argumentsInformation[] = sprintf('Iterator (%d element(s))', \count($argument->getValues()));
+                    if ($argument instanceof TaggedIteratorArgument) {
+                        $argumentsInformation[] = sprintf('Tagged Iterator for "%s"%s', $argument->getTag(), $options['is_debug'] ? '' : sprintf(' (%d element(s))', \count($argument->getValues())));
+                    } else {
+                        $argumentsInformation[] = sprintf('Iterator (%d element(s))', \count($argument->getValues()));
+                    }
                 } elseif ($argument instanceof Definition) {
                     $argumentsInformation[] = 'Inlined Service';
                 } else {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -182,6 +182,7 @@ abstract class AbstractDescriptorTest extends TestCase
 
     private function assertDescription($expectedDescription, $describedObject, array $options = [])
     {
+        $options['is_debug'] = false;
         $options['raw_output'] = true;
         $options['raw_text'] = true;
         $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31340
| License       | MIT
| Doc PR        | -

With this services config:

```yaml
my_service:
    class: stdClass
    arguments: [!tagged my_tag]

my_tagged_service_1:
    class: stdClass
    tags: [my_tag]

my_tagged_service_2:
    class: stdClass
    tags: [my_tag]
```
Executing `./bin/console debug:container my_service --show-arguments --env=dev` resulted in 

```bash
Information for Service "my_service"
====================================

 ---------------- -------------------------
  Option           Value
 ---------------- -------------------------
  Service ID       my_service
  Class            stdClass
  Tags             -
  Public           no
  Synthetic        no
  Lazy             no
  Shared           yes
  Abstract         no
  Autowired        yes
  Autoconfigured   yes
  Arguments        Iterator (0 element(s))
 ---------------- -------------------------
```
 With this fix the output changed to:

```bash
Information for Service "my_service"
====================================

 ---------------- ------------
  Option           Value
 ---------------- ------------
  Service ID       my_service
  Class            stdClass
  Tags             -
  Public           no
  Synthetic        no
  Lazy             no
  Shared           yes
  Abstract         no
  Autowired        yes
  Autoconfigured   yes
  Arguments        Tagged Iterator for "my_tag"
 ---------------- ------------
```

and with `./bin/console debug:container my_service --show-arguments --env=prod`

```bash
Information for Service "my_service_tagged_iterator"
====================================================

 ---------------- ---------------------------------------------
  Option           Value
 ---------------- ---------------------------------------------
  Service ID       my_service
  Class            stdClass
  Tags             -
  Public           no
  Synthetic        no
  Lazy             no
  Shared           yes
  Abstract         no
  Autowired        yes
  Autoconfigured   yes
  Arguments        Tagged Iterator for "my_tag" (2 element(s))
 ---------------- ---------------------------------------------
```

