### PR TITLE
[Security] fixed a fatal error when upgrading from 4.2

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -199,7 +199,15 @@ abstract class AbstractToken implements TokenInterface
      */
     public function __unserialize(array $data): void
     {
-        [$this->user, $this->authenticated, $this->roles, $this->attributes, $this->roleNames] = $data;
+        [$this->user, $this->authenticated, $this->roles, $this->attributes] = $data;
+
+        // migration path to 4.3+
+        if (null === $this->roleNames = $data[4] ?? null) {
+            $this->roleNames = [];
+            foreach ($this->roles as $role) {
+                $this->roleNames[] = (string) $role;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This is needed when upgrading a project from 4.2 to 4.3 to avoid a fatal PHP error when unserializing a token serialized on 4.2.
