### PR TITLE
[Routing][AnnotationClassLoader] fix utf-8 encoding in default route name

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -199,7 +199,8 @@ abstract class AnnotationClassLoader implements LoaderInterface
      */
     protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
     {
-        $name = strtolower(str_replace('\\', '_', $class->name).'_'.$method->name);
+        $name = str_replace('\\', '_', $class->name).'_'.$method->name;
+        $name = \function_exists('mb_strtolower') && preg_match('//u', $name) ? mb_strtolower($name, 'UTF-8') : strtolower($name);
         if ($this->defaultRouteIndex > 0) {
             $name .= '_'.$this->defaultRouteIndex;
         }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/EncodingClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/EncodingClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
+
+class EncodingClass
+{
+    public function routeÀction()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -324,6 +324,27 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->assertEquals(array_merge($classRouteData['methods'], $methodRouteData['methods']), $route->getMethods(), '->load merges class and method route methods');
     }
 
+    /**
+     * @requires function mb_strtolower
+     */
+    public function testDefaultRouteName()
+    {
+        $methodRouteData = [
+            'name' => null,
+        ];
+
+        $this->reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue([$this->getAnnotatedRoute($methodRouteData)]))
+        ;
+
+        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\EncodingClass');
+        $defaultName = array_keys($routeCollection->all())[0];
+
+        $this->assertSame($defaultName, 'symfony_component_routing_tests_fixtures_annotatedclasses_encodingclass_routeàction');
+    }
+
     private function getAnnotatedRoute($data)
     {
         return new Route($data);

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -29,7 +29,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 
     public function testLoad()
     {
-        $this->reader->expects($this->exactly(3))->method('getClassAnnotation');
+        $this->reader->expects($this->exactly(4))->method('getClassAnnotation');
 
         $this->reader
             ->expects($this->any())
@@ -52,6 +52,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
             'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
             'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass',
             'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\FooClass',
+            'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\EncodingClass',
         ]);
 
         $this->reader


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

If controller, or one of its methods, contain a unicode character and you run:
```
./bin/console debug:router
```
you get this:
![Zrzut ekranu 2019-05-8 o 14 00 48](https://user-images.githubusercontent.com/35422131/57374545-71863080-719b-11e9-999e-fe0a5051c089.png)

This PR fixes it into this:
![Zrzut ekranu 2019-05-8 o 14 00 59](https://user-images.githubusercontent.com/35422131/57374616-92e71c80-719b-11e9-9d13-5370213c22f7.png)

