### PR TITLE
[Validator] Add compared value path to violation parameters

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added the `compared_value_path` parameter in violations when using any 
+   comparison constraint with the `propertyPath` option.
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -77,12 +77,17 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
         }
 
         if (!$this->compareValues($value, $comparedValue)) {
-            $this->context->buildViolation($constraint->message)
+            $violationBuilder = $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE))
                 ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE))
                 ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($comparedValue))
-                ->setCode($this->getErrorCode())
-                ->addViolation();
+                ->setCode($this->getErrorCode());
+
+            if (null !== $path) {
+                $violationBuilder->setParameter('{{ compared_value_path }}', $path);
+            }
+
+            $violationBuilder->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -231,6 +231,28 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
             ->assertRaised();
     }
 
+    public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
+    {
+        list($dirtyValue, $dirtyValueAsString, $comparedValue, $comparedValueString, $comparedValueType) = current($this->provideAllInvalidComparisons());
+
+        $constraint = $this->createConstraint(['propertyPath' => 'value']);
+        $constraint->message = 'Constraint Message';
+
+        $object = new ComparisonTest_Class($comparedValue);
+
+        $this->setObject($object);
+
+        $this->validator->validate($dirtyValue, $constraint);
+
+        $this->buildViolation('Constraint Message')
+            ->setParameter('{{ value }}', $dirtyValueAsString)
+            ->setParameter('{{ compared_value }}', $comparedValueString)
+            ->setParameter('{{ compared_value_path }}', 'value')
+            ->setParameter('{{ compared_value_type }}', $comparedValueType)
+            ->setCode($this->getErrorCode())
+            ->assertRaised();
+    }
+
     /**
      * @return array
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -108,4 +108,9 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
     {
         $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
+
+    public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -111,4 +111,9 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
     {
         $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
+
+    public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -111,4 +111,9 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
     {
         $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
+
+    public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -111,4 +111,9 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
     {
         $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
+
+    public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

While it's not really useful to use as a placeholder in the violation message template (compared to hard-coding it into the message. Nor it is really user-friendly),
it becomes handy in conjunction with #29130 for any mapping logic on client-side.