### PR TITLE
Fix the tests that assume 'Europe/Saratov' as invalid timezone

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -123,10 +123,10 @@ class TimezoneTypeTest extends BaseTypeTest
     public function testIntlTimeZoneInputWithBc()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'intltimezone']);
-        $form->submit('Europe/Saratov');
+        $form->submit('Europe/Unknown');
 
         $this->assertNull($form->getData());
-        $this->assertNotContains('Europe/Saratov', $form->getConfig()->getAttribute('choice_list')->getValues());
+        $this->assertNotContains('Europe/Unknown', $form->getConfig()->getAttribute('choice_list')->getValues());
     }
 
     /**
@@ -135,10 +135,10 @@ class TimezoneTypeTest extends BaseTypeTest
     public function testIntlTimeZoneInputWithBcAndIntl()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'intltimezone', 'intl' => true]);
-        $form->submit('Europe/Saratov');
+        $form->submit('Europe/Unknown');
 
         $this->assertNull($form->getData());
-        $this->assertNotContains('Europe/Saratov', $form->getConfig()->getAttribute('choice_list')->getValues());
+        $this->assertNotContains('Europe/Unknown', $form->getConfig()->getAttribute('choice_list')->getValues());
     }
 
     public function testTimezonesAreSelectableWithIntl()

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -321,10 +321,10 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             'intlCompatible' => true,
         ]);
 
-        $this->validator->validate('Europe/Saratov', $constraint);
+        $this->validator->validate('Europe/Unknown', $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ value }}', '"Europe/Saratov"')
+            ->setParameter('{{ value }}', '"Europe/Unknown"')
             ->setCode(Timezone::TIMEZONE_IDENTIFIER_INTL_ERROR)
             ->assertRaised();
     }


### PR DESCRIPTION
Some timezone-related tests assume "Europe/Saratov" as a deprecated timezone.
While this seems to be actually true according to [unicode.org's reference](https://github.com/unicode-org/icu/blob/master/icu4c/source/data/misc/metaZones.txt#L3890) but
PHP [seems](https://www.php.net/manual/en/timezones.europe.php) keeping Saratov and bunch of others as valid locations,
which makes false-failures on Symfony's tests.
This patch fixes those failures.

Sponsored-by: Platform.sh

| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4, 4.2 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
