### PR TITLE
[HttpClient] display proper error message on TransportException when curl is used

### DIFF
--- a/src/Symfony/Component/HttpClient/Exception/HttpExceptionTrait.php
+++ b/src/Symfony/Component/HttpClient/Exception/HttpExceptionTrait.php
@@ -27,7 +27,7 @@ trait HttpExceptionTrait
         $this->response = $response;
         $code = $response->getInfo('http_code');
         $url = $response->getInfo('url');
-        $message = sprintf('HTTP %d returned for URL "%s".', $code, $url);
+        $message = sprintf('HTTP %d returned for "%s".', $code, $url);
 
         $httpCodeFound = false;
         $isJson = false;
@@ -37,7 +37,7 @@ trait HttpExceptionTrait
                     break;
                 }
 
-                $message = sprintf('%s returned for URL "%s".', $h, $url);
+                $message = sprintf('%s returned for "%s".', $h, $url);
                 $httpCodeFound = true;
             }
 

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -245,7 +245,7 @@ final class CurlResponse implements ResponseInterface
 
             while ($info = curl_multi_info_read($multi->handle)) {
                 $multi->handlesActivity[(int) $info['handle']][] = null;
-                $multi->handlesActivity[(int) $info['handle']][] = \in_array($info['result'], [\CURLE_OK, \CURLE_TOO_MANY_REDIRECTS], true) || (\CURLE_WRITE_ERROR === $info['result'] && 'destruct' === @curl_getinfo($info['handle'], CURLINFO_PRIVATE)) ? null : new TransportException(curl_error($info['handle']));
+                $multi->handlesActivity[(int) $info['handle']][] = \in_array($info['result'], [\CURLE_OK, \CURLE_TOO_MANY_REDIRECTS], true) || (\CURLE_WRITE_ERROR === $info['result'] && 'destruct' === @curl_getinfo($info['handle'], CURLINFO_PRIVATE)) ? null : new TransportException(sprintf('%s for"%s".', curl_strerror($info['result']), curl_getinfo($info['handle'], CURLINFO_EFFECTIVE_URL)));
             }
         } finally {
             self::$performing = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Reported independently by @GawainLynch and @tgalopin:
the message of TransportException is currently empty when using CurlHttpClient.

This now displays e.g.
```
  [Symfony\Component\HttpClient\Exception\TransportException]      
  Couldn't connect to server for http://localhost:8000/index.html  
```