### PR TITLE
[Intl] allow lowercase country code `forCountryCode`

### DIFF
--- a/src/Symfony/Component/Intl/CHANGELOG.md
+++ b/src/Symfony/Component/Intl/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * added `Timezones`
  * made country codes ISO 3166 compliant
  * excluded script code `Zzzz`
+ * allow lowercase country code `forCountryCode`
 
 4.2.0
 -----

--- a/src/Symfony/Component/Intl/Tests/TimezonesTest.php
+++ b/src/Symfony/Component/Intl/Tests/TimezonesTest.php
@@ -592,6 +592,7 @@ class TimezonesTest extends ResourceBundleTestCase
     public function testForCountryCode()
     {
         $this->assertSame(['Europe/Amsterdam'], Timezones::forCountryCode('NL'));
+        $this->assertSame(['Europe/Paris'], Timezones::forCountryCode('fr'));
         $this->assertSame(['Europe/Berlin', 'Europe/Busingen'], Timezones::forCountryCode('DE'));
     }
 

--- a/src/Symfony/Component/Intl/Timezones.php
+++ b/src/Symfony/Component/Intl/Timezones.php
@@ -103,7 +103,7 @@ final class Timezones extends ResourceBundle
     public static function forCountryCode(string $country): array
     {
         try {
-            return self::readEntry(['CountryToZone', $country], 'meta');
+            return self::readEntry(['CountryToZone', \strtoupper($country)], 'meta');
         } catch (MissingResourceException $e) {
             if (Countries::exists($country)) {
                 return [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31656 
| License       | MIT
| Doc PR        | 

Allow `Timezones::forCountryCode()` to be used with lowercase country code.
