### PR TITLE
[Messenger] Fix routable message bus default bus

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -106,6 +106,7 @@
         <!-- routable message bus -->
         <service id="messenger.routable_message_bus" class="Symfony\Component\Messenger\RoutableMessageBus">
             <argument /> <!-- Message bus locator -->
+            <argument type="service" id="messenger.default_bus" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/Messenger/Tests/RoutableMessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/RoutableMessageBusTest.php
@@ -50,41 +50,34 @@ class RoutableMessageBusTest extends TestCase
             ->willReturn($envelope);
 
         $container = $this->createMock(ContainerInterface::class);
-        $container->expects($this->once())->method('has')->with(MessageBusInterface::class)
-            ->willReturn(true);
-        $container->expects($this->once())->method('get')->with(MessageBusInterface::class)
-            ->willReturn($defaultBus);
 
-        $routableBus = new RoutableMessageBus($container);
+        $routableBus = new RoutableMessageBus($container, $defaultBus);
 
         $this->assertSame($envelope, $routableBus->dispatch($envelope, [$stamp]));
-    }
-
-    public function testItExceptionOnDefaultBusNotFound()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('Bus named "%s" does not exist.', MessageBusInterface::class));
-
-        $envelope = new Envelope(new \stdClass());
-
-        $container = $this->createMock(ContainerInterface::class);
-        $container->expects($this->once())->method('has')->with(MessageBusInterface::class)
-            ->willReturn(false);
-
-        $routableBus = new RoutableMessageBus($container);
-        $routableBus->dispatch($envelope);
     }
 
     public function testItExceptionOnBusNotFound()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('Bus named "%s" does not exist.', 'foo_bus'));
+        $this->expectExceptionMessage('Bus named "my_cool_bus" does not exist.');
 
-        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('foo_bus')]);
+        $envelope = new Envelope(new \stdClass(), [
+            new BusNameStamp('my_cool_bus'),
+        ]);
 
         $container = $this->createMock(ContainerInterface::class);
-        $container->expects($this->once())->method('has')->willReturn(false);
+        $routableBus = new RoutableMessageBus($container);
+        $routableBus->dispatch($envelope);
+    }
 
+    public function testItExceptionOnDefaultBusNotFound()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Envelope is missing a BusNameStamp and no fallback message bus is configured on RoutableMessageBus.');
+
+        $envelope = new Envelope(new \stdClass());
+
+        $container = $this->createMock(ContainerInterface::class);
         $routableBus = new RoutableMessageBus($container);
         $routableBus->dispatch($envelope);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

In #31288, we gave the `RoutableMessageBus` a "default" bus. We did that by using the `MessageBusInterface` service in the locator. But, no such service exists - I think that was just a huge oversight (and maybe @dirk39 named a bus this in the project he was testing on?). The services in the locator are very simply the keys under `framework.messenger.buses` or the default, which is a single `messenger.bus.default` id. There is an alias in the container for `MessageBusInterface`, but this is not added to the locator (and adding it would be a bit awkward, as `MessengerPass` is in the component and the interface alias is entirely a framework thing).

Cheers!