### PR TITLE
[Console] Provide setter methods for Question text and default value

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added `Question::setQuestion` and `Question::setDefault` to be able to set them directly
+ 
 4.3.0
 -----
 

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -274,4 +274,24 @@ class Question
     {
         return (bool) \count(array_filter(array_keys($array), 'is_string'));
     }
+
+    /**
+     * @return $this
+     */
+    public function setQuestion(string $question): Question
+    {
+        $this->question = $question;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setDefault($default = null): Question
+    {
+        $this->default = $default;
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
@@ -301,4 +301,14 @@ class QuestionTest extends TestCase
     {
         self::assertNull($this->question->getNormalizer());
     }
+
+    public function testSetQuestion()
+    {
+        self::assertSame($this->question->setQuestion('test')->getQuestion(), 'test');
+    }
+
+    public function testSetDefault()
+    {
+        self::assertSame($this->question->setDefault('test')->getDefault(), 'test');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | non
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #23147 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

I've seen the usage that could get of it. 

This is the simple implementation, but maybe we could clone the question, change the value then returning it, it means that you will get a new instance, with all the same config that you have set, but without altering the object ?