### PR TITLE
Read PHPUnit configuration to check for listeners too

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV5.php
@@ -41,7 +41,7 @@ class CommandForV5 extends \PHPUnit_TextUI_Command
                 $configuration = \PHPUnit_Util_Configuration::getInstance($this->arguments['configuration']);
             }
             foreach ($configuration->getListenerConfiguration() as $registeredListener) {
-                if (ltrim($registeredListener['class'], '\\') === ltrim(SymfonyTestsListenerForV5::class, '\\')) {
+                if (ltrim($registeredListener['class'], '\\') === 'Symfony\Bridge\PhpUnit\SymfonyTestsListener') {
                     $registeredLocally = true;
                     break;
                 }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV5.php
@@ -45,7 +45,6 @@ class CommandForV5 extends \PHPUnit_TextUI_Command
                     $registeredLocally = true;
                     break;
                 }
-
             }
         }
 

--- a/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV5.php
@@ -23,8 +23,6 @@ class CommandForV5 extends \PHPUnit_TextUI_Command
      */
     protected function createRunner()
     {
-        $listener = new SymfonyTestsListenerForV5();
-
         $this->arguments['listeners'] = isset($this->arguments['listeners']) ? $this->arguments['listeners'] : array();
 
         $registeredLocally = false;
@@ -37,8 +35,22 @@ class CommandForV5 extends \PHPUnit_TextUI_Command
             }
         }
 
+        if (isset($this->arguments['configuration'])) {
+            $configuration = $this->arguments['configuration'];
+            if (!($configuration instanceof \PHPUnit_Util_Configuration)) {
+                $configuration = \PHPUnit_Util_Configuration::getInstance($this->arguments['configuration']);
+            }
+            foreach ($configuration->getListenerConfiguration() as $registeredListener) {
+                if (ltrim($registeredListener['class'], '\\') === ltrim(SymfonyTestsListenerForV5::class, '\\')) {
+                    $registeredLocally = true;
+                    break;
+                }
+
+            }
+        }
+
         if (!$registeredLocally) {
-            $this->arguments['listeners'][] = $listener;
+            $this->arguments['listeners'][] = new SymfonyTestsListenerForV5();
         }
 
         return parent::createRunner();

--- a/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV6.php
@@ -46,7 +46,7 @@ class CommandForV6 extends BaseCommand
                 $configuration = Configuration::getInstance($this->arguments['configuration']);
             }
             foreach ($configuration->getListenerConfiguration() as $registeredListener) {
-                if (ltrim($registeredListener['class'], '\\') === ltrim(SymfonyTestsListener::class, '\\')) {
+                if (ltrim($registeredListener['class'], '\\') === 'Symfony\Bridge\PhpUnit\SymfonyTestsListener') {
                     $registeredLocally = true;
                     break;
                 }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV6.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\PhpUnit\Legacy;
 
 use PHPUnit\TextUI\Command as BaseCommand;
 use PHPUnit\TextUI\TestRunner as BaseRunner;
+use PHPUnit\Util\Configuration;
 use Symfony\Bridge\PhpUnit\SymfonyTestsListener;
 
 /**
@@ -27,8 +28,6 @@ class CommandForV6 extends BaseCommand
      */
     protected function createRunner(): BaseRunner
     {
-        $listener = new SymfonyTestsListener();
-
         $this->arguments['listeners'] = isset($this->arguments['listeners']) ? $this->arguments['listeners'] : [];
 
         $registeredLocally = false;
@@ -41,8 +40,21 @@ class CommandForV6 extends BaseCommand
             }
         }
 
+        if (isset($this->arguments['configuration'])) {
+            $configuration = $this->arguments['configuration'];
+            if (!($configuration instanceof Configuration)) {
+                $configuration = Configuration::getInstance($this->arguments['configuration']);
+            }
+            foreach ($configuration->getListenerConfiguration() as $registeredListener) {
+                if (ltrim($registeredListener['class'], '\\') === ltrim(SymfonyTestsListener::class, '\\')) {
+                    $registeredLocally = true;
+                    break;
+                }
+            }
+        }
+
         if (!$registeredLocally) {
-            $this->arguments['listeners'][] = $listener;
+            $this->arguments['listeners'][] = new SymfonyTestsListener();
         }
 
         return parent::createRunner();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | todo    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Trying to use simple-phpunit to get around phpunit dependency fun and support many versions of PHP in Drupal. See https://www.drupal.org/project/drupal/issues/303934. We're running into an issue that we register the Symfony event listener in our phpunit.xml file. We need to do this because we wrap your listener and intercept some deprecations. Without this fix the symfony tests listener gets registered twice.