### PR TITLE
Release v4.2.9

### DIFF
--- a/CHANGELOG-4.2.md
+++ b/CHANGELOG-4.2.md
@@ -7,6 +7,35 @@ in 4.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.2.0...v4.2.1
 
+* 4.2.9 (2019-05-28)
+
+ * bug #31584 [Workflow] Do not trigger extra guards (lyrixx)
+ * bug #31632 [Messenger] Use "real" memory usage to honor --memory-limit (chalasr)
+ * bug #31599 [Translation] Fixed issue with new vs old TranslatorInterface in TranslationDataCollector (althaus)
+ * bug #31349 [WebProfilerBundle] Use absolute URL for profiler links (Alumbrados)
+ * bug #31541 [DI] fix using bindings with locators of service subscribers (nicolas-grekas)
+ * bug #31568 [Process] Fix infinite waiting for stopped process (mshavliuk)
+ * bug #31551 [ProxyManager] isProxyCandidate() does not take into account interfaces (andrerom)
+ * bug #31335 [Doctrine] Respect parent class contract in ContainerAwareEventManager (Koc)
+ * bug #31421 [Routing][AnnotationClassLoader] fix utf-8 encoding in default route name (przemyslaw-bogusz)
+ * bug #31510 Use the current working dir as default first arg in 'link' binary (lyrixx)
+ * bug #31524 [HttpFoundation] prevent deprecation when filesize matches error code (xabbuh)
+ * bug #31535 [Debug] Wrap call to require_once in a try/catch (lyrixx)
+ * bug #31477 [PropertyAccess] Add missing property to PropertyAccessor (vudaltsov)
+ * bug #31479 [Cache] fix saving unrelated keys in recursive callback calls (nicolas-grekas)
+ * bug #31438 [Serializer] Fix denormalization of object with variadic constructor typed argument  (ajgarlag)
+ * bug #31445 [Messenger] Making cache rebuild correctly when message subscribers change (weaverryan)
+ * bug #31442 [Validator] Fix finding translator parent definition in compiler pass (deguif)
+ * bug #31475 [HttpFoundation] Allow set 'None' on samesite cookie flag (markitosgv)
+ * bug #31456 Remove deprecated usage of some Twig features (fabpot)
+ * bug #31207 [Routing] Fixed unexpected 404 NoConfigurationException (yceruto)
+ * bug #31261 [Console] Commands with an alias should not be recognized as ambiguous when using register (Simperfit)
+ * bug #31371 [DI] Removes number of elements information in debug mode (jschaedl)
+ * bug #31418 [FrameworkBundle] clarify the possible class/interface of the cache (xabbuh)
+ * bug #31411 [Intl] Fix root fallback locale (ro0NL)
+ * bug #31377 [Console] Fix auto-complete for ChoiceQuestion (multi-select answers) (battye)
+ * bug #31380 [WebProfilerBundle] Don't filter submitted IP values (javiereguiluz)
+
 * 4.2.8 (2019-05-01)
 
  * bug #31338 Revert "bug #30620 [FrameworkBundle][HttpFoundation] make session service resettable (dmaicher)" (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.2.9-DEV';
+    const VERSION = '4.2.9';
     const VERSION_ID = 40209;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 2;
     const RELEASE_VERSION = 9;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2019';
     const END_OF_LIFE = '01/2020';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.2.8...v4.2.9)

 * bug #31584 [Workflow] Do not trigger extra guards (@lyrixx)
 * bug #31632 [Messenger] Use "real" memory usage to honor --memory-limit (@chalasr)
 * bug #31599 [Translation] Fixed issue with new vs old TranslatorInterface in TranslationDataCollector (@althaus)
 * bug #31349 [WebProfilerBundle] Use absolute URL for profiler links (@Alumbrados)
 * bug #31541 [DI] fix using bindings with locators of service subscribers (@nicolas-grekas)
 * bug #31568 [Process] Fix infinite waiting for stopped process (@mshavliuk)
 * bug #31551 [ProxyManager] isProxyCandidate() does not take into account interfaces (@andrerom)
 * bug #31335 [Doctrine] Respect parent class contract in ContainerAwareEventManager (@Koc)
 * bug #31421 [Routing][AnnotationClassLoader] fix utf-8 encoding in default route name (@przemyslaw-bogusz)
 * bug #31510 Use the current working dir as default first arg in 'link' binary (@lyrixx)
 * bug #31524 [HttpFoundation] prevent deprecation when filesize matches error code (@xabbuh)
 * bug #31535 [Debug] Wrap call to require_once in a try/catch (@lyrixx)
 * bug #31477 [PropertyAccess] Add missing property to PropertyAccessor (@vudaltsov)
 * bug #31479 [Cache] fix saving unrelated keys in recursive callback calls (@nicolas-grekas)
 * bug #31438 [Serializer] Fix denormalization of object with variadic constructor typed argument  (@ajgarlag)
 * bug #31445 [Messenger] Making cache rebuild correctly when message subscribers change (@weaverryan)
 * bug #31442 [Validator] Fix finding translator parent definition in compiler pass (@deguif)
 * bug #31475 [HttpFoundation] Allow set 'None' on samesite cookie flag (@markitosgv)
 * bug #31456 Remove deprecated usage of some Twig features (@fabpot)
 * bug #31207 [Routing] Fixed unexpected 404 NoConfigurationException (@yceruto)
 * bug #31261 [Console] Commands with an alias should not be recognized as ambiguous when using register (@Simperfit)
 * bug #31371 [DI] Removes number of elements information in debug mode (@jschaedl)
 * bug #31418 [FrameworkBundle] clarify the possible class/interface of the cache (@xabbuh)
 * bug #31411 [Intl] Fix root fallback locale (@ro0NL)
 * bug #31377 [Console] Fix auto-complete for ChoiceQuestion (multi-select answers) (@battye)
 * bug #31380 [WebProfilerBundle] Don't filter submitted IP values (@javiereguiluz)
