### PR TITLE
[Ldap] add a test to getResources and binding

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Tests\Adapter\ExtLdap;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Ldap\Adapter\ExtLdap\Connection;
+use Symfony\Component\Ldap\Adapter\ExtLdap\EntryManager;
+use Symfony\Component\Ldap\Entry;
+
+class EntryManagerTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\Ldap\Exception\NotBoundException
+     * @expectedExceptionMessage Query execution is not possible without binding the connection first.
+     */
+    public function testGetResources()
+    {
+        $connection = $this->getMockBuilder(Connection::class)->getMock();
+        $connection
+            ->expects($this->once())
+            ->method('isBound')->willReturn(false);
+
+        $entry = new Entry('$$$$$$');
+        $entryManager = new EntryManager($connection);
+        $entryManager->update($entry);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

We could add more unit tests, but this is a beginning.