### PR TITLE
[FrameworkBundle] Enable Doctrine Messenger transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1707,6 +1707,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('messenger.transport.symfony_serializer');
             $container->removeDefinition('messenger.transport.amqp.factory');
             $container->removeDefinition('messenger.transport.redis.factory');
+            $container->removeDefinition('messenger.transport.doctrine.factory');
         } else {
             $container->getDefinition('messenger.transport.symfony_serializer')
                 ->replaceArgument(1, $config['serializer']['symfony_serializer']['format'])

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -81,6 +81,10 @@
             <tag name="kernel.reset" method="reset" />
         </service>
 
+        <service id="messenger.transport.doctrine.factory" class="Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory">
+            <tag name="messenger.transport_factory" />
+        </service>
+
         <!-- retry -->
         <service id="messenger.retry_strategy_locator">
             <tag name="container.service_locator" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
@@ -14,6 +14,7 @@ $container->loadFromExtension('framework', [
                 'serializer' => 'messenger.transport.native_php_serializer',
             ],
             'redis' => 'redis://127.0.0.1:6379/messages',
+            'doctrine' => 'doctrine://default',
         ],
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
@@ -18,6 +18,7 @@
                 </framework:options>
             </framework:transport>
             <framework:transport name="redis" dsn="redis://127.0.0.1:6379/messages" />
+            <framework:transport name="doctrine" dsn="doctrine://default" />
         </framework:messenger>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
@@ -12,3 +12,4 @@ framework:
                         name: Queue
                 serializer: 'messenger.transport.native_php_serializer'
             redis: 'redis://127.0.0.1:6379/messages'
+            doctrine: 'doctrine://default'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -674,6 +674,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->getAlias('messenger.default_bus')->isPublic());
         $this->assertFalse($container->hasDefinition('messenger.transport.amqp.factory'));
         $this->assertFalse($container->hasDefinition('messenger.transport.redis.factory'));
+        $this->assertFalse($container->hasDefinition('messenger.transport.doctrine.factory'));
         $this->assertTrue($container->hasDefinition('messenger.transport_factory'));
         $this->assertSame(TransportFactory::class, $container->getDefinition('messenger.transport_factory')->getClass());
     }
@@ -708,6 +709,16 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('redis://127.0.0.1:6379/messages', $transportArguments[0]);
 
         $this->assertTrue($container->hasDefinition('messenger.transport.redis.factory'));
+
+        $this->assertTrue($container->hasDefinition('messenger.transport.doctrine'));
+        $transportFactory = $container->getDefinition('messenger.transport.doctrine')->getFactory();
+        $transportArguments = $container->getDefinition('messenger.transport.doctrine')->getArguments();
+
+        $this->assertEquals([new Reference('messenger.transport_factory'), 'createTransport'], $transportFactory);
+        $this->assertCount(3, $transportArguments);
+        $this->assertSame('doctrine://default', $transportArguments[0]);
+
+        $this->assertTrue($container->hasDefinition('messenger.transport.doctrine.factory'));
     }
 
     public function testMessengerRouting()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Added Doctrine Messenger transport in FrameworkBundle extension.