### PR TITLE
[Messenger] Fix redis Connection::get() should be non blocking by default

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -31,7 +31,6 @@ class Connection
     private $stream;
     private $group;
     private $consumer;
-    private $blockingTimeout;
     private $couldHavePendingMessages = true;
 
     public function __construct(array $configuration, array $connectionCredentials = [], array $redisOptions = [], \Redis $redis = null)
@@ -42,7 +41,6 @@ class Connection
         $this->stream = $configuration['stream'] ?? '' ?: 'messages';
         $this->group = $configuration['group'] ?? '' ?: 'symfony';
         $this->consumer = $configuration['consumer'] ?? '' ?: 'consumer';
-        $this->blockingTimeout = $redisOptions['blocking_timeout'] ?? null;
     }
 
     public static function fromDsn(string $dsn, array $redisOptions = [], \Redis $redis = null): self
@@ -83,8 +81,7 @@ class Connection
                 $this->group,
                 $this->consumer,
                 [$this->stream => $messageId],
-                1,
-                $this->blockingTimeout
+                1
             );
         } catch (\RedisException $e) {
         }
@@ -142,7 +139,7 @@ class Connection
         }
     }
 
-    public function add(string $body, array $headers)
+    public function add(string $body, array $headers): void
     {
         $e = null;
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

The `\Redis::xreadgroup()` method waits until a message arrives or the specified timeout is reached before returning, which means that `RedisExt\Connection::get()` is blocking.
That's inconsistent with other transports which all returns immediately in case there is no message, for instance the AMQP transport uses `\Amqp::get()` instead of `\Amqp::consume()` for this reason.
It also short-circuits the worker's stop logic: both the `--time-limit` option of the `messenger:consume` command and the `messenger:stop-workers` don't work with the redis transport.
This returns early in case the message count is 0 and no blocking timeout has been configured.