### PR TITLE
Fix inconsistency in json format regarding DST value

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/IntlCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/IntlCasterTest.php
@@ -240,6 +240,12 @@ EOTXT;
         $expectedTimeType = $var->getTimeType();
         $expectedDateType = $var->getDateType();
 
+        $expectedTimeZone = $var->getTimeZone();
+        $expectedTimeZoneDisplayName = $expectedTimeZone->getDisplayName();
+        $expectedTimeZoneID = $expectedTimeZone->getID();
+        $expectedTimeZoneRawOffset = $expectedTimeZone->getRawOffset();
+        $expectedTimeZoneDSTSavings = $expectedTimeZone->useDaylightTime() ? "\n    dst_savings: ".$expectedTimeZone->getDSTSavings() : '';
+
         $expectedCalendarObject = $var->getCalendarObject();
         $expectedCalendarObjectType = $expectedCalendarObject->getType();
         $expectedCalendarObjectFirstDayOfWeek = $expectedCalendarObject->getFirstDayOfWeek();
@@ -254,13 +260,7 @@ EOTXT;
         $expectedCalendarObjectTimeZoneDisplayName = $expectedCalendarObjectTimeZone->getDisplayName();
         $expectedCalendarObjectTimeZoneID = $expectedCalendarObjectTimeZone->getID();
         $expectedCalendarObjectTimeZoneRawOffset = $expectedCalendarObjectTimeZone->getRawOffset();
-        $expectedCalendarObjectTimeZoneDSTSavings = $expectedCalendarObjectTimeZone->getDSTSavings();
-
-        $expectedTimeZone = $var->getTimeZone();
-        $expectedTimeZoneDisplayName = $expectedTimeZone->getDisplayName();
-        $expectedTimeZoneID = $expectedTimeZone->getID();
-        $expectedTimeZoneRawOffset = $expectedTimeZone->getRawOffset();
-        $expectedTimeZoneDSTSavings = $expectedTimeZone->getDSTSavings();
+        $expectedCalendarObjectTimeZoneDSTSavings = $expectedTimeZone->useDaylightTime() ? "\n      dst_savings: ".$expectedCalendarObjectTimeZone->getDSTSavings() : '';
 
         $expected = <<<EOTXT
 IntlDateFormatter {
@@ -282,15 +282,13 @@ IntlDateFormatter {
     time_zone: IntlTimeZone {
       display_name: "$expectedCalendarObjectTimeZoneDisplayName"
       id: "$expectedCalendarObjectTimeZoneID"
-      raw_offset: $expectedCalendarObjectTimeZoneRawOffset
-      dst_savings: $expectedCalendarObjectTimeZoneDSTSavings
+      raw_offset: $expectedCalendarObjectTimeZoneRawOffset$expectedCalendarObjectTimeZoneDSTSavings
     }
   }
   time_zone: IntlTimeZone {
     display_name: "$expectedTimeZoneDisplayName"
     id: "$expectedTimeZoneID"
-    raw_offset: $expectedTimeZoneRawOffset
-    dst_savings: $expectedTimeZoneDSTSavings
+    raw_offset: $expectedTimeZoneRawOffset$expectedTimeZoneDSTSavings
   }
 }
 EOTXT;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In absence of a known time zone we might or might not have DST.
If DST doesn't exist (eg, server has timezone set on GMT) the current test fails,
Becasue PHP doesn't dump `dst_savings` in the `IntlTimeZone` objects.

This patch takes care of this known point.

Sponsored-by: Platform.sh