### PR TITLE
[TwigBundle] Remove default value deprecation for twig.strict_variables option

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -128,13 +128,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('cache')->defaultValue('%kernel.cache_dir%/twig')->end()
                 ->scalarNode('charset')->defaultValue('%kernel.charset%')->end()
                 ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
-                ->booleanNode('strict_variables')
-                    ->defaultValue(function () {
-                        @trigger_error('Relying on the default value ("false") of the "twig.strict_variables" configuration option is deprecated since Symfony 4.1. You should use "%kernel.debug%" explicitly instead, which will be the new default in 5.0.', E_USER_DEPRECATED);
-
-                        return false;
-                    })
-                ->end()
+                ->booleanNode('strict_variables')->defaultValue('%kernel.debug%')->end()
                 ->scalarNode('auto_reload')->end()
                 ->integerNode('optimizations')->min(-1)->end()
                 ->scalarNode('default_path')

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -20,7 +20,6 @@ class ConfigurationTest extends TestCase
     public function testDoNoDuplicateDefaultFormResources()
     {
         $input = [
-            'strict_variables' => false, // to be removed in 5.0 relying on default
             'form_themes' => ['form_div_layout.html.twig'],
         ];
 
@@ -30,22 +29,9 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(['form_div_layout.html.twig'], $config['form_themes']);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Relying on the default value ("false") of the "twig.strict_variables" configuration option is deprecated since Symfony 4.1. You should use "%kernel.debug%" explicitly instead, which will be the new default in 5.0.
-     */
-    public function testGetStrictVariablesDefaultFalse()
-    {
-        $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), [[]]);
-
-        $this->assertFalse($config['strict_variables']);
-    }
-
     public function testGlobalsAreNotNormalized()
     {
         $input = [
-            'strict_variables' => false, // to be removed in 5.0 relying on default
             'globals' => ['some-global' => true],
         ];
 
@@ -58,7 +44,6 @@ class ConfigurationTest extends TestCase
     public function testArrayKeysInGlobalsAreNotNormalized()
     {
         $input = [
-            'strict_variables' => false, // to be removed in 5.0 relying on default
             'globals' => ['global' => ['some-key' => 'some-value']],
         ];
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/customTemplateEscapingGuesser.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/customTemplateEscapingGuesser.php
@@ -3,5 +3,4 @@
 $container->loadFromExtension('twig', [
     'autoescape_service' => 'my_project.some_bundle.template_escaping_guesser',
     'autoescape_service_method' => 'guess',
-    'strict_variables' => false, // to be removed in 5.0 relying on default
 ]);

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/empty.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/empty.php
@@ -1,5 +1,3 @@
 <?php
 
-$container->loadFromExtension('twig', [
-    'strict_variables' => false, // to be removed in 5.0 relying on default
-]);
+$container->loadFromExtension('twig');

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/extra.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/extra.php
@@ -4,5 +4,4 @@ $container->loadFromExtension('twig', [
     'paths' => [
         'namespaced_path3' => 'namespace3',
     ],
-    'strict_variables' => false, // to be removed in 5.0 relying on default
 ]);

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/formats.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/formats.php
@@ -11,5 +11,4 @@ $container->loadFromExtension('twig', [
         'decimal_point' => ',',
         'thousands_separator' => '.',
     ],
-    'strict_variables' => false, // to be removed in 5.0 relying on default
 ]);

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/customTemplateEscapingGuesser.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/customTemplateEscapingGuesser.xml
@@ -6,5 +6,5 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/twig https://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config autoescape-service="my_project.some_bundle.template_escaping_guesser" autoescape-service-method="guess" strict-variables="false" />
+    <twig:config autoescape-service="my_project.some_bundle.template_escaping_guesser" autoescape-service-method="guess" />
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/empty.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/empty.xml
@@ -6,5 +6,5 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/twig https://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config strict-variables="false" />
+    <twig:config />
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/formats.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/formats.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/twig https://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config strict-variables="false">
+    <twig:config>
         <twig:date format="Y-m-d" interval-format="%d" timezone="Europe/Berlin" />
         <twig:number-format decimals="2" decimal-point="," thousands-separator="." />
     </twig:config>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/customTemplateEscapingGuesser.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/customTemplateEscapingGuesser.yml
@@ -1,4 +1,3 @@
 twig:
     autoescape_service: my_project.some_bundle.template_escaping_guesser
     autoescape_service_method: guess
-    strict_variables: false # to be removed in 5.0 relying on default

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/empty.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/empty.yml
@@ -1,2 +1,1 @@
 twig:
-    strict_variables: false # to be removed in 5.0 relying on default

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/extra.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/extra.yml
@@ -1,4 +1,3 @@
 twig:
-    strict_variables: false # to be removed in 5.0 relying on default
     paths:
         namespaced_path3: namespace3

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/formats.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/formats.yml
@@ -1,5 +1,4 @@
 twig:
-    strict_variables: false # to be removed in 5.0 relying on default
     date:
         format: Y-m-d
         interval_format: '%d'

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -29,9 +29,7 @@ class TwigExtensionTest extends TestCase
     {
         $container = $this->createContainer();
         $container->registerExtension(new TwigExtension());
-        $container->loadFromExtension('twig', [
-            'strict_variables' => false, // to be removed in 5.0 relying on default
-        ]);
+        $container->loadFromExtension('twig');
         $this->compileContainer($container);
 
         $this->assertEquals('Twig\Environment', $container->getDefinition('twig')->getClass(), '->load() loads the twig.xml file');
@@ -155,7 +153,6 @@ class TwigExtensionTest extends TestCase
         $container->registerExtension(new TwigExtension());
         $container->loadFromExtension('twig', [
             'globals' => $globals,
-            'strict_variables' => false, // // to be removed in 5.0 relying on default
         ]);
         $this->compileContainer($container);
 
@@ -257,9 +254,7 @@ class TwigExtensionTest extends TestCase
             $container->register('debug.stopwatch', 'Symfony\Component\Stopwatch\Stopwatch');
         }
         $container->registerExtension(new TwigExtension());
-        $container->loadFromExtension('twig', [
-            'strict_variables' => false, // to be removed in 5.0 relying on default
-        ]);
+        $container->loadFromExtension('twig');
         $container->setAlias('test.twig.extension.debug.stopwatch', 'twig.extension.debug.stopwatch')->setPublic(true);
         $this->compileContainer($container);
 
@@ -287,9 +282,7 @@ class TwigExtensionTest extends TestCase
     {
         $container = $this->createContainer();
         $container->registerExtension(new TwigExtension());
-        $container->loadFromExtension('twig', [
-            'strict_variables' => false, // to be removed in 5.0 relying on default
-        ]);
+        $container->loadFromExtension('twig');
         $container->setParameter('kernel.environment', 'test');
         $container->setParameter('debug.file_link_format', 'test');
         $container->setParameter('foo', 'FooClass');

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
@@ -97,9 +97,6 @@ class CacheWarmingKernel extends Kernel
                     'secret' => '$ecret',
                     'form' => ['enabled' => false],
                 ])
-                ->loadFromExtension('twig', [ // to be removed in 5.0 relying on default
-                    'strict_variables' => false,
-                ])
             ;
         });
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
@@ -37,13 +37,6 @@ class EmptyAppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(function ($container) {
-            $container
-                ->loadFromExtension('twig', [ // to be removed in 5.0 relying on default
-                    'strict_variables' => false,
-                ])
-            ;
-        });
     }
 
     public function getCacheDir()

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -67,7 +67,6 @@ class NoTemplatingEntryKernel extends Kernel
                     'form' => ['enabled' => false],
                 ])
                 ->loadFromExtension('twig', [
-                    'strict_variables' => false, // to be removed in 5.0 relying on default
                     'default_path' => __DIR__.'/templates',
                 ])
             ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

See previous PR in 4.1 https://github.com/symfony/symfony/pull/25780
