### PR TITLE
[Process] `getInput` should return the input setted from `setInput` add `getValidatedInput`

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * deprecated returning a validated input from `Process::getInput()`
+ * added `Process::getValidatedInput()`
+ * added `Process::getOriginalInput()` to be able to get the original input and deprecated in favor or `Process::getInput` in Symfony 5.0
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -55,6 +55,7 @@ class Process implements \IteratorAggregate
     private $cwd;
     private $env;
     private $input;
+    private $originalInput;
     private $starttime;
     private $lastOutputTime;
     private $timeout;
@@ -1175,6 +1176,18 @@ class Process implements \IteratorAggregate
      */
     public function getInput()
     {
+        @trigger_error(sprintf('The %s::getInput will return the given input in Symfony 5.0, use %s::getValidatedInput() instead.', __CLASS__, __CLASS__), E_USER_DEPRECATED);
+
+        return $this->input;
+    }
+
+    public function getOriginalInput()
+    {
+        return $this->originalInput;
+    }
+
+    public function getValidatedInput()
+    {
         return $this->input;
     }
 
@@ -1194,6 +1207,8 @@ class Process implements \IteratorAggregate
         if ($this->isRunning()) {
             throw new LogicException('Input can not be set while the process is running.');
         }
+
+        $this->originalInput = $input;
 
         $this->input = ProcessUtils::validateInput(__METHOD__, $input);
 

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -322,7 +322,26 @@ class ProcessTest extends TestCase
     {
         $process = $this->getProcess('foo');
         $process->setInput($value);
-        $this->assertSame($expected, $process->getInput());
+        $this->assertSame($expected, $process->getValidatedInput());
+    }
+
+    public function testSetAndGetOriginalInput()
+    {
+        $process = $this->getProcess('foo');
+        $process->setInput('test');
+        $this->assertSame('test', $process->getOriginalInput());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\Process\Process::getInput will return the given input in Symfony 5.0, use Symfony\Component\Process\Process::getValidatedInput() instead.
+     */
+    public function testGetInput()
+    {
+        $process = $this->getProcess('foo');
+        $inputStream = new InputStream();
+        $process->setInput($inputStream);
+        $this->assertNotSame($inputStream, $process->getInput());
     }
 
     public function provideInputValues()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #22705  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

I don't know if it's the right way too and deprecate a method directly but I think this is the right call, since we want people to be able to get the information but at the same time the information should be returned from the getInput method directly.
