### PR TITLE
[FrameworkBundle] Add cache configuration for PropertyInfo

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -36,6 +36,10 @@
             <tag name="cache.pool" />
         </service>
 
+        <service id="cache.property_info" parent="cache.system" public="false">
+            <tag name="cache.pool" />
+        </service>
+
         <service id="cache.messenger.restart_workers_signal" parent="cache.app" public="false">
             <tag name="cache.pool" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
@@ -21,6 +21,11 @@
         <service id="Symfony\Component\PropertyInfo\PropertyListExtractorInterface" alias="property_info" />
         <service id="Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface" alias="property_info" />
 
+        <service id="property_info.cache" decorates="property_info" class="Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor">
+            <argument type="service" id="property_info.cache.inner" />
+            <argument type="service" id="cache.property_info" />
+        </service>
+
         <!-- Extractor -->
         <service id="property_info.reflection_extractor" class="Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor">
             <tag name="property_info.list_extractor" priority="-1000" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -104,6 +104,11 @@
             <argument type="service" id="cache.serializer" />
         </service>
 
+        <service id="serializer.mapping.cache_class_metadata_factory" decorates="serializer.mapping.class_metadata_factory" class="Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory">
+            <argument type="service" id="serializer.mapping.cache_class_metadata_factory.inner" />
+            <argument type="service" id="serializer.mapping.cache.symfony" />
+        </service>
+
         <!-- Encoders -->
         <service id="serializer.encoder.xml" class="Symfony\Component\Serializer\Encoder\XmlEncoder">
             <tag name="serializer.encoder" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1357,6 +1357,22 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->has('property_info'));
     }
 
+    public function testPropertyInfoCacheActivated()
+    {
+        $container = $this->createContainerFromFile('property_info');
+
+        $this->assertTrue($container->hasDefinition('property_info.cache'));
+
+        $cache = $container->getDefinition('property_info.cache')->getArgument(1);
+        $this->assertEquals(new Reference('cache.property_info'), $cache);
+    }
+
+    public function testPropertyInfoCacheDisabled()
+    {
+        $container = $this->createContainerFromFile('property_info', ['kernel.debug' => true, 'kernel.container_class' => __CLASS__]);
+        $this->assertFalse($container->hasDefinition('property_info.cache'));
+    }
+
     public function testEventDispatcherService()
     {
         $container = $this->createContainer(['kernel.charset' => 'UTF-8', 'kernel.secret' => 'secret']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The PropertyInfoExtractor was not cached by default but the class to do it was surprisingly here, unused.

I've added the configuration to enable it by default when it's not the development environment.

I haven't added the warmup part because there are too much arguments for the methods (class, property, context).

It will be a big boost for the performance! For this code:

```php
$book = $this->serializer->deserialize('{"id":3,"reviews":[{"id": 7, "body": "This book is fantastic!", "rating": 9, "letter": "A", "publicationDate": "2019"}],"isbn":"978-0-5533-9243-2","title":"Fool\'s Assassin","description":"A famous saga","author":"Robin Hobb","publicationDate":"2014"}', Book::class, 'json');
$this->serializer->serialize($book, 'json');
```

We obtain this:

![image](https://user-images.githubusercontent.com/10920253/57487994-2874d000-72b2-11e9-92a2-28b14a038194.png)

The Blackfire comparison is here: https://blackfire.io/profiles/compare/2c746d26-320a-4aab-80ef-7276c2e92b96/graph