### PR TITLE
[Debug] Wrap call to require_once in a try/catch

### DIFF
--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -185,7 +185,11 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
             }
         }
 
-        require_once $file;
+        try {
+            require_once $file;
+        } catch (\Throwable $e) {
+            return null;
+        }
 
         foreach ($candidates as $candidate) {
             if ($this->classExists($candidate)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/monolog-bundle/issues/236
| License       | MIT
| Doc PR        |

If the included file contains an error, it hides the real error. This
makes debugging harder.

How to reproduce:

```
composer create-project symfony/skeleton symfony-3.4 3.4
cd symfony-3.4
composer req monolog
```

Add to `monolog.yaml`:
```yaml
        elasticsearch:
            type: "elasticsearch"
            elasticsearch:
                host: 'elasticsearch'
                port: '9200'
            index: 'ep_php_logs_dev'
            level: 'debug'
            tags: 'monolog.logger'
            channels: ['!event']
```

This will fail because the the `\Elastica\Client` class does not exist.
But this error will be hidden by the `ClassNotFoundFatalErrorHandler`
because it will try to load the `Symfony\Component\Kernel\Client` and
this class extends `Symfony\Component\BrowserKit\Client`. The last one
is a soft dependency...

---

Before
```
Fatal error: Uncaught Error: Class 'Symfony\Component\BrowserKit\Client' not found in /tmp/symfony-3.4/vendor/symfony/http-kernel/Client.php:31
```

After:
```
Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "Client" from namespace "Elastica".
Did you forget a "use" statement for another namespace? in /tmp/symfony-es/var/cache/dev/ContainerWXN4mS9/srcApp_KernelDevDebugContainer.php:303
```

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->