### PR TITLE
[Messenger] On failure retry, make message appear received from original sender

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1659,6 +1659,7 @@ class FrameworkExtension extends Extension
             'before' => [
                 ['id' => 'add_bus_name_stamp_middleware'],
                 ['id' => 'dispatch_after_current_bus'],
+                ['id' => 'failed_message_processing_middleware'],
             ],
             'after' => [
                 ['id' => 'send_message'],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -48,6 +48,8 @@
             <argument type="service" id="validator" />
         </service>
 
+        <service id="messenger.middleware.failed_message_processing_middleware" class="Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware" />
+
         <service id="messenger.middleware.traceable" class="Symfony\Component\Messenger\Middleware\TraceableMiddleware" abstract="true">
             <argument type="service" id="debug.stopwatch" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -753,6 +753,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals([
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.commands']],
             ['id' => 'dispatch_after_current_bus'],
+            ['id' => 'failed_message_processing_middleware'],
             ['id' => 'send_message'],
             ['id' => 'handle_message'],
         ], $container->getParameter('messenger.bus.commands.middleware'));
@@ -761,6 +762,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals([
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.events']],
             ['id' => 'dispatch_after_current_bus'],
+            ['id' => 'failed_message_processing_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
             ['id' => 'send_message'],
             ['id' => 'handle_message'],

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -154,7 +154,7 @@ EOF
         }
 
         // avoid success message if nothing was processed
-        if (1 < $count) {
+        if (1 <= $count) {
             $io->success('All failed messages have been handled or removed!');
         }
     }

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 
 /**
@@ -83,14 +83,14 @@ EOF
 
         $rows = [];
         foreach ($envelopes as $envelope) {
-            /** @var SentToFailureTransportStamp $sentToFailureTransportStamp */
-            $sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class);
+            /** @var RedeliveryStamp|null $lastRedeliveryStamp */
+            $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
 
             $rows[] = [
                 $this->getMessageId($envelope),
                 \get_class($envelope->getMessage()),
-                null === $sentToFailureTransportStamp ? '' : $sentToFailureTransportStamp->getSentAt()->format('Y-m-d H:i:s'),
-                null === $sentToFailureTransportStamp ? '' : $sentToFailureTransportStamp->getExceptionMessage(),
+                null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s'),
+                null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getExceptionMessage(),
             ];
         }
 

--- a/src/Symfony/Component/Messenger/Middleware/FailedMessageProcessingMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/FailedMessageProcessingMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @experimental in 4.3
+ */
+class FailedMessageProcessingMiddleware implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        // look for "received" messages decorated with the SentToFailureTransportStamp
+        /** @var SentToFailureTransportStamp|null $sentToFailureStamp */
+        $sentToFailureStamp = $envelope->last(SentToFailureTransportStamp::class);
+        if (null !== $sentToFailureStamp && null !== $envelope->last(ReceivedStamp::class)) {
+            // mark the message as "received" from the original transport
+            // this guarantees the same behavior as when originally received
+            $envelope = $envelope->with(new ReceivedStamp($sentToFailureStamp->getOriginalReceiverName()));
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
+use Symfony\Component\Debug\Exception\FlattenException;
+
 /**
  * Stamp applied when a messages needs to be redelivered.
  *
@@ -20,14 +22,20 @@ class RedeliveryStamp implements StampInterface
 {
     private $retryCount;
     private $senderClassOrAlias;
+    private $redeliveredAt;
+    private $exceptionMessage;
+    private $flattenException;
 
     /**
      * @param string $senderClassOrAlias Alias from SendersLocator or just the class name
      */
-    public function __construct(int $retryCount, string $senderClassOrAlias)
+    public function __construct(int $retryCount, string $senderClassOrAlias, string $exceptionMessage = null, FlattenException $flattenException = null)
     {
         $this->retryCount = $retryCount;
         $this->senderClassOrAlias = $senderClassOrAlias;
+        $this->exceptionMessage = $exceptionMessage;
+        $this->flattenException = $flattenException;
+        $this->redeliveredAt = new \DateTimeImmutable();
     }
 
     public function getRetryCount(): int
@@ -36,12 +44,27 @@ class RedeliveryStamp implements StampInterface
     }
 
     /**
-     * Needed for this class to serialize through Symfony's serializer.
+     * The target sender this should be redelivered to.
      *
      * @internal
      */
     public function getSenderClassOrAlias(): string
     {
         return $this->senderClassOrAlias;
+    }
+
+    public function getExceptionMessage(): ?string
+    {
+        return $this->exceptionMessage;
+    }
+
+    public function getFlattenException(): ?FlattenException
+    {
+        return $this->flattenException;
+    }
+
+    public function getRedeliveredAt(): \DateTimeInterface
+    {
+        return $this->redeliveredAt;
     }
 }

