### PR TITLE
[Workflow] use method marking store

### DIFF
--- a/src/Symfony/Component/Workflow/StateMachine.php
+++ b/src/Symfony/Component/Workflow/StateMachine.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Workflow;
 
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
-use Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore;
+use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -22,6 +22,6 @@ class StateMachine extends Workflow
 {
     public function __construct(Definition $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, string $name = 'unnamed')
     {
-        parent::__construct($definition, $markingStore ?: new SingleStateMarkingStore(), $dispatcher, $name);
+        parent::__construct($definition, $markingStore ?: new MethodMarkingStore(true, 'marking'), $dispatcher, $name);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 (related to deprecation of single/multiple marking store)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | .
| License       | MIT
| Doc PR        | already documented

I think the deprecation of old marking store, the single one in the statemachine, was not patched here
Or did i miss something?

Thank you

Cc @lyrixx 