### PR TITLE
[HttpFoundation] [WIP] Allow "php://" streams at `BinaryFileResponse`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -350,6 +350,18 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertNull($response->headers->get('Content-Length'));
     }
 
+    public function testSplTempFileObject()
+    {
+        $file = new \SplTempFileObject(-1);
+        $file->fwrite('some content');
+        $file->fflush();
+        $file->rewind();
+
+        $response = new BinaryFileResponse($file);
+
+        $this->assertSame($response->getFile()->getFileInfo()->getPathname(), $file->getFileInfo()->getPathname());
+    }
+
     protected function provideResponse()
     {
         return new BinaryFileResponse(__DIR__.'/../README.md', 200, ['Content-Type' => 'application/octet-stream']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14969
| License       | MIT
| Doc PR        | n/a

See https://bugs.php.net/bug.php?id=78042

Related to #15133, #23785.
