### PR TITLE
[FrameworkBundle] Allow dots in translation domains

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1170,14 +1170,15 @@ class FrameworkExtension extends Extension
                 ->followLinks()
                 ->files()
                 ->filter(function (\SplFileInfo $file) {
-                    return 2 === substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());
+                    return 2 <= substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());
                 })
                 ->in($dirs)
                 ->sortByName()
             ;
 
             foreach ($finder as $file) {
-                list(, $locale) = explode('.', $file->getBasename(), 3);
+                $fileNameParts = explode('.', basename($file));
+                $locale = $fileNameParts[\count($fileNameParts) - 2];
                 if (!isset($files[$locale])) {
                     $files[$locale] = [];
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/translations/domain.with.dots.en.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/translations/domain.with.dots.en.yml
@@ -1,0 +1,3 @@
+domain:
+    with:
+        dots: It works!

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -817,6 +817,11 @@ abstract class FrameworkExtensionTest extends TestCase
             $files,
             '->registerTranslatorConfiguration() finds translation resources in default path'
         );
+        $this->assertContains(
+            strtr(__DIR__.'/Fixtures/translations/domain.with.dots.en.yml', '/', \DIRECTORY_SEPARATOR),
+            $files,
+            '->registerTranslatorConfiguration() finds translation resources with dots in domain'
+        );
 
         $calls = $container->getDefinition('translator.default')->getMethodCalls();
         $this->assertEquals(['fr'], $calls[1][1][0]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/translations/domain.with.dots.en.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/translations/domain.with.dots.en.yml
@@ -1,0 +1,1 @@
+message: It works!

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -373,6 +373,21 @@ class TranslatorTest extends TestCase
         $this->assertEquals('répertoire', $translator->trans('folder'));
     }
 
+    public function testLoadingTranslationFilesWithDotsInMessageDomain()
+    {
+        $loader = new \Symfony\Component\Translation\Loader\YamlFileLoader();
+        $resourceFiles = [
+            'en' => [
+                __DIR__.'/../Fixtures/Resources/translations/domain.with.dots.en.yml',
+            ],
+        ];
+
+        $translator = $this->getTranslator($loader, ['cache_dir' => $this->tmpDir, 'resource_files' => $resourceFiles], 'yml');
+        $translator->setLocale('en');
+        $translator->setFallbackLocales(['fr']);
+        $this->assertEquals('It works!', $translator->trans('message', [], 'domain.with.dots'));
+    }
+
     private function createTranslator($loader, $options, $translatorClass = '\Symfony\Bundle\FrameworkBundle\Translation\Translator', $loaderFomat = 'loader', $defaultLocale = 'en')
     {
         if (null === $defaultLocale) {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -165,7 +165,10 @@ class Translator extends BaseTranslator implements WarmableInterface
         foreach ($filesByLocale as $locale => $files) {
             foreach ($files as $key => $file) {
                 // filename is domain.locale.format
-                list($domain, $locale, $format) = explode('.', basename($file), 3);
+                $fileNameParts = explode('.', basename($file));
+                $format = array_pop($fileNameParts);
+                $locale = array_pop($fileNameParts);
+                $domain = implode('.', $fileNameParts);
                 $this->addResource($format, $file, $locale, $domain);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31400  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | tbd. <!-- required for new features -->

### Description

With this fix it is now possible to have `.` in translation domains like `app.security.en.yaml`.

### Todo

- [x] add a test case