### PR TITLE
[TwigBridge] Allow {% dump() %} tag

### DIFF
--- a/src/Symfony/Bridge/Twig/TokenParser/DumpTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/DumpTokenParser.php
@@ -21,8 +21,11 @@ use Twig\TokenParser\AbstractTokenParser;
  * Dump variables with:
  *
  *     {% dump %}
+ *     {% dump() %}
  *     {% dump foo %}
+ *     {% dump(foo) %}
  *     {% dump foo, bar %}
+ *     {% dump(foo, bar) %}
  *
  * @author Julien Galenski <julien.galenski@gmail.com>
  */
@@ -34,10 +37,18 @@ class DumpTokenParser extends AbstractTokenParser
     public function parse(Token $token)
     {
         $values = null;
-        if (!$this->parser->getStream()->test(Token::BLOCK_END_TYPE)) {
-            $values = $this->parser->getExpressionParser()->parseMultitargetExpression();
+
+        $stream = $this->parser->getStream();
+        if (!$stream->test(Token::BLOCK_END_TYPE)) {
+            if ($stream->test(Token::PUNCTUATION_TYPE, '(') && $stream->look()->test(Token::PUNCTUATION_TYPE, ')')) {
+                $stream->next();
+                $stream->next();
+            } else {
+                $values = $this->parser->getExpressionParser()->parseMultitargetExpression();
+            }
         }
-        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
+
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new DumpNode($this->parser->getVarName(), $values, $token->getLine(), $this->getTag());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I often find myself and others writing `{% dump() %}` to have all the current Twig available variables in the WDT. I guess it comes from the fact that when you do it for one variable you do `{% dump(var) %}` (use it like a function) + when you Google "twig dump all variables" and read the `dump` Twig doc (that is unrelated to the TwigBridge `dump` function and tag but that's not the point), you can read that the usage is `{{ dump() }}` so you can expect it to work the same way on the tag.