### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ env:
 
 matrix:
     include:
-        - php: hhvm-3.18
-          sudo: required
-          group: edge
         - php: 5.5
           env: php_extra="5.6 7.0 7.1"
         - php: 7.2
@@ -181,12 +178,6 @@ before_install:
               [[ -e $ext_cache ]] || (tfold ext.symfony_debug "cd src/Symfony/Component/Debug/Resources/ext && phpize && ./configure && make && mv modules/symfony_debug.so $ext_cache && phpize --clean")
               echo extension = $ext_cache >> $INI
           elif [[ $PHP = 7.* ]]; then
-              if ! php --ri sodium > /dev/null; then
-                  # install libsodium
-                  sudo apt-get install libsodium-dev -y
-                  tfold ext.libsodium tpecl libsodium sodium.so $INI
-              fi
-
               tfold ext.apcu tpecl apcu-5.1.16 apcu.so $INI
               tfold ext.mongodb tpecl mongodb-1.6.0alpha1 mongodb.so $INI
           fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

As per https://www.patreon.com/posts/ubuntu-14-04-lts-26560500, Ondej's PPA does not support older versions of PHP anymore and so libsodium is now installed by Ubuntu directly, but the version is too old for PHP.

To make the tests pass again, I've removed libsodium from older versions of PHP and removed HHVM in the matrix as the tests do not pass for an obscure reason (no output); don't want to investigate what it could be.



<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
