### PR TITLE
[Cache] Add Redis Sentinel support

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added support for connecting to Redis Sentinel clusters
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+
+class RedisAdapterSentinelTest extends AbstractRedisAdapterTest
+{
+    public static function setupBeforeClass()
+    {
+        if (!class_exists('Predis\Client')) {
+            self::markTestSkipped('The Predis\Client class is required.');
+        }
+        if (!$hosts = getenv('REDIS_SENTINEL_HOSTS')) {
+            self::markTestSkipped('REDIS_SENTINEL_HOSTS env var is not defined.');
+        }
+        if (!$service = getenv('REDIS_SENTINEL_SERVICE')) {
+            self::markTestSkipped('REDIS_SENTINEL_SERVICE env var is not defined.');
+        }
+
+        self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => $service]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid Redis DSN: cannot use both redis_cluster and redis_sentinel at the same time
+     */
+    public function testInvalidDSNHasBothClusterAndSentinel()
+    {
+        $dsn = 'redis:?host[redis1]&host[redis2]&host[redis3]&redis_cluster=1&redis_sentinel=mymaster';
+        RedisAdapter::createConnection($dsn);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#11545

This change adds support for Redis Sentinel clusters to the Cache component Redis adapter.

The DSN format is syntactically equivalent to cluster support, but adds a new parameter `redis_sentinel` that should be set to the sentinel service name.

This support requires the use of predis as the underlying connection library. The redis extension does not support sentinel at this time.