### PR TITLE
[Form] Remove deprecated implementation of ChoiceLoaderInterface in intl forms

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -12,28 +12,13 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
-use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CountryType extends AbstractType implements ChoiceLoaderInterface
+class CountryType extends AbstractType
 {
-    /**
-     * Country loaded choice list.
-     *
-     * The choices are lazy loaded and generated from the Intl component.
-     *
-     * {@link \Symfony\Component\Intl\Intl::getRegionBundle()}.
-     *
-     * @var ArrayChoiceList
-     *
-     * @deprecated since Symfony 4.1
-     */
-    private $choiceList;
-
     /**
      * {@inheritdoc}
      */
@@ -68,62 +53,5 @@ class CountryType extends AbstractType implements ChoiceLoaderInterface
     public function getBlockPrefix()
     {
         return 'country';
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadChoiceList($value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        if (null !== $this->choiceList) {
-            return $this->choiceList;
-        }
-
-        return $this->choiceList = new ArrayChoiceList(array_flip(Countries::getNames()), $value);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadChoicesForValues(array $values, $value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        // Optimize
-        $values = array_filter($values);
-        if (empty($values)) {
-            return [];
-        }
-
-        return $this->loadChoiceList($value)->getChoicesForValues($values);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadValuesForChoices(array $choices, $value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        // Optimize
-        $choices = array_filter($choices);
-        if (empty($choices)) {
-            return [];
-        }
-
-        // If no callable is set, choices are the same as values
-        if (null === $value) {
-            return $choices;
-        }
-
-        return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -12,28 +12,13 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
-use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
 use Symfony\Component\Intl\Currencies;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CurrencyType extends AbstractType implements ChoiceLoaderInterface
+class CurrencyType extends AbstractType
 {
-    /**
-     * Currency loaded choice list.
-     *
-     * The choices are lazy loaded and generated from the Intl component.
-     *
-     * {@link \Symfony\Component\Intl\Intl::getCurrencyBundle()}.
-     *
-     * @var ArrayChoiceList
-     *
-     * @deprecated since Symfony 4.1
-     */
-    private $choiceList;
-
     /**
      * {@inheritdoc}
      */
@@ -68,62 +53,5 @@ class CurrencyType extends AbstractType implements ChoiceLoaderInterface
     public function getBlockPrefix()
     {
         return 'currency';
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadChoiceList($value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        if (null !== $this->choiceList) {
-            return $this->choiceList;
-        }
-
-        return $this->choiceList = new ArrayChoiceList(array_flip(Currencies::getNames()), $value);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadChoicesForValues(array $values, $value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        // Optimize
-        $values = array_filter($values);
-        if (empty($values)) {
-            return [];
-        }
-
-        return $this->loadChoiceList($value)->getChoicesForValues($values);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadValuesForChoices(array $choices, $value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        // Optimize
-        $choices = array_filter($choices);
-        if (empty($choices)) {
-            return [];
-        }
-
-        // If no callable is set, choices are the same as values
-        if (null === $value) {
-            return $choices;
-        }
-
-        return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -12,28 +12,13 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
-use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
 use Symfony\Component\Intl\Languages;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class LanguageType extends AbstractType implements ChoiceLoaderInterface
+class LanguageType extends AbstractType
 {
-    /**
-     * Language loaded choice list.
-     *
-     * The choices are lazy loaded and generated from the Intl component.
-     *
-     * {@link \Symfony\Component\Intl\Intl::getLanguageBundle()}.
-     *
-     * @var ArrayChoiceList
-     *
-     * @deprecated since Symfony 4.1
-     */
-    private $choiceList;
-
     /**
      * {@inheritdoc}
      */
@@ -68,62 +53,5 @@ class LanguageType extends AbstractType implements ChoiceLoaderInterface
     public function getBlockPrefix()
     {
         return 'language';
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadChoiceList($value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        if (null !== $this->choiceList) {
-            return $this->choiceList;
-        }
-
-        return $this->choiceList = new ArrayChoiceList(array_flip(Languages::getNames()), $value);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadChoicesForValues(array $values, $value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        // Optimize
-        $values = array_filter($values);
-        if (empty($values)) {
-            return [];
-        }
-
-        return $this->loadChoiceList($value)->getChoicesForValues($values);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadValuesForChoices(array $choices, $value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        // Optimize
-        $choices = array_filter($choices);
-        if (empty($choices)) {
-            return [];
-        }
-
-        // If no callable is set, choices are the same as values
-        if (null === $value) {
-            return $choices;
-        }
-
-        return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
@@ -12,28 +12,13 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
-use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class LocaleType extends AbstractType implements ChoiceLoaderInterface
+class LocaleType extends AbstractType
 {
-    /**
-     * Locale loaded choice list.
-     *
-     * The choices are lazy loaded and generated from the Intl component.
-     *
-     * {@link \Symfony\Component\Intl\Intl::getLocaleBundle()}.
-     *
-     * @var ArrayChoiceList
-     *
-     * @deprecated since Symfony 4.1
-     */
-    private $choiceList;
-
     /**
      * {@inheritdoc}
      */
@@ -68,62 +53,5 @@ class LocaleType extends AbstractType implements ChoiceLoaderInterface
     public function getBlockPrefix()
     {
         return 'locale';
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadChoiceList($value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        if (null !== $this->choiceList) {
-            return $this->choiceList;
-        }
-
-        return $this->choiceList = new ArrayChoiceList(array_flip(Locales::getNames()), $value);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadChoicesForValues(array $values, $value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        // Optimize
-        $values = array_filter($values);
-        if (empty($values)) {
-            return [];
-        }
-
-        return $this->loadChoiceList($value)->getChoicesForValues($values);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since Symfony 4.1
-     */
-    public function loadValuesForChoices(array $choices, $value = null)
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.1, use the "choice_loader" option instead.', __METHOD__), E_USER_DEPRECATED);
-
-        // Optimize
-        $choices = array_filter($choices);
-        if (empty($choices)) {
-            return [];
-        }
-
-        // If no callable is set, choices are the same as values
-        if (null === $value) {
-            return $choices;
-        }
-
-        return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
-use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class CountryTypeTest extends BaseTypeTest
@@ -80,15 +79,5 @@ class CountryTypeTest extends BaseTypeTest
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'FR', $expectedData = 'FR')
     {
         parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testInvalidChoiceValuesAreDropped()
-    {
-        $type = new CountryType();
-
-        $this->assertSame([], $type->loadChoicesForValues(['foo']));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
-use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class CurrencyTypeTest extends BaseTypeTest
@@ -61,15 +60,5 @@ class CurrencyTypeTest extends BaseTypeTest
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'EUR', $expectedData = 'EUR')
     {
         parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testInvalidChoiceValuesAreDropped()
-    {
-        $type = new CurrencyType();
-
-        $this->assertSame([], $type->loadChoicesForValues(['foo']));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
-use Symfony\Component\Form\Extension\Core\Type\LanguageType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class LanguageTypeTest extends BaseTypeTest
@@ -72,15 +71,5 @@ class LanguageTypeTest extends BaseTypeTest
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'en', $expectedData = 'en')
     {
         parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testInvalidChoiceValuesAreDropped()
-    {
-        $type = new LanguageType();
-
-        $this->assertSame([], $type->loadChoicesForValues(['foo']));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
-use Symfony\Component\Form\Extension\Core\Type\LocaleType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class LocaleTypeTest extends BaseTypeTest
@@ -61,15 +60,5 @@ class LocaleTypeTest extends BaseTypeTest
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'en', $expectedData = 'en')
     {
         parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testInvalidChoiceValuesAreDropped()
-    {
-        $type = new LocaleType();
-
-        $this->assertSame([], $type->loadChoicesForValues(['foo']));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

See previous PR https://github.com/symfony/symfony/pull/26825 (4.1)
