### PR TITLE
[Messenger] Fix doctrine tests

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
@@ -37,11 +37,8 @@ class DoctrineIntegrationTest extends TestCase
      */
     public function createConnection()
     {
-        if ($dsn = getenv('MESSENGER_DOCTRINE_DSN')) {
-            $this->driverConnection = DriverManager::getConnection(['url' => $dsn]);
-        } else {
-            $this->driverConnection = DriverManager::getConnection(['pdo' => new \PDO('sqlite:'.sys_get_temp_dir().'/symfony.messenger.sqlite')]);
-        }
+        $dsn = getenv('MESSENGER_DOCTRINE_DSN') ?: 'sqlite:///'.sys_get_temp_dir().'/symfony.messenger.sqlite';
+        $this->driverConnection = DriverManager::getConnection(['url' => $dsn]);
         $this->connection = new Connection([], $this->driverConnection);
         // call send to auto-setup the table
         $this->connection->setup();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

Not sure why, but when passing in `pdo`, the Doctrine `Connection::_conn` property is a PDO instance and isn't wrapped. In the master branch of `doctrine/dbal`, they now check for this an throw an exception. 

@nicolas-grekas has a PR in Doctrine for this (https://github.com/doctrine/dbal/pull/3543), but I don't see any reason we shouldn't just avoid the `pdo` option entirely.