### PR TITLE
[TwigBundle] bump Twig bridge dependency

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/config": "^4.2|^5.0",
-        "symfony/twig-bridge": "^4.3|^5.0",
+        "symfony/twig-bridge": "^4.4|^5.0",
         "symfony/http-foundation": "^4.3|^5.0",
         "symfony/http-kernel": "^4.1|^5.0",
         "symfony/polyfill-ctype": "~1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31688
| License       | MIT
| Doc PR        |

We need a version of the `DebugCommand` class that is compatible with
its service definition in the Twig bundle.