### PR TITLE
[Serializer] Remove CsvEncoder "as_collection" deprecation & change default value

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -382,6 +382,7 @@ SecurityBundle
 Serializer
 ----------
 
+ * The default value of the `CsvEncoder` "as_collection" option was changed to `true`.
  * The `AbstractNormalizer::handleCircularReference()` method has two new `$format` and `$context` arguments.
 
 Translation

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * throw an exception when creating a `Serializer` with normalizers which neither implement `NormalizerInterface` nor `DenormalizerInterface`
  * throw an exception when creating a `Serializer` with encoders which neither implement `EncoderInterface` nor `DecoderInterface`
+ * changed the default value of the `CsvEncoder` "as_collection" option to `true`
 
 4.3.0
 -----

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -327,21 +327,6 @@ CSV
         $this->assertFalse($this->encoder->supportsDecoding('foo'));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Relying on the default value (false) of the "as_collection" option is deprecated since 4.2. You should set it to false explicitly instead as true will be the default value in 5.0.
-     */
-    public function testDecodeLegacy()
-    {
-        $expected = ['foo' => 'a', 'bar' => 'b'];
-
-        $this->assertEquals($expected, $this->encoder->decode(<<<'CSV'
-foo,bar
-a,b
-CSV
-        , 'csv'));
-    }
-
     public function testDecodeAsSingle()
     {
         $expected = ['foo' => 'a', 'bar' => 'b'];
@@ -382,9 +367,7 @@ foo
 a
 
 CSV
-        , 'csv', [
-            CsvEncoder::AS_COLLECTION_KEY => true, // Can be removed in 5.0
-        ]));
+        , 'csv'));
     }
 
     public function testDecodeToManyRelation()
@@ -449,9 +432,7 @@ CSV
 a;bar-baz
 'hell''o';b;c
 CSV
-        , 'csv', [
-            CsvEncoder::AS_COLLECTION_KEY => true, // Can be removed in 5.0
-        ]));
+        , 'csv'));
     }
 
     public function testDecodeCustomSettingsPassedInContext()
@@ -466,7 +447,6 @@ CSV
             CsvEncoder::ENCLOSURE_KEY => "'",
             CsvEncoder::ESCAPE_CHAR_KEY => '|',
             CsvEncoder::KEY_SEPARATOR_KEY => '-',
-            CsvEncoder::AS_COLLECTION_KEY => true, // Can be removed in 5.0
         ]));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes  (AppVeyor failure unrelated. See https://github.com/symfony/symfony/pull/31685/files)  <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27715   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

As planned in #27715