### PR TITLE
[Ldap] Add exception for mapping ldap errors

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Ldap\Adapter\ExtLdap;
 
 use Symfony\Component\Ldap\Adapter\AbstractConnection;
+use Symfony\Component\Ldap\Exception\AlreadyExistsException;
 use Symfony\Component\Ldap\Exception\ConnectionException;
+use Symfony\Component\Ldap\Exception\ConnectionTimeoutException;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
 use Symfony\Component\Ldap\Exception\LdapException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,6 +25,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Connection extends AbstractConnection
 {
+    private const LDAP_INVALID_CREDENTIALS = '0x31';
+    private const LDAP_TIMEOUT = '0x55';
+    private const LDAP_ALREADY_EXISTS = '0x44';
+
     /** @var bool */
     private $bound = false;
 
@@ -51,7 +58,16 @@ class Connection extends AbstractConnection
         }
 
         if (false === @ldap_bind($this->connection, $dn, $password)) {
-            throw new ConnectionException(ldap_error($this->connection));
+            $error = ldap_error($this->connection);
+            switch (ldap_errno($this->connection)) {
+                case self::LDAP_INVALID_CREDENTIALS:
+                    throw new InvalidCredentialsException($error);
+                case self::LDAP_TIMEOUT:
+                    throw new ConnectionTimeoutException($error);
+                case self::LDAP_ALREADY_EXISTS:
+                    throw new AlreadyExistsException($error);
+            }
+            throw new ConnectionException($error);
         }
 
         $this->bound = true;

--- a/src/Symfony/Component/Ldap/Exception/AlreadyExistsException.php
+++ b/src/Symfony/Component/Ldap/Exception/AlreadyExistsException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Exception;
+
+/**
+ * AlreadyExistsException is thrown if the element already exists.
+ *
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+class AlreadyExistsException extends ConnectionException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Ldap/Exception/ConnectionTimeoutException.php
+++ b/src/Symfony/Component/Ldap/Exception/ConnectionTimeoutException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Exception;
+
+/**
+ * ConnectionException is thrown if binding to ldap time out.
+ *
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+class ConnectionTimeoutException extends ConnectionException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Ldap/Exception/InvalidCredentialsException.php
+++ b/src/Symfony/Component/Ldap/Exception/InvalidCredentialsException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Exception;
+
+/**
+ * ConnectionException is thrown if binding to ldap has been done with invalid credentials .
+ *
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+class InvalidCredentialsException extends ConnectionException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Collection;
 use Symfony\Component\Ldap\Adapter\ExtLdap\UpdateOperation;
 use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\AlreadyExistsException;
 use Symfony\Component\Ldap\Exception\LdapException;
 use Symfony\Component\Ldap\Exception\NotBoundException;
 use Symfony\Component\Ldap\Exception\UpdateOperationException;
@@ -72,6 +73,26 @@ class LdapManagerTest extends LdapTestCase
         ]);
 
         $em = $this->adapter->getEntryManager();
+        $em->add($entry);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testLdapAddDouble()
+    {
+        $this->expectException(AlreadyExistsException::class);
+        $this->executeSearchQuery(1);
+
+        $entry = new Entry('cn=Elsa Amrouche,dc=symfony,dc=com', [
+            'sn' => ['eamrouche'],
+            'objectclass' => [
+                'inetOrgPerson',
+            ],
+        ]);
+
+        $em = $this->adapter->getEntryManager();
+        $em->add($entry);
         $em->add($entry);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #28677   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

Maybe we could add more exception code since the list has a lot of errors, maybe we could add a class that maps the error to the right exeptions. see https://www.php.net/manual/en/function.ldap-errno.php