### PR TITLE
Fix the interface incompatibility of EventDispatchers

### DIFF
--- a/src/Symfony/Component/EventDispatcher/LegacyEventDispatcherProxy.php
+++ b/src/Symfony/Component/EventDispatcher/LegacyEventDispatcherProxy.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\EventDispatcher;
 
 use Psr\EventDispatcher\StoppableEventInterface;
 use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 /**
  * An helper class to provide BC/FC with the legacy signature of EventDispatcherInterface::dispatch().
@@ -26,7 +26,7 @@ final class LegacyEventDispatcherProxy implements EventDispatcherInterface
 {
     private $dispatcher;
 
-    public static function decorate(?EventDispatcherInterface $dispatcher): ?EventDispatcherInterface
+    public static function decorate(?ContractsEventDispatcherInterface $dispatcher): ?ContractsEventDispatcherInterface
     {
         if (null === $dispatcher) {
             return null;


### PR DESCRIPTION
The `LegacyEventDispatcherProxy` now implements the full
`EventDispatcherInterface` from the `EventDispatcherBundle`.
Before it just implemented the Interface from the `Contracts` Bundle,
that made it incompatible with the `WrappedListener`.
This fixes #31457.

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #31457
| License       | MIT
| Doc PR        | /
