### PR TITLE
Subarray of sequential array must be inline in Yaml

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -116,13 +116,13 @@ class Dumper
                     $dumpObjectAsInlineMap = empty((array) $value);
                 }
 
-                $willBeInlined = $inline - 1 <= 0 || !\is_array($value) && $dumpObjectAsInlineMap || empty($value);
+                $willBeInlined = !$dumpAsMap || $inline - 1 <= 0 || !\is_array($value) && $dumpObjectAsInlineMap || empty($value);
 
                 $output .= sprintf('%s%s%s%s',
                     $prefix,
                     $dumpAsMap ? Inline::dump($key, $flags).':' : '-',
                     $willBeInlined ? ' ' : "\n",
-                    $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags)
+                    $this->dump($value, $dumpAsMap ? $inline - 1 : 0, $willBeInlined ? 0 : $indent + $this->indentation, $flags)
                 ).($willBeInlined ? "\n" : '');
             }
         }

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -37,8 +37,8 @@ class DumperTest extends TestCase
         ],
         'barfoo' => [
             ['foo' => 'bar'],
-            ['bar', 'foo']
-        ]
+            ['bar', 'foo'],
+        ],
     ];
 
     protected function setUp()

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -32,9 +32,13 @@ class DumperTest extends TestCase
             'bar' => [1, 'foo'],
             'foobar' => [
                 'foo' => 'bar',
-                'bar' => [1, 'foo'],
+                'bar' => [1, 'foo', ['foo' => 'bar']],
             ],
         ],
+        'barfoo' => [
+            ['foo' => 'bar'],
+            ['bar', 'foo']
+        ]
     ];
 
     protected function setUp()
@@ -72,6 +76,10 @@ foobar:
               bar:
                      - 1
                      - foo
+                     - { foo: bar }
+barfoo:
+       - { foo: bar }
+       - [bar, foo]
 
 EOF;
         $this->assertEquals($expected, $dumper->dump($this->array, 4, 0));
@@ -101,6 +109,10 @@ foobar:
               bar:
                      - 1
                      - foo
+                     - { foo: bar }
+barfoo:
+       - { foo: bar }
+       - [bar, foo]
 
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 4, 0));
@@ -134,7 +146,7 @@ EOF;
     public function testInlineLevel()
     {
         $expected = <<<'EOF'
-{ '': bar, foo: '#bar', 'foo''bar': {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
+{ '': bar, foo: '#bar', 'foo''bar': {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo, { foo: bar }] } }, barfoo: [{ foo: bar }, [bar, foo]] }
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, -10), '->dump() takes an inline level argument');
         $this->assertEquals($expected, $this->dumper->dump($this->array, 0), '->dump() takes an inline level argument');
@@ -144,7 +156,8 @@ EOF;
 foo: '#bar'
 'foo''bar': {  }
 bar: [1, foo]
-foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } }
+foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo, { foo: bar }] } }
+barfoo: [{ foo: bar }, [bar, foo]]
 
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 1), '->dump() takes an inline level argument');
@@ -159,7 +172,10 @@ bar:
 foobar:
     foo: bar
     bar: [1, foo]
-    foobar: { foo: bar, bar: [1, foo] }
+    foobar: { foo: bar, bar: [1, foo, { foo: bar }] }
+barfoo:
+    - { foo: bar }
+    - [bar, foo]
 
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 2), '->dump() takes an inline level argument');
@@ -178,7 +194,10 @@ foobar:
         - foo
     foobar:
         foo: bar
-        bar: [1, foo]
+        bar: [1, foo, { foo: bar }]
+barfoo:
+    - { foo: bar }
+    - [bar, foo]
 
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 3), '->dump() takes an inline level argument');
@@ -200,6 +219,10 @@ foobar:
         bar:
             - 1
             - foo
+            - { foo: bar }
+barfoo:
+    - { foo: bar }
+    - [bar, foo]
 
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 4), '->dump() takes an inline level argument');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Hello,

As I investigated [this issue](https://github.com/symfony/maker-bundle/issues/396), I noticed this rule which seems to me implicit to avoid generation like

```yaml
foo:
    -
        bar: baz
        qux: quux
```

Instead of

```yaml
foo:
    - { bar: baz, qux: quux }
```

Here is the most surgicals changes to obtain the expected result without breaking the existing output.
