### PR TITLE
[Ldap] add a test on parsing the rdn

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
@@ -18,6 +18,22 @@ use Symfony\Component\Ldap\Entry;
 class EntryManagerTest extends TestCase
 {
     /**
+     * @expectedException \Symfony\Component\Ldap\Exception\LdapException
+     * @expectedExceptionMessage Entry "$$$$$$" malformed, could not parse RDN.
+     */
+    public function testMove()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('isBound')->willReturn(true);
+
+        $entry = new Entry('$$$$$$');
+        $entryManager = new EntryManager($connection);
+        $entryManager->move($entry, 'a');
+    }
+
+    /**
      * @expectedException \Symfony\Component\Ldap\Exception\NotBoundException
      * @expectedExceptionMessage Query execution is not possible without binding the connection first.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

One more test on the rdn directly.

- [x] When #31552 has been merged this one needs to be rebased.