### PR TITLE
[WebProfilerBundle][Form] The form data collector return serialized data

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -32,7 +32,8 @@
     "conflict": {
         "symfony/dependency-injection": "<3.4",
         "symfony/messenger": "<4.2",
-        "symfony/var-dumper": "<3.4"
+        "symfony/var-dumper": "<3.4",
+        "symfony/form": "<4.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\WebProfilerBundle\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31476 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | not needed <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

This bug occurs because at some point the FormDataCollector was returning serialized data, this has been changed in the upcoming branches but it seems that the bug occurs when using different version of the form component and the WebProfilerBundle.

This bugfix add a conflict param on the WebProfilerBundle to avoid using version of the form component who still serialize the data.
