### PR TITLE
[SECURITY] AbstractAuthenticationListener.php error instead info. Rebase of #28462

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -176,7 +176,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     private function onFailure(Request $request, AuthenticationException $failed)
     {
         if (null !== $this->logger) {
-            $this->logger->info('Authentication request failed.', ['exception' => $failed]);
+            $this->logger->error('Authentication request failed.', ['exception' => $failed]);
         }
 
         $token = $this->tokenStorage->getToken();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch? | 4.4
| -- | --
| Bug fix? | yes
| New feature? | no
| BC breaks? | no I think
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | ...
| License | MIT

Rebase of #28462. Origin description:
> ```
> [2018-09-13 20:43:38] security.INFO: Authentication request failed. {"exception":"[object] (Symfony\\Component\\Security\\Core\\Exception\\AuthenticationServiceException(code: 0): An exception occurred while executing
>  ...
>  Doctrine\\DBAL\\Driver\\PDOException(code: 42S22): SQLSTATE[42S22]: Column not found: 1054 Unknown column 't0.phone' in 'field list' at
> ```
> 
> Definitely I think this is NOT info, but error.
> And since it's info, it's not logged in production because of `fingers_crossed` with `action_level: error` - so to actually see the real error behind `Authentication request could not be processed due to a system problem.` I had to debug on production. Very bad practice IMHO.
