### PR TITLE
[PropertyInfo] Add missing documentation link in Readme

### DIFF
--- a/src/Symfony/Component/PropertyInfo/README.md
+++ b/src/Symfony/Component/PropertyInfo/README.md
@@ -7,6 +7,7 @@ of popular sources.
 Resources
 ---------
 
+  * [Documentation](https://symfony.com/doc/current/components/property_info.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | yes   
| Fixed tickets | no
| License       | MIT
| Doc PR        | 

Missing link to Property Info documentation
