### PR TITLE
[OptionsResolver] Support callable as lazy option default

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added support for callables as lazy options
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -174,8 +174,9 @@ class OptionsResolver implements Options
 
         // If an option is a closure that should be evaluated lazily, store it
         // in the "lazy" property.
-        if ($value instanceof \Closure) {
-            $reflClosure = new \ReflectionFunction($value);
+        if ($value instanceof \Closure || \is_callable($value)) {
+            $closure = $value instanceof \Closure ? $value : \Closure::fromCallable($value);
+            $reflClosure = new \ReflectionFunction($closure);
             $params = $reflClosure->getParameters();
 
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
@@ -190,7 +191,7 @@ class OptionsResolver implements Options
                 }
 
                 // Store closure for later evaluation
-                $this->lazy[$option][] = $value;
+                $this->lazy[$option][] = $closure;
                 $this->defined[$option] = true;
 
                 // Make sure the option is processed and is not nested anymore
@@ -201,7 +202,7 @@ class OptionsResolver implements Options
 
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && self::class === $class->name && (!isset($params[1]) || (null !== ($class = $params[1]->getClass()) && Options::class === $class->name))) {
                 // Store closure for later evaluation
-                $this->nested[$option][] = $value;
+                $this->nested[$option][] = $closure;
                 $this->defaults[$option] = [];
                 $this->defined[$option] = true;
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -121,6 +121,34 @@ class OptionsResolverTest extends TestCase
         $this->assertEquals(['foo' => 'lazy'], $this->resolver->resolve());
     }
 
+    public function testSetLazyFromCallable()
+    {
+        $object = new class() {
+            public function resolve(Options $options): string
+            {
+                return 'lazy';
+            }
+        };
+
+        $this->resolver->setDefault('foo', [$object, 'resolve']);
+
+        $this->assertEquals(['foo' => 'lazy'], $this->resolver->resolve());
+    }
+
+    public function testSetLazyFromCallableObject()
+    {
+        $object = new class() {
+            public function __invoke(Options $options): string
+            {
+                return 'lazy';
+            }
+        };
+
+        $this->resolver->setDefault('foo', $object);
+
+        $this->assertEquals(['foo' => 'lazy'], $this->resolver->resolve());
+    }
+
     public function testClosureWithoutTypeHintNotInvoked()
     {
         $closure = function ($options) {
@@ -141,6 +169,34 @@ class OptionsResolverTest extends TestCase
         $this->resolver->setDefault('foo', $closure);
 
         $this->assertSame(['foo' => $closure], $this->resolver->resolve());
+    }
+
+    public function testCallableWithoutTypeHintNotInvoked()
+    {
+        $object = new class() {
+            public function __invoke($options): void
+            {
+                Assert::fail('Should not be called');
+            }
+        };
+
+        $this->resolver->setDefault('foo', $object);
+
+        $this->assertSame(['foo' => $object], $this->resolver->resolve());
+    }
+
+    public function testCallableWithoutParametersNotInvoked()
+    {
+        $object = new class() {
+            public function __invoke(): void
+            {
+                Assert::fail('Should not be called');
+            }
+        };
+
+        $this->resolver->setDefault('foo', $object);
+
+        $this->assertSame(['foo' => $object], $this->resolver->resolve());
     }
 
     public function testAccessPreviousDefaultValue()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | Todo (complete https://symfony.com/doc/current/components/options_resolver.html#default-values-that-depend-on-another-option)

While I'm not aware of any limitation justifying it, OptionResolvers defaults as lazy value are limited to `\Closure` instances. This PRs adds support for any callable, by creating a `\Closure` instance from it (and keep checking the `Options` typehint is set on first argument):

```php
$object = new class {
    public function resolve(Options $options): string {
        return 'lazy';
    }
};

$this->resolver->setDefault('foo', [$object, 'resolve']);
```