### PR TITLE
[Messenger] remove send_and_handle which can be achieved with SyncTransport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -22,6 +22,8 @@ CHANGELOG
    `framework.messenger.default_serializer`, which holds the string service
    id and `framework.messenger.symfony_serializer`, which configures the
    options if you're using Symfony's serializer.
+ * [BC Break] Removed the `framework.messenger.routing.send_and_handle` configuration.
+   Instead of setting it to true, configure a `SyncTransport` and route messages to it.
  * Added information about deprecated aliases in `debug:autowiring` 
  * Added php ini session options `sid_length` and `sid_bits_per_character` 
    to the `session` section of the configuration

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1125,7 +1125,6 @@ class Configuration implements ConfigurationInterface
                                         if (!\is_int($k)) {
                                             $newConfig[$k] = [
                                                 'senders' => $v['senders'] ?? (\is_array($v) ? array_values($v) : [$v]),
-                                                'send_and_handle' => $v['send_and_handle'] ?? false,
                                             ];
                                         } else {
                                             $newConfig[$v['message-class']]['senders'] = array_map(
@@ -1134,7 +1133,6 @@ class Configuration implements ConfigurationInterface
                                                 },
                                                 array_values($v['sender'])
                                             );
-                                            $newConfig[$v['message-class']]['send-and-handle'] = $v['send-and-handle'] ?? false;
                                         }
                                     }
 
@@ -1147,7 +1145,6 @@ class Configuration implements ConfigurationInterface
                                         ->requiresAtLeastOneElement()
                                         ->prototype('scalar')->end()
                                     ->end()
-                                    ->booleanNode('send_and_handle')->defaultFalse()->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1744,7 +1744,6 @@ class FrameworkExtension extends Extension
         }
 
         $messageToSendersMapping = [];
-        $messagesToSendAndHandle = [];
         foreach ($config['routing'] as $message => $messageConfiguration) {
             if ('*' !== $message && !class_exists($message) && !interface_exists($message, false)) {
                 throw new LogicException(sprintf('Invalid Messenger routing configuration: class or interface "%s" not found.', $message));
@@ -1758,7 +1757,6 @@ class FrameworkExtension extends Extension
             }
 
             $messageToSendersMapping[$message] = $messageConfiguration['senders'];
-            $messagesToSendAndHandle[$message] = $messageConfiguration['send_and_handle'];
         }
 
         $senderReferences = [];
@@ -1769,7 +1767,6 @@ class FrameworkExtension extends Extension
         $container->getDefinition('messenger.senders_locator')
             ->replaceArgument(0, $messageToSendersMapping)
             ->replaceArgument(1, ServiceLocatorTagPass::register($container, $senderReferences))
-            ->replaceArgument(2, $messagesToSendAndHandle)
         ;
 
         $container->getDefinition('messenger.retry_strategy_locator')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -11,7 +11,6 @@
         <service id="messenger.senders_locator" class="Symfony\Component\Messenger\Transport\Sender\SendersLocator">
             <argument type="collection" /> <!-- Per message senders map -->
             <argument /> <!-- senders locator -->
-            <argument type="collection" /> <!-- Messages to send and handle -->
         </service>
         <service id="messenger.middleware.send_message" class="Symfony\Component\Messenger\Middleware\SendMessageMiddleware">
             <tag name="monolog.logger" channel="messenger" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -434,7 +434,6 @@
             <xsd:element name="sender" type="messenger_routing_sender" />
         </xsd:choice>
         <xsd:attribute name="message-class" type="xsd:string" use="required"/>
-        <xsd:attribute name="send-and-handle" type="xsd:boolean" default="false"/>
     </xsd:complexType>
 
     <xsd:complexType name="messenger_routing_sender">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
@@ -10,7 +10,6 @@ $container->loadFromExtension('framework', [
             'Symfony\Component\Messenger\Tests\Fixtures\DummyMessage' => ['amqp', 'audit'],
             'Symfony\Component\Messenger\Tests\Fixtures\SecondMessage' => [
                 'senders' => ['amqp', 'audit'],
-                'send_and_handle' => true,
             ],
             '*' => 'amqp',
         ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
@@ -13,7 +13,7 @@
                 <framework:sender service="amqp" />
                 <framework:sender service="audit" />
             </framework:routing>
-            <framework:routing message-class="Symfony\Component\Messenger\Tests\Fixtures\SecondMessage" send-and-handle="true">
+            <framework:routing message-class="Symfony\Component\Messenger\Tests\Fixtures\SecondMessage">
                 <framework:sender service="amqp" />
                 <framework:sender service="audit" />
             </framework:routing>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
@@ -7,7 +7,6 @@ framework:
             'Symfony\Component\Messenger\Tests\Fixtures\DummyMessage': [amqp, audit]
             'Symfony\Component\Messenger\Tests\Fixtures\SecondMessage':
                 senders: [amqp, audit]
-                send_and_handle: true
             '*': amqp
         transports:
             amqp: 'amqp://localhost/%2f/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -40,7 +40,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
-use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -715,13 +714,6 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('messenger_routing');
         $senderLocatorDefinition = $container->getDefinition('messenger.senders_locator');
 
-        $messageToSendAndHandleMapping = [
-            DummyMessage::class => false,
-            SecondMessage::class => true,
-            '*' => false,
-        ];
-
-        $this->assertSame($messageToSendAndHandleMapping, $senderLocatorDefinition->getArgument(2));
         $sendersMapping = $senderLocatorDefinition->getArgument(0);
         $this->assertEquals([
             'amqp',

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * [BC BREAK] `SendersLocatorInterface` has an additional method:
    `getSenderByAlias()`.
+ * Removed argument `?bool &$handle = false` from `SendersLocatorInterface::getSenders`
  * A new `ListableReceiverInterface` was added, which a receiver
    can implement (when applicable) to enable listing and fetching
    individual messages by id (used in the new "Failed Messages" commands).

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocatorInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocatorInterface.php
@@ -27,12 +27,9 @@ interface SendersLocatorInterface
     /**
      * Gets the senders for the given message name.
      *
-     * @param bool|null &$handle True after calling the method when the next middleware
-     *                           should also get the message; false otherwise
-     *
      * @return iterable|SenderInterface[] Indexed by sender alias if available
      */
-    public function getSenders(Envelope $envelope, ?bool &$handle = false): iterable;
+    public function getSenders(Envelope $envelope): iterable;
 
     /**
      * Returns a specific sender by its alias.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/11236

The send_and_handle option is pretty awkward and we don't need it anymore because the same thing can be achieved with the SyncTransport from #30759

So the following example from the doc in https://symfony.com/doc/current/messenger.html#routing
```yaml
framework:
    messenger:
        routing:
            'My\Message\ThatIsGoingToBeSentAndHandledLocally':
                 senders: [amqp]
                 send_and_handle: true
```
is the same as
```yaml
framework:
    messenger:
        routing:
            'My\Message\ThatIsGoingToBeSentAndHandledLocally':
                 senders: [amqp, sync]
```

https://github.com/symfony/symfony/pull/31401#pullrequestreview-235396370
