### PR TITLE
[Translation] Fixed issue with new vs old TranslatorInterface in TranslationDataCollector

### DIFF
--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -68,9 +68,9 @@ class DataCollectorTranslator implements LegacyTranslatorInterface, TranslatorIn
     {
         if ($this->translator instanceof TranslatorInterface) {
             $trans = $this->translator->trans($id, ['%count%' => $number] + $parameters, $domain, $locale);
+        } else {
+            $trans = $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
         }
-
-        $trans = $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
 
         $this->collectMessage($locale, $domain, $id, $trans, ['%count%' => $number] + $parameters);
 


### PR DESCRIPTION
I'm not sure when this gets executed, but overriding `$trans` directly after the `if` simply looks wrong.

| Q             | A
| ------------- | ---
| Branch?       | 4.3-beta2, but last change at that position is a couple of months 
| Bug fix?      | yes, me thinks
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Cheers
Matthias