### PR TITLE
[DomCrawler] Update docblock of Form `offsetSet` function

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -333,8 +333,8 @@ class Form extends Link implements \ArrayAccess
     /**
      * Sets the value of a field.
      *
-     * @param string       $name  The field name
-     * @param string|array $value The value of the field
+     * @param string $name  The field name
+     * @param mixed  $value The value of the field
      *
      * @throws \InvalidArgumentException if the field does not exist
      */


### PR DESCRIPTION
Function offsetSet can accept mixed arguments.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | According to https://github.com/phpstan/phpstan/issues/2127
| License       | MIT
