### PR TITLE
[Messenger] Fix missing auto_setup for RedisTransport

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -42,13 +42,13 @@ class ConnectionTest extends TestCase
     public function testFromDsnWithOptions()
     {
         $this->assertEquals(
-            new Connection(['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1'], [
+            new Connection(['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1', 'auto_setup' => false], [
                 'host' => 'localhost',
                 'port' => 6379,
             ], [
                 'serializer' => 2,
             ]),
-            Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['serializer' => 2])
+            Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['serializer' => 2, 'auto_setup' => false])
         );
     }
 
@@ -117,10 +117,6 @@ class ConnectionTest extends TestCase
     {
         $redis = new \Redis();
         $connection = Connection::fromDsn('redis://localhost/messenger-rejectthenget', [], $redis);
-        try {
-            $connection->setup();
-        } catch (TransportException $e) {
-        }
 
         $connection->add('1', []);
         $connection->add('2', []);
@@ -139,10 +135,6 @@ class ConnectionTest extends TestCase
         $redis = new \Redis();
 
         $connection = Connection::fromDsn('redis://localhost/messenger-getnonblocking', [], $redis);
-        try {
-            $connection->setup();
-        } catch (TransportException $e) {
-        }
 
         $this->assertNull($connection->get()); // no message, should return null immediately
         $connection->add('1', []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Should be my last PR for messenger 4.3's Redis transport :)
Not having it makes it inconsistent with other transports and is especially annoying in tests.