### PR TITLE
[HttpKernel] The methods of the deprecated event should be final

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -19,3 +19,12 @@ DependencyInjection
      my_service:
        factory: ['@factory_service', method]
    ```
+
+HttpKernel
+----------
+
+* The method `FilterControllerArgumentsEvent::getArguments()` marked final.
+* The method `FilterControllerEvent::getController()` marked final.
+* The method `FilterResponseEvent::getResponse()` marked final.
+* The method `GetResponseForExceptionEvent::getException()` marked final.
+* The method `PostResponseEvent::getResponse()` marked final.

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+* The method `FilterControllerArgumentsEvent::getArguments()` has been made final
+* The method `FilterControllerEvent::getController()` has been made final
+* The method `FilterResponseEvent::getResponse()` has been made final
+* The method `GetResponseForExceptionEvent::getException()` has been made final
+* The method `PostResponseEvent::getResponse()` has been made final
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/Event/FilterControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterControllerArgumentsEvent.php
@@ -29,6 +29,8 @@ class FilterControllerArgumentsEvent extends ControllerEvent
     }
 
     /**
+     * @final since Symfony 4.4
+     *
      * @return array
      */
     public function getArguments()

--- a/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
@@ -31,6 +31,8 @@ class FilterControllerEvent extends KernelEvent
     /**
      * Returns the current controller.
      *
+     * @final since Symfony 4.4
+     *
      * @return callable
      */
     public function getController()

--- a/src/Symfony/Component/HttpKernel/Event/FilterResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterResponseEvent.php
@@ -32,6 +32,8 @@ class FilterResponseEvent extends KernelEvent
     /**
      * Returns the current response object.
      *
+     * @final since Symfony 4.4
+     *
      * @return Response
      */
     public function getResponse()

--- a/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
@@ -41,6 +41,8 @@ class GetResponseForExceptionEvent extends RequestEvent
     /**
      * Returns the thrown exception.
      *
+     * @final since Symfony 4.4
+     *
      * @return \Exception The thrown exception
      */
     public function getException()

--- a/src/Symfony/Component/HttpKernel/Event/PostResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/PostResponseEvent.php
@@ -32,6 +32,8 @@ class PostResponseEvent extends KernelEvent
     /**
      * Returns the response for which this event was thrown.
      *
+     * @final since Symfony 4.4
+     *
      * @return Response
      */
     public function getResponse()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->


This PRs allows to change the return types in 5.0 of the differents methods of the deprecated events class.

As said in https://github.com/symfony/symfony/pull/31672#discussion_r288480871