### PR TITLE
[FrameworkBundle] Inform the user when save_path will be ignored

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -470,6 +470,12 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('session')
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return empty($v['handler_id']) && !empty($v['save_path']);
+                        })
+                        ->thenInvalid('Session save path is ignored without a handler service')
+                    ->end()
                     ->info('session configuration')
                     ->canBeEnabled()
                     ->children()
@@ -498,7 +504,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultTrue()
                             ->setDeprecated('The "%path%.%node%" option is enabled by default and deprecated since Symfony 3.4. It will be always enabled in 4.0.')
                         ->end()
-                        ->scalarNode('save_path')->defaultValue('%kernel.cache_dir%/sessions')->end()
+                        ->scalarNode('save_path')->end()
                         ->integerNode('metadata_update_threshold')
                             ->defaultValue('0')
                             ->info('seconds to wait between 2 session metadata updates')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -873,11 +873,20 @@ class FrameworkExtension extends Extension
 
         // session handler (the internal callback registered with PHP session management)
         if (null === $config['handler_id']) {
+            // If the user set a save_path without using a non-default \SessionHandler, it will silently be ignored
+            if (isset($config['save_path'])) {
+                throw new LogicException('Session save path is ignored without a handler service');
+            }
+
             // Set the handler class to be null
             $container->getDefinition('session.storage.native')->replaceArgument(1, null);
             $container->getDefinition('session.storage.php_bridge')->replaceArgument(0, null);
         } else {
             $container->setAlias('session.handler', $config['handler_id'])->setPrivate(true);
+        }
+
+        if (!isset($config['save_path'])) {
+            $config['save_path'] = ini_get('session.save_path');
         }
 
         $container->setParameter('session.save_path', $config['save_path']);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -378,7 +378,6 @@ class ConfigurationTest extends TestCase
                 'handler_id' => 'session.handler.native_file',
                 'cookie_httponly' => true,
                 'gc_probability' => 1,
-                'save_path' => '%kernel.cache_dir%/sessions',
                 'metadata_update_threshold' => '0',
                 'use_strict_mode' => true,
             ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_savepath.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_savepath.php
@@ -1,0 +1,8 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'session' => [
+        'handler_id' => null,
+        'save_path' => '/some/path',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_savepath.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_savepath.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:session handler-id="null" save-path="/some/path"/>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_savepath.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_savepath.yml
@@ -1,0 +1,4 @@
+framework:
+    session:
+        handler_id: null
+        save_path: /some/path

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -472,6 +473,12 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('session'), '->registerSessionConfiguration() loads session.xml');
         $this->assertNull($container->getDefinition('session.storage.native')->getArgument(1));
         $this->assertNull($container->getDefinition('session.storage.php_bridge')->getArgument(0));
+    }
+
+    public function testNullSessionHandlerWithSavePath()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->createContainerFromFile('session_savepath');
     }
 
     public function testRequest()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  / maybe??
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31611 
| License       | MIT

When a project is created, framework.yaml or config.yml has handler_id set to ~. This uses the native php SessionHandler object which is instantiated with the save_path setting from php.ini or php-fpm.d/www.conf. If you set a save_path, it is silently ignored. When using mod_php for apache or php-fpm running as apache/nginx this is typically not a big deal (except your session files are stored someplace other than you actually wanted). However if using php-fpm and running as a non-standard user for the distro, it will fail silently. Sessions won't be saved because the setting has no effect. This throws a warning in those cases to inform the user.

_It could be a BC because it changes the default configuration however fixes a 'long standing bug' if you will. Not sure what you want to do about that part._