### PR TITLE
Add exception as HTML comment to beginning and end of `exception_full.html.twig`

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added HTML comment to beginning and end of `exception_full.html.twig`
+
 4.2.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception_full.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception_full.html.twig
@@ -137,6 +137,14 @@
     {{ exception.message }} ({{ status_code }} {{ status_text }})
 {% endblock %}
 
+{% block before_html %}
+<!-- {{ exception.message }} ({{ status_code }} {{ status_text }}) -->
+{% endblock %}
+
+{% block after_html %}
+<!-- {{ exception.message }} ({{ status_code }} {{ status_text }}) -->
+{% endblock %}
+
 {% block body %}
     {% include '@Twig/Exception/exception.html.twig' %}
 {% endblock %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
@@ -1,3 +1,4 @@
+{% block before_html %}{% endblock %}
 <!DOCTYPE html>
 <html>
     <head>
@@ -34,3 +35,4 @@
         {{ include('@Twig/base_js.html.twig') }}
     </body>
 </html>
+{% block after_html %}{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| License       | MIT

## Description

Every now and then you are confronted with an exception in Symfony's debug mode. Sometimes, you will see this in your browser console or terminal. To make it easier to easily see what's going on, this change adds a HTML comment on 2 locations:
- between the `<html>` and `<head>` tag;
- between the `</body>` and `</html>` tag.

This way, you don't have to scan the very verbose HTML that Symfony generates. You can quickly glance at the end or the beginning.

## How does it look?

```html
<!-- Notice: Undefined index: payouts in /Volumes/CS/www/src/Generated/GraphQL/Query/TransactionList/Data.php line 33 (500 Internal Server Error) -->
<html>
    <head>
        <meta charset="UTF-8">
        <meta name="robots" content="noindex,nofollow">
        <meta name="viewport" content="width=device-width,initial-scale=1">
        <title>    Notice: Undefined index: payouts in /Volumes/CS/www/src/Generated/GraphQL/Query/TransactionList/Data.php line 33 (500 Internal Server Error)
</title>
        <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAgCAYAAAABtRhCAAADVUlEQVRIx82XX0jTURTHLYPyqZdefQx66CEo80+aYpoIkqzUikz6Z5klQoWUWYRIJYEUGpQ+lIr9U5dOTLdCtkmWZis3rbnC5fw/neYW002307mX/cZvP3/7o1PwwOdh95x7vnf39zvnd29AgBer2xO6DclAXiMqZAqxIiNIN/IYSUS2BPhjmGATchUxI+ADWiRhpWK7HKuHFVBFdmU5YvnI4grFGCaReF/EBH4KsZlGgj2JBTuCYBWRIYF8YoEOJ6wBt/gEs7mBbyOjQXruPLSdOgPCiEiPSUUHDoL8Ug5IUo9B/d5wrt+G7OAKNrODPuVdB6vRCIzN6SdBlpW9RIgk/1FeAXabzRlrUPVCS/JhbmwudztnGeeH9AyXBIwtmM3wLinZJZHifjHw2V+NBoRh+9ixQrbgbnaSIcl7cGea6hoXQbNe7za241oeO5Z0p42M4BV2EqP2D50wo+6HzvwC6C4sApNOR8cmOrtcnhtj2kYRyC9eBvXzKrBZrXSs72kFd1t3MoKVbMekQkEnSNKOO8fac3LpmK6l1TlGtsxmsdKFsecPYgwxst0cwROMYDXboSotg0WLBRqjY51jLYcENElXwW2XJKPydvoI2GN9T8rBtrAArYIUruBJXkFheCQYlCpQP6uk5dAQFQNaUROMSGVQFxLmkoQsxDJrhLbTZ+nvVsERME9MgPJRKV/58AsyomTSzE813WLFvWK++qI0xSfQl8k8Pg46sYRuv5t6dS+4RqxDwaa4BGjYH+NTQvKScIp9+YL/hoZh3jDtLRHtt2C3g6bmhX+CpsFBWg7ilDSPgj0lD2ncr5ev/BP8VvyAJhqVyZeUhPOrEhEFxgEtjft846Z/guQTNT89Q5P9flMLoth4F7808wKtWWKzAwNQHxrh/1vaid2F+XpYTSbQf1XA2McOmOpROnvpvMEA4tSjq1cW0sws2gCYxswY6TKkvzYnJq1NHZLnRU4BX+4U0uburvusu8Kv8iHY7qefkM4IFngJHEOUXmLEPgiGsI8YnlZILit3vSSLRTQe/MPIZva5pshNIEmyFQlCvruJKXPkCEfmePzkphXHdzZNQdoRI9KPlBAxlj/I8U97ERPS5bjGbWDFbEdqHVe5caTBeZZx2H/IMvzeN15yoQAAAABJRU5ErkJggg==%0A">
       
       <!-- ... clip ... -->

    Sfjs.addEventListener(document, 'DOMContentLoaded', function() {
        Sfjs.createTabs();
        Sfjs.createToggles();
        Sfjs.createFilters();
    });

/*]]>*/</script>

    </body>
</html>
<!-- Notice: Undefined index: payouts in /Volumes/CS/www/src/Generated/GraphQL/Query/TransactionList/Data.php line 33 (500 Internal Server Error) -->
```


