### PR TITLE
Marked several components as incompatible with EventDispatcher 5

### DIFF
--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "symfony/config": "^3.4|^4.0|^5.0",
-        "symfony/event-dispatcher": "^4.3|^5.0",
+        "symfony/event-dispatcher": "^4.3",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
         "symfony/lock": "^3.4|^4.0|^5.0",
         "symfony/process": "^3.4|^4.0|^5.0",
@@ -41,7 +41,7 @@
     },
     "conflict": {
         "symfony/dependency-injection": "<3.4",
-        "symfony/event-dispatcher": "<4.3",
+        "symfony/event-dispatcher": "<4.3|>=5",
         "symfony/process": "<3.3"
     },
     "autoload": {

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/event-dispatcher": "^4.3|^5.0",
+        "symfony/event-dispatcher": "^4.3",
         "symfony/intl": "^4.3|^5.0",
         "symfony/options-resolver": "~4.3|^5.0",
         "symfony/polyfill-ctype": "~1.8",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/event-dispatcher": "^4.3|^5.0",
+        "symfony/event-dispatcher": "^4.3",
         "symfony/http-foundation": "^4.1.1|^5.0",
         "symfony/debug": "^3.4|^4.0|^5.0",
         "symfony/polyfill-ctype": "^1.8",

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1.3",
         "egulias/email-validator": "^2.0",
         "psr/log": "~1.0",
-        "symfony/event-dispatcher": "^4.3|^5.0",
+        "symfony/event-dispatcher": "^4.3",
         "symfony/mime": "^4.3|^5.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "psr/container": "^1.0",
-        "symfony/event-dispatcher": "^4.3|^5.0",
+        "symfony/event-dispatcher": "^4.3",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
         "symfony/ldap": "^3.4|^4.0|^5.0",
@@ -30,7 +30,7 @@
         "psr/log": "~1.0"
     },
     "conflict": {
-        "symfony/event-dispatcher": "<4.3",
+        "symfony/event-dispatcher": "<4.3|>=5",
         "symfony/security-guard": "<4.3"
     },
     "suggest": {

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -28,6 +28,7 @@
         "psr/log": "~1.0"
     },
     "conflict": {
+        "symfony/event-dispatcher": ">=5",
         "symfony/security-csrf": "<3.4.11|~4.0,<4.0.11"
     },
     "suggest": {

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -40,6 +40,9 @@
         "symfony/ldap": "^3.4|^4.0|^5.0",
         "psr/log": "~1.0"
     },
+    "conflict": {
+        "symfony/event-dispatcher": ">=5"
+    },
     "suggest": {
         "psr/container-implementation": "To instantiate the Security class",
         "symfony/form": "",

--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -26,13 +26,13 @@
     "require-dev": {
         "psr/log": "~1.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-        "symfony/event-dispatcher": "^4.3|^5.0",
+        "symfony/event-dispatcher": "^4.3",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
         "symfony/security-core": "^3.4|^4.0|^5.0",
         "symfony/validator": "^3.4|^4.0|^5.0"
     },
     "conflict": {
-        "symfony/event-dispatcher": "<4.3"
+        "symfony/event-dispatcher": "<4.3|>=5"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Workflow\\": "" }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Quite a few components still use the old event class that is to be removed in Symfony 5. This PR ensures that they are only installed with EventDispatcher 4.

Follow up to #31709 