### PR TITLE
[Process] Fix infinite waiting for stopped process

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -427,6 +427,7 @@ class Process implements \IteratorAggregate
         } while ($running);
 
         while ($this->isRunning()) {
+            $this->checkTimeout();
             usleep(1000);
         }
 

--- a/src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
+++ b/src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+require \dirname(__DIR__).'/vendor/autoload.php';
+
+list('e' => $php) = getopt('e:') + ['e' => 'php'];
+
+try {
+    $process = new Process("exec $php -r \"echo 'ready'; trigger_error('error', E_USER_ERROR);\"");
+    $process->start();
+    $process->setTimeout(0.5);
+    while (false === strpos($process->getOutput(), 'ready')) {
+        usleep(1000);
+    }
+    $process->signal(SIGSTOP);
+    $process->wait();
+
+    return $process->getExitCode();
+} catch (ProcessTimedOutException $t) {
+    echo $t->getMessage().PHP_EOL;
+
+    return 1;
+}

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1551,6 +1551,15 @@ EOTXT;
         $this->assertSame($env, $p->getEnv());
     }
 
+    public function testWaitStoppedDeadProcess()
+    {
+        $process = $this->getProcess(self::$phpBin.' '.__DIR__.'/ErrorProcessInitiator.php -e '.self::$phpBin);
+        $process->start();
+        $process->setTimeout(2);
+        $process->wait();
+        $this->assertFalse($process->isRunning());
+    }
+
     /**
      * @param string      $commandline
      * @param string|null $cwd


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31548
| License       | MIT

### Description
Add a regression test `Symfony\Component\Process\Tests\ProcessTest:testWaitStoppedDeadProcess` to reproduce the related bug #31548 . It consists of one file `ErrorProcessInitiator.php`, which executes as another process because otherwise if `Process::wait()` goes in an infinite loop (which is test checks) it will be impossible to handle it and stop test correctly.

The second commit contains bug fix, which is only `$this->checkTimeout();` call, that prevents infinite loop.
