### PR TITLE
[HttpFoundation] File does not support backslashes in filenames

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -115,7 +115,7 @@ class File extends \SplFileInfo
             throw new FileException(sprintf('Unable to write in the "%s" directory', $directory));
         }
 
-        $target = rtrim($directory, '/\\').\DIRECTORY_SEPARATOR.(null === $name ? $this->getBasename() : $this->getName($name));
+        $target = rtrim($directory, \DIRECTORY_SEPARATOR).\DIRECTORY_SEPARATOR.(null === $name ? $this->getBasename() : $this->getName($name));
 
         return new self($target, false);
     }
@@ -129,10 +129,8 @@ class File extends \SplFileInfo
      */
     protected function getName($name)
     {
-        $originalName = str_replace('\\', '/', $name);
-        $pos = strrpos($originalName, '/');
-        $originalName = false === $pos ? $originalName : substr($originalName, $pos + 1);
+        $pos = strrpos($name, \DIRECTORY_SEPARATOR);
 
-        return $originalName;
+        return (false === $pos) ? $name : substr($name, $pos + 1);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -112,11 +112,9 @@ class FileTest extends TestCase
     {
         return [
             ['original.gif', 'original.gif'],
-            ['..\\..\\original.gif', 'original.gif'],
-            ['../../original.gif', 'original.gif'],
+            ['..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'original.gif', 'original.gif'],
             ['файлfile.gif', 'файлfile.gif'],
-            ['..\\..\\файлfile.gif', 'файлfile.gif'],
-            ['../../файлfile.gif', 'файлfile.gif'],
+            ['..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'файлfile.gif', 'файлfile.gif'],
         ];
     }
 
@@ -134,6 +132,30 @@ class FileTest extends TestCase
 
         $file = new File($path);
         $movedFile = $file->move($targetDir, $filename);
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\File', $movedFile);
+
+        $this->assertFileExists($targetPath);
+        $this->assertFileNotExists($path);
+        $this->assertEquals(realpath($targetPath), $movedFile->getRealPath());
+
+        @unlink($targetPath);
+    }
+
+    public function testMoveWithBackslashOnUnix()
+    {
+        if (\DIRECTORY_SEPARATOR == '\\') {
+            return;
+        }
+
+        $path = __DIR__.'/Fixtures/test\\copy.gif';
+        $targetDir = __DIR__.'/Fixtures/directory';
+        $targetPath = $targetDir.'/test\\copy.gif';
+        @unlink($path);
+        @unlink($targetPath);
+        copy(__DIR__.'/Fixtures/test.gif', $path);
+
+        $file = new File($path);
+        $movedFile = $file->move($targetDir);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\File', $movedFile);
 
         $this->assertFileExists($targetPath);

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -189,7 +189,7 @@ class UploadedFileTest extends TestCase
     {
         $file = new UploadedFile(
             __DIR__.'/Fixtures/test.gif',
-            '../../original.gif',
+            '..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'original.gif',
             'image/gif',
             filesize(__DIR__.'/Fixtures/test.gif'),
             null


### PR DESCRIPTION
…names

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | #31236
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The File class, which is e.g. used for moving files to a new location, strips all backslash characters in the filename - due to the line `$originalName = str_replace('\\', '/', $name);` in the `getName` method. Backslashes are valid as part of filenames on Unix systems, so use `DIRECTORY_SEPARATOR` instead.