### PR TITLE
[WebProfilerBundle] Show an error message if the <body> tag is not closed

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -141,7 +141,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
             $toolbar = "\n".str_replace("\n", '', $this->twig->render(
                 '@WebProfiler/Profiler/toolbar_error.html.twig',
                 [
-                    'error_message' => 'An error occured while loading the debug toolbar. Did you forget to close the <body> tag?',
+                    'error_message' => 'An error occurred while loading the debug toolbar. Did you forget to close the <body> tag?',
                 ]
             ))."\n";
 

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -131,6 +131,20 @@ class WebDebugToolbarListener implements EventSubscriberInterface
                     'csp_style_nonce' => isset($nonces['csp_style_nonce']) ? $nonces['csp_style_nonce'] : null,
                 ]
             ))."\n";
+
+            $content = substr($content, 0, $pos).$toolbar.substr($content, $pos);
+            $response->setContent($content);
+        } elseif (false !== $pos = strripos($content, '<body>')) {
+            // We want the debug bar to be after the <body> tag, not before.
+            $pos += 6;
+
+            $toolbar = "\n".str_replace("\n", '', $this->twig->render(
+                '@WebProfiler/Profiler/toolbar_error.html.twig',
+                [
+                    'error_message' => 'An error occured while loading the debug toolbar. Did you forget to close the <body> tag?',
+                ]
+            ))."\n";
+
             $content = substr($content, 0, $pos).$toolbar.substr($content, $pos);
             $response->setContent($content);
         }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -433,7 +433,7 @@ div.sf-toolbar .sf-toolbar-block a:hover {
 
 .sf-toolbarreset p.error-message {
     font-size: 1.1em;
-    margin-left: 10px
+    margin-left: 10px;
 }
 
 @media (min-width: 768px) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -431,6 +431,11 @@ div.sf-toolbar .sf-toolbar-block a:hover {
     color: #FFF;
 }
 
+.sf-toolbarreset p.error-message {
+    font-size: 1.1em;
+    margin-left: 10px
+}
+
 @media (min-width: 768px) {
 
     .sf-toolbar-icon .sf-toolbar-label,

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_error.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_error.html.twig
@@ -1,0 +1,6 @@
+<div class="sf-toolbarreset clear-fix" style="display: block">
+    <p class="error-message">{{ error_message }}</p>
+</div>
+<style>
+    {{ include('@WebProfiler/Profiler/toolbar.css.twig') }}
+</style>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -205,6 +205,22 @@ class WebDebugToolbarListenerTest extends TestCase
     /**
      * @depends testToolbarIsInjected
      */
+    public function testErrorToolbarIsInjectedOnHtmlResponseWithoutClosingBodyTag()
+    {
+        $response = new Response('<html><body><div>Some content</div></html>');
+        $response->headers->set('X-Debug-Token', 'xxxxxxxx');
+
+        $event = new ResponseEvent($this->getKernelMock(), $this->getRequestMock(), HttpKernelInterface::MASTER_REQUEST, $response);
+
+        $listener = new WebDebugToolbarListener($this->getTwigMock());
+        $listener->onKernelResponse($event);
+
+        $this->assertEquals("<html><body>\nWDT\n<div>Some content</div></html>", $response->getContent());
+    }
+
+    /**
+     * @depends testToolbarIsInjected
+     */
     public function testToolbarIsNotInjectedOnXmlHttpRequests()
     {
         $response = new Response('<html><head></head><body></body></html>');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | _none_   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | _none_

In some situations, it can happen that the HTML `<body>` tag is not closed, which leads the Web Debug Toolbar to disappear without any explanation, which is quite troubling for inexperienced developers.
In this PR, I propose to show a clear error inviting the developer to fix their DOM.

![A bar at the bottom displaying "An error occurred while loading the debug toolbar. Did you forget to close the <body> tag?"](https://user-images.githubusercontent.com/7600265/57967271-0b4c9b00-795d-11e9-9371-e867ffad2002.png)