### PR TITLE
[FrameworkBundle] fix deprecation of fragments by using FQCN

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/templates/fragment.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/templates/fragment.html.twig
@@ -1,7 +1,7 @@
-{{ render(controller('TestBundle:Fragment:inlined', {'options': {'bar': bar, 'eleven': 11}})) }}
+{{ render(controller('Symfony\\Bundle\\FrameworkBundle\\Tests\\Functional\\Bundle\\TestBundle\\Controller\\FragmentController::inlinedAction', {'options': {'bar': bar, 'eleven': 11}})) }}
 --
-{{ render(controller('TestBundle:Fragment:customformat', {'_format': 'html'})) }}
+{{ render(controller('Symfony\\Bundle\\FrameworkBundle\\Tests\\Functional\\Bundle\\TestBundle\\Controller\\FragmentController::customformatAction', {'_format': 'html'})) }}
 --
-{{ render(controller('TestBundle:Fragment:customlocale', {'_locale': 'es'})) }}
+{{ render(controller('Symfony\\Bundle\\FrameworkBundle\\Tests\\Functional\\Bundle\\TestBundle\\Controller\\FragmentController::customlocaleAction', {'_locale': 'es'})) }}
 --
-{{ app.request.setLocale('fr') }}{{ render(controller('TestBundle:Fragment:forwardlocale')) -}}
+{{ app.request.setLocale('fr') }}{{ render(controller('Symfony\\Bundle\\FrameworkBundle\\Tests\\Functional\\Bundle\\TestBundle\\Controller\\FragmentController::forwardlocaleAction')) -}}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | non  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | non <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

This fixes the error I got in https://travis-ci.org/symfony/symfony/jobs/538890475 and I don't understand why it doesn't fail anywhere else.
