### PR TITLE
[PhpunitBridge] Fix not unserialized logs after DeprecationErrorHandler refacto

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -133,6 +133,7 @@ class DeprecationErrorHandler
         if ($deprecation->originatesFromAnObject()) {
             $class = $deprecation->originatingClass();
             $method = $deprecation->originatingMethod();
+            $msg = $deprecation->getMessage();
 
             if (0 !== error_reporting()) {
                 $group = 'unsilenced';

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -133,6 +133,11 @@ class Deprecation
         return $this->originMethod;
     }
 
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
     /**
      * @param string $utilPrefix
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

During the refactoring for #29211 , it seems a little bug was introduced. When using runInSeparateProcess, deprecation message isn't unserialized anymore.
