### PR TITLE
[HttpFoundation] Allow set 'None' on samesite cookie flag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -28,6 +28,7 @@ class Cookie
     private $raw;
     private $sameSite;
 
+    const SAMESITE_NONE = 'none';
     const SAMESITE_LAX = 'lax';
     const SAMESITE_STRICT = 'strict';
 
@@ -128,7 +129,7 @@ class Cookie
             $sameSite = strtolower($sameSite);
         }
 
-        if (!\in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, null], true)) {
+        if (!\in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, self::SAMESITE_NONE, null], true)) {
             throw new \InvalidArgumentException('The "sameSite" parameter value is not valid.');
         }
 


### PR DESCRIPTION
Allow set samesite cookie flag to 'None' value

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | #31467 
| License       | MIT

Google introduces new Chrome policy, marking all none setted samesite flag to 'Strict' by default. If you want to allow third party cookies you must set samesite flag to None. 

This PR fixes #31467, allow to put samesite Cookie flag to None.
