### PR TITLE
[Filesystem] fix wrong method call casing

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -572,7 +572,7 @@ class Filesystem
         $targetDirInfo = new \SplFileInfo($targetDir);
 
         foreach ($iterator as $file) {
-            if ($file->getPathName() === $targetDir || $file->getRealPath() === $targetDir || 0 === strpos($file->getRealPath(), $targetDirInfo->getRealPath())) {
+            if ($file->getPathname() === $targetDir || $file->getRealPath() === $targetDir || 0 === strpos($file->getRealPath(), $targetDirInfo->getRealPath())) {
                 continue;
             }
 


### PR DESCRIPTION
fix wrong method call casing for [`SplFileInfo::getPathname()`](https://www.php.net/manual/en/splfileinfo.getpathname.php)


| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