--- a/src/Symfony/Component/Messenger/Stamp/SentToFailureTransportStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SentToFailureTransportStamp.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
-use Symfony\Component\Debug\Exception\FlattenException;
-
 /**
  * Stamp applied when a message is sent to the failure transport.
  *
@@ -22,36 +20,15 @@ use Symfony\Component\Debug\Exception\FlattenException;
  */
 class SentToFailureTransportStamp implements StampInterface
 {
-    private $exceptionMessage;
     private $originalReceiverName;
-    private $flattenException;
-    private $sentAt;
 
-    public function __construct(string $exceptionMessage, string $originalReceiverName, FlattenException $flattenException = null)
+    public function __construct(string $originalReceiverName)
     {
-        $this->exceptionMessage = $exceptionMessage;
         $this->originalReceiverName = $originalReceiverName;
-        $this->flattenException = $flattenException;
-        $this->sentAt = new \DateTimeImmutable();
-    }
-
-    public function getExceptionMessage(): string
-    {
-        return $this->exceptionMessage;
     }
 
     public function getOriginalReceiverName(): string
     {
         return $this->originalReceiverName;
-    }
-
-    public function getFlattenException(): ?FlattenException
-    {
-        return $this->flattenException;
-    }
-
-    public function getSentAt(): \DateTimeInterface
-    {
-        return $this->sentAt;
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
@@ -1,0 +1,281 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Retry\MultiplierRetryStrategy;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Worker;
+
+class FailureIntegrationTest extends TestCase
+{
+    public function testRequeMechanism()
+    {
+        $transport1 = new DummyFailureTestSenderAndReceiver();
+        $transport2 = new DummyFailureTestSenderAndReceiver();
+        $failureTransport = new DummyFailureTestSenderAndReceiver();
+        $transports = [
+            'transport1' => $transport1,
+            'transport2' => $transport2,
+            'the_failure_transport' => $failureTransport,
+        ];
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->expects($this->any())
+            ->method('has')
+            ->willReturn(true);
+        $locator->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($transportName) use ($transports) {
+                return $transports[$transportName];
+            });
+        $senderLocator = new SendersLocator(
+            [DummyMessage::class => ['transport1', 'transport2']],
+            $locator
+        );
+
+        // using to so we can lazily get the bus later and avoid circular problem
+        $transport1HandlerThatFails = new DummyTestHandler(true);
+        $allTransportHandlerThatWorks = new DummyTestHandler(false);
+        $transport2HandlerThatWorks = new DummyTestHandler(false);
+        $container = new Container();
+        $handlerLocator = new HandlersLocator([
+            DummyMessage::class => [
+                new HandlerDescriptor($transport1HandlerThatFails, [
+                    'from_transport' => 'transport1',
+                    'alias' => 'handler_that_fails',
+                ]),
+                new HandlerDescriptor($allTransportHandlerThatWorks, [
+                    'alias' => 'handler_that_works1',
+                ]),
+                new HandlerDescriptor($transport2HandlerThatWorks, [
+                    'from_transport' => 'transport2',
+                    'alias' => 'handler_that_works2',
+                ]),
+            ],
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $bus = new MessageBus([
+            new FailedMessageProcessingMiddleware(),
+            new SendMessageMiddleware($senderLocator),
+            new HandleMessageMiddleware($handlerLocator),
+        ]);
+        $container->set('bus', $bus);
+        $dispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener($bus, 'the_failure_transport'));
+
+        $runWorker = function (string $transportName, int $maxRetries) use ($transports, $bus, $dispatcher): ?\Throwable {
+            $throwable = null;
+            $failedListener = function (WorkerMessageFailedEvent $event) use (&$throwable) {
+                $throwable = $event->getThrowable();
+            };
+            $dispatcher->addListener(WorkerMessageFailedEvent::class, $failedListener);
+
+            $worker = new Worker([$transportName => $transports[$transportName]], $bus, [$transportName => new MultiplierRetryStrategy($maxRetries)], $dispatcher);
+
+            $worker->run([], function (?Envelope $envelope) use ($worker) {
+                // handle one envelope, then stop
+                if (null !== $envelope) {
+                    $worker->stop();
+                }
+            });
+
+            $dispatcher->removeListener(WorkerMessageFailedEvent::class, $failedListener);
+
+            return $throwable;
+        };
+
+        // send the message
+        $envelope = new Envelope(new DummyMessage('API'));
+        $bus->dispatch($envelope);
+
+        // message has been sent
+        $this->assertCount(1, $transport1->getMessagesWaitingToBeReceived());
+        $this->assertCount(1, $transport2->getMessagesWaitingToBeReceived());
+        $this->assertCount(0, $failureTransport->getMessagesWaitingToBeReceived());
+
+        // receive the message - one handler will fail and the message
+        // will be sent back to transport1 to be retried
+        /*
+         * Receive the message from "transport1"
+         */
+        $throwable = $runWorker('transport1', 1);
+        // make sure this is failing for the reason we think
+        $this->assertInstanceOf(HandlerFailedException::class, $throwable);
+        // handler for transport1 and all transports were called
+        $this->assertSame(1, $transport1HandlerThatFails->getTimesCalled());
+        $this->assertSame(1, $allTransportHandlerThatWorks->getTimesCalled());
+        $this->assertSame(0, $transport2HandlerThatWorks->getTimesCalled());
+        // one handler failed and the message is retried (resent to transport1)
+        $this->assertCount(1, $transport1->getMessagesWaitingToBeReceived());
+        $this->assertEmpty($failureTransport->getMessagesWaitingToBeReceived());
+
+        /*
+         * Receive the message for a (final) retry
+         */
+        $runWorker('transport1', 1);
+        // only the "failed" handler is called a 2nd time
+        $this->assertSame(2, $transport1HandlerThatFails->getTimesCalled());
+        $this->assertSame(1, $allTransportHandlerThatWorks->getTimesCalled());
+        // handling fails again, message is sent to failure transport
+        $this->assertCount(0, $transport1->getMessagesWaitingToBeReceived());
+        $this->assertCount(1, $failureTransport->getMessagesWaitingToBeReceived());
+        /** @var Envelope $failedEnvelope */
+        $failedEnvelope = $failureTransport->getMessagesWaitingToBeReceived()[0];
+        /** @var SentToFailureTransportStamp $sentToFailureStamp */
+        $sentToFailureStamp = $failedEnvelope->last(SentToFailureTransportStamp::class);
+        $this->assertNotNull($sentToFailureStamp);
+        /** @var RedeliveryStamp $redeliveryStamp */
+        $redeliveryStamp = $failedEnvelope->last(RedeliveryStamp::class);
+        $this->assertNotNull($redeliveryStamp);
+        $this->assertSame('Failure from call 2', $redeliveryStamp->getExceptionMessage());
+
+        /*
+         * Failed message is handled, fails, and sent for a retry
+         */
+        $throwable = $runWorker('the_failure_transport', 1);
+        // make sure this is failing for the reason we think
+        $this->assertInstanceOf(HandlerFailedException::class, $throwable);
+        // only the "failed" handler is called a 3rd time
+        $this->assertSame(3, $transport1HandlerThatFails->getTimesCalled());
+        $this->assertSame(1, $allTransportHandlerThatWorks->getTimesCalled());
+        // handling fails again, message is retried
+        $this->assertCount(1, $failureTransport->getMessagesWaitingToBeReceived());
+        // transport2 still only holds the original message
+        // a new message was never mistakenly delivered to it
+        $this->assertCount(1, $transport2->getMessagesWaitingToBeReceived());
+
+        /*
+         * Message is retried on failure transport then discarded
+         */
+        $runWorker('the_failure_transport', 1);
+        // only the "failed" handler is called a 4th time
+        $this->assertSame(4, $transport1HandlerThatFails->getTimesCalled());
+        $this->assertSame(1, $allTransportHandlerThatWorks->getTimesCalled());
+        // handling fails again, message is discarded
+        $this->assertCount(0, $failureTransport->getMessagesWaitingToBeReceived());
+
+        /*
+         * Execute handlers on transport2
+         */
+        $runWorker('transport2', 1);
+        // transport1 handler is not called again
+        $this->assertSame(4, $transport1HandlerThatFails->getTimesCalled());
+        // all transport handler is now called again
+        $this->assertSame(2, $allTransportHandlerThatWorks->getTimesCalled());
+        // transport1 handler called for the first time
+        $this->assertSame(1, $transport2HandlerThatWorks->getTimesCalled());
+        // all transport should be empty
+        $this->assertEmpty($transport1->getMessagesWaitingToBeReceived());
+        $this->assertEmpty($transport2->getMessagesWaitingToBeReceived());
+        $this->assertEmpty($failureTransport->getMessagesWaitingToBeReceived());
+
+        /*
+         * Dispatch the original message again
+         */
+        $bus->dispatch($envelope);
+        // handle the message, but with no retries
+        $runWorker('transport1', 0);
+        // now make the handler work!
+        $transport1HandlerThatFails->setShouldThrow(false);
+        $runWorker('the_failure_transport', 1);
+        // the failure transport is empty because it worked
+        $this->assertEmpty($failureTransport->getMessagesWaitingToBeReceived());
+    }
+}
+
+class DummyFailureTestSenderAndReceiver implements ReceiverInterface, SenderInterface
+{
+    private $messagesWaiting = [];
+
+    public function get(): iterable
+    {
+        $message = array_shift($this->messagesWaiting);
+
+        if (null === $message) {
+            return [];
+        }
+
+        return [$message];
+    }
+
+    public function ack(Envelope $envelope): void
+    {
+    }
+
+    public function reject(Envelope $envelope): void
+    {
+    }
+
+    public function send(Envelope $envelope): Envelope
+    {
+        $this->messagesWaiting[] = $envelope;
+
+        return $envelope;
+    }
+
+    /**
+     * @return Envelope[]
+     */
+    public function getMessagesWaitingToBeReceived(): array
+    {
+        return $this->messagesWaiting;
+    }
+}
+
+class DummyTestHandler
+{
+    private $timesCalled = 0;
+    private $shouldThrow;
+
+    public function __construct(bool $shouldThrow)
+    {
+        $this->shouldThrow = $shouldThrow;
+    }
+
+    public function __invoke()
+    {
+        ++$this->timesCalled;
+
+        if ($this->shouldThrow) {
+            throw new \Exception('Failure from call '.$this->timesCalled);
+        }
+    }
+
+    public function getTimesCalled(): int
+    {
+        return $this->timesCalled;
+    }
+
+    public function setShouldThrow(bool $shouldThrow)
+    {
+        $this->shouldThrow = $shouldThrow;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/RetryIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/RetryIntegrationTest.php
@@ -38,8 +38,8 @@ class RetryIntegrationTest extends TestCase
         $senderLocator->method('get')->with('sender_alias')->willReturn($senderAndReceiver);
         $senderLocator = new SendersLocator([DummyMessage::class => ['sender_alias']], $senderLocator);
 
-        $handler = new DummyMessageHandlerFailingFirstTimes(0, 'A');
-        $throwingHandler = new DummyMessageHandlerFailingFirstTimes(1, 'B');
+        $handler = new DummyMessageHandlerFailingFirstTimes(0);
+        $throwingHandler = new DummyMessageHandlerFailingFirstTimes(1);
         $handlerLocator = new HandlersLocator([
             DummyMessage::class => [
                 new HandlerDescriptor($handler, ['alias' => 'first']),

--- a/src/Symfony/Component/Messenger/Tests/Stamp/RedeliveryStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/RedeliveryStampTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Tests\Stamp;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 
 class RedeliveryStampTest extends TestCase
@@ -21,5 +22,16 @@ class RedeliveryStampTest extends TestCase
         $stamp = new RedeliveryStamp(10, 'sender_alias');
         $this->assertSame(10, $stamp->getRetryCount());
         $this->assertSame('sender_alias', $stamp->getSenderClassOrAlias());
+        $this->assertInstanceOf(\DateTimeInterface::class, $stamp->getRedeliveredAt());
+        $this->assertNull($stamp->getExceptionMessage());
+        $this->assertNull($stamp->getFlattenException());
+    }
+
+    public function testGettersPopulated()
+    {
+        $flattenException = new FlattenException();
+        $stamp = new RedeliveryStamp(10, 'sender_alias', 'exception message', $flattenException);
+        $this->assertSame('exception message', $stamp->getExceptionMessage());
+        $this->assertSame($flattenException, $stamp->getFlattenException());
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Stamp/SentToFailureTransportStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/SentToFailureTransportStampTest.php
@@ -12,22 +12,13 @@
 namespace Symfony\Component\Messenger\Tests\Stamp;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 
 class SentToFailureTransportStampTest extends TestCase
 {
-    public function testGetters()
+    public function testGetOriginalReceiverName()
     {
-        $flattenException = new FlattenException();
-        $stamp = new SentToFailureTransportStamp(
-            'exception message',
-            'original_receiver',
-            $flattenException
-        );
-        $this->assertSame('exception message', $stamp->getExceptionMessage());
+        $stamp = new SentToFailureTransportStamp('original_receiver');
         $this->assertSame('original_receiver', $stamp->getOriginalReceiverName());
-        $this->assertSame($flattenException, $stamp->getFlattenException());
-        $this->assertInstanceOf(\DateTimeInterface::class, $stamp->getSentAt());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (4.3)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31413
| License       | MIT
| Doc PR        | symfony/symfony-docs#11236

Fixes a bug when using the transport-based handler config from #30958. This also adds a pretty robust integration test that dispatches a complex message with transport-based handler config, failures, failure transport, etc - and verifies the correct behavior.

Cheers!