### PR TITLE
[PropertyAccess] Introduces PropertyAccessor::getValues() method

### DIFF
--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,52 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added `getValues($objects, $propertyPath)` to `PropertyAccessor` class
+   With:
+
+   ```php
+   class User
+   {
+       private $username;
+
+       public function __construct(string $username)
+       {
+           $this->username = $username;
+       }
+
+       public function getUsername(): string
+       {
+           return $this->username;
+       }
+   }
+
+   $users = [
+       new User('foo'),
+       new User('bar'),
+   ];
+   ```
+
+   you can now do this:
+
+   ```php
+   $propertyAccessor = PropertyAccess::createPropertyAccessor();
+   $usernames = $propertyAccessor->getValues($users, 'username');
+   ```
+
+   and will get:
+
+   ```
+   // print_r($usernames);
+   Array
+   (
+       [0] => foo
+       [1] => bar
+   )
+   ```
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -79,6 +79,16 @@ class PropertyAccessor implements PropertyAccessorInterface
         $this->ignoreInvalidProperty = !$throwExceptionOnInvalidPropertyPath;
     }
 
+    public function getValues($objects, $propertyPath)
+    {
+        return array_map(
+            function ($object) use ($propertyPath) {
+                return $this->getValue($object, $propertyPath);
+            },
+            $objects
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -50,6 +50,21 @@ interface PropertyAccessorInterface
     public function setValue(&$objectOrArray, $propertyPath, $value);
 
     /**
+     * Returns the values at the end of the property path of the object graph of the objects given in the given $objects array.
+     *
+     * @param array                         $objects       The array of objects to traverse
+     * @param string|PropertyPathInterface  $propertyPath  The property path to read
+     *
+     * @return array The values at the end of the property path of each object in the given $objects array
+     *
+     * @throws Exception\InvalidArgumentException If the property path is invalid
+     * @throws Exception\AccessException          If a property/index does not exist or is not public
+     * @throws Exception\UnexpectedTypeException  If a value within the path is neither object
+     *                                            nor array
+     */
+    public function getValues($objects, $propertyPath);
+
+    /**
      * Returns the value at the end of the property path of the object graph.
      *
      * Example:

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassGetValues.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassGetValues.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class TestClassGetValues
+{
+    private $stringValue;
+    private $intValue;
+    private $dateTimeValue;
+    private $arrayValue;
+
+    public function __construct(string $stringValue, int $intValue, \DateTimeImmutable $dateTimeValue, array $arrayValue)
+    {
+        $this->stringValue = $stringValue;
+        $this->intValue = $intValue;
+        $this->dateTimeValue = $dateTimeValue;
+        $this->arrayValue = $arrayValue;
+    }
+
+    public function getStringValue(): string
+    {
+        return $this->stringValue;
+    }
+
+    public function getIntValue(): int
+    {
+        return $this->intValue;
+    }
+    public function getDateTimeValue(): \DateTimeImmutable
+    {
+        return $this->dateTimeValue;
+    }
+
+    public function getArrayValue(): array
+    {
+        return $this->arrayValue;
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\ReturnTyped;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassGetValues;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassIsWritable;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicGet;
@@ -761,5 +762,23 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->setValue($object, 'aircraft', ['aeroplane']);
 
         $this->assertEquals(['aeroplane'], $object->getAircraft());
+    }
+
+    public function testGetValuesOfArrayOfObjects()
+    {
+        $objects = [
+            $foo = new TestClassGetValues('foo', 1, new \DateTimeImmutable('today'), []),
+            $bar = new TestClassGetValues('bar', 2, new \DateTimeImmutable('yesterday'), []),
+        ];
+
+        $this->assertEquals([$foo->getStringValue(), $bar->getStringValue()], $this->propertyAccessor->getValues($objects, 'stringValue'));
+        $this->assertEquals([$foo->getIntValue(), $bar->getIntValue()], $this->propertyAccessor->getValues($objects, 'intValue'));
+        $this->assertEquals([$foo->getDateTimeValue(), $bar->getDateTimeValue()], $this->propertyAccessor->getValues($objects, 'dateTimeValue'));
+        $this->assertEquals([$foo->getArrayValue(), $bar->getArrayValue()], $this->propertyAccessor->getValues($objects, 'arrayValue'));
+
+        $objects = [
+            new TestClassGetValues('foo', 1, new \DateTimeImmutable('today'), ['foo' => 'bar']),
+        ];
+        $this->assertEquals(['bar'], $this->propertyAccessor->getValues($objects, 'arrayValue[foo]'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30647   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | tbd.  <!-- required for new features -->

With:

```php
class User 
{
    private $username;

    public function __construct(string $username)
    {
        $this->username = $username;
    }

    public function getUsername(): string
    {
        return $this->username;
    }
}

$users = [
    new User('foo'),
    new User('bar'),
];
```

you can now do this:

```php
$propertyAccessor = PropertyAccess::createPropertyAccessor();
$usernames = $propertyAccessor->getValues($users, 'username');
```
and will get:
```
// print_r($usernames);
Array
(
    [0] => foo
    [1] => bar
)
```
