### PR TITLE
[HttpClient] fix handling exceptions thrown before first mock chunk

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -25,7 +25,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class MockResponse implements ResponseInterface
 {
-    use ResponseTrait;
+    use ResponseTrait {
+        doDestruct as public __destruct;
+    }
 
     private $body;
     private $requestOptions = [];
@@ -162,8 +164,8 @@ class MockResponse implements ResponseInterface
                     $offset = 0;
                     $chunk[1]->getStatusCode();
                     $response->headers = $chunk[1]->getHeaders(false);
-                    $multi->handlesActivity[$id][] = new FirstChunk();
                     self::readResponse($response, $chunk[0], $chunk[1], $offset);
+                    $multi->handlesActivity[$id][] = new FirstChunk();
                 } catch (\Throwable $e) {
                     $multi->handlesActivity[$id][] = null;
                     $multi->handlesActivity[$id][] = $e;

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -115,7 +115,7 @@ class MockHttpClientTest extends HttpClientTestCase
             case 'testResolve':
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);
-                $responses[] = $client->request('GET', 'http://symfony.com:8057/');
+                $responses[] = new MockResponse((function () { throw new \Exception('Fake connection timeout'); yield ''; })(), ['response_headers' => $headers]);
                 break;
 
             case 'testTimeoutOnStream':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Discovered while fixing a 60s timeout on a test case, which this fixes too.