### PR TITLE
[Validator] add Validation::createCallable()

### DIFF
--- a/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
+++ b/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Exception;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * @author Jan Vernieuwe <jan.vernieuwe@phpro.be>
+ */
+class ValidationFailedException extends RuntimeException
+{
+    private $violations;
+    private $value;
+
+    public function __construct($value, ConstraintViolationListInterface $violations)
+    {
+        $this->violations = $violations;
+        $this->value = $value;
+        parent::__construct($violations);
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getViolations(): ConstraintViolationListInterface
+    {
+        return $this->violations;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Validator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @author Jan Vernieuwe <jan.vernieuwe@phpro.be>
+ */
+class ValidationTest extends TestCase
+{
+    public function testCreateCallableValid()
+    {
+        $validator = Validation::createCallable(new Email());
+        $this->assertEquals('test@example.com', $validator('test@example.com'));
+    }
+
+    public function testCreateCallableInvalid()
+    {
+        $validator = Validation::createCallable(new Email());
+        $this->expectException(ValidationFailedException::class);
+        $validator('test');
+    }
+}

--- a/src/Symfony/Component/Validator/Validation.php
+++ b/src/Symfony/Component/Validator/Validation.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator;
 
+use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -20,6 +21,23 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 final class Validation
 {
+    /**
+     * Creates a callable chain of constraints.
+     */
+    public static function createCallable(Constraint ...$constraints): callable
+    {
+        $validator = self::createValidator();
+
+        return static function ($value) use ($constraints, $validator) {
+            $violations = $validator->validate($value, $constraints);
+            if (0 !== $violations->count()) {
+                throw new ValidationFailedException($value, $violations);
+            }
+
+            return $value;
+        };
+    }
+
     /**
      * Creates a new validator.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

This is an initial PR to check/discuss the implementation of a callable validator.
If there is interest in merging this, I will gladly update the docs and such.

The use case is mainly for validation of console questions, since the default validation has been removed in the latest version and i could not find an easy solution to replace it (if there already is some solution for this, i'm not aware of it) and the question helper uses callables.
This small class allows the standard symfony validators to be used in console questions, or any other location that requires a callable validator.

Example use case:
```php
$io = new SymfonyStyle($input, $output);
$required = new CallableValidator([new NotBlank()]);
$wsdl = $io->ask('Wsdl location (URL or path to file)', null, $required);
```

As said before, this is by no means the final version, but I would like to know if there is interest  in merging this (and receive some feedback about the implementation) before I put any more effort into this.
