### PR TITLE
[Messenger][DoctrineBridge] Throws UnrecoverableMessageHandlingException when passed invalid entity manager name

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
@@ -12,8 +12,8 @@
 namespace Symfony\Bridge\Doctrine\Messenger;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
@@ -40,10 +40,10 @@ class DoctrineCloseConnectionMiddleware implements MiddlewareInterface
      */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
-
-        if (!$entityManager instanceof EntityManagerInterface) {
-            throw new \InvalidArgumentException(sprintf('The ObjectManager with name "%s" must be an instance of EntityManagerInterface', $this->entityManagerName));
+        try {
+            $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
+        } catch (\InvalidArgumentException $e) {
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
         }
 
         try {

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
@@ -12,8 +12,8 @@
 namespace Symfony\Bridge\Doctrine\Messenger;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
@@ -40,10 +40,10 @@ class DoctrinePingConnectionMiddleware implements MiddlewareInterface
      */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
-
-        if (!$entityManager instanceof EntityManagerInterface) {
-            throw new \InvalidArgumentException(sprintf('The ObjectManager with name "%s" must be an instance of EntityManagerInterface', $this->entityManagerName));
+        try {
+            $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
+        } catch (\InvalidArgumentException $e) {
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
         }
 
         $connection = $entityManager->getConnection();

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
@@ -12,8 +12,8 @@
 namespace Symfony\Bridge\Doctrine\Messenger;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
@@ -40,10 +40,10 @@ class DoctrineTransactionMiddleware implements MiddlewareInterface
      */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
-
-        if (!$entityManager instanceof EntityManagerInterface) {
-            throw new \InvalidArgumentException(sprintf('The ObjectManager with name "%s" must be an instance of EntityManagerInterface', $this->entityManagerName));
+        try {
+            $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
+        } catch (\InvalidArgumentException $e) {
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
         }
 
         $entityManager->getConnection()->beginTransaction();

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Messenger\DoctrinePingConnectionMiddleware;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 
 class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
@@ -70,5 +71,20 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
         ;
 
         $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+    }
+
+    public function testInvalidEntityManagerThrowsException()
+    {
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry
+            ->method('getManager')
+            ->with('unknown_manager')
+            ->will($this->throwException(new \InvalidArgumentException()));
+
+        $middleware = new DoctrinePingConnectionMiddleware($managerRegistry, 'unknown_manager');
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock(false));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -29,7 +29,7 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/form": "~4.3",
         "symfony/http-kernel": "~3.4|~4.0",
-        "symfony/messenger": "~4.2",
+        "symfony/messenger": "~4.3",
         "symfony/property-access": "~3.4|~4.0",
         "symfony/property-info": "~3.4|~4.0",
         "symfony/proxy-manager-bridge": "~3.4|~4.0",
@@ -49,7 +49,7 @@
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/dependency-injection": "<3.4",
         "symfony/form": "<4.3",
-        "symfony/messenger": "<4.2"
+        "symfony/messenger": "<4.3"
     },
     "suggest": {
         "symfony/form": "",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | not sure
| Deprecations? | no
| Tests pass?   | Waiting for Travis
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

1. Throws `UnrecoverableMessageHandlingException` and do not retry messages if middlewares missconfigured
2.  `getManager()` doesn't return null. Actually [it throws](https://github.com/doctrine/persistence/blob/master/lib/Doctrine/Persistence/AbstractManagerRegistry.php#L144-L160) `\InvalidArgumentException` in requested entity manager not exists.

Not sure, should this changes considered as BC-break.

Also I can extract abstract Doctrine middleware but not sure what branch should I use for it? Master or 4.3?