### PR TITLE
[Serializer] Allow nullable constructor args without defaults

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -376,6 +376,8 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
                     unset($data[$key]);
                 } elseif ($constructorParameter->isDefaultValueAvailable()) {
                     $params[] = $constructorParameter->getDefaultValue();
+                } elseif ($constructorParameter->allowsNull()) {
+                    $params[] = null;
                 } else {
                     throw new RuntimeException(sprintf('Cannot create an instance of %s from serialized data because its constructor requires parameter "%s" to be present.', $class, $constructorParameter->name));
                 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NullableConstructorArgumentDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NullableConstructorArgumentDummy.php
@@ -22,7 +22,7 @@ class NullableConstructorArgumentDummy
 
     public function setFoo($foo)
     {
-        $this->foo = 'this setter should not be called when using the constructor argument';
+        throw new \RuntimeException('this setter should not be called when using the constructor argument');
     }
 
     public function getFoo()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -149,4 +149,15 @@ class AbstractNormalizerTest extends TestCase
             $this->assertInstanceOf(Dummy::class, $foo);
         }
     }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testObjectWithNullableConstructorArgumentNotProvided()
+    {
+        $normalizer = new ObjectNormalizer();
+        $dummy = $normalizer->denormalize([], NullableConstructorArgumentDummy::class);
+
+        $this->assertNull($dummy->getFoo());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | N/A

The logic in AbstractNormalizer#instantiateObject allows for parameters that have default values to be null, but does not allow for a nullable parameter to not be provided.

This PR makes a change to the Normalizer that will still handle the case where a constructor argument is nullable but has no default.

