### PR TITLE
Use AsserEquals for floating-point values

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -52,7 +52,8 @@ class JsonResponseTest extends TestCase
         $this->assertSame('0', $response->getContent());
 
         $response = new JsonResponse(0.1);
-        $this->assertSame('0.1', $response->getContent());
+        $this->assertEquals('0.1', $response->getContent());
+        $this->assertInternalType('string', $response->getContent());
 
         $response = new JsonResponse(true);
         $this->assertSame('true', $response->getContent());
@@ -140,7 +141,8 @@ class JsonResponseTest extends TestCase
 
         $response = JsonResponse::create(0.1);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
-        $this->assertSame('0.1', $response->getContent());
+        $this->assertEquals('0.1', $response->getContent());
+        $this->assertInternalType('string', $response->getContent());
 
         $response = JsonResponse::create(true);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);


### PR DESCRIPTION
Use AssertEquals for these two specific case will do a better job,
since it'll convert both '0.1' and result of `getContent()` into PHP's
internal representation of floating-point and compares them and it should be fine.
Using `AssertSame` for this tests brings floating-point serialization
into consideration which of course will be php.ini specific.


Sponsored-by: Platform.sh

| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4, 4.2 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
