### PR TITLE
[HttpFoundation] Do not set X-Accel-Redirect for paths outside of X-Accel-Mapping

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -223,12 +223,17 @@ class BinaryFileResponse extends Response
                     list($pathPrefix, $location) = $part;
                     if (substr($path, 0, \strlen($pathPrefix)) === $pathPrefix) {
                         $path = $location.substr($path, \strlen($pathPrefix));
+                        // Only set X-Accel-Redirect header if a valid URI can be produced
+                        // as nginx does not serve arbitrary file paths.
+                        $this->headers->set($type, $path);
+                        $this->maxlen = 0;
                         break;
                     }
                 }
+            } else {
+                $this->headers->set($type, $path);
+                $this->maxlen = 0;
             }
-            $this->headers->set($type, $path);
-            $this->maxlen = 0;
         } elseif ($request->headers->has('Range')) {
             // Process the range headers.
             if (!$request->headers->has('If-Range') || $this->hasValidIfRangeHeader($request->headers->get('If-Range'))) {

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -339,6 +339,7 @@ class BinaryFileResponseTest extends ResponseTestCase
             ['/var/www/var/www/files/foo.txt', '/var/www/=/files/', '/files/var/www/files/foo.txt'],
             ['/home/Foo/bar.txt', '/var/www/=/files/,/home/Foo/=/baz/', '/baz/bar.txt'],
             ['/home/Foo/bar.txt', '"/var/www/"="/files/", "/home/Foo/"="/baz/"', '/baz/bar.txt'],
+            ['/tmp/bar.txt', '"/var/www/"="/files/", "/home/Foo/"="/baz/"', null],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Currently `BinaryFileResponse`, when configured with `X-Accel-Redirect` sendfile type, will only substitute file paths specified in `X-Accel-Mapping`. But if the provided file path does not have a defined prefix, then the resulting header will include absolute path. Nginx expects a valid URI, therefore this will result in an issue that is very hard to detect and debug as it will not show up in error logs and instead the request would just hang for some time and will be re-served without query parameters(?).
