### PR TITLE
[DI] remove support for non-string default env() parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * removed support for auto-discovered extension configuration class which does not implement `ConfigurationInterface`
+* removed support for non-string default env() parameters
 
 4.4.0
 -----

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -45,16 +45,8 @@ class EnvPlaceholderParameterBag extends ParameterBag
             if (!preg_match('/^(?:\w*+:)*+\w++$/', $env)) {
                 throw new InvalidArgumentException(sprintf('Invalid %s name: only "word" characters are allowed.', $name));
             }
-
-            if ($this->has($name)) {
-                $defaultValue = parent::get($name);
-
-                if (null !== $defaultValue && !is_scalar($defaultValue)) { // !is_string in 5.0
-                    //throw new RuntimeException(sprintf('The default value of an env() parameter must be a string or null, but "%s" given to "%s".', \gettype($defaultValue), $name));
-                    throw new RuntimeException(sprintf('The default value of an env() parameter must be scalar or null, but "%s" given to "%s".', \gettype($defaultValue), $name));
-                } elseif (is_scalar($defaultValue) && !\is_string($defaultValue)) {
-                    @trigger_error(sprintf('A non-string default value of an env() parameter is deprecated since 4.3, cast "%s" to string instead.', $name), E_USER_DEPRECATED);
-                }
+            if ($this->has($name) && null !== ($defaultValue = parent::get($name)) && !\is_string($defaultValue)) {
+                throw new RuntimeException(sprintf('The default value of an env() parameter must be a string or null, but "%s" given to "%s".', \gettype($defaultValue), $name));
             }
 
             $uniqueName = md5($name.uniqid(mt_rand(), true));
@@ -146,19 +138,8 @@ class EnvPlaceholderParameterBag extends ParameterBag
         parent::resolve();
 
         foreach ($this->envPlaceholders as $env => $placeholders) {
-            if (!$this->has($name = "env($env)")) {
-                continue;
-            }
-            if (is_numeric($default = $this->parameters[$name])) {
-                if (!\is_string($default)) {
-                    @trigger_error(sprintf('A non-string default value of env parameter "%s" is deprecated since 4.3, cast it to string instead.', $env), E_USER_DEPRECATED);
-                }
-                $this->parameters[$name] = (string) $default;
-            } elseif (null !== $default && !is_scalar($default)) { // !is_string in 5.0
-                //throw new RuntimeException(sprintf('The default value of env parameter "%s" must be a string or null, %s given.', $env, \gettype($default)));
-                throw new RuntimeException(sprintf('The default value of env parameter "%s" must be scalar or null, %s given.', $env, \gettype($default)));
-            } elseif (is_scalar($default) && !\is_string($default)) {
-                @trigger_error(sprintf('A non-string default value of env parameter "%s" is deprecated since 4.3, cast it to string instead.', $env), E_USER_DEPRECATED);
+            if ($this->has($name = "env($env)") && null !== ($default = $this->parameters[$name]) && !\is_string($default)) {
+                throw new RuntimeException(sprintf('The default value of env parameter "%s" must be a string or null, %s given.', $env, \gettype($default)));
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -59,8 +59,8 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation A non-string default value of an env() parameter is deprecated since 4.3, cast "env(FLOATISH)" to string instead.
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage The default value of an env() parameter must be a string or null, but "double" given to "env(FLOATISH)".
      */
     public function testDefaultEnvWithoutPrefixIsValidatedInConfig()
     {
@@ -72,8 +72,6 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         ]);
 
         $this->doProcess($container);
-
-        $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -112,32 +112,26 @@ class EnvPlaceholderParameterBagTest extends TestCase
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation A non-string default value of env parameter "INT_VAR" is deprecated since 4.3, cast it to string instead.
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage The default value of env parameter "INT_VAR" must be a string or null, integer given.
      */
-    public function testResolveEnvCastsIntToString()
+    public function testResolveEnvRequiresStrings()
     {
         $bag = new EnvPlaceholderParameterBag();
         $bag->get('env(INT_VAR)');
         $bag->set('env(INT_VAR)', 2);
         $bag->resolve();
-        $this->assertSame('2', $bag->all()['env(INT_VAR)']);
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation A non-string default value of an env() parameter is deprecated since 4.3, cast "env(INT_VAR)" to string instead.
-     * @expectedDeprecation A non-string default value of env parameter "INT_VAR" is deprecated since 4.3, cast it to string instead.
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage The default value of an env() parameter must be a string or null, but "integer" given to "env(INT_VAR)".
      */
     public function testGetDefaultScalarEnv()
     {
         $bag = new EnvPlaceholderParameterBag();
         $bag->set('env(INT_VAR)', 2);
-        $this->assertStringMatchesFormat('env_%s_INT_VAR_%s', $bag->get('env(INT_VAR)'));
-        $this->assertSame(2, $bag->all()['env(INT_VAR)']);
-        $bag->resolve();
-        $this->assertStringMatchesFormat('env_%s_INT_VAR_%s', $bag->get('env(INT_VAR)'));
-        $this->assertSame('2', $bag->all()['env(INT_VAR)']);
+        $bag->get('env(INT_VAR)');
     }
 
     public function testGetDefaultEnv()
@@ -163,7 +157,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The default value of env parameter "ARRAY_VAR" must be scalar or null, array given.
+     * @expectedExceptionMessage The default value of env parameter "ARRAY_VAR" must be a string or null, array given.
      */
     public function testResolveThrowsOnBadDefaultValue()
     {
@@ -185,7 +179,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The default value of an env() parameter must be scalar or null, but "array" given to "env(ARRAY_VAR)".
+     * @expectedExceptionMessage The default value of an env() parameter must be a string or null, but "array" given to "env(ARRAY_VAR)".
      */
     public function testGetThrowsOnBadDefaultValue()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

See #27808