### PR TITLE
[DI] default to service id - *not* FQCN - when building tagged locators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -21,22 +21,26 @@ class TaggedIteratorArgument extends IteratorArgument
     private $tag;
     private $indexAttribute;
     private $defaultIndexMethod;
-    private $useFqcnAsFallback = false;
+    private $needsIndexes = false;
 
     /**
      * @param string      $tag                The name of the tag identifying the target services
      * @param string|null $indexAttribute     The name of the attribute that defines the key referencing each service in the tagged collection
      * @param string|null $defaultIndexMethod The static method that should be called to get each service's key when their tag doesn't define the previous attribute
-     * @param bool        $useFqcnAsFallback  Whether the FQCN of the service should be used as index when neither the attribute nor the method are defined
+     * @param bool        $needsIndexes       Whether indexes are required and should be generated when computing the map
      */
-    public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $useFqcnAsFallback = false)
+    public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $needsIndexes = false)
     {
         parent::__construct([]);
+
+        if (null === $indexAttribute && $needsIndexes) {
+            $indexAttribute = preg_match('/[^.]++$/', $tag, $m) ? $m[0] : $tag;
+        }
 
         $this->tag = $tag;
         $this->indexAttribute = $indexAttribute;
         $this->defaultIndexMethod = $defaultIndexMethod ?: ('getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute ?? ''))).'Name');
-        $this->useFqcnAsFallback = $useFqcnAsFallback;
+        $this->needsIndexes = $needsIndexes;
     }
 
     public function getTag()
@@ -54,8 +58,8 @@ class TaggedIteratorArgument extends IteratorArgument
         return $this->defaultIndexMethod;
     }
 
-    public function useFqcnAsFallback(): bool
+    public function needsIndexes(): bool
     {
-        return $this->useFqcnAsFallback;
+        return $this->needsIndexes;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -41,12 +41,12 @@ trait PriorityTaggedServiceTrait
      */
     private function findAndSortTaggedServices($tagName, ContainerBuilder $container)
     {
-        $indexAttribute = $defaultIndexMethod = $useFqcnAsFallback = null;
+        $indexAttribute = $defaultIndexMethod = $needsIndexes = null;
 
         if ($tagName instanceof TaggedIteratorArgument) {
             $indexAttribute = $tagName->getIndexAttribute();
             $defaultIndexMethod = $tagName->getDefaultIndexMethod();
-            $useFqcnAsFallback = $tagName->useFqcnAsFallback();
+            $needsIndexes = $tagName->needsIndexes();
             $tagName = $tagName->getTag();
         }
 
@@ -55,7 +55,7 @@ trait PriorityTaggedServiceTrait
         foreach ($container->findTaggedServiceIds($tagName, true) as $serviceId => $attributes) {
             $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
 
-            if (null === $indexAttribute && !$useFqcnAsFallback) {
+            if (null === $indexAttribute && !$needsIndexes) {
                 $services[$priority][] = new Reference($serviceId);
 
                 continue;
@@ -77,8 +77,8 @@ trait PriorityTaggedServiceTrait
             $class = $r->name;
 
             if (!$r->hasMethod($defaultIndexMethod)) {
-                if ($useFqcnAsFallback) {
-                    $services[$priority][$class] = new TypedReference($serviceId, $class);
+                if ($needsIndexes) {
+                    $services[$priority][$serviceId] = new TypedReference($serviceId, $class);
 
                     continue;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

While reviewing #30926 I realized that defaulting to the FQCN is a shortcut that isn't useful enough.
Defaulting to the service id provides the same experience in practice because service ids are FQCN by default.
But when they aren't, the service id is the proper index to default to when building the locator.