### PR TITLE
[Validator] Fix finding translator parent definition in compiler pass

### DIFF
--- a/src/Symfony/Component/Validator/DependencyInjection/AddValidatorInitializersPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddValidatorInitializersPass.php
@@ -62,7 +62,7 @@ class AddValidatorInitializersPass implements CompilerPassInterface
                 }
 
                 while (!($class = $translator->getClass()) && $translator instanceof ChildDefinition) {
-                    $translator = $translator->getParent();
+                    $translator = $container->findDefinition($translator->getParent());
                 }
 
                 if (!is_subclass_of($class, LegacyTranslatorInterface::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Method `ChildDefintion::getParent()` returns a string, but here it is expected to return an object of class `Definition` in order to call `getClass` on it in the loop.
