### PR TITLE
[HttpFoundation] suppress warning from static analyser 

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -702,7 +702,7 @@ class Request
      */
     public function getSession()
     {
-        /** @var callable $session */
+        /** @var callable|null $session */
         $session = $this->session;
         if (!$session instanceof SessionInterface && null !== $session) {
             $this->setSession($session = $session());

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -702,9 +702,9 @@ class Request
      */
     public function getSession()
     {
-        /** @var callable|null $session */
         $session = $this->session;
         if (!$session instanceof SessionInterface && null !== $session) {
+            /** @var callable|null $session */
             $this->setSession($session = $session());
         }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -702,6 +702,7 @@ class Request
      */
     public function getSession()
     {
+        /** @var callable $session */
         $session = $this->session;
         if (!$session instanceof SessionInterface && null !== $session) {
             $this->setSession($session = $session());


### PR DESCRIPTION
Add anotation to suppress warning: function name must be callable - a string

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | no
| License       | MIT
| Doc PR        | 

Add anotation to suppress warning: function name must be callable - a string
