### PR TITLE
Add missed use class for Symfony\Bundle\FrameworkBundle\Test\WebTestCase::$client

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -23,7 +23,7 @@ abstract class WebTestCase extends KernelTestCase
 {
     use WebTestAssertionsTrait;
 
-    /** @var Client|null */
+    /** @var KernelBrowser|null */
     protected static $client;
 
     protected function doTearDown(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

In `Symfony\Bundle\FrameworkBundle\Test\WebTestCase::$client` property exists phpdoc about property class, but no `use` declaration added.

As `Symfony\Bundle\FrameworkBundle\Client` deprecated, and actually this will be `Symfony\Bundle\FrameworkBundle\KernelBrowser` instance, we can put `KernelBrowser` instead `Client` (not sure about BC)
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
