### PR TITLE
[WebProfilerBundle] Makes it possible to work with the profiler on another vhost

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
@@ -1,5 +1,5 @@
 <div class="sf-toolbar-block sf-toolbar-block-{{ name }} sf-toolbar-status-{{ status|default('normal') }} {{ additional_classes|default('') }}" {{ block_attrs|default('')|raw }}>
-    {% if link is not defined or link %}<a href="{{ path('_profiler', { token: token, panel: name }) }}">{% endif %}
+    {% if link is not defined or link %}<a href="{{ url('_profiler', { token: token, panel: name }) }}">{% endif %}
         <div class="sf-toolbar-icon">{{ icon|default('') }}</div>
     {% if link|default(false) %}</a>{% endif %}
         <div class="sf-toolbar-info">{{ text|default('') }}</div>


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

when the profiler is not on the same vhost than the page we're working on, the profiler links are not working

there's already a few places where the link is an absolute url but the toolbar item are host relative, I think this is the only place where it's missing
