### PR TITLE
Disable php_unit_mock_short_will_return rule of php-cs

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -18,6 +18,8 @@ return PhpCsFixer\Config::create()
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced'],
         // Part of future @Symfony ruleset in PHP-CS-Fixer To be removed from the config file once upgrading
         'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        // Part of @Symfony:risky in PHP-CS-Fixer 2.15.0. Incompatible with PHPUnit 4 that is required for Symfony 3.4
+        'php_unit_mock_short_will_return' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -