### PR TITLE
[Messenger] Fix rejecting of pending messages

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -89,7 +89,7 @@ class Connection
         } catch (\RedisException $e) {
         }
 
-        if ($e || (false === $messages && !$this->couldHavePendingMessages)) {
+        if ($e || false === $messages) {
             throw new TransportException(
                 ($e ? $e->getMessage() : $this->connection->getLastError()) ?? 'Could not read messages from the redis stream.'
             );
@@ -132,7 +132,8 @@ class Connection
     {
         $e = null;
         try {
-            $deleted = $this->connection->xdel($this->stream, [$id]);
+            $deleted = $this->connection->xack($this->stream, $this->group, [$id]);
+            $deleted = $this->connection->xdel($this->stream, [$id]) && $deleted;
         } catch (\RedisException $e) {
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #...   
| License       | MIT
| Doc PR        | -

As discussed in https://github.com/symfony/symfony/pull/31387#issuecomment-489605683. It seems pending messages are not removed by calling xdel so we need to call xack first to remove them from the pending state and then call xdel to remove it from the complete stream.

It seems to be the correct way as mentioned in: https://github.com/antirez/redis/issues/5754

Test should be the same as added in: https://github.com/symfony/symfony/pull/31387/files#diff-46c1e03dafbcebc46b5cace7d05de20c