### PR TITLE
[Mailer] adding experimental disclaimer in readme

### DIFF
--- a/src/Symfony/Component/Mailer/README.md
+++ b/src/Symfony/Component/Mailer/README.md
@@ -3,6 +3,11 @@ Mailer Component
 
 The Mailer component helps sending emails.
 
+**This Component is experimental**.
+[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
+are not covered by Symfony's
+[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
+
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Mailer Component is marked as experimental in code, but not in readme.
got confused while checking the readme files of the new components