### PR TITLE
[MonologBridge] RouteProcessor class is now final to ease the the removal of deprecated event

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -25,6 +25,11 @@ DependencyInjection
        factory: ['@factory_service', method]
    ```
 
+MonologBridge
+--------------
+
+* The `RouteProcessor` has been marked final.
+
 TwigBridge
 ----------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -275,6 +275,11 @@ Monolog
 
  * The methods `DebugProcessor::getLogs()`, `DebugProcessor::countErrors()`, `Logger::getLogs()` and `Logger::countErrors()` have a new `$request` argument.
 
+MonologBridge
+--------------
+
+* The `RouteProcessor` class is final.
+
 Process
 -------
 

--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+* The `RouteProcessor` class has been made final
+
 4.3.0
 -----
 

--- a/src/Symfony/Bridge/Monolog/Processor/RouteProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/RouteProcessor.php
@@ -21,6 +21,8 @@ use Symfony\Contracts\Service\ResetInterface;
  * Adds the current route information to the log entry.
  *
  * @author Piotr Stankowski <git@trakos.pl>
+ *
+ * @final since Symfony 4.4
  */
 class RouteProcessor implements EventSubscriberInterface, ResetInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

To ease the removal of deprecated events this class has been made final as said in https://github.com/symfony/symfony/pull/31672#discussion_r288479232