### PR TITLE
[Security] Rename firewalls’ pattern to path

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+* Deprecated firewalls’ `pattern` option, use `path` instead
+
 4.3.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -277,11 +277,11 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $matcher = null;
         if (isset($firewall['request_matcher'])) {
             $matcher = new Reference($firewall['request_matcher']);
-        } elseif (isset($firewall['pattern']) || isset($firewall['host'])) {
-            $pattern = isset($firewall['pattern']) ? $firewall['pattern'] : null;
+        } elseif (isset($firewall['path']) || isset($firewall['host']) || !empty($firewall['methods'])) {
+            $path = $firewall['pattern'] ?? $firewall['path'] ?? null;
             $host = isset($firewall['host']) ? $firewall['host'] : null;
             $methods = isset($firewall['methods']) ? $firewall['methods'] : [];
-            $matcher = $this->createRequestMatcher($container, $pattern, $host, null, $methods);
+            $matcher = $this->createRequestMatcher($container, $path, $host, null, $methods);
         }
 
         $config->replaceArgument(2, $matcher ? (string) $matcher : null);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_customized_config.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_customized_config.php
@@ -15,6 +15,6 @@ $container->loadFromExtension('security', [
         ],
     ],
     'firewalls' => [
-        'simple' => ['pattern' => '/login', 'security' => false],
+        'simple' => ['path' => '/login', 'security' => false],
     ],
 ]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_default_strategy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_default_strategy.php
@@ -11,6 +11,6 @@ $container->loadFromExtension('security', [
         ],
     ],
     'firewalls' => [
-        'simple' => ['pattern' => '/login', 'security' => false],
+        'simple' => ['path' => '/login', 'security' => false],
     ],
 ]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service.php
@@ -14,6 +14,6 @@ $container->loadFromExtension('security', [
         ],
     ],
     'firewalls' => [
-        'simple' => ['pattern' => '/login', 'security' => false],
+        'simple' => ['path' => '/login', 'security' => false],
     ],
 ]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service_and_strategy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service_and_strategy.php
@@ -15,6 +15,6 @@ $container->loadFromExtension('security', [
         ],
     ],
     'firewalls' => [
-        'simple' => ['pattern' => '/login', 'security' => false],
+        'simple' => ['path' => '/login', 'security' => false],
     ],
 ]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -65,7 +65,7 @@ $container->loadFromExtension('security', [
     ],
 
     'firewalls' => [
-        'simple' => ['provider' => 'default', 'pattern' => '/login', 'security' => false],
+        'simple' => ['provider' => 'default', 'path' => '/login', 'security' => false],
         'secure' => ['stateless' => true,
             'provider' => 'default',
             'http_basic' => true,
@@ -80,7 +80,7 @@ $container->loadFromExtension('security', [
         ],
         'host' => [
             'provider' => 'default',
-            'pattern' => '/test',
+            'path' => '/test',
             'host' => 'foo\\.example\\.org',
             'methods' => ['GET', 'POST'],
             'anonymous' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
@@ -11,7 +11,7 @@ $container->loadFromExtension('security', [
         ],
     ],
     'firewalls' => [
-        'simple' => ['pattern' => '/login', 'security' => false],
+        'simple' => ['path' => '/login', 'security' => false],
         'secure' => [
             'stateless' => true,
             'http_basic' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_customized_config.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_customized_config.xml
@@ -13,6 +13,6 @@
             </memory>
         </provider>
 
-        <firewall name="simple" pattern="/login" security="false" />
+        <firewall name="simple" path="/login" security="false" />
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_default_strategy.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_default_strategy.xml
@@ -11,6 +11,6 @@
             </memory>
         </provider>
 
-        <firewall name="simple" pattern="/login" security="false" />
+        <firewall name="simple" path="/login" security="false" />
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service.xml
@@ -13,6 +13,6 @@
             </memory>
         </provider>
 
-        <firewall name="simple" pattern="/login" security="false" />
+        <firewall name="simple" path="/login" security="false" />
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service_and_strategy.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service_and_strategy.xml
@@ -13,6 +13,6 @@
             </memory>
         </provider>
 
-        <firewall name="simple" pattern="/login" security="false" />
+        <firewall name="simple" path="/login" security="false" />
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -45,7 +45,7 @@
             <chain providers="service, basic" />
         </provider>
 
-        <firewall name="simple" pattern="/login" security="false" provider="default" />
+        <firewall name="simple" path="/login" security="false" provider="default" />
 
         <firewall name="secure" stateless="true" provider="default">
             <http-basic />
@@ -59,7 +59,7 @@
             <remember-me secret="TheSecret"/>
         </firewall>
 
-        <firewall name="host" pattern="/test" host="foo\.example\.org" methods="GET,POST" provider="default">
+        <firewall name="host" path="/test" host="foo\.example\.org" methods="GET,POST" provider="default">
             <anonymous />
             <http-basic />
         </firewall>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
@@ -11,7 +11,7 @@
             </memory>
         </provider>
 
-        <firewall name="simple" pattern="/login" security="false" />
+        <firewall name="simple" path="/login" security="false" />
 
         <firewall name="secure" stateless="true">
             <http-basic />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_customized_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_customized_config.yml
@@ -8,4 +8,4 @@ security:
                 users:
                     foo: { password: foo, roles: ROLE_USER }
     firewalls:
-        simple: { pattern: /login, security: false }
+        simple: { path: /login, security: false }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_default_strategy.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_default_strategy.yml
@@ -5,4 +5,4 @@ security:
                 users:
                     foo: { password: foo, roles: ROLE_USER }
     firewalls:
-        simple: { pattern: /login, security: false }
+        simple: { path: /login, security: false }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service.yml
@@ -7,4 +7,4 @@ security:
                 users:
                     foo: { password: foo, roles: ROLE_USER }
     firewalls:
-        simple: { pattern: /login, security: false }
+        simple: { path: /login, security: false }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service_and_strategy.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service_and_strategy.yml
@@ -8,4 +8,4 @@ security:
                 users:
                     foo: { password: foo, roles: ROLE_USER }
     firewalls:
-        simple: { pattern: /login, security: false }
+        simple: { path: /login, security: false }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -45,7 +45,7 @@ security:
 
 
     firewalls:
-        simple: { pattern: /login, security: false }
+        simple: { path: /login, security: false }
         secure:
             provider: default
             stateless: true
@@ -62,7 +62,7 @@ security:
 
         host:
             provider: default
-            pattern: /test
+            path: /test
             host: foo\.example\.org
             methods: [GET,POST]
             anonymous: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
@@ -6,7 +6,7 @@ security:
                     foo: { password: foo, roles: ROLE_USER }
 
     firewalls:
-        simple: { pattern: /login, security: false }
+        simple: { path: /login, security: false }
         secure:
             stateless: true
             http_basic: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -26,7 +26,7 @@ class SecurityExtensionTest extends TestCase
 {
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The check_path "/some_area/login_check" for login method "form_login" is not matched by the firewall pattern "/secured_area/.*".
+     * @expectedExceptionMessage The check_path "/some_area/login_check" for login method "form_login" is not matched by the firewall path "/secured_area/.*".
      */
     public function testInvalidCheckPath()
     {
@@ -39,7 +39,7 @@ class SecurityExtensionTest extends TestCase
 
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '/secured_area/.*',
+                    'path' => '/secured_area/.*',
                     'form_login' => [
                         'check_path' => '/some_area/login_check',
                     ],
@@ -65,7 +65,7 @@ class SecurityExtensionTest extends TestCase
 
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '/.*',
+                    'path' => '/.*',
                 ],
             ],
         ]);
@@ -91,7 +91,7 @@ class SecurityExtensionTest extends TestCase
 
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '/.*',
+                    'path' => '/.*',
                     'http_basic' => [],
                 ],
             ],
@@ -113,7 +113,7 @@ class SecurityExtensionTest extends TestCase
 
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '/.*',
+                    'path' => '/.*',
                     'http_basic' => null,
                 ],
             ],
@@ -135,11 +135,11 @@ class SecurityExtensionTest extends TestCase
 
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '^/admin',
+                    'path' => '^/admin',
                     'http_basic' => null,
                 ],
                 'stateless_firewall' => [
-                    'pattern' => '/.*',
+                    'path' => '/.*',
                     'stateless' => true,
                     'http_basic' => null,
                 ],
