### PR TITLE
[HttpKernel] Don't install HttpKernel 4.4 with Console 5

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "symfony/browser-kit": "^4.3|^5.0",
         "symfony/config": "^3.4|^4.0|^5.0",
-        "symfony/console": "^3.4|^4.0|^5.0",
+        "symfony/console": "^3.4|^4.0",
         "symfony/css-selector": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^4.3|^5.0",
         "symfony/dom-crawler": "^3.4|^4.0|^5.0",
@@ -49,6 +49,7 @@
     "conflict": {
         "symfony/browser-kit": "<4.3",
         "symfony/config": "<3.4",
+        "symfony/console": ">=5",
         "symfony/dependency-injection": "<4.3",
         "symfony/translation": "<4.2",
         "symfony/var-dumper": "<4.1.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Another attempt to get the build of #31709 green. Because the base class of `ConsoleEvent` was changed, the Console component 5.0 in going to be incompatible with `DebugHandlersListener` in HttpKernel 4.4.