### PR TITLE
[Messenger] Making cache rebuild correctly when message subscribers change

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Config\Resource;
 
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface as LegacyServiceSubscriberInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
 /**
@@ -162,6 +163,13 @@ class ReflectionClassResource implements SelfCheckingResourceInterface, \Seriali
         if (interface_exists(EventSubscriberInterface::class, false) && $class->isSubclassOf(EventSubscriberInterface::class)) {
             yield EventSubscriberInterface::class;
             yield print_r($class->name::getSubscribedEvents(), true);
+        }
+
+        if (interface_exists(MessageSubscriberInterface::class, false) && $class->isSubclassOf(MessageSubscriberInterface::class)) {
+            yield MessageSubscriberInterface::class;
+            foreach ($class->name::getHandledMessages() as $key => $value) {
+                yield $key.print_r($value, true);
+            }
         }
 
         if (interface_exists(LegacyServiceSubscriberInterface::class, false) && $class->isSubclassOf(LegacyServiceSubscriberInterface::class)) {

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -24,6 +24,7 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",
+        "symfony/messenger": "~4.1",
         "symfony/yaml": "~3.4|~4.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31409
| License       | MIT
| Doc PR        | not needed

An edge-case that's identical to `EventSubscriberInterface`: when the return value of `getHandledMessages()` changes, the container needs to be rebuilt. 

If you're wondering why these checks aren't in their own resource class, see #25984 - it's something we probably should do, but haven't done yet.