### PR TITLE
[PHPUnitBridge] Use a more appropriate group when deprecating mode

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -228,9 +228,9 @@ class DeprecationErrorHandler
             return $this->configuration = Configuration::inWeakMode();
         }
         if (self::MODE_WEAK_VENDORS === $mode) {
-            ++$this->deprecations['remaining selfCount'];
+            ++$this->deprecations['remaining directCount'];
             $msg = sprintf('Setting SYMFONY_DEPRECATIONS_HELPER to "%s" is deprecated in favor of "max[self]=0"', $mode);
-            $ref = &$this->deprecations['remaining self'][$msg]['count'];
+            $ref = &$this->deprecations['remaining direct'][$msg]['count'];
             ++$ref;
             $mode = 'max[self]=0';
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The deprecation comes from a vendor: the phpunit bridge itself, so it's
either the direct or the indirect group. And since only the end user is
supposed to set the group, then this is supposed to be a direct
deprecation.