### PR TITLE
Create an abstract HTTP transport and extend it in all HTTP transports

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Http/SesTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Http/SesTransport.php
@@ -13,10 +13,9 @@ namespace Symfony\Component\Mailer\Bridge\Amazon\Http;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mailer\Transport\Http\AbstractHttpTransport;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -24,11 +23,10 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @experimental in 4.3
  */
-class SesTransport extends AbstractTransport
+class SesTransport extends AbstractHttpTransport
 {
     private const ENDPOINT = 'https://email.%region%.amazonaws.com';
 
-    private $client;
     private $accessKey;
     private $secretKey;
     private $region;
@@ -38,12 +36,11 @@ class SesTransport extends AbstractTransport
      */
     public function __construct(string $accessKey, string $secretKey, string $region = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        $this->client = $client ?? HttpClient::create();
         $this->accessKey = $accessKey;
         $this->secretKey = $secretKey;
         $this->region = $region ?: 'eu-west-1';
 
-        parent::__construct($dispatcher, $logger);
+        parent::__construct($client, $dispatcher, $logger);
     }
 
     protected function doSend(SentMessage $message): void

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/MandrillTransport.php
@@ -13,10 +13,9 @@ namespace Symfony\Component\Mailer\Bridge\Mailchimp\Http;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mailer\Transport\Http\AbstractHttpTransport;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -24,18 +23,16 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @experimental in 4.3
  */
-class MandrillTransport extends AbstractTransport
+class MandrillTransport extends AbstractHttpTransport
 {
     private const ENDPOINT = 'https://mandrillapp.com/api/1.0/messages/send-raw.json';
-    private $client;
     private $key;
 
     public function __construct(string $key, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         $this->key = $key;
-        $this->client = $client ?? HttpClient::create();
 
-        parent::__construct($dispatcher, $logger);
+        parent::__construct($client, $dispatcher, $logger);
     }
 
     protected function doSend(SentMessage $message): void

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
@@ -13,10 +13,9 @@ namespace Symfony\Component\Mailer\Bridge\Mailgun\Http;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mailer\Transport\Http\AbstractHttpTransport;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -26,20 +25,18 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @experimental in 4.3
  */
-class MailgunTransport extends AbstractTransport
+class MailgunTransport extends AbstractHttpTransport
 {
     private const ENDPOINT = 'https://api.mailgun.net/v3/%domain%/messages.mime';
     private $key;
     private $domain;
-    private $client;
 
     public function __construct(string $key, string $domain, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         $this->key = $key;
         $this->domain = $domain;
-        $this->client = $client ?? HttpClient::create();
 
-        parent::__construct($dispatcher, $logger);
+        parent::__construct($client, $dispatcher, $logger);
     }
 
     protected function doSend(SentMessage $message): void

--- a/src/Symfony/Component/Mailer/Transport/Http/AbstractHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Http/AbstractHttpTransport.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Transport\Http;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Victor Bocharsky <victor@symfonycasts.com>
+ *
+ * @experimental in 4.3
+ */
+abstract class AbstractHttpTransport extends AbstractTransport
+{
+    protected $client;
+
+    public function __construct(HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    {
+        $this->client = $client;
+        if (null === $client) {
+            if (!class_exists(HttpClient::class)) {
+                throw new \LogicException(sprintf('You cannot use "%s" as the HttpClient component is not installed. Try running "composer require symfony/http-client".', __CLASS__));
+            }
+
+            $this->client = HttpClient::create();
+        }
+
+        parent::__construct($dispatcher, $logger);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

Right now when you try to use an HTTP transport e.g. Mailgun w/o HTTP client installed - the error message is:
> Attempted to load class "HttpClient" from namespace "Symfony\Component\HttpClient".
Did you forget a "use" statement for "Http\Client\HttpClient"?

Not clear enough about what to do. After this PR the error message will be:
> You cannot use "Symfony\Component\Mailer\Bridge\Mailgun\Http\MailgunTransport" as the HttpClient component is not installed. Try running "composer require symfony/http-client".

Actually, we already have a similar check for API:
https://github.com/symfony/symfony/blob/2c9a1960a164a857cd551881b580266bc77bdafa/src/Symfony/Component/Mailer/Transport/Http/Api/AbstractApiTransport.php#L37-L44
