### PR TITLE
[Workflow] Do not trigger extra guards

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -304,6 +304,45 @@ class WorkflowTest extends TestCase
         $this->assertSame($eventNameExpected, $eventDispatcher->dispatchedEvents);
     }
 
+    public function testApplyDoesNotTriggerExtraGuardWithEventDispatcher()
+    {
+        $transitions[] = new Transition('a-b', 'a', 'b');
+        $transitions[] = new Transition('a-c', 'a', 'c');
+        $definition = new Definition(['a', 'b', 'c'], $transitions);
+
+        $subject = new \stdClass();
+        $subject->marking = null;
+        $eventDispatcher = new EventDispatcherMock();
+        $workflow = new Workflow($definition, new MultipleStateMarkingStore(), $eventDispatcher, 'workflow_name');
+
+        $eventNameExpected = [
+            'workflow.guard',
+            'workflow.workflow_name.guard',
+            'workflow.workflow_name.guard.a-b',
+            'workflow.leave',
+            'workflow.workflow_name.leave',
+            'workflow.workflow_name.leave.a',
+            'workflow.transition',
+            'workflow.workflow_name.transition',
+            'workflow.workflow_name.transition.a-b',
+            'workflow.enter',
+            'workflow.workflow_name.enter',
+            'workflow.workflow_name.enter.b',
+            'workflow.entered',
+            'workflow.workflow_name.entered',
+            'workflow.workflow_name.entered.b',
+            'workflow.completed',
+            'workflow.workflow_name.completed',
+            'workflow.workflow_name.completed.a-b',
+            'workflow.announce',
+            'workflow.workflow_name.announce',
+        ];
+
+        $marking = $workflow->apply($subject, 'a-b');
+
+        $this->assertSame($eventNameExpected, $eventDispatcher->dispatchedEvents);
+    }
+
     public function testEventName()
     {
         $definition = $this->createComplexWorkflowDefinition();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31582
| License       | MIT
| Doc PR        |

---

With this patch, guards are executed only on wanted transitions

**Note for merger**: This is already fixed (in a different manner) in 4.2, So this patch should not be included in 4.2, instead take: #31585 or discard changes of Workflow class but keep tests