### PR TITLE
[FrameworkBundle] fix test fixture using deprecated controller 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
@@ -37,7 +37,9 @@ class ResolveControllerNameSubscriber implements EventSubscriberInterface
         $controller = $event->getRequest()->attributes->get('_controller');
         if (\is_string($controller) && false === strpos($controller, '::') && 2 === substr_count($controller, ':')) {
             // controller in the a:b:c notation then
-            $event->getRequest()->attributes->set('_controller', $this->parser->parse($controller, false));
+            $event->getRequest()->attributes->set('_controller', $parsedNotation = $this->parser->parse($controller, false));
+
+            @trigger_error(sprintf('Referencing controllers with %s is deprecated since Symfony 4.1, use "%s" instead.', $controller, $parsedNotation), E_USER_DEPRECATED);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/EventListener/ResolveControllerNameSubscriberTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/EventListener/ResolveControllerNameSubscriberTest.php
@@ -20,6 +20,9 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ResolveControllerNameSubscriberTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testReplacesControllerAttribute()
     {
         $parser = $this->getMockBuilder(ControllerNameParser::class)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/templates/fragment.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/templates/fragment.html.twig
@@ -1,7 +1,7 @@
-{{ render(controller('TestBundle:Fragment:inlined', {'options': {'bar': bar, 'eleven': 11}})) }}
+{{ render(controller('Symfony\\Bundle\\FrameworkBundle\\Tests\\Functional\\Bundle\\TestBundle\\Controller\\FragmentController::inlinedAction', {'options': {'bar': bar, 'eleven': 11}})) }}
 --
-{{ render(controller('TestBundle:Fragment:customformat', {'_format': 'html'})) }}
+{{ render(controller('Symfony\\Bundle\\FrameworkBundle\\Tests\\Functional\\Bundle\\TestBundle\\Controller\\FragmentController::customformatAction', {'_format': 'html'})) }}
 --
-{{ render(controller('TestBundle:Fragment:customlocale', {'_locale': 'es'})) }}
+{{ render(controller('Symfony\\Bundle\\FrameworkBundle\\Tests\\Functional\\Bundle\\TestBundle\\Controller\\FragmentController::customlocaleAction', {'_locale': 'es'})) }}
 --
-{{ app.request.setLocale('fr') }}{{ render(controller('TestBundle:Fragment:forwardlocale')) -}}
+{{ app.request.setLocale('fr') }}{{ render(controller('Symfony\\Bundle\\FrameworkBundle\\Tests\\Functional\\Bundle\\TestBundle\\Controller\\FragmentController::forwardlocaleAction')) -}}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

https://github.com/symfony/symfony/pull/21035/files#diff-636946f5b52668178ede98d59135a181 reintroduced some deprecated controller notations (#26085) which wasn't spotted because ResolveControllerNameSubscriber missed a deprecation trigger. This also adds this trigger.
