### PR TITLE
[Intl] Prevent infinite loops

### DIFF
--- a/src/Symfony/Component/Intl/Locale.php
+++ b/src/Symfony/Component/Intl/Locale.php
@@ -83,6 +83,10 @@ final class Locale extends \Locale
                 return null;
             }
 
+            if (0 === \count($localSubTags)) {
+                return null;
+            }
+
             array_pop($localeSubTags);
 
             $fallback = locale_compose($localeSubTags);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4.22+
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

It is possible that `locale_parse($locale)` returns an empty array under some circumstances (I can observe this on my machine but I'm not clear on _why_). In this scenario `locale_compose($localeSubTags)` will return `false` instead of the expected `null` (the expected return values are `string|null` with `string` carrying on the locale lookup and `null` breaking it). This results in an infinite loop on my machine at least.