### PR TITLE
[Form] Throw exception when render a field which was already rendered

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * removed the `ChoiceLoaderInterface` implementation in `CountryType`, `LanguageType`, `LocaleType` and `CurrencyType`
  * removed `getExtendedType()` method of the `FormTypeExtensionInterface`
  * added static `getExtendedTypes()` method to the `FormTypeExtensionInterface`
+ * calling to `FormRenderer::searchAndRenderBlock()` method for fields which were already rendered throw a `BadMethodCallException`
 
 4.3.0
 -----

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -133,9 +133,7 @@ class FormRenderer implements FormRendererInterface
 
         if ($renderOnlyOnce && $view->isRendered()) {
             // This is not allowed, because it would result in rendering same IDs multiple times, which is not valid.
-            @trigger_error(sprintf('You are calling "form_%s" for field "%s" which has already been rendered before, trying to render fields which were already rendered is deprecated since Symfony 4.2 and will throw an exception in 5.0.', $blockNameSuffix, $view->vars['name']), E_USER_DEPRECATED);
-            // throw new BadMethodCallException(sprintf('Field "%s" has already been rendered. Save result of previous  render call to variable and output that instead.', $view->vars['name']));
-            return '';
+            throw new BadMethodCallException(sprintf('Field "%s" has already been rendered, save the result of previous render call to a variable and output that instead.', $view->vars['name']));
         }
 
         // The cache key for storing the variables and types

--- a/src/Symfony/Component/Form/Tests/FormRendererTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRendererTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\Form\FormView;
 
 class FormRendererTest extends TestCase
 {
@@ -25,5 +27,20 @@ class FormRendererTest extends TestCase
 
         $this->assertEquals('Is active', $renderer->humanize('is_active'));
         $this->assertEquals('Is active', $renderer->humanize('isActive'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\BadMethodCallException
+     * @expectedExceptionMessage Field "foo" has already been rendered, save the result of previous render call to a variable and output that instead.
+     */
+    public function testRenderARenderedField()
+    {
+        $formView = new FormView();
+        $formView->vars['name'] = 'foo';
+        $formView->setRendered();
+
+        $engine = $this->getMockBuilder('Symfony\Component\Form\FormRendererEngineInterface')->getMock();
+        $renderer = new FormRenderer($engine);
+        $renderer->searchAndRenderBlock($formView, 'row');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

See https://github.com/symfony/symfony/pull/27247
