### PR TITLE
[Dotenv] Test do not use putenv

### DIFF
--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -431,4 +431,14 @@ class DotenvTest extends TestCase
         $dotenv = new Dotenv(false);
         $this->assertInstanceOf(Dotenv::class, $dotenv);
     }
+
+    public function testDoNotUsePutenv()
+    {
+        $dotenv = new Dotenv(false);
+        $dotenv->populate(['TEST_USE_PUTENV' => 'no']);
+
+        $this->assertSame('no', $_SERVER['TEST_USE_PUTENV']);
+        $this->assertSame('no', $_ENV['TEST_USE_PUTENV']);
+        $this->assertFalse(getenv('TEST_USE_PUTENV'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The related pull request is https://github.com/symfony/symfony/pull/31062.

If the `$usePutenv` flag is set to `false`, `putenv` won't be executed. I just add a small test for this situation.


