### PR TITLE
[Intl] Improve the error message when country code is wrong

### DIFF
--- a/src/Symfony/Component/Intl/Tests/TimezonesTest.php
+++ b/src/Symfony/Component/Intl/Tests/TimezonesTest.php
@@ -605,6 +605,15 @@ class TimezonesTest extends ResourceBundleTestCase
 
     /**
      * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
+     * @expectedExceptionMessage Country codes must be in uppercase, but "nl" was passed. Try with "NL" country code instead.
+     */
+    public function testForCountryCodeWithWrongCountryCode()
+    {
+        Timezones::forCountryCode('nl');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
      */
     public function testGetCountryCodeWithUnknownTimezone()
     {

--- a/src/Symfony/Component/Intl/Timezones.php
+++ b/src/Symfony/Component/Intl/Timezones.php
@@ -109,6 +109,10 @@ final class Timezones extends ResourceBundle
                 return [];
             }
 
+            if (Countries::exists(strtoupper($country))) {
+                throw new MissingResourceException(sprintf('Country codes must be in uppercase, but "%s" was passed. Try with "%s" country code instead.', $country, strtoupper($country)));
+            }
+
             throw $e;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31656
| License       | MIT
| Doc PR        | (not needed)

