### PR TITLE
[HttpKernel] Make DebugHandlersListener internal

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 4.3 to 4.4
 =======================
 
+HttpKernel
+----------
+
+* The `DebugHandlersListener` class has been marked as `final`
+
 DependencyInjection
 -------------------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -254,6 +254,7 @@ HttpKernel
  * Removed `GetResponseForExceptionEvent`, use `ExceptionEvent` instead
  * Removed `PostResponseEvent`, use `TerminateEvent` instead
  * Removed `TranslatorListener` in favor of `LocaleAwareListener`
+ * The `DebugHandlersListener` class has been made `final`
 
 Intl
 ----

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+* The `DebugHandlersListener` class has been marked as `final`
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -27,6 +27,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * Configures errors and exceptions handlers.
  *
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @final since Symfony 4.4
  */
 class DebugHandlersListener implements EventSubscriberInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Required to remove the legacy `Event` argument type declaration from its `configure()` method in 5.0.
Unlocks #31689 