### PR TITLE
[Form] Add WAI-ARIA attributes to form elements

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
@@ -23,9 +23,17 @@ col-sm-2
 {# Rows #}
 
 {% block form_row -%}
-    {%- set widget_attr = {} -%}
+    {%- set describedby = '' -%}
+    {%- if errors|length > 0 -%}
+        {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+    {%- endif -%}
     {%- if help is not empty -%}
-        {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
+        {%- set describedby = (describedby~" "~id~"_help") | trim -%}
+    {%- endif -%}
+    {%- if describedby is not empty -%}
+        {%- set widget_attr = {attr: {'aria-describedby': describedby}} -%}
+    {%- else -%}
+        {%- set widget_attr = {} -%}
     {%- endif -%}
     <div{% with {attr: row_attr|merge({class: (row_attr.class|default('') ~ ' form-group' ~ ((not compound or force_error|default(false)) and not valid ? ' has-error'))|trim})} %}{{ block('attributes') }}{% endwith %}>
         {{- form_label(form) -}}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -110,7 +110,7 @@
     {%- set widget_attr = {} -%}
     {%- set describedby = '' -%}
     {%- if errors|length > 0 -%}
-        {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+        {%- set describedby = "form-error-"~id -%}
     {%- endif -%}
     {%- if help is not empty -%}
         {%- set describedby = (describedby~" "~id~"_help") | trim -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -165,7 +165,7 @@
 
 {% block form_errors -%}
     {% if errors|length > 0 -%}
-    {% if form is not rootform %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
+    {% if form is not rootform %}<span class="help-block" role="alert">{% else %}<div class="alert alert-danger" role="alert">{% endif %}
     <ul class="list-unstyled">
         {%- for error in errors -%}
             <li><span class="glyphicon glyphicon-exclamation-sign"></span> {{ error.message }}</li>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -108,8 +108,17 @@
 
 {% block form_row -%}
     {%- set widget_attr = {} -%}
+    {%- set describedby = '' -%}
+    {%- if errors|length > 0 -%}
+        {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+    {%- endif -%}
     {%- if help is not empty -%}
-        {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
+        {%- set describedby = (describedby~" "~id~"_help") | trim -%}
+    {%- endif -%}
+    {%- if describedby is not empty -%}
+        {%- set widget_attr = {attr: {'aria-describedby': describedby}} -%}
+    {%- else -%}
+        {%- set widget_attr = {} -%}
     {%- endif -%}
     <div{% with {attr: row_attr|merge({class: (row_attr.class|default('') ~ ' form-group' ~ ((not compound or force_error|default(false)) and not valid ? ' has-error'))|trim})} %}{{ block('attributes') }}{% endwith %}>
         {{- form_label(form) }} {# -#}
@@ -165,7 +174,7 @@
 
 {% block form_errors -%}
     {% if errors|length > 0 -%}
-    {% if form is not rootform %}<span class="help-block" role="alert">{% else %}<div class="alert alert-danger" role="alert">{% endif %}
+    {% if form is not rootform %}<span class="help-block" role="alert" id="form-error-{{ form.vars.id }}">{% else %}<div class="alert alert-danger" role="alert" id="form-error-{{ form.vars.id }}">{% endif %}
     <ul class="list-unstyled">
         {%- for error in errors -%}
             <li><span class="glyphicon glyphicon-exclamation-sign"></span> {{ error.message }}</li>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
@@ -26,7 +26,7 @@ col-sm-2
     {%- else -%}
         {%- set describedby = '' -%}
         {%- if errors|length > 0 -%}
-            {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+            {%- set describedby = "form-error-"~id -%}
         {%- endif -%}
         {%- if help is not empty -%}
             {%- set describedby = (describedby~" "~id~"_help") | trim -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
@@ -24,11 +24,19 @@ col-sm-2
     {%- if expanded is defined and expanded -%}
         {{ block('fieldset_form_row') }}
     {%- else -%}
-    {%- set widget_attr = {} -%}
-    {%- if help is not empty -%}
-        {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
-    {%- endif -%}
-        <div{% with {attr: row_attr|merge({class: (row_attr.class|default('') ~ ' form-group row' ~ ((not compound or force_error|default(false)) and not valid ? ' is-invalid'))|trim})} %}{{ block('attributes') }}{% endwith %}>
+        {%- set describedby = '' -%}
+        {%- if errors|length > 0 -%}
+            {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+        {%- endif -%}
+        {%- if help is not empty -%}
+            {%- set describedby = (describedby~" "~id~"_help") | trim -%}
+        {%- endif -%}
+        {%- if describedby is not empty -%}
+            {%- set widget_attr = {attr: {'aria-describedby': describedby}} -%}
+        {%- else -%}
+            {%- set widget_attr = {} -%}
+        {%- endif -%}
+            <div{% with {attr: row_attr|merge({class: (row_attr.class|default('') ~ ' form-group row' ~ ((not compound or force_error|default(false)) and not valid ? ' is-invalid'))|trim})} %}{{ block('attributes') }}{% endwith %}>
             {{- form_label(form) -}}
             <div class="{{ block('form_group_class') }}">
                 {{- form_widget(form, widget_attr) -}}
@@ -39,9 +47,17 @@ col-sm-2
 {%- endblock form_row %}
 
 {% block fieldset_form_row -%}
-    {%- set widget_attr = {} -%}
+    {%- set describedby = '' -%}
+    {%- if errors|length > 0 -%}
+        {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+    {%- endif -%}
     {%- if help is not empty -%}
-        {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
+        {%- set describedby = (describedby~" "~id~"_help") | trim -%}
+    {%- endif -%}
+    {%- if describedby is not empty -%}
+        {%- set widget_attr = {attr: {'aria-describedby': describedby}} -%}
+    {%- else -%}
+        {%- set widget_attr = {} -%}
     {%- endif -%}
     <fieldset{% with {attr: row_attr|merge({class: (row_attr.class|default('') ~ ' form-group')|trim})} %}{{ block('attributes') }}{% endwith %}>
         <div class="row{% if (not compound or force_error|default(false)) and not valid %} is-invalid{% endif %}">

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -300,7 +300,7 @@
 
 {% block form_errors -%}
     {%- if errors|length > 0 -%}
-        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block">
+        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block" role="alert">
             {%- for error in errors -%}
                 <span class="d-block">
                     <span class="form-error-icon badge badge-danger text-uppercase">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -285,9 +285,17 @@
     {%- if compound is defined and compound -%}
         {%- set element = 'fieldset' -%}
     {%- endif -%}
-    {%- set widget_attr = {} -%}
+    {%- set describedby = '' -%}
+    {%- if errors|length > 0 -%}
+        {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+    {%- endif -%}
     {%- if help is not empty -%}
-        {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
+        {%- set describedby = (describedby~" "~id~"_help") | trim -%}
+    {%- endif -%}
+    {%- if describedby is not empty -%}
+        {%- set widget_attr = {attr: {'aria-describedby': describedby}} -%}
+    {%- else -%}
+        {%- set widget_attr = {} -%}
     {%- endif -%}
     <{{ element|default('div') }}{% with {attr: row_attr|merge({class: (row_attr.class|default('') ~ ' form-group')|trim})} %}{{ block('attributes') }}{% endwith %}>
         {{- form_label(form) -}}
@@ -300,7 +308,7 @@
 
 {% block form_errors -%}
     {%- if errors|length > 0 -%}
-        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block" role="alert">
+        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block" role="alert" id="form-error-{{ form.vars.id }}">
             {%- for error in errors -%}
                 <span class="d-block">
                     <span class="form-error-icon badge badge-danger text-uppercase">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -424,6 +424,9 @@
 {%- endblock form_rows -%}
 
 {%- block widget_attributes -%}
+    {%- if not valid %}
+        {% set attr = {'aria-invalid': 'true'}|merge(attr) %}
+    {% endif -%}
     id="{{ id }}" name="{{ full_name }}"
     {%- if disabled %} disabled="disabled"{% endif -%}
     {%- if required %} required="required"{% endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -385,7 +385,7 @@
 
 {%- block form_errors -%}
     {%- if errors|length > 0 -%}
-    <ul>
+    <ul role="alert">
         {%- for error in errors -%}
             <li>{{ error.message }}</li>
         {%- endfor -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -332,9 +332,17 @@
 {%- endblock repeated_row -%}
 
 {%- block form_row -%}
-    {%- set widget_attr = {} -%}
+    {%- set describedby = '' -%}
+    {%- if errors|length > 0 -%}
+        {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+    {%- endif -%}
     {%- if help is not empty -%}
-        {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
+        {%- set describedby = (describedby~" "~id~"_help") | trim -%}
+    {%- endif -%}
+    {%- if describedby is not empty -%}
+        {%- set widget_attr = {attr: {'aria-describedby': describedby}} -%}
+    {%- else -%}
+        {%- set widget_attr = {} -%}
     {%- endif -%}
     <div{% with {attr: row_attr} %}{{ block('attributes') }}{% endwith %}>
         {{- form_label(form) -}}
@@ -385,7 +393,7 @@
 
 {%- block form_errors -%}
     {%- if errors|length > 0 -%}
-    <ul role="alert">
+    <ul role="alert" id="form-error-{{ id }}">
         {%- for error in errors -%}
             <li>{{ error.message }}</li>
         {%- endfor -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
@@ -1,9 +1,17 @@
 {% use "form_div_layout.html.twig" %}
 
 {%- block form_row -%}
-    {%- set widget_attr = {} -%}
+    {%- set describedby = '' -%}
+    {%- if errors|length > 0 -%}
+        {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+    {%- endif -%}
     {%- if help is not empty -%}
-        {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
+        {%- set describedby = (describedby~" "~id~"_help") | trim -%}
+    {%- endif -%}
+    {%- if describedby is not empty -%}
+        {%- set widget_attr = {attr: {'aria-describedby': describedby}} -%}
+    {%- else -%}
+        {%- set widget_attr = {} -%}
     {%- endif -%}
     <tr{% with {attr: row_attr} %}{{ block('attributes') }}{% endwith %}>
         <td>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -333,7 +333,7 @@
 
 {% block form_errors -%}
     {% if errors|length > 0 -%}
-        {% if form is not rootform %}<small class="error">{% else %}<div data-alert class="alert-box alert">{% endif %}
+        {% if form is not rootform %}<small class="error">{% else %}<div data-alert class="alert-box alert" role="alert">{% endif %}
         {%- for error in errors -%}
             {{ error.message }}
             {% if not loop.last %}, {% endif %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -275,9 +275,17 @@
 {# Rows #}
 
 {% block form_row -%}
-    {%- set widget_attr = {} -%}
+    {%- set describedby = '' -%}
+    {%- if errors|length > 0 -%}
+        {%- set describedby = (describedby~" form-error-"~id) | trim -%}
+    {%- endif -%}
     {%- if help is not empty -%}
-        {%- set widget_attr = {attr: {'aria-describedby': id ~"_help"}} -%}
+        {%- set describedby = (describedby~" "~id~"_help") | trim -%}
+    {%- endif -%}
+    {%- if describedby is not empty -%}
+        {%- set widget_attr = {attr: {'aria-describedby': describedby}} -%}
+    {%- else -%}
+        {%- set widget_attr = {} -%}
     {%- endif -%}
     <div{% with {attr: row_attr|merge({class: (row_attr.class|default('') ~ ' row')|trim})} %}{{ block('attributes') }}{% endwith %}>
         <div class="large-12 columns{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
@@ -333,7 +341,7 @@
 
 {% block form_errors -%}
     {% if errors|length > 0 -%}
-        {% if form is not rootform %}<small class="error">{% else %}<div data-alert class="alert-box alert" role="alert">{% endif %}
+        {% if form is not rootform %}<small class="error" id="form-error-{{ form.vars.id }}">{% else %}<div data-alert class="alert-box alert" role="alert" id="form-error-{{ form.vars.id }}">{% endif %}
         {%- for error in errors -%}
             {{ error.message }}
             {% if not loop.last %}, {% endif %}

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2501,6 +2501,18 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $this->assertMatchesXpath($html, '//input[@aria-invalid="true"]');
     }
 
+    public function testAriaRoleAlertShowsUpWhenFormHasErrors()
+    {
+        // Rather a smoke test - make sure role="alert" shows up *somewhere*, so this is generic enough for all layouts
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form->addError(new FormError('[trans]Error 1[/trans]'));
+        $form->addError(new FormError('[trans]Error 2[/trans]'));
+        $view = $form->createView();
+        $html = $this->renderErrors($view);
+
+        $this->assertMatchesXpath($html, '//*[@role="alert"]');
+    }
+
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2476,6 +2476,31 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value" />', $html);
     }
 
+    public function testAriaInvalidIfGivenIsNotChanged()
+    {
+        $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [
+            'attr' => ['aria-invalid' => 'whatever'],
+        ]);
+
+        $view = $form->createView();
+        $view->vars['valid'] = false;
+        $html = $this->renderWidget($view);
+
+        // compare plain HTML to check the whitespace
+        $this->assertMatchesXpath($html, '//input[@aria-invalid="whatever"]');
+    }
+
+    public function testAriaInvalidAttributeIfFormIsNotValid()
+    {
+        $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value');
+        $view = $form->createView();
+        $view->vars['valid'] = false;
+        $html = $this->renderWidget($view);
+
+        // compare plain HTML to check the whitespace
+        $this->assertMatchesXpath($html, '//input[@aria-invalid="true"]');
+    }
+
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2513,6 +2513,17 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $this->assertMatchesXpath($html, '//*[@role="alert"]');
     }
 
+    public function testAriaDescribedByAlsoContainsIdForErrorMessages()
+    {
+        $form = $this->factory->createNamed('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form->addError(new FormError('[trans]Error 1[/trans]'));
+        $view = $form->createView();
+        $html = $this->renderRow($view);
+
+        $this->assertMatchesXpath($html, '//*[@id="form-error-myfield"]');
+        $this->assertMatchesXpath($html, '//*[@aria-describedby="form-error-myfield"]');
+    }
+
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 


<img src="https://globalaccessibilityawarenessday.org/downloads/gaad-keyboardlogo.jpg" width=100  /> Today (May 16, 2019) is [Global Accessibility Awareness Day](https://globalaccessibilityawarenessday.org/).

So, let's improve the Form layouts and make Symfony Forms more accessible and usable by persons with disabilities!

There's probably a lot more we can do. Feel free to add comments and suggestions for additional markup. 

As far as I know, for some of the attributes and markup the best practice is disputed. Probably we'll have to sort out the ones everyone agrees to.

#gaad #a11y #wcag #bitv 

#### ARIA `@aria-invalid`

* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute
* https://www.w3.org/TR/WCAG20-TECHS/ARIA21.html

#### ARIA `@role="alert"`

* https://www.w3.org/WAI/GL/wiki/Using_ARIA_role_of_alert_for_Error_Feedback_in_Forms
* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role

#### Linking form fields and corresponding error messages via `aria-describedby`

* https://developer.paciellogroup.com/blog/2018/09/describing-aria-describedby/
* https://testen.bitv-test.de/index.php?a=di&iid=103&s=n

/cc @polarbirke