### PR TITLE
Use the current working dir as default first arg in 'link' binary

### DIFF
--- a/link
+++ b/link
@@ -23,14 +23,12 @@ use Symfony\Component\Filesystem\Filesystem;
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 
-if (2 !== $argc) {
-    echo 'Link dependencies to components to a local clone of the main symfony/symfony GitHub repository.'.PHP_EOL.PHP_EOL;
-    echo "Usage: $argv[0] /path/to/the/project".PHP_EOL;
-    exit(1);
-}
+$pathToProject = $argv[1] ?? getcwd();
 
-if (!is_dir("$argv[1]/vendor/symfony")) {
-    echo "The directory \"$argv[1]\" does not exist or the dependencies are not installed, did you forget to run \"composer install\" in your project?".PHP_EOL;
+if (!is_dir("$pathToProject/vendor/symfony")) {
+    echo 'Link dependencies to components to a local clone of the main symfony/symfony GitHub repository.'.PHP_EOL.PHP_EOL;
+    echo "Usage: $argv[0] /path/to/the/project".PHP_EOL.PHP_EOL;
+    echo "The directory \"$pathToProject\" does not exist or the dependencies are not installed, did you forget to run \"composer install\" in your project?".PHP_EOL;
     exit(1);
 }
 
@@ -48,7 +46,7 @@ foreach ($directories as $dir) {
     }
 }
 
-foreach (glob("$argv[1]/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
+foreach (glob("$pathToProject/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
     $package = 'symfony/'.basename($dir);
     if (is_link($dir)) {
         echo "\"$package\" is already a symlink, skipping.".PHP_EOL;
@@ -66,6 +64,6 @@ foreach (glob("$argv[1]/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) 
     echo "\"$package\" has been linked to \"$sfPackages[$package]\".".PHP_EOL;
 }
 
-foreach (glob("$argv[1]/var/cache/*") as $cacheDir) {
+foreach (glob("$pathToProject/var/cache/*") as $cacheDir) {
     $filesystem->remove($cacheDir);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

I don't know how you work on symfony, but each time I face the same issue

1. I go on lyrixx/symfony (my fork)
1. I execute `pwd` and copy it
1. I go to an application
1. I paste the cwd + add `/link` and hit enter
1. I got an error because I missed the "target"
1. I replay the last command and add ` .`

With this PR, I will save the last 2 items...

Event if it's a "new feature", I targeted 3.4.