@@ -251,7 +251,7 @@ class SecurityExtensionTest extends TestCase
             ],
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '/.*',
+                    'path' => '/.*',
                     'http_basic' => [],
                 ],
             ],
@@ -289,7 +289,7 @@ class SecurityExtensionTest extends TestCase
             ],
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '/.*',
+                    'path' => '/.*',
                     'http_basic' => [],
                 ],
             ],
@@ -310,7 +310,7 @@ class SecurityExtensionTest extends TestCase
 
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '/.*',
+                    'path' => '/.*',
                     'http_basic' => null,
                 ],
             ],
@@ -333,7 +333,7 @@ class SecurityExtensionTest extends TestCase
 
             'firewalls' => [
                 'some_firewall' => [
-                    'pattern' => '/.*',
+                    'path' => '/.*',
                     'http_basic' => ['provider' => 'second'],
                 ],
             ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
@@ -24,7 +24,7 @@ security:
         # configuration file, but it's here for testing purposes (do not use
         # this file in a real world scenario though)
         login_form:
-            pattern: ^/login$
+            path: ^/login$
             security: false
 
         default:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -16,7 +16,7 @@ services:
 security:
     firewalls:
         secure:
-            pattern: ^/secure/
+            path: ^/secure/
             http_basic: { realm: "Secure Gateway API" }
             entry_point: firewall_entry_point.entry_point.stub
         default:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config_form_login.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config_form_login.yml
@@ -4,6 +4,6 @@ imports:
 security:
     firewalls:
         secure:
-            pattern: ^/
+            path: ^/
             form_login:
                 check_path: /login_check

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
@@ -13,7 +13,7 @@ security:
 
     firewalls:
         main:
-            pattern: ^/
+            path: ^/
             anonymous: true
             json_login:
                check_path:    /chk

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
@@ -13,7 +13,7 @@ security:
 
     firewalls:
         main:
-            pattern: ^/
+            path: ^/
             anonymous: true
             json_login:
                check_path:    /chk

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
@@ -24,7 +24,7 @@ security:
 
     firewalls:
         main:
-            pattern:  ^/login
+            path:  ^/login
             stateless: true
             anonymous: true
             json_login_ldap:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordEncode/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/PasswordEncode/config.yml
@@ -23,5 +23,5 @@ security:
 
     firewalls:
         test:
-            pattern:  ^/
+            path:  ^/
             security: false

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/config.yml
@@ -16,7 +16,7 @@ security:
         # configuration file, but it's here for testing purposes (do not use
         # this file in a real world scenario though)
         login_form:
-            pattern: ^/login$
+            path: ^/login$
             security: false
 
         default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | maybe https://github.com/symfony/symfony-docs/pull/11574

The same way `pattern` has been replaced by `path` in the routing component (cf. https://github.com/symfony/symfony/issues/5989) consistency would be better if the security component did the same.