### PR TITLE
[Dotenv] Prevent empty $_ENV superglobal

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -132,12 +132,16 @@ final class Dotenv
     public function populate(array $values, bool $overrideExistingVars = false): void
     {
         $updateLoadedVars = false;
+        $alwaysSetEnvSuperglobal = (false === strpos(ini_get('variables_order'), 'E')) ? true : false;
         $loadedVars = array_flip(explode(',', $_SERVER['SYMFONY_DOTENV_VARS'] ?? $_ENV['SYMFONY_DOTENV_VARS'] ?? ''));
 
         foreach ($values as $name => $value) {
             $notHttpName = 0 !== strpos($name, 'HTTP_');
             // don't check existence with getenv() because of thread safety issues
             if (!isset($loadedVars[$name]) && (!$overrideExistingVars && (isset($_ENV[$name]) || (isset($_SERVER[$name]) && $notHttpName)))) {
+                if ($alwaysSetEnvSuperglobal) {
+                    $_ENV[$name] = $_SERVER[$name];
+                }
                 continue;
             }
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -306,6 +306,30 @@ class DotenvTest extends TestCase
     }
 
     /**
+     * If ini_get('variables_order') does not contain 'E' then $_ENV is not set.
+     * Nevertheless, $_ENV should be filled with populated variables.
+     */
+    public function testLoadWithMissingEnvSuperglobal()
+    {
+        $preserveEnvSuperglobal = $_ENV;
+        $preserveVariablesOrderSetting = ini_get('variables_order');
+
+        unset($_ENV);
+        ini_set('variables_order', 'GPCS');
+
+        putenv('TEST_ENV_VAR=original_value');
+        $_SERVER['TEST_ENV_VAR'] = 'original_value';
+
+        $dotenv = new Dotenv(true);
+        $dotenv->populate(['TEST_ENV_VAR' => 'new_value']);
+
+        $this->assertSame('original_value', $_ENV['TEST_ENV_VAR']);
+
+        $_ENV = $preserveEnvSuperglobal;
+        ini_set('variables_order', $preserveVariablesOrderSetting);
+    }
+
+    /**
      * @expectedException \Symfony\Component\Dotenv\Exception\PathException
      */
     public function testLoadDirectory()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master, 4.3, 4.2, ..., 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31504
| License       | MIT
| Doc PR        | n/A

Prevent that `$_ENV` is incomplete if `variables_order` does not contain "E".