### PR TITLE
[DI] deprecate short callables in yaml

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -1,0 +1,21 @@
+UPGRADE FROM 4.3 to 4.4
+=======================
+
+DependencyInjection
+-------------------
+
+ * Deprecated support for short factories and short configurators in Yaml
+
+   Before:
+   ```yaml
+   services:
+     my_service:
+       factory: factory_service:method
+   ```
+
+   After:
+   ```yaml
+   services:
+     my_service:
+       factory: ['@factory_service', method]
+   ```

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -69,6 +69,22 @@ DependencyInjection
         env(NAME): '1.5'
    ```
 
+ * Removed support for short factories and short configurators in Yaml
+
+   Before:
+   ```yaml
+   services:
+     my_service:
+       factory: factory_service:method
+   ```
+
+   After:
+   ```yaml
+   services:
+     my_service:
+       factory: ['@factory_service', method]
+   ```
+
 DoctrineBridge
 --------------
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * deprecated support for short factories and short configurators in Yaml
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -574,27 +574,28 @@ class YamlFileLoader extends FileLoader
     /**
      * Parses a callable.
      *
-     * @param string|array $callable  A callable
-     * @param string       $parameter A parameter (e.g. 'factory' or 'configurator')
-     * @param string       $id        A service identifier
-     * @param string       $file      A parsed file
+     * @param string|array $callable  A callable reference
+     * @param string       $parameter The type of callable (e.g. 'factory' or 'configurator')
      *
      * @throws InvalidArgumentException When errors occur
      *
      * @return string|array|Reference A parsed callable
      */
-    private function parseCallable($callable, $parameter, $id, $file)
+    private function parseCallable($callable, string $parameter, string $id, string $file)
     {
         if (\is_string($callable)) {
             if ('' !== $callable && '@' === $callable[0]) {
                 if (false === strpos($callable, ':')) {
                     return [$this->resolveServices($callable, $file), '__invoke'];
                 }
-                throw new InvalidArgumentException(sprintf('The value of the "%s" option for the "%s" service must be the id of the service without the "@" prefix (replace "%s" with "%s").', $parameter, $id, $callable, substr($callable, 1)));
+
+                throw new InvalidArgumentException(sprintf('The value of the "%s" option for the "%s" service must be the id of the service without the "@" prefix (replace "%s" with "%s" in "%s").', $parameter, $id, $callable, substr($callable, 1), $file));
             }
 
             if (false !== strpos($callable, ':') && false === strpos($callable, '::')) {
                 $parts = explode(':', $callable);
+
+                @trigger_error(sprintf('Using short %s syntax for service "%s" is deprecated since Symfony 4.4, use "[\'@%s\', \'%s\']" instead.', $parameter, $id, ...$parts), E_USER_DEPRECATED);
 
                 return [$this->resolveServices('@'.$parts[0], $file), $parts[1]];
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -191,6 +191,9 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame($message, $container->getAlias('alias_for_foobar')->getDeprecationMessage('alias_for_foobar'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testLoadFactoryShortSyntax()
     {
         $container = new ContainerBuilder();
@@ -208,10 +211,13 @@ class YamlFileLoaderTest extends TestCase
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value of the "factory" option for the "invalid_factory" service must be the id of the service without the "@" prefix (replace "@factory:method" with "factory:method").');
+        $this->expectExceptionMessage('The value of the "factory" option for the "invalid_factory" service must be the id of the service without the "@" prefix (replace "@factory:method" with "factory:method"');
         $loader->load('bad_factory_syntax.yml');
     }
 
+    /**
+     * @group legacy
+     */
     public function testLoadConfiguratorShortSyntax()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11589

This deprecates defining factories as `foo:method` instead of `['@foo', 'method']` in yaml.

This is confusing syntax and misses the opportunity to raise an error when one does a typo and uses a single colon instead of two.

This basically reverts #19190