### PR TITLE
[ProxyManager] isProxyCandidate() does not take into account interfaces

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -47,7 +47,7 @@ class ProxyDumper implements DumperInterface
      */
     public function isProxyCandidate(Definition $definition)
     {
-        return $definition->isLazy() && ($class = $definition->getClass()) && class_exists($class);
+        return $definition->isLazy() && ($class = $definition->getClass()) && (class_exists($class) || interface_exists($class));
     }
 
     /**

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
 
 /**
  * Tests for {@see \Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper}.
@@ -137,6 +138,7 @@ class ProxyDumperTest extends TestCase
         $definitions = [
             [new Definition(__CLASS__), true],
             [new Definition('stdClass'), true],
+            [new Definition(DumperInterface::class), true],
             [new Definition(uniqid('foo', true)), false],
             [new Definition(), false],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | N/A

When using factories it's common best practice to use interface as class name, especially in cases
where you know implementation can differ. Before this fix ProxyManager did not allow these to be lazy.

As we have have this issue on 2.8 and 3.4. it's very hard to debug, and goes against best practice for factories to not fix it, this is suggested for 2.8.
