### PR TITLE
[Serializer] Fix BC break: DEPTH_KEY_PATTERN must be public

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -41,7 +41,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * How to track the current depth in the context.
      */
-    private const DEPTH_KEY_PATTERN = 'depth_%s::%s';
+    public const DEPTH_KEY_PATTERN = 'depth_%s::%s';
 
     /**
      * While denormalizing, we can verify that types match.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
 Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Fix a BC break introduced by #30888. This constant is used by API Platform.
