### PR TITLE
[Filesystem] Add watch method to watch filesystem for changes

### DIFF
--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * added `watch()` method to watch filesystem for changes
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Filesystem/Tests/Fixtures/ChangeFileResource.php
+++ b/src/Symfony/Component/Filesystem/Tests/Fixtures/ChangeFileResource.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Fixtures;
+
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\Resource\ResourceInterface;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+class ChangeFileResource implements ResourceInterface
+{
+    private $path;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public function detectChanges(): array
+    {
+        return [new FileChangeEvent($this->path, FileChangeEvent::FILE_CHANGED)];
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Fixtures/ChangeFileResource.php
+++ b/src/Symfony/Component/Filesystem/Tests/Fixtures/ChangeFileResource.php
@@ -17,7 +17,7 @@ use Symfony\Component\Filesystem\Watcher\Resource\ResourceInterface;
 /**
  * @author Pierre du Plessis <pdples@gmail.com>
  */
-class ChangeFileResource implements ResourceInterface
+final class ChangeFileResource implements ResourceInterface
 {
     private $path;
 

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/FileSystemWatchTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/FileSystemWatchTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Tests\Fixtures\ChangeFileResource;
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\FileChangeWatcher;
+use Symfony\Component\Filesystem\Watcher\Resource\DirectoryResource;
+use Symfony\Component\Filesystem\Watcher\Resource\ResourceInterface;
+
+class FileSystemWatchTest extends FilesystemTestCase
+{
+    public function testWatch()
+    {
+        $workspace = $this->workspace;
+
+        $locator = new class($workspace) {
+            private $workspace;
+
+            public function __construct($workspace)
+            {
+                $this->workspace = $workspace;
+            }
+
+            public function locate($path): ?ResourceInterface
+            {
+                return new ChangeFileResource($this->workspace.'/foobar.txt');
+            }
+        };
+
+        $watcher = new FileChangeWatcher();
+        $ref = new \ReflectionProperty($watcher, 'locator');
+        $ref->setAccessible(true);
+        $ref->setValue($watcher, $locator);
+
+        $count = 0;
+        $watcher->watch($this->workspace, function ($file, $code) use (&$count) {
+            $this->assertSame($this->workspace.'/foobar.txt', $file);
+            $this->assertSame(FileChangeEvent::FILE_CHANGED, $code);
+            ++$count;
+
+            if (2 === $count) {
+                return false;
+            }
+        });
+
+        $this->assertSame(2, $count);
+    }
+
+    public function testWatchTimeout()
+    {
+        $locator = new class() {
+            public function locate($path): ?ResourceInterface
+            {
+                return new DirectoryResource($path);
+            }
+        };
+
+        $watcher = new FileChangeWatcher();
+        $ref = new \ReflectionProperty($watcher, 'locator');
+        $ref->setAccessible(true);
+        $ref->setValue($watcher, $locator);
+
+        $start = microtime(true);
+        $watcher->watch($this->workspace, function ($file, $code) {
+        }, 500);
+
+        $this->assertTrue(microtime(true) - $start > 0.5);
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/FileSystemWatchTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/FileSystemWatchTest.php
@@ -39,9 +39,7 @@ class FileSystemWatchTest extends FilesystemTestCase
         };
 
         $watcher = new FileChangeWatcher();
-        $ref = new \ReflectionProperty($watcher, 'locator');
-        $ref->setAccessible(true);
-        $ref->setValue($watcher, $locator);
+        $watcher->locator = $locator;
 
         $count = 0;
         $watcher->watch($this->workspace, function ($file, $code) use (&$count) {
@@ -72,9 +70,9 @@ class FileSystemWatchTest extends FilesystemTestCase
         $ref->setValue($watcher, $locator);
 
         $start = microtime(true);
-        $watcher->watch($this->workspace, function ($file, $code) {
+        $watcher->watch($this->workspace, static function ($file, $code) {
         }, 500);
 
-        $this->assertTrue(microtime(true) - $start > 0.5);
+        $this->assertGreaterThan(0.5, microtime(true) - $start);
     }
 }

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/ArrayResourceTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/ArrayResourceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\Resource\ArrayResource;
+use Symfony\Component\Filesystem\Watcher\Resource\FileResource;
+
+class ArrayResourceTest extends FilesystemTestCase
+{
+    public function testFileChange()
+    {
+        $file = $this->workspace.'/foo.txt';
+        touch($file);
+
+        $resource = new ArrayResource([new FileResource($file)]);
+
+        $this->assertSame([], $resource->detectChanges());
+
+        touch($file, time() + 1);
+
+        $this->assertEquals([new FileChangeEvent($file, FileChangeEvent::FILE_CHANGED)], $resource->detectChanges());
+        $this->assertSame([], $resource->detectChanges());
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/DirectoryResourceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\Resource\DirectoryResource;
+
+class DirectoryResourceTest extends FilesystemTestCase
+{
+    public function testCreateFile()
+    {
+        $dir = $this->workspace.\DIRECTORY_SEPARATOR.'foo';
+        mkdir($dir);
+
+        $resource = new DirectoryResource($dir);
+
+        $this->assertSame([], $resource->detectChanges());
+
+        touch($dir.'/foo.txt');
+
+        $this->assertEquals([new FileChangeEvent($dir.\DIRECTORY_SEPARATOR.'foo.txt', FileChangeEvent::FILE_CREATED)], $resource->detectChanges());
+        $this->assertSame([], $resource->detectChanges());
+    }
+
+    public function testDeleteFile()
+    {
+        $dir = $this->workspace.\DIRECTORY_SEPARATOR.'foo';
+        mkdir($dir);
+
+        touch($dir.'/foo.txt');
+        touch($dir.'/bar.txt');
+
+        $resource = new DirectoryResource($dir);
+
+        $this->assertSame([], $resource->detectChanges());
+
+        unlink($dir.'/foo.txt');
+
+        $this->assertEquals([new FileChangeEvent($dir.\DIRECTORY_SEPARATOR.'foo.txt', FileChangeEvent::FILE_DELETED)], $resource->detectChanges());
+        $this->assertSame([], $resource->detectChanges());
+    }
+
+    public function testFileChanges()
+    {
+        $dir = $this->workspace.\DIRECTORY_SEPARATOR.'foo';
+        mkdir($dir);
+
+        touch($dir.'/foo.txt');
+        touch($dir.'/bar.txt');
+
+        $resource = new DirectoryResource($dir);
+
+        $this->assertSame([], $resource->detectChanges());
+
+        touch($dir.'/foo.txt', time() + 1);
+
+        $this->assertEquals([new FileChangeEvent($dir.\DIRECTORY_SEPARATOR.'foo.txt', FileChangeEvent::FILE_CHANGED)], $resource->detectChanges());
+        $this->assertSame([], $resource->detectChanges());
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/FileResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\Resource\FileResource;
+
+class FileResourceTest extends FilesystemTestCase
+{
+    public function testFileChanges()
+    {
+        $file = $this->workspace.'/foo.txt';
+        touch($file);
+
+        $resource = new FileResource($file);
+
+        $this->assertSame([], $resource->detectChanges());
+
+        touch($file, time() + 1);
+
+        $this->assertEquals([new FileChangeEvent($file, FileChangeEvent::FILE_CHANGED)], $resource->detectChanges());
+        $this->assertSame([], $resource->detectChanges());
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/Locator/FileResourceLocatorTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/Locator/FileResourceLocatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher\Resource\Locator;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Watcher\Resource\ArrayResource;
+use Symfony\Component\Filesystem\Watcher\Resource\DirectoryResource;
+use Symfony\Component\Filesystem\Watcher\Resource\FileResource;
+use Symfony\Component\Filesystem\Watcher\Resource\Locator\FileResourceLocator;
+
+class FileResourceLocatorTest extends FilesystemTestCase
+{
+    public function testLocateIterator()
+    {
+        $locator = new FileResourceLocator();
+
+        $path = new \ArrayIterator([$this->createFile('foo.txt')]);
+
+        $this->assertEquals(new ArrayResource([new FileResource($this->workspace.\DIRECTORY_SEPARATOR.'foo.txt')]), $locator->locate($path));
+    }
+
+    public function testLocateSplFileInfo()
+    {
+        $locator = new FileResourceLocator();
+
+        $path = new \SplFileInfo($this->createFile('foo.txt'));
+
+        $this->assertEquals(new FileResource($this->workspace.\DIRECTORY_SEPARATOR.'foo.txt'), $locator->locate($path));
+    }
+
+    public function testFilePath()
+    {
+        $locator = new FileResourceLocator();
+
+        $path = $this->createFile('foo.txt');
+
+        $this->assertEquals(new FileResource($this->workspace.\DIRECTORY_SEPARATOR.'foo.txt'), $locator->locate($path));
+    }
+
+    public function testGlob()
+    {
+        $locator = new FileResourceLocator();
+
+        $this->createFile('bar.txt');
+        $this->createFile('foo.txt');
+
+        $this->assertEquals(
+            new ArrayResource([new FileResource($this->workspace.\DIRECTORY_SEPARATOR.'bar.txt'), new FileResource($this->workspace.\DIRECTORY_SEPARATOR.'foo.txt')]),
+            $locator->locate($this->workspace.\DIRECTORY_SEPARATOR.'*.txt')
+        );
+    }
+
+    public function testArray()
+    {
+        $locator = new FileResourceLocator();
+
+        $path = [$this->createFile('foo.txt')];
+
+        $this->assertEquals(new ArrayResource([new FileResource($this->workspace.\DIRECTORY_SEPARATOR.'foo.txt')]), $locator->locate($path));
+    }
+
+    public function testDirectory()
+    {
+        $locator = new FileResourceLocator();
+
+        $dir = $this->createDirecty('foobar');
+
+        $this->assertEquals(new DirectoryResource($this->workspace.\DIRECTORY_SEPARATOR.'foobar'), $locator->locate($dir));
+    }
+
+    private function createFile(string $file)
+    {
+        $fullPath = $this->workspace.\DIRECTORY_SEPARATOR.$file;
+        touch($fullPath);
+
+        return $fullPath;
+    }
+
+    private function createDirecty(string $dir)
+    {
+        $fullPath = $this->workspace.\DIRECTORY_SEPARATOR.$dir;
+
+        mkdir($fullPath, 0777, true);
+
+        return $fullPath;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/FileChangeEvent.php
+++ b/src/Symfony/Component/Filesystem/Watcher/FileChangeEvent.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Filesystem\Watcher;
 /**
  * @author Pierre du Plessis <pdples@gmail.com>
  */
-class FileChangeEvent
+final class FileChangeEvent
 {
     public const FILE_CHANGED = 1;
     public const FILE_DELETED = 2;

--- a/src/Symfony/Component/Filesystem/Watcher/FileChangeEvent.php
+++ b/src/Symfony/Component/Filesystem/Watcher/FileChangeEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+class FileChangeEvent
+{
+    public const FILE_CHANGED = 1;
+    public const FILE_DELETED = 2;
+    public const FILE_CREATED = 3;
+
+    private $file;
+
+    private $event;
+
+    public function __construct(string $file, int $event)
+    {
+        $this->file = $file;
+        $this->event = $event;
+    }
+
+    public function getFile(): string
+    {
+        return $this->file;
+    }
+
+    public function getEvent(): int
+    {
+        return $this->event;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
@@ -18,7 +18,7 @@ use Symfony\Component\Filesystem\Watcher\Resource\Locator\FileResourceLocator;
  *
  * @internal
  */
-class FileChangeWatcher implements WatcherInterface
+final class FileChangeWatcher implements WatcherInterface
 {
     private $locator;
 
@@ -27,7 +27,7 @@ class FileChangeWatcher implements WatcherInterface
         $this->locator = new FileResourceLocator();
     }
 
-    public function watch($path, callable $callback, float $timeout = null)
+    public function watch($path, callable $callback, float $timeout = null): void
     {
         $resource = $this->locator->locate($path);
 

--- a/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
@@ -32,7 +32,7 @@ final class FileChangeWatcher implements WatcherInterface
         $resource = $this->locator->locate($path);
 
         if (!$resource) {
-            throw new \InvalidArgumentException(sprintf('%s is not a valid path to watch', \gettype($path)));
+            throw new \InvalidArgumentException(sprintf('"%s" is not a valid path to watch.', \gettype($path)));
         }
 
         $run = true;

--- a/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher;
+
+use Symfony\Component\Filesystem\Watcher\Resource\Locator\FileResourceLocator;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ *
+ * @internal
+ */
+class FileChangeWatcher implements WatcherInterface
+{
+    private $locator;
+
+    public function __construct()
+    {
+        $this->locator = new FileResourceLocator();
+    }
+
+    public function watch($path, callable $callback, float $timeout = null)
+    {
+        $resource = $this->locator->locate($path);
+
+        if (!$resource) {
+            throw new \InvalidArgumentException(sprintf('%s is not a valid path to watch', \gettype($path)));
+        }
+
+        $run = true;
+        $start = microtime(true);
+
+        while ($run) {
+            if ($changes = $resource->detectChanges()) {
+                foreach ($changes as $change) {
+                    $run = false !== $callback($change->getFile(), $change->getEvent());
+                }
+
+                $start = microtime(true);
+            }
+
+            if (null !== $timeout && ($timeout / 1000) <= (microtime(true) - $start)) {
+                break;
+            }
+
+            sleep(1);
+        }
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
@@ -20,7 +20,7 @@ use Symfony\Component\Filesystem\Watcher\Resource\Locator\FileResourceLocator;
  */
 final class FileChangeWatcher implements WatcherInterface
 {
-    private $locator;
+    public $locator;
 
     public function __construct()
     {

--- a/src/Symfony/Component/Filesystem/Watcher/INotifyWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/INotifyWatcher.php
@@ -25,7 +25,7 @@ final class INotifyWatcher implements WatcherInterface
         $inotifyInit = inotify_init();
 
         if (false === $inotifyInit) {
-            throw new IOException('Unable initialize inotify', 0, null, $path);
+            throw new IOException('Unable initialize inotify.', 0, null, $path);
         }
 
         stream_set_blocking($inotifyInit, false);

--- a/src/Symfony/Component/Filesystem/Watcher/INotifyWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/INotifyWatcher.php
@@ -18,9 +18,9 @@ use Symfony\Component\Filesystem\Exception\IOException;
  *
  * @internal
  */
-class INotifyWatcher implements WatcherInterface
+final class INotifyWatcher implements WatcherInterface
 {
-    public function watch($path, callable $callback, float $timeout = null)
+    public function watch($path, callable $callback, float $timeout = null): void
     {
         $inotifyInit = inotify_init();
 
@@ -90,7 +90,7 @@ class INotifyWatcher implements WatcherInterface
         }
     }
 
-    private function scanPath($path)
+    private function scanPath($path): iterable
     {
         foreach (glob($path, GLOB_ONLYDIR) as $directory) {
             yield $directory;

--- a/src/Symfony/Component/Filesystem/Watcher/INotifyWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/INotifyWatcher.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ *
+ * @internal
+ */
+class INotifyWatcher implements WatcherInterface
+{
+    public function watch($path, callable $callback, float $timeout = null)
+    {
+        $inotifyInit = inotify_init();
+
+        if (false === $inotifyInit) {
+            throw new IOException('Unable initialize inotify', 0, null, $path);
+        }
+
+        stream_set_blocking($inotifyInit, false);
+
+        $isDir = is_dir($path);
+
+        if ($isDir) {
+            $watchId = inotify_add_watch($inotifyInit, $path, IN_CREATE | IN_DELETE | IN_MODIFY);
+        } else {
+            $watchId = inotify_add_watch($inotifyInit, $path, IN_MODIFY);
+        }
+
+        try {
+            $read = [$inotifyInit];
+            $write = null;
+            $except = null;
+            $tvSec = null === $timeout ? null : 0;
+            $tvUsec = null === $timeout ? null : $timeout * 1000;
+
+            while (true) {
+                if (0 === stream_select($read, $write, $except, $tvSec, $tvUsec)) {
+                    $read = [$inotifyInit];
+                    break;
+                }
+
+                $events = inotify_read($inotifyInit);
+
+                if (false === $events) {
+                    continue;
+                }
+
+                foreach ($events as $event) {
+                    $code = null;
+                    switch ($event['mask']) {
+                        case IN_CREATE:
+                            $code = FileChangeEvent::FILE_CREATED;
+                            break;
+                        case IN_DELETE:
+                            $code = FileChangeEvent::FILE_DELETED;
+                            break;
+                        case IN_MODIFY:
+                            $code = FileChangeEvent::FILE_CHANGED;
+                            break;
+                    }
+
+                    if (false === $callback(($isDir ? $path : '').$event['name'], $code)) {
+                        break;
+                    }
+                }
+            }
+        } finally {
+            inotify_rm_watch($inotifyInit, $watchId);
+            fclose($inotifyInit);
+        }
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/ArrayResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/ArrayResource.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ *
+ * @internal
+ */
+class ArrayResource implements ResourceInterface
+{
+    /**
+     * @var ResourceInterface[]
+     */
+    private $resources;
+
+    public function __construct(array $resources)
+    {
+        $this->resources = $resources;
+    }
+
+    public function detectChanges(): array
+    {
+        $events = [];
+
+        foreach ($this->resources as $resource) {
+            if ($changed = $resource->detectChanges()) {
+                $events = array_merge($events, $changed);
+            }
+        }
+
+        return $events;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/ArrayResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/ArrayResource.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Filesystem\Watcher\Resource;
  *
  * @internal
  */
-class ArrayResource implements ResourceInterface
+final class ArrayResource implements ResourceInterface
 {
     /**
      * @var ResourceInterface[]

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/DirectoryResource.php
@@ -73,7 +73,7 @@ final class DirectoryResource implements ResourceInterface
         $files = [];
 
         /** @var \SplFileInfo $file */
-        foreach (new \RecursiveDirectoryIterator($this->dir, \RecursiveDirectoryIterator::SKIP_DOTS) as $file) {
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->dir, \RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
             $path = $file->getRealPath();
             $files[$path] = new FileResource($path);
         }

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/DirectoryResource.php
@@ -18,7 +18,7 @@ use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
  *
  * @internal
  */
-class DirectoryResource implements ResourceInterface
+final class DirectoryResource implements ResourceInterface
 {
     private $dir;
 

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/DirectoryResource.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ *
+ * @internal
+ */
+class DirectoryResource implements ResourceInterface
+{
+    private $dir;
+
+    /**
+     * @var FileResource[]
+     */
+    private $files;
+
+    public function __construct(string $dir)
+    {
+        $this->dir = $dir;
+
+        $this->files = $this->getFiles();
+    }
+
+    public function detectChanges(): array
+    {
+        $events = [];
+
+        $currentFiles = $this->getFiles();
+
+        // Check if any files has been added
+        foreach (array_keys($currentFiles) as $path) {
+            if (!isset($this->files[$path])) {
+                $this->files = $currentFiles;
+
+                $events[] = new FileChangeEvent($path, FileChangeEvent::FILE_CREATED);
+            }
+        }
+
+        // Check if any files has been deleted
+        foreach (array_keys($this->files) as $file) {
+            if (!isset($currentFiles[$file])) {
+                $this->files = $currentFiles;
+
+                $events[] = new FileChangeEvent($file, FileChangeEvent::FILE_DELETED);
+            }
+        }
+
+        // Check for any changes in files
+        foreach ($this->files as $file) {
+            if ($event = $file->detectChanges()) {
+                $events = array_merge($events, $event);
+            }
+        }
+
+        return $events;
+    }
+
+    private function getFiles(): array
+    {
+        $files = [];
+
+        /** @var \SplFileInfo $file */
+        foreach (new \RecursiveDirectoryIterator($this->dir, \RecursiveDirectoryIterator::SKIP_DOTS) as $file) {
+            $path = $file->getRealPath();
+            $files[$path] = new FileResource($path);
+        }
+
+        return $files;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/FileResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/FileResource.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ *
+ * @internal
+ */
+class FileResource implements ResourceInterface
+{
+    private $file;
+
+    private $lastModified;
+
+    public function __construct(string $file)
+    {
+        $this->file = $file;
+        $this->lastModified = filemtime($file);
+    }
+
+    public function detectChanges(): array
+    {
+        if ($this->isModified()) {
+            $this->updateModifiedTime();
+
+            return [new FileChangeEvent($this->file, FileChangeEvent::FILE_CHANGED)];
+        }
+
+        return [];
+    }
+
+    private function isModified(): bool
+    {
+        clearstatcache(false, $this->file);
+
+        return $this->lastModified < filemtime($this->file);
+    }
+
+    private function updateModifiedTime(): void
+    {
+        $this->lastModified = filemtime($this->file);
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/FileResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/FileResource.php
@@ -18,7 +18,7 @@ use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
  *
  * @internal
  */
-class FileResource implements ResourceInterface
+final class FileResource implements ResourceInterface
 {
     private $file;
 

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/Locator/FileResourceLocator.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/Locator/FileResourceLocator.php
@@ -22,7 +22,7 @@ use Symfony\Component\Finder\Finder;
  *
  * @internal
  */
-class FileResourceLocator
+final class FileResourceLocator
 {
     public function locate($path): ?ResourceInterface
     {

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/Locator/FileResourceLocator.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/Locator/FileResourceLocator.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource\Locator;
+
+use Symfony\Component\Filesystem\Watcher\Resource\ArrayResource;
+use Symfony\Component\Filesystem\Watcher\Resource\DirectoryResource;
+use Symfony\Component\Filesystem\Watcher\Resource\FileResource;
+use Symfony\Component\Filesystem\Watcher\Resource\ResourceInterface;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ *
+ * @internal
+ */
+class FileResourceLocator
+{
+    public function locate($path): ?ResourceInterface
+    {
+        if ($path instanceof Finder || $path instanceof \Iterator) {
+            $path = iterator_to_array($path);
+        }
+
+        if ($path instanceof \SplFileInfo) {
+            $path = $path->getRealPath();
+        }
+
+        if (\is_array($path)) {
+            return new ArrayResource(array_map([$this, 'locate'], $path));
+        }
+
+        if (\is_string($path)) {
+            if (is_dir($path)) {
+                return new DirectoryResource($path);
+            }
+
+            $paths = glob($path, \defined('GLOB_BRACE') ? GLOB_BRACE : 0);
+
+            if (1 === \count($paths)) {
+                return new FileResource($paths[0]);
+            }
+
+            return new ArrayResource(array_map(function ($path) {
+                return new FileResource($path);
+            }, $paths));
+        }
+
+        return null;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/ResourceInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+interface ResourceInterface
+{
+    public function detectChanges(): array;
+}

--- a/src/Symfony/Component/Filesystem/Watcher/WatcherInterface.php
+++ b/src/Symfony/Component/Filesystem/Watcher/WatcherInterface.php
@@ -11,10 +11,17 @@
 
 namespace Symfony\Component\Filesystem\Watcher;
 
+use Symfony\Component\Filesystem\Exception\IOException;
+
 /**
  * @author Pierre du Plessis <pdples@gmail.com>
  */
 interface WatcherInterface
 {
-    public function watch($path, callable $callback, float $timeout = null);
+    /**
+     * @param mixed    $path     The path to watch for changes. Can be a path to a file or directory, iterator or array with paths
+     * @param callable $callback The callback to execute when a change is detected
+     * @param float    $timeout  The idle timeout in milliseconds after which the process will be aborted if there are no changes detected
+     */
+    public function watch($path, callable $callback, float $timeout = null): void;
 }

--- a/src/Symfony/Component/Filesystem/Watcher/WatcherInterface.php
+++ b/src/Symfony/Component/Filesystem/Watcher/WatcherInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+interface WatcherInterface
+{
+    public function watch($path, callable $callback, float $timeout = null);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | TBD

Add a watch method to the Filesystem component to monitor the filesystem for changes, and executing a callback function whenever a change is detected.

The watch method can take any parameter and uses a resource locator to transform a path to a resource. The resource can then be monitored for any changes. When a directory is monitored, you can get changed events when a file in the directory changes, when a new file is created or when an existing file is deleted. It also tries to make usage of Inotify is the extension is installed.

Example usage:

```php
$fs = new Filesystem();

$fs->watch('/path/to/some/directory', function ($file, $event) {
    if ($event === FileChangeEvent::FILE_CREATED) {
        echo $file.' was created!';
    }
});
```

If you want to bail out of the watch events, the callback can return `false` to stop the process.

```php
$fs = new Filesystem();

$fs->watch('/path/to/some/directory', function ($file, $event) {
    if ($event === FileChangeEvent::FILE_DELETED) {
        echo $file.' was deleted!';
        return false; // <- Will stop the watch process and continue with execution of the the rest of the application
    }
});
```