### PR TITLE
[Mailer][Messenger] Changing messenger bus id from 'message_bus' to 'messenger.default_bus'

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="mailer" class="Symfony\Component\Mailer\Mailer">
             <argument type="service" id="mailer.transport" />
-            <argument type="service" id="message_bus" on-invalid="ignore" />
+            <argument type="service" id="messenger.default_bus" on-invalid="ignore" />
         </service>
         <service id="Symfony\Component\Mailer\MailerInterface" alias="mailer" />
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30690
| License       | MIT
| Doc PR        | -

Follow up of #30690