### PR TITLE
[Messenger] Add `from_transport` in subscriber's phpdoc

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
@@ -32,13 +32,14 @@ interface MessageSubscriberInterface extends MessageHandlerInterface
      *     yield FirstMessage::class => ['priority' => 0];
      *     yield SecondMessage::class => ['priority => -10];
      *
-     * It can also specify a method, a priority and/or a bus per message:
+     * It can also specify a method, a priority, a bus and/or a transport per message:
      *
      *     yield FirstMessage::class => ['method' => 'firstMessageMethod'];
      *     yield SecondMessage::class => [
      *         'method' => 'secondMessageMethod',
      *         'priority' => 20,
      *         'bus' => 'my_bus_name',
+     *         'from_transport' => 'your_transport_name',
      *     ];
      *
      * The benefit of using `yield` instead of returning an array is that you can `yield` multiple times the


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | ø
| BC breaks?    | ø
| Deprecations? | ø
| Tests pass?   | yes
| Fixed tickets | #30958
| License       | MIT
| Doc PR        | ø

Add the `from_transport` to the subscriber's phpdoc as it was missed from the original PR.