### PR TITLE
[Messenger] Use "real" memory usage to honor --memory-limit

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Receiver/StopWhenMemoryUsageIsExceededReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/StopWhenMemoryUsageIsExceededReceiver.php
@@ -32,7 +32,7 @@ class StopWhenMemoryUsageIsExceededReceiver implements ReceiverInterface
         $this->memoryLimit = $memoryLimit;
         $this->logger = $logger;
         $this->memoryResolver = $memoryResolver ?: function () {
-            return \memory_get_usage();
+            return \memory_get_usage(true);
         };
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/29957
| License       | MIT
| Doc PR        | n/a

At least it's consistent with what other daemon-based libraries do:
https://github.com/php-enqueue/enqueue-dev/blob/master/pkg/enqueue/Consumption/Extension/LimitConsumerMemoryExtension.php#L58
https://github.com/M6Web/DaemonBundle/blob/master/src/M6Web/Bundle/DaemonBundle/Command/DaemonCommand.php#L493