### PR TITLE
Routing - Allow optional parameters throughout the route

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherTrait.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherTrait.php
@@ -155,7 +155,7 @@ trait CompiledUrlMatcherTrait
                     }
 
                     foreach ($vars as $i => $v) {
-                        if (isset($matches[1 + $i])) {
+                        if (isset($matches[1 + $i]) && '' !== $matches[1 + $i]) {
                             $ret[$v] = $matches[1 + $i];
                         }
                     }

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -256,7 +256,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     protected function mergeDefaults($params, $defaults)
     {
         foreach ($params as $key => $value) {
-            if (!\is_int($key) && null !== $value) {
+            if (!\is_int($key) && null !== $value && '' !== $value) {
                 $defaults[$key] = $value;
             }
         }

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -207,7 +207,7 @@ class RouteCompiler implements RouteCompilerInterface
                 if ('variable' === $token[0] && !($token[5] ?? false) && $route->hasDefault($token[3])) {
                     $firstOptional = $i;
                 } else {
-                    break;
+                    continue;
                 }
             }
         }
@@ -292,25 +292,21 @@ class RouteCompiler implements RouteCompilerInterface
             return preg_quote($token[1], self::REGEX_DELIMITER);
         } else {
             // Variable tokens
-            if (0 === $index && 0 === $firstOptional) {
-                // When the only token is an optional variable token, the separator is required
-                return sprintf('%s(?P<%s>%s)?', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
-            } else {
-                $regexp = sprintf('%s(?P<%s>%s)', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
-                if ($index >= $firstOptional) {
-                    // Enclose each optional token in a subpattern to make it optional.
-                    // "?:" means it is non-capturing, i.e. the portion of the subject string that
-                    // matched the optional subpattern is not passed back.
-                    $regexp = "(?:$regexp";
-                    $nbTokens = \count($tokens);
-                    if ($nbTokens - 1 == $index) {
-                        // Close the optional subpatterns
-                        $regexp .= str_repeat(')?', $nbTokens - $firstOptional - (0 === $firstOptional ? 1 : 0));
-                    }
+            $regexp = sprintf('%s(?P<%s>%s)', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
+            if ($index >= $firstOptional) {
+                // Enclose each optional token in a subpattern to make it optional.
+                // "?:" means it is non-capturing, i.e. the portion of the subject string that
+                // matched the optional subpattern is not passed back.
+                $regexp = "(?:$regexp";
+                $nbTokens = \count($tokens);
+                if ($nbTokens - 1 == $index || $firstOptional === 0) {
+                    // Close the optional subpatterns
+                    $repeat = $nbTokens - $firstOptional - (0 === $firstOptional ? 1 : 0);
+                    $regexp .= str_repeat(')?', $repeat === 0 ? 1 : $repeat);
                 }
-
-                return $regexp;
             }
+
+            return $regexp;
         }
     }
 

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -276,9 +276,9 @@ class RouteCompiler implements RouteCompilerInterface
     /**
      * Computes the regexp used to match a specific token. It can be static text or a subpattern.
      *
-     * @param array $tokens        The route tokens
-     * @param int   $index         The index of the current token
-     * @param bool  $isOptional    Whether the index is optional or not
+     * @param array $tokens     The route tokens
+     * @param int   $index      The index of the current token
+     * @param bool  $isOptional Whether the index is optional or not
      *
      * @return string The regexp pattern for a single token
      */

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -198,32 +198,22 @@ class RouteCompiler implements RouteCompilerInterface
             $tokens[] = ['text', substr($pattern, $pos)];
         }
 
-        // find the first & rest of the optional tokens
-        $firstOptional = null;
+        // find all of the optional tokens
         $optionalParameters = [];
         if (!$isHost) {
             for ($i = \count($tokens) - 1; $i >= 0; --$i) {
                 $token = $tokens[$i];
                 // variable is optional when it is not important and has a default value
                 if ('variable' === $token[0] && !($token[5] ?? false) && $route->hasDefault($token[3])) {
-                    if (is_null($firstOptional)) {
-                        $firstOptional = $i;
-                    }
-
                     $optionalParameters[] = $i;
                 }
             }
         }
 
-        // If there were no first optionals then set to max
-        if (is_null($firstOptional)) {
-            $firstOptional = PHP_INT_MAX;
-        }
-
         // compute the matching regexp
         $regexp = '';
         for ($i = 0, $nbToken = \count($tokens); $i < $nbToken; ++$i) {
-            $regexp .= self::computeRegexp($tokens, $i, in_array($i, $optionalParameters));
+            $regexp .= self::computeRegexp($tokens, $i, \in_array($i, $optionalParameters));
         }
         $regexp = self::REGEX_DELIMITER.'^'.$regexp.'$'.self::REGEX_DELIMITER.'sD'.($isHost ? 'i' : '');
 
@@ -288,7 +278,7 @@ class RouteCompiler implements RouteCompilerInterface
      *
      * @param array $tokens        The route tokens
      * @param int   $index         The index of the current token
-     * @param bool   $isOptional Whether the index is optional or not
+     * @param bool  $isOptional    Whether the index is optional or not
      *
      * @return string The regexp pattern for a single token
      */
@@ -300,7 +290,7 @@ class RouteCompiler implements RouteCompilerInterface
             return preg_quote($token[1], self::REGEX_DELIMITER);
         } else {
             // Variable tokens
-            if ($index === 0 && $isOptional && \count($tokens) === 1) {
+            if (0 === $index && $isOptional && 1 === \count($tokens)) {
                 // When the only token is an optional variable token, the separator is required
                 return sprintf('%s(?P<%s>%s)?', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
             }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/compiled_url_matcher11.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/compiled_url_matcher11.php
@@ -11,51 +11,51 @@ return [
     ],
     [ // $regexpList
         0 => '{^(?'
-                .'|/(en|fr)/(?'
+                .'|(?:/(en|fr))?/(?'
                     .'|admin/post(?'
-                        .'|(*:32)'
+                        .'|(*:37)'
                         .'|/(?'
-                            .'|new(*:46)'
-                            .'|(\\d+)(*:58)'
-                            .'|(\\d+)/edit(*:75)'
-                            .'|(\\d+)/delete(*:94)'
+                            .'|new(*:51)'
+                            .'|(\\d+)(*:63)'
+                            .'|(\\d+)/edit(*:80)'
+                            .'|(\\d+)/delete(*:99)'
                         .')'
                     .')'
                     .'|blog(?'
-                        .'|(*:110)'
+                        .'|(*:115)'
                         .'|/(?'
-                            .'|rss\\.xml(*:130)'
+                            .'|rss\\.xml(*:135)'
                             .'|p(?'
-                                .'|age/([^/]++)(*:154)'
-                                .'|osts/([^/]++)(*:175)'
+                                .'|age/([^/]++)(*:159)'
+                                .'|osts/([^/]++)(*:180)'
                             .')'
-                            .'|comments/(\\d+)/new(*:202)'
-                            .'|search(*:216)'
+                            .'|comments/(\\d+)/new(*:207)'
+                            .'|search(*:221)'
                         .')'
                     .')'
                     .'|log(?'
-                        .'|in(*:234)'
-                        .'|out(*:245)'
+                        .'|in(*:239)'
+                        .'|out(*:250)'
                     .')'
                 .')'
-                .'|/(en|fr)?(*:264)'
+                .'|/(en|fr)?(*:269)'
             .')/?$}sD',
     ],
     [ // $dynamicRoutes
-        32 => [[['_route' => 'a', '_locale' => 'en'], ['_locale'], null, null, true, false, null]],
-        46 => [[['_route' => 'b', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-        58 => [[['_route' => 'c', '_locale' => 'en'], ['_locale', 'id'], null, null, false, true, null]],
-        75 => [[['_route' => 'd', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
-        94 => [[['_route' => 'e', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
-        110 => [[['_route' => 'f', '_locale' => 'en'], ['_locale'], null, null, true, false, null]],
-        130 => [[['_route' => 'g', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-        154 => [[['_route' => 'h', '_locale' => 'en'], ['_locale', 'page'], null, null, false, true, null]],
-        175 => [[['_route' => 'i', '_locale' => 'en'], ['_locale', 'page'], null, null, false, true, null]],
-        202 => [[['_route' => 'j', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
-        216 => [[['_route' => 'k', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-        234 => [[['_route' => 'l', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-        245 => [[['_route' => 'm', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-        264 => [
+        37 => [[['_route' => 'a', '_locale' => 'en'], ['_locale'], null, null, true, false, null]],
+        51 => [[['_route' => 'b', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+        63 => [[['_route' => 'c', '_locale' => 'en'], ['_locale', 'id'], null, null, false, true, null]],
+        80 => [[['_route' => 'd', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
+        99 => [[['_route' => 'e', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
+        115 => [[['_route' => 'f', '_locale' => 'en'], ['_locale'], null, null, true, false, null]],
+        135 => [[['_route' => 'g', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+        159 => [[['_route' => 'h', '_locale' => 'en'], ['_locale', 'page'], null, null, false, true, null]],
+        180 => [[['_route' => 'i', '_locale' => 'en'], ['_locale', 'page'], null, null, false, true, null]],
+        207 => [[['_route' => 'j', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
+        221 => [[['_route' => 'k', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+        239 => [[['_route' => 'l', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+        250 => [[['_route' => 'm', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+        269 => [
             [['_route' => 'n', '_locale' => 'en'], ['_locale'], null, null, false, true, null],
             [null, null, null, null, false, false, 0],
         ],

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher11.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher11.php
@@ -16,51 +16,51 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $this->context = $context;
         $this->regexpList = [
             0 => '{^(?'
-                    .'|/(en|fr)/(?'
+                    .'|(?:/(en|fr))?/(?'
                         .'|admin/post(?'
-                            .'|(*:32)'
+                            .'|(*:37)'
                             .'|/(?'
-                                .'|new(*:46)'
-                                .'|(\\d+)(*:58)'
-                                .'|(\\d+)/edit(*:75)'
-                                .'|(\\d+)/delete(*:94)'
+                                .'|new(*:51)'
+                                .'|(\\d+)(*:63)'
+                                .'|(\\d+)/edit(*:80)'
+                                .'|(\\d+)/delete(*:99)'
                             .')'
                         .')'
                         .'|blog(?'
-                            .'|(*:110)'
+                            .'|(*:115)'
                             .'|/(?'
-                                .'|rss\\.xml(*:130)'
+                                .'|rss\\.xml(*:135)'
                                 .'|p(?'
-                                    .'|age/([^/]++)(*:154)'
-                                    .'|osts/([^/]++)(*:175)'
+                                    .'|age/([^/]++)(*:159)'
+                                    .'|osts/([^/]++)(*:180)'
                                 .')'
-                                .'|comments/(\\d+)/new(*:202)'
-                                .'|search(*:216)'
+                                .'|comments/(\\d+)/new(*:207)'
+                                .'|search(*:221)'
                             .')'
                         .')'
                         .'|log(?'
-                            .'|in(*:234)'
-                            .'|out(*:245)'
+                            .'|in(*:239)'
+                            .'|out(*:250)'
                         .')'
                     .')'
-                    .'|/(en|fr)?(*:264)'
+                    .'|/(en|fr)?(*:269)'
                 .')/?$}sD',
         ];
         $this->dynamicRoutes = [
-            32 => [[['_route' => 'a', '_locale' => 'en'], ['_locale'], null, null, true, false, null]],
-            46 => [[['_route' => 'b', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-            58 => [[['_route' => 'c', '_locale' => 'en'], ['_locale', 'id'], null, null, false, true, null]],
-            75 => [[['_route' => 'd', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
-            94 => [[['_route' => 'e', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
-            110 => [[['_route' => 'f', '_locale' => 'en'], ['_locale'], null, null, true, false, null]],
-            130 => [[['_route' => 'g', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-            154 => [[['_route' => 'h', '_locale' => 'en'], ['_locale', 'page'], null, null, false, true, null]],
-            175 => [[['_route' => 'i', '_locale' => 'en'], ['_locale', 'page'], null, null, false, true, null]],
-            202 => [[['_route' => 'j', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
-            216 => [[['_route' => 'k', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-            234 => [[['_route' => 'l', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-            245 => [[['_route' => 'm', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
-            264 => [
+            37 => [[['_route' => 'a', '_locale' => 'en'], ['_locale'], null, null, true, false, null]],
+            51 => [[['_route' => 'b', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+            63 => [[['_route' => 'c', '_locale' => 'en'], ['_locale', 'id'], null, null, false, true, null]],
+            80 => [[['_route' => 'd', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
+            99 => [[['_route' => 'e', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
+            115 => [[['_route' => 'f', '_locale' => 'en'], ['_locale'], null, null, true, false, null]],
+            135 => [[['_route' => 'g', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+            159 => [[['_route' => 'h', '_locale' => 'en'], ['_locale', 'page'], null, null, false, true, null]],
+            180 => [[['_route' => 'i', '_locale' => 'en'], ['_locale', 'page'], null, null, false, true, null]],
+            207 => [[['_route' => 'j', '_locale' => 'en'], ['_locale', 'id'], null, null, false, false, null]],
+            221 => [[['_route' => 'k', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+            239 => [[['_route' => 'l', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+            250 => [[['_route' => 'm', '_locale' => 'en'], ['_locale'], null, null, false, false, null]],
+            269 => [
                 [['_route' => 'n', '_locale' => 'en'], ['_locale'], null, null, false, true, null],
                 [null, null, null, null, false, false, 0],
             ],

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -321,8 +321,8 @@ class UrlMatcherTest extends TestCase
         // z and _format are optional.
         $this->assertEquals(['w' => 'wwwww', 'x' => 'x', 'y' => 'y', 'z' => 'default-z', '_format' => 'html', '_route' => 'test'], $matcher->match('/wwwwwxy'));
 
-        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
-        $matcher->match('/wxy.html');
+        // The route compiler allowed multiple optionals within a route
+        $this->assertEquals(['w' => 'w', 'x' => 'x', 'y' => 'y', 'z' => 'default-z', '_format' => 'xml', '_route' => 'test'], $matcher->match('/wxy.xml'));
     }
 
     public function testOptionalVariableWithNoRealSeparator()
@@ -955,7 +955,7 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($coll);
 
-        $this->assertEquals(['_route' => 'b', 'b' => ''], $matcher->match('/en-en/'));
+        $this->assertEquals(['_route' => 'b', 'b' => 'bbb'], $matcher->match('/en-en'));
     }
 
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -74,7 +74,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with several variables that have default values',
                 ['/foo/{bar}/{foobar}', ['bar' => 'bar', 'foobar' => '']],
-                '/foo', '#^/foo(?:/(?P<bar>[^/]++)(?:/(?P<foobar>[^/]++))?)?$#sD', ['bar', 'foobar'], [
+                '/foo', '#^/foo(?:/(?P<bar>[^/]++))?(?:/(?P<foobar>[^/]++))?$#sD', ['bar', 'foobar'], [
                     ['variable', '/', '[^/]++', 'foobar'],
                     ['variable', '/', '[^/]++', 'bar'],
                     ['text', '/foo'],
@@ -84,7 +84,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with several variables but some of them have no default values',
                 ['/foo/{bar}/{foobar}', ['bar' => 'bar']],
-                '/foo', '#^/foo(?:/(?P<bar>[^/]++)(?:/(?P<foobar>[^/]++))?)?$#sD', ['bar', 'foobar'], [
+                '/foo', '#^/foo(?:/(?P<bar>[^/]++))?/(?P<foobar>[^/]++)$#sD', ['bar', 'foobar'], [
                     ['variable', '/', '[^/]++', 'foobar'],
                     ['variable', '/', '[^/]++', 'bar'],
                     ['text', '/foo'],
@@ -94,7 +94,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with an optional variable as the first segment',
                 ['/{bar}', ['bar' => 'bar']],
-                '', '#^(?:/(?P<bar>[^/]++))?$#sD', ['bar'], [
+                '', '#^/(?P<bar>[^/]++)?$#sD', ['bar'], [
                     ['variable', '/', '[^/]++', 'bar'],
                 ],
             ],
@@ -102,7 +102,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with a requirement of 0',
                 ['/{bar}', ['bar' => null], ['bar' => '0']],
-                '', '#^(?:/(?P<bar>0))?$#sD', ['bar'], [
+                '', '#^/(?P<bar>0)?$#sD', ['bar'], [
                     ['variable', '/', '0', 'bar'],
                 ],
             ],
@@ -110,7 +110,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with an optional variable as the first segment with requirements',
                 ['/{bar}', ['bar' => 'bar'], ['bar' => '(foo|bar)']],
-                '', '#^(?:/(?P<bar>(?:foo|bar)))?$#sD', ['bar'], [
+                '', '#^/(?P<bar>(?:foo|bar))?$#sD', ['bar'], [
                     ['variable', '/', '(?:foo|bar)', 'bar'],
                 ],
             ],
@@ -146,7 +146,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route without separator between variables',
                 ['/{w}{x}{y}{z}.{_format}', ['z' => 'default-z', '_format' => 'html'], ['y' => '(y|Y)']],
-                '', '#^/(?P<w>[^/\.]+)(?P<x>[^/\.]+)(?P<y>(?:y|Y))(?:(?P<z>[^/\.]++)(?:\.(?P<_format>[^/]++))?)?$#sD', ['w', 'x', 'y', 'z', '_format'], [
+                '', '#^/(?P<w>[^/\.]+)(?P<x>[^/\.]+)(?P<y>(?:y|Y))(?:(?P<z>[^/\.]++))?(?:\.(?P<_format>[^/]++))?$#sD', ['w', 'x', 'y', 'z', '_format'], [
                     ['variable', '.', '[^/]++', '_format'],
                     ['variable', '', '[^/\.]++', 'z'],
                     ['variable', '', '(?:y|Y)', 'y'],
@@ -176,12 +176,12 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with an explicit UTF-8 requirement',
                 ['/{bar}', ['bar' => null], ['bar' => '.'], ['utf8' => true]],
-                '', '#^(?:/(?P<bar>.))?$#sDu', ['bar'], [
+                '', '#^/(?P<bar>.)?$#sDu', ['bar'], [
                     ['variable', '/', '.', 'bar', true],
                 ],
             ],
 
-            [// $name, $arguments, $prefix, $regex, $variables, $tokens
+            [
                 'Route with an optional variable as the first segment with extra segments',
                 ['/{foo}/bar', ['foo' => 'footest']],
                 '',
@@ -191,7 +191,20 @@ class RouteCompilerTest extends TestCase
                     ['text', '/bar'],
                     ['variable', '/', '[^/]++', 'foo'],
                 ],
-            ]
+            ],
+
+            [
+                'Route with an optional variable as the first segment with extra segments and more placeholder segments',
+                ['/{foo}/bar/{another}', ['foo' => 'footest']],
+                '',
+                '#^(?:/(?P<foo>[^/]++))?/bar/(?P<another>[^/]++)$#sD',
+                ['foo', 'another'],
+                [
+                    ['variable', '/', '[^/]++', 'another'],
+                    ['text', '/bar'],
+                    ['variable', '/', '[^/]++', 'foo'],
+                ],
+            ],
         ];
     }
 

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -84,7 +84,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with several variables but some of them have no default values',
                 ['/foo/{bar}/{foobar}', ['bar' => 'bar']],
-                '/foo', '#^/foo/(?P<bar>[^/]++)/(?P<foobar>[^/]++)$#sD', ['bar', 'foobar'], [
+                '/foo', '#^/foo(?:/(?P<bar>[^/]++)(?:/(?P<foobar>[^/]++))?)?$#sD', ['bar', 'foobar'], [
                     ['variable', '/', '[^/]++', 'foobar'],
                     ['variable', '/', '[^/]++', 'bar'],
                     ['text', '/foo'],
@@ -94,7 +94,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with an optional variable as the first segment',
                 ['/{bar}', ['bar' => 'bar']],
-                '', '#^/(?P<bar>[^/]++)?$#sD', ['bar'], [
+                '', '#^(?:/(?P<bar>[^/]++))?$#sD', ['bar'], [
                     ['variable', '/', '[^/]++', 'bar'],
                 ],
             ],
@@ -102,7 +102,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with a requirement of 0',
                 ['/{bar}', ['bar' => null], ['bar' => '0']],
-                '', '#^/(?P<bar>0)?$#sD', ['bar'], [
+                '', '#^(?:/(?P<bar>0))?$#sD', ['bar'], [
                     ['variable', '/', '0', 'bar'],
                 ],
             ],
@@ -110,7 +110,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with an optional variable as the first segment with requirements',
                 ['/{bar}', ['bar' => 'bar'], ['bar' => '(foo|bar)']],
-                '', '#^/(?P<bar>(?:foo|bar))?$#sD', ['bar'], [
+                '', '#^(?:/(?P<bar>(?:foo|bar)))?$#sD', ['bar'], [
                     ['variable', '/', '(?:foo|bar)', 'bar'],
                 ],
             ],
@@ -118,7 +118,7 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with only optional variables',
                 ['/{foo}/{bar}', ['foo' => 'foo', 'bar' => 'bar']],
-                '', '#^/(?P<foo>[^/]++)?(?:/(?P<bar>[^/]++))?$#sD', ['foo', 'bar'], [
+                '', '#^(?:/(?P<foo>[^/]++))?(?:/(?P<bar>[^/]++))?$#sD', ['foo', 'bar'], [
                     ['variable', '/', '[^/]++', 'bar'],
                     ['variable', '/', '[^/]++', 'foo'],
                 ],
@@ -176,10 +176,22 @@ class RouteCompilerTest extends TestCase
             [
                 'Route with an explicit UTF-8 requirement',
                 ['/{bar}', ['bar' => null], ['bar' => '.'], ['utf8' => true]],
-                '', '#^/(?P<bar>.)?$#sDu', ['bar'], [
+                '', '#^(?:/(?P<bar>.))?$#sDu', ['bar'], [
                     ['variable', '/', '.', 'bar', true],
                 ],
             ],
+
+            [// $name, $arguments, $prefix, $regex, $variables, $tokens
+                'Route with an optional variable as the first segment with extra segments',
+                ['/{foo}/bar', ['foo' => 'footest']],
+                '',
+                '#^(?:/(?P<foo>[^/]++))?/bar$#sD',
+                ['foo'],
+                [
+                    ['text', '/bar'],
+                    ['variable', '/', '[^/]++', 'foo'],
+                ],
+            ]
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes - #31166 
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31166 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11600

Feature request defined #31166 
The purpose of this PR is to allow optional parameters in earlier segments in routes. This would allow for routes such as: `/{locale}/some/route`, where locale is optional to match the following:
- /en/some/route
- /some/route

The use case for the above example is to allow redirecting to a locale specific endpoint from the non locale specific endpoint.

This also allows for routes such as:
- `/{optional}/foo/{nonoptional}`, this would match /foo/anything as well as /something/foo/anything, but not /something/foo
