### PR TITLE
[HttpClient] make $response->getInfo('debug') return extended logs about the HTTP transaction

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -189,18 +189,24 @@ trait ResponseTrait
      */
     abstract protected static function select(ClientState $multi, float $timeout): int;
 
-    private static function addResponseHeaders(array $responseHeaders, array &$info, array &$headers): void
+    private static function addResponseHeaders(array $responseHeaders, array &$info, array &$headers, string &$debug = ''): void
     {
         foreach ($responseHeaders as $h) {
             if (11 <= \strlen($h) && '/' === $h[4] && preg_match('#^HTTP/\d+(?:\.\d+)? ([12345]\d\d) .*#', $h, $m)) {
-                $headers = [];
+                if ($headers) {
+                    $debug .= "< \r\n";
+                    $headers = [];
+                }
                 $info['http_code'] = (int) $m[1];
             } elseif (2 === \count($m = explode(':', $h, 2))) {
                 $headers[strtolower($m[0])][] = ltrim($m[1]);
             }
 
+            $debug .= "< {$h}\r\n";
             $info['response_headers'][] = $h;
         }
+
+        $debug .= "< \r\n";
 
         if (!$info['http_code']) {
             throw new TransportException('Invalid or missing HTTP status line.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This maps the `CURLOPT_VERBOSE` mode of curl to the `debug` info and emulates it when using `NativeHttpClient`.

For example:
```
* Found bundle for host http2-push.io: 0x56193881ae40 [can multiplex]\n
* Re-using existing connection! (#0) with host http2-push.io\n
* Connected to http2-push.io (216.239.38.21) port 443 (#0)\n
* Using Stream ID: 3 (easy handle 0x5619388fcd50)\n
> GET /css/style.css HTTP/2\r\n
Host: http2-push.io\r\n
User-Agent: Symfony HttpClient/Curl\r\n
Accept-Encoding: deflate, gzip\r\n
\r\n
< HTTP/2 200 \r\n
< date: Mon, 27 May 2019 18:23:23 GMT\r\n
< expires: Mon, 27 May 2019 18:33:23 GMT\r\n
< etag: "0CqJow"\r\n
< x-cloud-trace-context: 543375291bd3b71b67fe389260ad1fbd;o=1\r\n
< content-type: text/css\r\n
< content-encoding: gzip\r\n
< server: Google Frontend\r\n
< content-length: 1805\r\n
< cache-control: public, max-age=600\r\n
< age: 0\r\n
< \r\n
* Connection #0 to host http2-push.io left intact\n
```