### PR TITLE
[TwigBridge] Swapped $rootDir and $fileLinkFormatter arguments in DebugCommand

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -19,3 +19,9 @@ DependencyInjection
      my_service:
        factory: ['@factory_service', method]
    ```
+
+TwigBridge
+----------
+
+ * Deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
+   `DebugCommand::__construct()` method, swap the variables position.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -404,6 +404,7 @@ TwigBundle
 TwigBridge
 ----------
 
+ * Removed argument `$rootDir` from the `DebugCommand::__construct()` method and the 5th argument must be an instance of `FileLinkFormatter`
  * removed the `$requestStack` and `$requestContext` arguments of the 
    `HttpFoundationExtension`, pass a `Symfony\Component\HttpFoundation\UrlHelper`
    instance as the only argument instead

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
+   `DebugCommand::__construct()` method, swap the variables position.
+
 4.3.0
 -----
 

--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -42,7 +42,11 @@ class DebugCommand extends Command
     private $filesystemLoaders;
     private $fileLinkFormatter;
 
-    public function __construct(Environment $twig, string $projectDir = null, array $bundlesMetadata = [], string $twigDefaultPath = null, string $rootDir = null, FileLinkFormatter $fileLinkFormatter = null)
+    /**
+     * @param FileLinkFormatter|null $fileLinkFormatter
+     * @param string|null            $rootDir
+     */
+    public function __construct(Environment $twig, string $projectDir = null, array $bundlesMetadata = [], string $twigDefaultPath = null, $fileLinkFormatter = null, $rootDir = null)
     {
         parent::__construct();
 
@@ -50,8 +54,16 @@ class DebugCommand extends Command
         $this->projectDir = $projectDir;
         $this->bundlesMetadata = $bundlesMetadata;
         $this->twigDefaultPath = $twigDefaultPath;
-        $this->rootDir = $rootDir;
-        $this->fileLinkFormatter = $fileLinkFormatter;
+
+        if (\is_string($fileLinkFormatter) || $rootDir instanceof FileLinkFormatter) {
+            @trigger_error(sprintf('Passing a string as "$fileLinkFormatter" 5th argument or an instance of FileLinkFormatter as "$rootDir" 6th argument of the "%s()" method is deprecated since Symfony 4.4, swap the variables position.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->rootDir = $fileLinkFormatter;
+            $this->fileLinkFormatter = $rootDir;
+        } else {
+            $this->fileLinkFormatter = $fileLinkFormatter;
+            $this->rootDir = $rootDir;
+        }
     }
 
     protected function configure()

--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -342,7 +342,7 @@ TXT
         }
 
         $application = new Application();
-        $application->add(new DebugCommand($environment, $projectDir, $bundleMetadata, $defaultPath, $rootDir));
+        $application->add(new DebugCommand($environment, $projectDir, $bundleMetadata, $defaultPath, null, $rootDir));
         $command = $application->find('debug:twig');
 
         return new CommandTester($command);

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/console.xml
@@ -12,8 +12,8 @@
             <argument>%kernel.project_dir%</argument>
             <argument>%kernel.bundles_metadata%</argument>
             <argument>%twig.default_path%</argument>
-            <argument>%kernel.root_dir%</argument>
             <argument type="service" id="debug.file_link_formatter" on-invalid="null" />
+            <argument>%kernel.root_dir%</argument>
             <tag name="console.command" command="debug:twig" />
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is necessary to remove the `$rootDir` in 5.0, see https://github.com/symfony/symfony/pull/31667
