### PR TITLE
[Intl] Enable error handler during compile

### DIFF
--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -68,6 +68,12 @@ function get_icu_version_from_genrb($genrb)
     return $matches[1];
 }
 
+error_reporting(E_ALL);
+
+set_error_handler(function ($type, $msg, $file, $line) {
+    throw new \ErrorException($msg, 0, $type, $file, $line);
+});
+
 set_exception_handler(function (\Throwable $exception) {
     echo "\n";
 
@@ -82,10 +88,7 @@ set_exception_handler(function (\Throwable $exception) {
         echo get_class($cause).': '.$cause->getMessage()."\n";
         echo "\n";
         echo $cause->getFile().':'.$cause->getLine()."\n";
-        foreach ($cause->getTrace() as $trace) {
-            echo $trace['file'].':'.$trace['line']."\n";
-        }
-        echo "\n";
+        echo $cause->getTraceAsString()."\n";
 
         $cause = $cause->getPrevious();
         $root = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Enable PHP error logging during ICU compiliation.

I noticed it was hiding e.g. "array to string conversion" when working on timezones, only after verifying the compilation output.

Current branches (34/42/43) are error-free, so this is safe to merge upstream without any side effects.