### PR TITLE
[Security] added support for updated "distinguished name" format in x509 authentication

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
@@ -44,7 +44,10 @@ class X509AuthenticationListener extends AbstractPreAuthenticatedListener
         $user = null;
         if ($request->server->has($this->userKey)) {
             $user = $request->server->get($this->userKey);
-        } elseif ($request->server->has($this->credentialKey) && preg_match('#/emailAddress=(.+\@.+\..+)(/|$)#', $request->server->get($this->credentialKey), $matches)) {
+        } elseif (
+            $request->server->has($this->credentialKey)
+            && preg_match('#emailAddress=(.+\@.+\.[^,/]+)($|,|/)#', $request->server->get($this->credentialKey), $matches)
+        ) {
             $user = $matches[1];
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/X509AuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/X509AuthenticationListenerTest.php
@@ -56,9 +56,8 @@ class X509AuthenticationListenerTest extends TestCase
     /**
      * @dataProvider dataProviderGetPreAuthenticatedDataNoUser
      */
-    public function testGetPreAuthenticatedDataNoUser($emailAddress)
+    public function testGetPreAuthenticatedDataNoUser($emailAddress, $credentials)
     {
-        $credentials = 'CN=Sample certificate DN/emailAddress='.$emailAddress;
         $request = new Request([], [], [], [], [], ['SSL_CLIENT_S_DN' => $credentials]);
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
@@ -76,10 +75,12 @@ class X509AuthenticationListenerTest extends TestCase
 
     public static function dataProviderGetPreAuthenticatedDataNoUser()
     {
-        return [
-            'basicEmailAddress' => ['cert@example.com'],
-            'emailAddressWithPlusSign' => ['cert+something@example.com'],
-        ];
+        yield ['cert@example.com', 'CN=Sample certificate DN/emailAddress=cert@example.com'];
+        yield ['cert+something@example.com', 'CN=Sample certificate DN/emailAddress=cert+something@example.com'];
+        yield ['cert@example.com', 'CN=Sample certificate DN,emailAddress=cert@example.com'];
+        yield ['cert+something@example.com', 'CN=Sample certificate DN,emailAddress=cert+something@example.com'];
+        yield ['cert+something@example.com', 'emailAddress=cert+something@example.com,CN=Sample certificate DN'];
+        yield ['cert+something@example.com', 'emailAddress=cert+something@example.com'];
     }
 
     /**


### PR DESCRIPTION
RFC 2253 (https://tools.ietf.org/html/rfc2253)
issue: https://github.com/symfony/symfony/issues/31406

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | #31406
| License       | MIT
| Doc PR        |