### PR TITLE
Use willReturn() instead of will(returnValue())

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -18,8 +18,6 @@ return PhpCsFixer\Config::create()
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced'],
         // Part of future @Symfony ruleset in PHP-CS-Fixer To be removed from the config file once upgrading
         'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
-        // Part of @Symfony:risky in PHP-CS-Fixer 2.15.0. Incompatible with PHPUnit 4 that is required for Symfony 3.4
-        'php_unit_mock_short_will_return' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -166,20 +166,20 @@ class DoctrineDataCollectorTest extends TestCase
             ->getMock();
         $connection->expects($this->any())
             ->method('getDatabasePlatform')
-            ->will($this->returnValue(new MySqlPlatform()));
+            ->willReturn(new MySqlPlatform());
 
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
         $registry
             ->expects($this->any())
             ->method('getConnectionNames')
-            ->will($this->returnValue(['default' => 'doctrine.dbal.default_connection']));
+            ->willReturn(['default' => 'doctrine.dbal.default_connection']);
         $registry
             ->expects($this->any())
             ->method('getManagerNames')
-            ->will($this->returnValue(['default' => 'doctrine.orm.default_entity_manager']));
+            ->willReturn(['default' => 'doctrine.orm.default_entity_manager']);
         $registry->expects($this->any())
             ->method('getConnection')
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $logger = $this->getMockBuilder('Doctrine\DBAL\Logging\DebugStack')->getMock();
         $logger->queries = $queries;

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -44,9 +44,9 @@ class DoctrineExtensionTest extends TestCase
 
         $this->extension->expects($this->any())
             ->method('getObjectManagerElementName')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 return 'doctrine.orm.'.$name;
-            }));
+            });
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/ExpressionLanguage/DoctrineParserCacheTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ExpressionLanguage/DoctrineParserCacheTest.php
@@ -26,7 +26,7 @@ class DoctrineParserCacheTest extends TestCase
 
         $doctrineCacheMock->expects($this->once())
             ->method('fetch')
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar');
 
         $result = $parserCache->fetch('foo');
 
@@ -41,7 +41,7 @@ class DoctrineParserCacheTest extends TestCase
         $doctrineCacheMock
             ->expects($this->once())
             ->method('fetch')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->assertNull($parserCache->fetch(''));
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
@@ -34,47 +34,47 @@ class DoctrineOrmTypeGuesserTest extends TestCase
         // Simple field, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
         $classMetadata->fieldMappings['field'] = true;
-        $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(false));
+        $classMetadata->expects($this->once())->method('isNullable')->with('field')->willReturn(false);
 
         $return[] = [$classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE)];
 
         // Simple field, nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
         $classMetadata->fieldMappings['field'] = true;
-        $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isNullable')->with('field')->willReturn(true);
 
         $return[] = [$classMetadata, new ValueGuess(false, Guess::MEDIUM_CONFIDENCE)];
 
         // One-to-one, nullable (by default)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = ['joinColumns' => [[]]];
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = [$classMetadata, new ValueGuess(false, Guess::HIGH_CONFIDENCE)];
 
         // One-to-one, nullable (explicit)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = ['joinColumns' => [['nullable' => true]]];
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = [$classMetadata, new ValueGuess(false, Guess::HIGH_CONFIDENCE)];
 
         // One-to-one, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(true);
 
         $mapping = ['joinColumns' => [['nullable' => false]]];
-        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->will($this->returnValue($mapping));
+        $classMetadata->expects($this->once())->method('getAssociationMapping')->with('field')->willReturn($mapping);
 
         $return[] = [$classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE)];
 
         // One-to-many, no clue
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(false));
+        $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->willReturn(false);
 
         $return[] = [$classMetadata, null];
 
@@ -84,10 +84,10 @@ class DoctrineOrmTypeGuesserTest extends TestCase
     private function getGuesser(ClassMetadata $classMetadata)
     {
         $em = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();
-        $em->expects($this->once())->method('getClassMetaData')->with('TestEntity')->will($this->returnValue($classMetadata));
+        $em->expects($this->once())->method('getClassMetaData')->with('TestEntity')->willReturn($classMetadata);
 
         $registry = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
-        $registry->expects($this->once())->method('getManagers')->will($this->returnValue([$em]));
+        $registry->expects($this->once())->method('getManagers')->willReturn([$em]);
 
         return new DoctrineOrmTypeGuesser($registry);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -38,11 +38,11 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
 
         $manager->expects($this->any())
             ->method('getManager')
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         $manager->expects($this->any())
             ->method('getManagerForClass')
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         return [
             new CoreExtension(),

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1087,7 +1087,7 @@ class EntityTypeTest extends BaseTypeTest
         $this->emRegistry->expects($this->once())
             ->method('getManagerForClass')
             ->with(self::SINGLE_IDENT_CLASS)
-            ->will($this->returnValue($this->em));
+            ->willReturn($this->em);
 
         $this->factory->createNamed('name', static::TESTED_TYPE, null, [
             'class' => self::SINGLE_IDENT_CLASS,
@@ -1237,7 +1237,7 @@ class EntityTypeTest extends BaseTypeTest
         $registry->expects($this->any())
             ->method('getManager')
             ->with($this->equalTo($name))
-            ->will($this->returnValue($em));
+            ->willReturn($em);
 
         return $registry;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -188,7 +188,7 @@ class EntityUserProviderTest extends TestCase
         $manager->expects($this->any())
             ->method('getManager')
             ->with($this->equalTo($name))
-            ->will($this->returnValue($em));
+            ->willReturn($em);
 
         return $manager;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -82,7 +82,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $registry->expects($this->any())
                  ->method('getManager')
                  ->with($this->equalTo(self::EM_NAME))
-                 ->will($this->returnValue($em));
+                 ->willReturn($em);
 
         return $registry;
     }
@@ -104,14 +104,14 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         ;
         $em->expects($this->any())
             ->method('getRepository')
-            ->will($this->returnValue($repositoryMock))
+            ->willReturn($repositoryMock)
         ;
 
         $classMetadata = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadata')->getMock();
         $classMetadata
             ->expects($this->any())
             ->method('hasField')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $reflParser = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionParser')
             ->disableOriginalConstructor()
@@ -125,12 +125,12 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $refl
             ->expects($this->any())
             ->method('getValue')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $classMetadata->reflFields = ['name' => $refl];
         $em->expects($this->any())
             ->method('getClassMetadata')
-            ->will($this->returnValue($classMetadata))
+            ->willReturn($classMetadata)
         ;
 
         return $em;
@@ -366,7 +366,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $repository = $this->createRepositoryMock();
         $repository->expects($this->once())
             ->method('findByCustom')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
         $this->em = $this->createEntityManagerMock($repository);
         $this->registry = $this->createRegistryMock($this->em);
@@ -394,15 +394,15 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $repository = $this->createRepositoryMock();
         $repository->expects($this->once())
             ->method('findByCustom')
-            ->will(
-                $this->returnCallback(function () use ($entity) {
+            ->willReturnCallback(
+                function () use ($entity) {
                     $returnValue = [
                         $entity,
                     ];
                     next($returnValue);
 
                     return $returnValue;
-                })
+                }
             )
         ;
         $this->em = $this->createEntityManagerMock($repository);
@@ -430,7 +430,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $repository = $this->createRepositoryMock();
         $repository->expects($this->once())
             ->method('findByCustom')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $this->em = $this->createEntityManagerMock($repository);
         $this->registry = $this->createRegistryMock($this->em);
@@ -564,7 +564,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $repository->expects($this->once())
             ->method('findByCustom')
-            ->will($this->returnValue([$entity1]))
+            ->willReturn([$entity1])
         ;
 
         $this->em->persist($entity1);
@@ -635,7 +635,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $repository = $this->createRepositoryMock();
         $repository
              ->method('find')
-             ->will($this->returnValue(null))
+             ->willReturn(null)
         ;
 
         $this->em = $this->createEntityManagerMock($repository);

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -50,7 +50,7 @@ class ConsoleHandlerTest extends TestCase
         $output
             ->expects($this->atLeastOnce())
             ->method('getVerbosity')
-            ->will($this->returnValue($verbosity))
+            ->willReturn($verbosity)
         ;
         $handler = new ConsoleHandler($output, true, $map);
         $this->assertSame($isHandling, $handler->isHandling(['level' => $level]),
@@ -114,12 +114,12 @@ class ConsoleHandlerTest extends TestCase
         $output
             ->expects($this->at(0))
             ->method('getVerbosity')
-            ->will($this->returnValue(OutputInterface::VERBOSITY_QUIET))
+            ->willReturn(OutputInterface::VERBOSITY_QUIET)
         ;
         $output
             ->expects($this->at(1))
             ->method('getVerbosity')
-            ->will($this->returnValue(OutputInterface::VERBOSITY_DEBUG))
+            ->willReturn(OutputInterface::VERBOSITY_DEBUG)
         ;
         $handler = new ConsoleHandler($output);
         $this->assertFalse($handler->isHandling(['level' => Logger::NOTICE]),
@@ -144,7 +144,7 @@ class ConsoleHandlerTest extends TestCase
         $output
             ->expects($this->any())
             ->method('getVerbosity')
-            ->will($this->returnValue(OutputInterface::VERBOSITY_DEBUG))
+            ->willReturn(OutputInterface::VERBOSITY_DEBUG)
         ;
         $output
             ->expects($this->once())

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -95,10 +95,10 @@ class WebProcessorTest extends TestCase
             ->getMock();
         $event->expects($this->any())
             ->method('isMasterRequest')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
 
         return [$event, $server];
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -62,7 +62,7 @@ class HttpKernelExtensionTest extends TestCase
     protected function getFragmentHandler($return)
     {
         $strategy = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\Fragment\\FragmentRendererInterface')->getMock();
-        $strategy->expects($this->once())->method('getName')->will($this->returnValue('inline'));
+        $strategy->expects($this->once())->method('getName')->willReturn('inline');
         $strategy->expects($this->once())->method('render')->will($return);
 
         $context = $this->getMockBuilder('Symfony\\Component\\HttpFoundation\\RequestStack')
@@ -70,7 +70,7 @@ class HttpKernelExtensionTest extends TestCase
             ->getMock()
         ;
 
-        $context->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $context->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         return new FragmentHandler($context, [$strategy], false);
     }
@@ -82,9 +82,9 @@ class HttpKernelExtensionTest extends TestCase
         $twig->addExtension(new HttpKernelExtension());
 
         $loader = $this->getMockBuilder('Twig\RuntimeLoader\RuntimeLoaderInterface')->getMock();
-        $loader->expects($this->any())->method('load')->will($this->returnValueMap([
+        $loader->expects($this->any())->method('load')->willReturnMap([
             ['Symfony\Bridge\Twig\Extension\HttpKernelRuntime', new HttpKernelRuntime($renderer)],
-        ]));
+        ]);
         $twig->addRuntimeLoader($loader);
 
         return $twig->render('index');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplateFinderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplateFinderTest.php
@@ -34,7 +34,7 @@ class TemplateFinderTest extends TestCase
         $kernel
             ->expects($this->once())
             ->method('getBundles')
-            ->will($this->returnValue(['BaseBundle' => new BaseBundle()]))
+            ->willReturn(['BaseBundle' => new BaseBundle()])
         ;
 
         $parser = new TemplateFilenameParser();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
@@ -68,13 +68,13 @@ class TemplatePathsCacheWarmerTest extends TestCase
         $this->templateFinder
             ->expects($this->once())
             ->method('findAllTemplates')
-            ->will($this->returnValue([$template]));
+            ->willReturn([$template]);
 
         $this->fileLocator
             ->expects($this->once())
             ->method('locate')
             ->with($template->getPath())
-            ->will($this->returnValue(\dirname($this->tmpDir).'/path/to/template.html.twig'));
+            ->willReturn(\dirname($this->tmpDir).'/path/to/template.html.twig');
 
         $warmer = new TemplatePathsCacheWarmer($this->templateFinder, $this->templateLocator);
         $warmer->warmUp($this->tmpDir);
@@ -87,7 +87,7 @@ class TemplatePathsCacheWarmerTest extends TestCase
         $this->templateFinder
             ->expects($this->once())
             ->method('findAllTemplates')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $this->fileLocator
             ->expects($this->never())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -82,7 +82,7 @@ class RouterDebugCommandTest extends TestCase
         $router
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->will($this->returnValue($routeCollection));
+            ->willReturn($routeCollection);
 
         return $router;
     }
@@ -93,13 +93,13 @@ class RouterDebugCommandTest extends TestCase
         $container
             ->expects($this->atLeastOnce())
             ->method('has')
-            ->will($this->returnCallback(function ($id) {
+            ->willReturnCallback(function ($id) {
                 if ('console.command_loader' === $id) {
                     return false;
                 }
 
                 return true;
-            }))
+            })
         ;
         $container
             ->expects($this->any())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -80,11 +80,11 @@ class RouterMatchCommandTest extends TestCase
         $router
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->will($this->returnValue($routeCollection));
+            ->willReturn($routeCollection);
         $router
             ->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($requestContext));
+            ->willReturn($requestContext);
 
         return $router;
     }
@@ -95,9 +95,9 @@ class RouterMatchCommandTest extends TestCase
         $container
             ->expects($this->atLeastOnce())
             ->method('has')
-            ->will($this->returnCallback(function ($id) {
+            ->willReturnCallback(function ($id) {
                 return 'console.command_loader' !== $id;
-            }))
+            })
         ;
         $container
             ->expects($this->any())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -136,26 +136,26 @@ class TranslationDebugCommandTest extends TestCase
         $translator
             ->expects($this->any())
             ->method('getFallbackLocales')
-            ->will($this->returnValue(['en']));
+            ->willReturn(['en']);
 
         $extractor = $this->getMockBuilder('Symfony\Component\Translation\Extractor\ExtractorInterface')->getMock();
         $extractor
             ->expects($this->any())
             ->method('extract')
-            ->will(
-                $this->returnCallback(function ($path, $catalogue) use ($extractedMessages) {
+            ->willReturnCallback(
+                function ($path, $catalogue) use ($extractedMessages) {
                     $catalogue->add($extractedMessages);
-                })
+                }
             );
 
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Reader\TranslationReader')->getMock();
         $loader
             ->expects($this->any())
             ->method('read')
-            ->will(
-                $this->returnCallback(function ($path, $catalogue) use ($loadedMessages) {
+            ->willReturnCallback(
+                function ($path, $catalogue) use ($loadedMessages) {
                     $catalogue->add($loadedMessages);
-                })
+                }
             );
 
         if (null === $kernel) {
@@ -173,23 +173,23 @@ class TranslationDebugCommandTest extends TestCase
             $kernel
                 ->expects($this->any())
                 ->method('getBundle')
-                ->will($this->returnValueMap($returnValues));
+                ->willReturnMap($returnValues);
         }
 
         $kernel
             ->expects($this->any())
             ->method('getRootDir')
-            ->will($this->returnValue($this->translationDir));
+            ->willReturn($this->translationDir);
 
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock()));
+            ->willReturn($this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock());
 
         $command = new TranslationDebugCommand($translator, $loader, $extractor, $this->translationDir.'/translations', $this->translationDir.'/templates');
 
@@ -214,23 +214,23 @@ class TranslationDebugCommandTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->any())
             ->method('get')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['translation.extractor', 1, $extractor],
                 ['translation.reader', 1, $loader],
                 ['translator', 1, $translator],
                 ['kernel', 1, $kernel],
-            ]));
+            ]);
 
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($container));
+            ->willReturn($container);
 
         $command = new TranslationDebugCommand();
         $command->setContainer($container);
@@ -250,7 +250,7 @@ class TranslationDebugCommandTest extends TestCase
         $bundle
             ->expects($this->any())
             ->method('getPath')
-            ->will($this->returnValue($path))
+            ->willReturn($path)
         ;
 
         return $bundle;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -114,36 +114,36 @@ class TranslationUpdateCommandTest extends TestCase
         $translator
             ->expects($this->any())
             ->method('getFallbackLocales')
-            ->will($this->returnValue(['en']));
+            ->willReturn(['en']);
 
         $extractor = $this->getMockBuilder('Symfony\Component\Translation\Extractor\ExtractorInterface')->getMock();
         $extractor
             ->expects($this->any())
             ->method('extract')
-            ->will(
-                $this->returnCallback(function ($path, $catalogue) use ($extractedMessages) {
+            ->willReturnCallback(
+                function ($path, $catalogue) use ($extractedMessages) {
                     foreach ($extractedMessages as $domain => $messages) {
                         $catalogue->add($messages, $domain);
                     }
-                })
+                }
             );
 
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Reader\TranslationReader')->getMock();
         $loader
             ->expects($this->any())
             ->method('read')
-            ->will(
-                $this->returnCallback(function ($path, $catalogue) use ($loadedMessages) {
+            ->willReturnCallback(
+                function ($path, $catalogue) use ($loadedMessages) {
                     $catalogue->add($loadedMessages);
-                })
+                }
             );
 
         $writer = $this->getMockBuilder('Symfony\Component\Translation\Writer\TranslationWriter')->getMock();
         $writer
             ->expects($this->any())
             ->method('getFormats')
-            ->will(
-                $this->returnValue(['xlf', 'yml', 'yaml'])
+            ->willReturn(
+                ['xlf', 'yml', 'yaml']
             );
 
         if (null === $kernel) {
@@ -161,23 +161,23 @@ class TranslationUpdateCommandTest extends TestCase
             $kernel
                 ->expects($this->any())
                 ->method('getBundle')
-                ->will($this->returnValueMap($returnValues));
+                ->willReturnMap($returnValues);
         }
 
         $kernel
             ->expects($this->any())
             ->method('getRootDir')
-            ->will($this->returnValue($this->translationDir));
+            ->willReturn($this->translationDir);
 
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock()));
+            ->willReturn($this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock());
 
         $command = new TranslationUpdateCommand($writer, $loader, $extractor, 'en', $this->translationDir.'/translations', $this->translationDir.'/templates');
 
@@ -203,24 +203,24 @@ class TranslationUpdateCommandTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->any())
             ->method('get')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['translation.extractor', 1, $extractor],
                 ['translation.reader', 1, $loader],
                 ['translation.writer', 1, $writer],
                 ['translator', 1, $translator],
                 ['kernel', 1, $kernel],
-            ]));
+            ]);
 
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($container));
+            ->willReturn($container);
 
         $command = new TranslationUpdateCommand();
         $command->setContainer($container);
@@ -240,7 +240,7 @@ class TranslationUpdateCommandTest extends TestCase
         $bundle
             ->expects($this->any())
             ->method('getPath')
-            ->will($this->returnValue($path))
+            ->willReturn($path)
         ;
 
         return $bundle;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -206,7 +206,7 @@ class ApplicationTest extends TestCase
                 ->expects($this->atLeastOnce())
                 ->method('get')
                 ->with($this->equalTo('event_dispatcher'))
-                ->will($this->returnValue($dispatcher));
+                ->willReturn($dispatcher);
         }
 
         $container
@@ -226,12 +226,12 @@ class ApplicationTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue($bundles))
+            ->willReturn($bundles)
         ;
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($container))
+            ->willReturn($container)
         ;
 
         return $kernel;
@@ -243,9 +243,9 @@ class ApplicationTest extends TestCase
         $bundle
             ->expects($this->once())
             ->method('registerCommands')
-            ->will($this->returnCallback(function (Application $application) use ($commands) {
+            ->willReturnCallback(function (Application $application) use ($commands) {
                 $application->addCommands($commands);
-            }))
+            })
         ;
 
         return $bundle;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -156,13 +156,13 @@ class ControllerNameParserTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundle')
-            ->will($this->returnCallback(function ($bundle) use ($bundles) {
+            ->willReturnCallback(function ($bundle) use ($bundles) {
                 if (!isset($bundles[$bundle])) {
                     throw new \InvalidArgumentException(sprintf('Invalid bundle name "%s"', $bundle));
                 }
 
                 return $bundles[$bundle];
-            }))
+            })
         ;
 
         $bundles = [
@@ -175,7 +175,7 @@ class ControllerNameParserTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue($bundles))
+            ->willReturn($bundles)
         ;
 
         return new ControllerNameParser($kernel);
@@ -184,8 +184,8 @@ class ControllerNameParserTest extends TestCase
     private function getBundle($namespace, $name)
     {
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
-        $bundle->expects($this->any())->method('getName')->will($this->returnValue($name));
-        $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue($namespace));
+        $bundle->expects($this->any())->method('getName')->willReturn($name);
+        $bundle->expects($this->any())->method('getNamespace')->willReturn($namespace);
 
         return $bundle;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -55,7 +55,7 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         $parser->expects($this->once())
             ->method('parse')
             ->with($shortName)
-            ->will($this->returnValue('Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController::testAction'))
+            ->willReturn('Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController::testAction')
         ;
 
         $resolver = $this->createControllerResolver(null, null, $parser);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -43,9 +43,9 @@ abstract class ControllerTraitTest extends TestCase
         $requestStack->push($request);
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+        $kernel->expects($this->once())->method('handle')->willReturnCallback(function (Request $request) {
             return new Response($request->getRequestFormat().'--'.$request->getLocale());
-        }));
+        });
 
         $container = new Container();
         $container->set('request_stack', $requestStack);
@@ -110,7 +110,7 @@ abstract class ControllerTraitTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $container = new Container();
         $container->set('security.token_storage', $tokenStorage);
@@ -137,7 +137,7 @@ abstract class ControllerTraitTest extends TestCase
             ->expects($this->once())
             ->method('serialize')
             ->with([], 'json', ['json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS])
-            ->will($this->returnValue('[]'));
+            ->willReturn('[]');
 
         $container->set('serializer', $serializer);
 
@@ -158,7 +158,7 @@ abstract class ControllerTraitTest extends TestCase
             ->expects($this->once())
             ->method('serialize')
             ->with([], 'json', ['json_encode_options' => 0, 'other' => 'context'])
-            ->will($this->returnValue('[]'));
+            ->willReturn('[]');
 
         $container->set('serializer', $serializer);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -72,7 +72,7 @@ class RedirectControllerTest extends TestCase
             ->expects($this->once())
             ->method('generate')
             ->with($this->equalTo($route), $this->equalTo($expectedAttributes))
-            ->will($this->returnValue($url));
+            ->willReturn($url);
 
         $controller = new RedirectController($router);
 
@@ -250,23 +250,23 @@ class RedirectControllerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('getScheme')
-            ->will($this->returnValue($scheme));
+            ->willReturn($scheme);
         $request
             ->expects($this->any())
             ->method('getHost')
-            ->will($this->returnValue($host));
+            ->willReturn($host);
         $request
             ->expects($this->any())
             ->method('getPort')
-            ->will($this->returnValue($port));
+            ->willReturn($port);
         $request
             ->expects($this->any())
             ->method('getBaseUrl')
-            ->will($this->returnValue($baseUrl));
+            ->willReturn($baseUrl);
         $request
             ->expects($this->any())
             ->method('getQueryString')
-            ->will($this->returnValue($queryString));
+            ->willReturn($queryString);
 
         return $request;
     }
@@ -288,24 +288,24 @@ class RedirectControllerTest extends TestCase
                 ->expects($this->once())
                 ->method('hasParameter')
                 ->with($this->equalTo('request_listener.http_port'))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
             $container
                 ->expects($this->once())
                 ->method('getParameter')
                 ->with($this->equalTo('request_listener.http_port'))
-                ->will($this->returnValue($httpPort));
+                ->willReturn($httpPort);
         }
         if (null !== $httpsPort) {
             $container
                 ->expects($this->once())
                 ->method('hasParameter')
                 ->with($this->equalTo('request_listener.https_port'))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
             $container
                 ->expects($this->once())
                 ->method('getParameter')
                 ->with($this->equalTo('request_listener.https_port'))
-                ->will($this->returnValue($httpsPort));
+                ->willReturn($httpsPort);
         }
 
         $controller = new RedirectController();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -49,9 +49,9 @@ class TemplateControllerTest extends TestCase
         $twig->expects($this->once())->method('render')->willReturn('bar');
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $container->expects($this->at(0))->method('has')->will($this->returnValue(false));
-        $container->expects($this->at(1))->method('has')->will($this->returnValue(true));
-        $container->expects($this->at(2))->method('get')->will($this->returnValue($twig));
+        $container->expects($this->at(0))->method('has')->willReturn(false);
+        $container->expects($this->at(1))->method('has')->willReturn(true);
+        $container->expects($this->at(2))->method('get')->willReturn($twig);
 
         $controller = new TemplateController();
         $controller->setContainer($container);
@@ -69,7 +69,7 @@ class TemplateControllerTest extends TestCase
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->at(0))->method('has')->willReturn(true);
-        $container->expects($this->at(1))->method('get')->will($this->returnValue($templating));
+        $container->expects($this->at(1))->method('get')->willReturn($templating);
 
         $controller = new TemplateController();
         $controller->setContainer($container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -248,7 +248,7 @@ class RouterTest extends TestCase
         $loader
             ->expects($this->any())
             ->method('load')
-            ->will($this->returnValue($routes))
+            ->willReturn($routes)
         ;
 
         $sc = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Container')->setMethods(['get'])->getMock();
@@ -256,7 +256,7 @@ class RouterTest extends TestCase
         $sc
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($loader))
+            ->willReturn($loader)
         ;
 
         return $sc;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/DelegatingEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/DelegatingEngineTest.php
@@ -67,7 +67,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('renderResponse')
             ->with('template.php', ['foo' => 'bar'])
-            ->will($this->returnValue($response));
+            ->willReturn($response);
         $container = $this->getContainerMock(['engine' => $engine]);
 
         $delegatingEngine = new DelegatingEngine($container, ['engine']);
@@ -91,7 +91,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('supports')
             ->with($template)
-            ->will($this->returnValue($supports));
+            ->willReturn($supports);
 
         return $engine;
     }
@@ -103,7 +103,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('supports')
             ->with($template)
-            ->will($this->returnValue($supports));
+            ->willReturn($supports);
 
         return $engine;
     }
@@ -117,7 +117,7 @@ class DelegatingEngineTest extends TestCase
             $container->expects($this->at($i++))
                 ->method('get')
                 ->with($id)
-                ->will($this->returnValue($service));
+                ->willReturn($service);
         }
 
         return $container;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
@@ -47,7 +47,7 @@ class GlobalVariablesTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue('token'));
+            ->willReturn('token');
 
         $this->assertSame('token', $this->globals->getToken());
     }
@@ -77,12 +77,12 @@ class GlobalVariablesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $this->assertSame($expectedUser, $this->globals->getUser());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
@@ -27,7 +27,7 @@ class TemplateLocatorTest extends TestCase
             ->expects($this->once())
             ->method('locate')
             ->with($template->getPath())
-            ->will($this->returnValue('/path/to/template'))
+            ->willReturn('/path/to/template')
         ;
 
         $locator = new TemplateLocator($fileLocator);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -26,13 +26,13 @@ class TemplateNameParserTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getBundle')
-            ->will($this->returnCallback(function ($bundle) {
+            ->willReturnCallback(function ($bundle) {
                 if (\in_array($bundle, ['SensioFooBundle', 'SensioCmsFooBundle', 'FooBundle'])) {
                     return true;
                 }
 
                 throw new \InvalidArgumentException();
-            }))
+            })
         ;
         $this->parser = new TemplateNameParser($kernel);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TimedPhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TimedPhpEngineTest.php
@@ -31,7 +31,7 @@ class TimedPhpEngineTest extends TestCase
         $stopwatch->expects($this->once())
             ->method('start')
             ->with('template.php (index.php)', 'template')
-            ->will($this->returnValue($stopwatchEvent));
+            ->willReturn($stopwatchEvent);
 
         $stopwatchEvent->expects($this->once())->method('stop');
 
@@ -56,7 +56,7 @@ class TimedPhpEngineTest extends TestCase
         $templateNameParser = $this->getMockBuilder('Symfony\Component\Templating\TemplateNameParserInterface')->getMock();
         $templateNameParser->expects($this->any())
             ->method('parse')
-            ->will($this->returnValue($templateReference));
+            ->willReturn($templateReference);
 
         return $templateNameParser;
     }
@@ -91,7 +91,7 @@ class TimedPhpEngineTest extends TestCase
         $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
         $loader->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($storage));
+            ->willReturn($storage);
 
         return $loader;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -147,7 +147,7 @@ class TranslatorTest extends TestCase
             ->expects($this->once())
             ->method('getParameter')
             ->with('kernel.default_locale')
-            ->will($this->returnValue('en'))
+            ->willReturn('en')
         ;
         $translator = new Translator($container, new MessageFormatter());
 
@@ -357,53 +357,53 @@ class TranslatorTest extends TestCase
         $loader
             ->expects($this->at(0))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('fr', [
+            ->willReturn($this->getCatalogue('fr', [
                 'foo' => 'foo (FR)',
-            ])))
+            ]))
         ;
         $loader
             ->expects($this->at(1))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('en', [
+            ->willReturn($this->getCatalogue('en', [
                 'foo' => 'foo (EN)',
                 'bar' => 'bar (EN)',
                 'choice' => '{0} choice 0 (EN)|{1} choice 1 (EN)|]1,Inf] choice inf (EN)',
-            ])))
+            ]))
         ;
         $loader
             ->expects($this->at(2))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('es', [
+            ->willReturn($this->getCatalogue('es', [
                 'foobar' => 'foobar (ES)',
-            ])))
+            ]))
         ;
         $loader
             ->expects($this->at(3))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('pt-PT', [
+            ->willReturn($this->getCatalogue('pt-PT', [
                 'foobarfoo' => 'foobarfoo (PT-PT)',
-            ])))
+            ]))
         ;
         $loader
             ->expects($this->at(4))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('pt_BR', [
+            ->willReturn($this->getCatalogue('pt_BR', [
                 'other choice' => '{0} other choice 0 (PT-BR)|{1} other choice 1 (PT-BR)|]1,Inf] other choice inf (PT-BR)',
-            ])))
+            ]))
         ;
         $loader
             ->expects($this->at(5))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('fr.UTF-8', [
+            ->willReturn($this->getCatalogue('fr.UTF-8', [
                 'foobarbaz' => 'foobarbaz (fr.UTF-8)',
-            ])))
+            ]))
         ;
         $loader
             ->expects($this->at(6))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('sr@latin', [
+            ->willReturn($this->getCatalogue('sr@latin', [
                 'foobarbax' => 'foobarbax (sr@latin)',
-            ])))
+            ]))
         ;
 
         return $loader;
@@ -415,7 +415,7 @@ class TranslatorTest extends TestCase
         $container
             ->expects($this->any())
             ->method('get')
-            ->will($this->returnValue($loader))
+            ->willReturn($loader)
         ;
 
         return $container;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
@@ -68,7 +68,7 @@ class ConstraintValidatorFactoryTest extends TestCase
         $constraint
             ->expects($this->exactly(2))
             ->method('validatedBy')
-            ->will($this->returnValue('Fully\\Qualified\\ConstraintValidator\\Class\\Name'));
+            ->willReturn('Fully\\Qualified\\ConstraintValidator\\Class\\Name');
 
         $factory = new ConstraintValidatorFactory(new Container());
         $factory->getInstance($constraint);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -132,17 +132,17 @@ class AbstractFactoryTest extends TestCase
         $factory
             ->expects($this->once())
             ->method('createAuthProvider')
-            ->will($this->returnValue('auth_provider'))
+            ->willReturn('auth_provider')
         ;
         $factory
             ->expects($this->atLeastOnce())
             ->method('getListenerId')
-            ->will($this->returnValue('abstract_listener'))
+            ->willReturn('abstract_listener')
         ;
         $factory
             ->expects($this->any())
             ->method('getKey')
-            ->will($this->returnValue('abstract_factory'))
+            ->willReturn('abstract_factory')
         ;
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/PreviewErrorControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/PreviewErrorControllerTest.php
@@ -44,7 +44,7 @@ class PreviewErrorControllerTest extends TestCase
                 }),
                 $this->equalTo(HttpKernelInterface::SUB_REQUEST)
             )
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $controller = new PreviewErrorController($kernel, $logicalControllerName);
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -24,7 +24,7 @@ class FilesystemLoaderTest extends TestCase
         $locator
             ->expects($this->once())
             ->method('locate')
-            ->will($this->returnValue(__DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig'))
+            ->willReturn(__DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig')
         ;
         $loader = new FilesystemLoader($locator, $parser);
         $loader->addPath(__DIR__.'/../DependencyInjection/Fixtures/Resources/views', 'namespace');
@@ -44,7 +44,7 @@ class FilesystemLoaderTest extends TestCase
         $locator
             ->expects($this->once())
             ->method('locate')
-            ->will($this->returnValue($template = __DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig'))
+            ->willReturn($template = __DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig')
         ;
         $loader = new FilesystemLoader($locator, $parser);
 
@@ -61,7 +61,7 @@ class FilesystemLoaderTest extends TestCase
             ->expects($this->once())
             ->method('parse')
             ->with('name.format.engine')
-            ->will($this->returnValue(new TemplateReference('', '', 'name', 'format', 'engine')))
+            ->willReturn(new TemplateReference('', '', 'name', 'format', 'engine'))
         ;
 
         $locator = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
@@ -85,14 +85,14 @@ class FilesystemLoaderTest extends TestCase
             ->expects($this->once())
             ->method('parse')
             ->with('name.format.engine')
-            ->will($this->returnValue(new TemplateReference('', '', 'name', 'format', 'engine')))
+            ->willReturn(new TemplateReference('', '', 'name', 'format', 'engine'))
         ;
 
         $locator = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
         $locator
             ->expects($this->once())
             ->method('locate')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $loader = new FilesystemLoader($locator, $parser);

--- a/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
@@ -18,13 +18,13 @@ class TemplateIteratorTest extends TestCase
     public function testGetIterator()
     {
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
-        $bundle->expects($this->any())->method('getName')->will($this->returnValue('BarBundle'));
-        $bundle->expects($this->any())->method('getPath')->will($this->returnValue(__DIR__.'/Fixtures/templates/BarBundle'));
+        $bundle->expects($this->any())->method('getName')->willReturn('BarBundle');
+        $bundle->expects($this->any())->method('getPath')->willReturn(__DIR__.'/Fixtures/templates/BarBundle');
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Kernel')->disableOriginalConstructor()->getMock();
-        $kernel->expects($this->any())->method('getBundles')->will($this->returnValue([
+        $kernel->expects($this->any())->method('getBundles')->willReturn([
             $bundle,
-        ]));
+        ]);
         $iterator = new TemplateIterator($kernel, __DIR__.'/Fixtures/templates', [__DIR__.'/Fixtures/templates/Foo' => 'Foo'], __DIR__.'/DependencyInjection/Fixtures/templates');
 
         $sorted = iterator_to_array($iterator);

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -97,11 +97,11 @@ class ProfilerControllerTest extends TestCase
         $profiler
             ->expects($this->exactly(2))
             ->method('loadProfile')
-            ->will($this->returnCallback(function ($token) {
+            ->willReturnCallback(function ($token) {
                 if ('found' == $token) {
                     return new Profile($token);
                 }
-            }))
+            })
         ;
 
         $controller = $this->createController($profiler, $twig, $withCsp);
@@ -149,7 +149,7 @@ class ProfilerControllerTest extends TestCase
         $profiler
             ->expects($this->once())
             ->method('find')
-            ->will($this->returnValue($tokens));
+            ->willReturn($tokens);
 
         $request = Request::create('/_profiler/empty/search/results', 'GET', [
             'limit' => 2,

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Csp/ContentSecurityPolicyHandlerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Csp/ContentSecurityPolicyHandlerTest.php
@@ -200,7 +200,7 @@ class ContentSecurityPolicyHandlerTest extends TestCase
 
         $generator->expects($this->any())
             ->method('generate')
-            ->will($this->returnValue($value));
+            ->willReturn($value);
 
         return $generator;
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -244,7 +244,7 @@ class WebDebugToolbarListenerTest extends TestCase
             ->expects($this->once())
             ->method('generate')
             ->with('_profiler', ['token' => 'xxxxxxxx'], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->will($this->returnValue('http://mydomain.com/_profiler/xxxxxxxx'))
+            ->willReturn('http://mydomain.com/_profiler/xxxxxxxx')
         ;
 
         $event = new FilterResponseEvent($this->getKernelMock(), $this->getRequestMock(), HttpKernelInterface::MASTER_REQUEST, $response);
@@ -302,10 +302,10 @@ class WebDebugToolbarListenerTest extends TestCase
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->setMethods(['getSession', 'isXmlHttpRequest', 'getRequestFormat'])->disableOriginalConstructor()->getMock();
         $request->expects($this->any())
             ->method('isXmlHttpRequest')
-            ->will($this->returnValue($isXmlHttpRequest));
+            ->willReturn($isXmlHttpRequest);
         $request->expects($this->any())
             ->method('getRequestFormat')
-            ->will($this->returnValue($requestFormat));
+            ->willReturn($requestFormat);
 
         $request->headers = new HeaderBag();
 
@@ -313,7 +313,7 @@ class WebDebugToolbarListenerTest extends TestCase
             $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')->disableOriginalConstructor()->getMock();
             $request->expects($this->any())
                 ->method('getSession')
-                ->will($this->returnValue($session));
+                ->willReturn($session);
         }
 
         return $request;
@@ -324,7 +324,7 @@ class WebDebugToolbarListenerTest extends TestCase
         $templating = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
         $templating->expects($this->any())
             ->method('render')
-            ->will($this->returnValue($render));
+            ->willReturn($render);
 
         return $templating;
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -69,7 +69,7 @@ class TemplateManagerTest extends TestCase
         $this->profiler->expects($this->any())
             ->method('has')
             ->withAnyParameters()
-            ->will($this->returnCallback([$this, 'profilerHasCallback']));
+            ->willReturnCallback([$this, 'profilerHasCallback']);
 
         $this->assertEquals('FooBundle:Collector:foo.html.twig', $this->templateManager->getName(new ProfileDummy(), 'foo'));
     }
@@ -83,7 +83,7 @@ class TemplateManagerTest extends TestCase
         $this->profiler->expects($this->any())
             ->method('has')
             ->withAnyParameters()
-            ->will($this->returnCallback([$this, 'profileHasCollectorCallback']));
+            ->willReturnCallback([$this, 'profileHasCollectorCallback']);
 
         $result = $this->templateManager->getTemplates(new ProfileDummy());
         $this->assertArrayHasKey('foo', $result);
@@ -124,14 +124,14 @@ class TemplateManagerTest extends TestCase
 
         $this->twigEnvironment->expects($this->any())
             ->method('loadTemplate')
-            ->will($this->returnValue('loadedTemplate'));
+            ->willReturn('loadedTemplate');
 
         if (interface_exists('Twig\Loader\SourceContextLoaderInterface')) {
             $loader = $this->getMockBuilder('Twig\Loader\SourceContextLoaderInterface')->getMock();
         } else {
             $loader = $this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock();
         }
-        $this->twigEnvironment->expects($this->any())->method('getLoader')->will($this->returnValue($loader));
+        $this->twigEnvironment->expects($this->any())->method('getLoader')->willReturn($loader);
 
         return $this->twigEnvironment;
     }

--- a/src/Symfony/Component/Asset/Tests/PathPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PathPackageTest.php
@@ -89,7 +89,7 @@ class PathPackageTest extends TestCase
     private function getContext($basePath)
     {
         $context = $this->getMockBuilder('Symfony\Component\Asset\Context\ContextInterface')->getMock();
-        $context->expects($this->any())->method('getBasePath')->will($this->returnValue($basePath));
+        $context->expects($this->any())->method('getBasePath')->willReturn($basePath);
 
         return $context;
     }

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -107,7 +107,7 @@ class UrlPackageTest extends TestCase
     private function getContext($secure)
     {
         $context = $this->getMockBuilder('Symfony\Component\Asset\Context\ContextInterface')->getMock();
-        $context->expects($this->any())->method('isSecure')->will($this->returnValue($secure));
+        $context->expects($this->any())->method('isSecure')->willReturn($secure);
 
         return $context;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -80,7 +80,7 @@ class ChainAdapterTest extends AdapterTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         return $pruneable;
     }
@@ -97,7 +97,7 @@ class ChainAdapterTest extends AdapterTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         return $pruneable;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -173,7 +173,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         return $pruneable;
     }
@@ -190,7 +190,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         return $pruneable;
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
@@ -78,7 +78,7 @@ class ChainCacheTest extends CacheTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         return $pruneable;
     }
@@ -95,7 +95,7 @@ class ChainCacheTest extends CacheTestCase
         $pruneable
             ->expects($this->atLeastOnce())
             ->method('prune')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         return $pruneable;
     }

--- a/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
@@ -35,12 +35,12 @@ class DelegatingLoaderTest extends TestCase
     public function testSupports()
     {
         $loader1 = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader1->expects($this->once())->method('supports')->will($this->returnValue(true));
+        $loader1->expects($this->once())->method('supports')->willReturn(true);
         $loader = new DelegatingLoader(new LoaderResolver([$loader1]));
         $this->assertTrue($loader->supports('foo.xml'), '->supports() returns true if the resource is loadable');
 
         $loader1 = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader1->expects($this->once())->method('supports')->will($this->returnValue(false));
+        $loader1->expects($this->once())->method('supports')->willReturn(false);
         $loader = new DelegatingLoader(new LoaderResolver([$loader1]));
         $this->assertFalse($loader->supports('foo.foo'), '->supports() returns false if the resource is not loadable');
     }
@@ -48,7 +48,7 @@ class DelegatingLoaderTest extends TestCase
     public function testLoad()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader->expects($this->once())->method('supports')->will($this->returnValue(true));
+        $loader->expects($this->once())->method('supports')->willReturn(true);
         $loader->expects($this->once())->method('load');
         $resolver = new LoaderResolver([$loader]);
         $loader = new DelegatingLoader($resolver);
@@ -62,7 +62,7 @@ class DelegatingLoaderTest extends TestCase
     public function testLoadThrowsAnExceptionIfTheResourceCannotBeLoaded()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader->expects($this->once())->method('supports')->will($this->returnValue(false));
+        $loader->expects($this->once())->method('supports')->willReturn(false);
         $resolver = new LoaderResolver([$loader]);
         $loader = new DelegatingLoader($resolver);
 

--- a/src/Symfony/Component/Config/Tests/Loader/LoaderResolverTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/LoaderResolverTest.php
@@ -32,7 +32,7 @@ class LoaderResolverTest extends TestCase
         $this->assertFalse($resolver->resolve('foo.foo'), '->resolve() returns false if no loader is able to load the resource');
 
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
-        $loader->expects($this->once())->method('supports')->will($this->returnValue(true));
+        $loader->expects($this->once())->method('supports')->willReturn(true);
         $resolver = new LoaderResolver([$loader]);
         $this->assertEquals($loader, $resolver->resolve(function () {}), '->resolve() returns the loader for the given resource');
     }

--- a/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
@@ -34,7 +34,7 @@ class LoaderTest extends TestCase
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('foo.xml')
-            ->will($this->returnValue($resolvedLoader));
+            ->willReturn($resolvedLoader);
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);
@@ -52,7 +52,7 @@ class LoaderTest extends TestCase
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('FOOBAR')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);
@@ -66,13 +66,13 @@ class LoaderTest extends TestCase
         $resolvedLoader->expects($this->once())
             ->method('load')
             ->with('foo')
-            ->will($this->returnValue('yes'));
+            ->willReturn('yes');
 
         $resolver = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderResolverInterface')->getMock();
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('foo')
-            ->will($this->returnValue($resolvedLoader));
+            ->willReturn($resolvedLoader);
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);
@@ -86,13 +86,13 @@ class LoaderTest extends TestCase
         $resolvedLoader->expects($this->once())
             ->method('load')
             ->with('foo', 'bar')
-            ->will($this->returnValue('yes'));
+            ->willReturn('yes');
 
         $resolver = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderResolverInterface')->getMock();
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('foo', 'bar')
-            ->will($this->returnValue($resolvedLoader));
+            ->willReturn($resolvedLoader);
 
         $loader = new ProjectLoader1();
         $loader->setResolver($resolver);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -660,7 +660,7 @@ class ApplicationTest extends TestCase
         $application = $this->getMockBuilder('Symfony\Component\Console\Application')->setMethods(['getNamespaces'])->getMock();
         $application->expects($this->once())
             ->method('getNamespaces')
-            ->will($this->returnValue(['foo:sublong', 'bar:sub']));
+            ->willReturn(['foo:sublong', 'bar:sub']);
 
         $this->assertEquals('foo:sublong', $application->findNamespace('f:sub'));
     }
@@ -804,7 +804,7 @@ class ApplicationTest extends TestCase
         $application->setAutoExit(false);
         $application->expects($this->any())
             ->method('getTerminalWidth')
-            ->will($this->returnValue(120));
+            ->willReturn(120);
         $application->register('foo')->setCode(function () {
             throw new \InvalidArgumentException("\n\nline 1 with extra spaces        \nline 2\n\nline 4\n");
         });

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -321,7 +321,7 @@ class CommandTest extends TestCase
         $command = $this->getMockBuilder('TestCommand')->setMethods(['execute'])->getMock();
         $command->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue('2.3'));
+            ->willReturn('2.3');
         $exitCode = $command->run(new StringInput(''), new NullOutput());
         $this->assertSame(2, $exitCode, '->run() returns integer exit code (casts numeric to int)');
     }

--- a/src/Symfony/Component/Console/Tests/Helper/AbstractQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/AbstractQuestionHelperTest.php
@@ -21,7 +21,7 @@ abstract class AbstractQuestionHelperTest extends TestCase
         $mock = $this->getMockBuilder(StreamableInputInterface::class)->getMock();
         $mock->expects($this->any())
             ->method('isInteractive')
-            ->will($this->returnValue($interactive));
+            ->willReturn($interactive);
 
         if ($stream) {
             $mock->expects($this->any())

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -114,7 +114,7 @@ class HelperSetTest extends TestCase
         $mock_helper = $this->getMockBuilder('\Symfony\Component\Console\Helper\HelperInterface')->getMock();
         $mock_helper->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name));
+            ->willReturn($name);
 
         if ($helperset) {
             $mock_helper->expects($this->any())

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -1068,7 +1068,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $mock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
         $mock->expects($this->any())
             ->method('isInteractive')
-            ->will($this->returnValue($interactive));
+            ->willReturn($interactive);
 
         return $mock;
     }

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -154,7 +154,7 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
         $mock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
         $mock->expects($this->any())
             ->method('isInteractive')
-            ->will($this->returnValue($interactive));
+            ->willReturn($interactive);
 
         return $mock;
     }

--- a/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
+++ b/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
@@ -166,7 +166,7 @@ class ConsoleLoggerTest extends TestCase
         } else {
             $dummy = $this->getMock('Symfony\Component\Console\Tests\Logger\DummyTest', ['__toString']);
         }
-        $dummy->method('__toString')->will($this->returnValue('DUMMY'));
+        $dummy->method('__toString')->willReturn('DUMMY');
 
         $this->getLogger()->warning($dummy);
 

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -234,7 +234,7 @@ class ErrorHandlerTest extends TestCase
             $logger
                 ->expects($this->once())
                 ->method('log')
-                ->will($this->returnCallback($warnArgCheck))
+                ->willReturnCallback($warnArgCheck)
             ;
 
             $handler = ErrorHandler::register();
@@ -262,7 +262,7 @@ class ErrorHandlerTest extends TestCase
             $logger
                 ->expects($this->once())
                 ->method('log')
-                ->will($this->returnCallback($logArgCheck))
+                ->willReturnCallback($logArgCheck)
             ;
 
             $handler = ErrorHandler::register();
@@ -318,7 +318,7 @@ class ErrorHandlerTest extends TestCase
         $logger
             ->expects($this->once())
             ->method('log')
-            ->will($this->returnCallback($logArgCheck))
+            ->willReturnCallback($logArgCheck)
         ;
 
         $handler = new ErrorHandler();
@@ -349,7 +349,7 @@ class ErrorHandlerTest extends TestCase
             $logger
                 ->expects($this->exactly(2))
                 ->method('log')
-                ->will($this->returnCallback($logArgCheck))
+                ->willReturnCallback($logArgCheck)
             ;
 
             $handler->setDefaultLogger($logger, E_ERROR);
@@ -503,7 +503,7 @@ class ErrorHandlerTest extends TestCase
             $logger
                 ->expects($this->once())
                 ->method('log')
-                ->will($this->returnCallback($logArgCheck))
+                ->willReturnCallback($logArgCheck)
             ;
 
             $handler->setDefaultLogger($logger, E_PARSE);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
@@ -31,13 +31,13 @@ class AutowireExceptionPassTest extends TestCase
         $autowireException = new AutowiringFailedException('foo_service_id', 'An autowiring exception message');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
-            ->will($this->returnValue([$autowireException]));
+            ->willReturn([$autowireException]);
 
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
             ->method('getInlinedServiceIds')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $container = new ContainerBuilder();
         $container->register('foo_service_id');
@@ -60,18 +60,18 @@ class AutowireExceptionPassTest extends TestCase
         $autowireException = new AutowiringFailedException('a_service', 'An autowiring exception message');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
-            ->will($this->returnValue([$autowireException]));
+            ->willReturn([$autowireException]);
 
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
             ->method('getInlinedServiceIds')
-            ->will($this->returnValue([
+            ->willReturn([
                 // a_service inlined into b_service
                 'a_service' => ['b_service'],
                 // b_service inlined into c_service
                 'b_service' => ['c_service'],
-            ]));
+            ]);
 
         $container = new ContainerBuilder();
         // ONLY register c_service in the final container
@@ -95,18 +95,18 @@ class AutowireExceptionPassTest extends TestCase
         $autowireException = new AutowiringFailedException('a_service', 'An autowiring exception message');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
-            ->will($this->returnValue([$autowireException]));
+            ->willReturn([$autowireException]);
 
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
             ->method('getInlinedServiceIds')
-            ->will($this->returnValue([
+            ->willReturn([
                 // a_service inlined into b_service
                 'a_service' => ['b_service'],
                 // b_service inlined into c_service
                 'b_service' => ['c_service'],
-            ]));
+            ]);
 
         // do NOT register c_service in the container
         $container = new ContainerBuilder();
@@ -126,13 +126,13 @@ class AutowireExceptionPassTest extends TestCase
         $autowireException = new AutowiringFailedException('non_existent_service');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
-            ->will($this->returnValue([$autowireException]));
+            ->willReturn([$autowireException]);
 
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
             ->method('getInlinedServiceIds')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $container = new ContainerBuilder();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -30,18 +30,18 @@ class MergeExtensionConfigurationPassTest extends TestCase
         $extension = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface')->getMock();
         $extension->expects($this->any())
             ->method('getXsdValidationBasePath')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $extension->expects($this->any())
             ->method('getNamespace')
-            ->will($this->returnValue('http://example.org/schema/dic/foo'));
+            ->willReturn('http://example.org/schema/dic/foo');
         $extension->expects($this->any())
             ->method('getAlias')
-            ->will($this->returnValue('foo'));
+            ->willReturn('foo');
         $extension->expects($this->once())
             ->method('load')
-            ->will($this->returnCallback(function (array $config, ContainerBuilder $container) use (&$tmpProviders) {
+            ->willReturnCallback(function (array $config, ContainerBuilder $container) use (&$tmpProviders) {
                 $tmpProviders = $container->getExpressionLanguageProviders();
-            }));
+            });
 
         $provider = $this->getMockBuilder('Symfony\\Component\\ExpressionLanguage\\ExpressionFunctionProviderInterface')->getMock();
         $container = new ContainerBuilder(new ParameterBag());
@@ -76,7 +76,7 @@ class MergeExtensionConfigurationPassTest extends TestCase
         $extension = $this->getMockBuilder(FooExtension::class)->setMethods(['getConfiguration'])->getMock();
         $extension->expects($this->exactly(2))
             ->method('getConfiguration')
-            ->will($this->returnValue(new FooConfiguration()));
+            ->willReturn(new FooConfiguration());
 
         $container = new ContainerBuilder(new ParameterBag());
         $container->registerExtension($extension);

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
@@ -67,10 +67,10 @@ class ContainerParametersResourceCheckerTest extends TestCase
                     [$this->equalTo('locales')],
                     [$this->equalTo('default_locale')]
                 )
-                ->will($this->returnValueMap([
+                ->willReturnMap([
                     ['locales', ['fr', 'en']],
                     ['default_locale', 'fr'],
-                ]))
+                ])
             ;
         }, true];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1059,7 +1059,7 @@ class ContainerBuilderTest extends TestCase
     public function testRegisteredButNotLoadedExtension()
     {
         $extension = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface')->getMock();
-        $extension->expects($this->once())->method('getAlias')->will($this->returnValue('project'));
+        $extension->expects($this->once())->method('getAlias')->willReturn('project');
         $extension->expects($this->never())->method('load');
 
         $container = new ContainerBuilder();
@@ -1071,7 +1071,7 @@ class ContainerBuilderTest extends TestCase
     public function testRegisteredAndLoadedExtension()
     {
         $extension = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface')->getMock();
-        $extension->expects($this->exactly(2))->method('getAlias')->will($this->returnValue('project'));
+        $extension->expects($this->exactly(2))->method('getAlias')->willReturn('project');
         $extension->expects($this->once())->method('load')->with([['foo' => 'bar']]);
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -862,13 +862,13 @@ class FormTest extends TestCase
         $field
             ->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name))
+            ->willReturn($name)
         ;
 
         $field
             ->expects($this->any())
             ->method('getValue')
-            ->will($this->returnValue($value))
+            ->willReturn($value)
         ;
 
         return $field;

--- a/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
@@ -43,7 +43,7 @@ class ImmutableEventDispatcherTest extends TestCase
         $this->innerDispatcher->expects($this->once())
             ->method('dispatch')
             ->with('event', $event)
-            ->will($this->returnValue('result'));
+            ->willReturn('result');
 
         $this->assertSame('result', $this->dispatcher->dispatch('event', $event));
     }
@@ -53,7 +53,7 @@ class ImmutableEventDispatcherTest extends TestCase
         $this->innerDispatcher->expects($this->once())
             ->method('getListeners')
             ->with('event')
-            ->will($this->returnValue('result'));
+            ->willReturn('result');
 
         $this->assertSame('result', $this->dispatcher->getListeners('event'));
     }
@@ -63,7 +63,7 @@ class ImmutableEventDispatcherTest extends TestCase
         $this->innerDispatcher->expects($this->once())
             ->method('hasListeners')
             ->with('event')
-            ->will($this->returnValue('result'));
+            ->willReturn('result');
 
         $this->assertSame('result', $this->dispatcher->hasListeners('event'));
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -36,18 +36,18 @@ class ExpressionLanguageTest extends TestCase
         $cacheItemMock
             ->expects($this->exactly(2))
             ->method('get')
-            ->will($this->returnCallback(function () use (&$savedParsedExpression) {
+            ->willReturnCallback(function () use (&$savedParsedExpression) {
                 return $savedParsedExpression;
-            }))
+            })
         ;
 
         $cacheItemMock
             ->expects($this->exactly(1))
             ->method('set')
             ->with($this->isInstanceOf(ParsedExpression::class))
-            ->will($this->returnCallback(function ($parsedExpression) use (&$savedParsedExpression) {
+            ->willReturnCallback(function ($parsedExpression) use (&$savedParsedExpression) {
                 $savedParsedExpression = $parsedExpression;
-            }))
+            })
         ;
 
         $cacheMock
@@ -85,9 +85,9 @@ class ExpressionLanguageTest extends TestCase
             ->expects($this->exactly(1))
             ->method('save')
             ->with('1%20%2B%201%2F%2F', $this->isInstanceOf(ParsedExpression::class))
-            ->will($this->returnCallback(function ($key, $expression) use (&$savedParsedExpression) {
+            ->willReturnCallback(function ($key, $expression) use (&$savedParsedExpression) {
                 $savedParsedExpression = $expression;
-            }))
+            })
         ;
 
         $parsedExpression = $expressionLanguage->parse('1 + 1', []);
@@ -213,18 +213,18 @@ class ExpressionLanguageTest extends TestCase
         $cacheItemMock
             ->expects($this->exactly(2))
             ->method('get')
-            ->will($this->returnCallback(function () use (&$savedParsedExpression) {
+            ->willReturnCallback(function () use (&$savedParsedExpression) {
                 return $savedParsedExpression;
-            }))
+            })
         ;
 
         $cacheItemMock
             ->expects($this->exactly(1))
             ->method('set')
             ->with($this->isInstanceOf(ParsedExpression::class))
-            ->will($this->returnCallback(function ($parsedExpression) use (&$savedParsedExpression) {
+            ->willReturnCallback(function ($parsedExpression) use (&$savedParsedExpression) {
                 $savedParsedExpression = $parsedExpression;
-            }))
+            })
         ;
 
         $cacheMock

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilterIteratorTest.php
@@ -26,9 +26,9 @@ class FilterIteratorTest extends RealIteratorTestCase
         $i = $this->getMockForAbstractClass('Symfony\Component\Finder\Iterator\FilterIterator', [$i]);
         $i->expects($this->any())
             ->method('accept')
-            ->will($this->returnCallback(function () use ($i) {
+            ->willReturnCallback(function () use ($i) {
                 return (bool) preg_match('/\.php/', (string) $i->current());
-            })
+            }
         );
 
         $c = 0;

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -473,7 +473,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     {
         $this->csrfTokenManager->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(new CsrfToken('token_id', 'foo&bar')));
+            ->willReturn(new CsrfToken('token_id', 'foo&bar'));
 
         $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($this->factory

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -312,10 +312,10 @@ abstract class AbstractRequestHandlerTest extends TestCase
     {
         $this->serverParams->expects($this->once())
             ->method('getContentLength')
-            ->will($this->returnValue($contentLength));
+            ->willReturn($contentLength);
         $this->serverParams->expects($this->any())
             ->method('getNormalizedIniPostMaxSize')
-            ->will($this->returnValue($iniMax));
+            ->willReturn($iniMax);
 
         $options = ['post_max_size_message' => 'Max {{ max }}!'];
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, $options);

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -339,7 +339,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     {
         $this->csrfTokenManager->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(new CsrfToken('token_id', 'foo&bar')));
+            ->willReturn(new CsrfToken('token_id', 'foo&bar'));
 
         $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($this->factory

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -42,7 +42,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with([])
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices([]));
         $this->assertSame($list, $this->factory->createListFromChoices([]));
@@ -58,7 +58,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices2)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list, $this->factory->createListFromChoices($choices2));
@@ -74,11 +74,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromChoices')
             ->with($choices1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromChoices')
             ->with($choices2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list2, $this->factory->createListFromChoices($choices2));
@@ -96,7 +96,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices1)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list, $this->factory->createListFromChoices($choices2));
@@ -115,11 +115,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromChoices')
             ->with($choices1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromChoices')
             ->with($choices2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list2, $this->factory->createListFromChoices($choices2));
@@ -134,7 +134,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices, $closure)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromChoices($choices, $closure));
         $this->assertSame($list, $this->factory->createListFromChoices($choices, $closure));
@@ -151,11 +151,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromChoices')
             ->with($choices, $closure1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromChoices')
             ->with($choices, $closure2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromChoices($choices, $closure1));
         $this->assertSame($list2, $this->factory->createListFromChoices($choices, $closure2));
@@ -169,7 +169,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromLoader($loader));
         $this->assertSame($list, $this->factory->createListFromLoader($loader));
@@ -185,11 +185,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromLoader')
             ->with($loader1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromLoader')
             ->with($loader2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromLoader($loader1));
         $this->assertSame($list2, $this->factory->createListFromLoader($loader2));
@@ -204,7 +204,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader, $closure)
-            ->will($this->returnValue($list));
+            ->willReturn($list);
 
         $this->assertSame($list, $this->factory->createListFromLoader($loader, $closure));
         $this->assertSame($list, $this->factory->createListFromLoader($loader, $closure));
@@ -221,11 +221,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromLoader')
             ->with($loader, $closure1)
-            ->will($this->returnValue($list1));
+            ->willReturn($list1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createListFromLoader')
             ->with($loader, $closure2)
-            ->will($this->returnValue($list2));
+            ->willReturn($list2);
 
         $this->assertSame($list1, $this->factory->createListFromLoader($loader, $closure1));
         $this->assertSame($list2, $this->factory->createListFromLoader($loader, $closure2));
@@ -240,7 +240,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $preferred)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, $preferred));
         $this->assertSame($view, $this->factory->createView($list, $preferred));
@@ -257,11 +257,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, $preferred1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, $preferred2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, $preferred1));
         $this->assertSame($view2, $this->factory->createView($list, $preferred2));
@@ -276,7 +276,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $preferred)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, $preferred));
         $this->assertSame($view, $this->factory->createView($list, $preferred));
@@ -293,11 +293,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, $preferred1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, $preferred2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, $preferred1));
         $this->assertSame($view2, $this->factory->createView($list, $preferred2));
@@ -312,7 +312,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, $labels)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, $labels));
         $this->assertSame($view, $this->factory->createView($list, null, $labels));
@@ -329,11 +329,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, $labels1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, $labels2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, $labels1));
         $this->assertSame($view2, $this->factory->createView($list, null, $labels2));
@@ -348,7 +348,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, $index)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, null, $index));
         $this->assertSame($view, $this->factory->createView($list, null, null, $index));
@@ -365,11 +365,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, null, $index1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, null, $index2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, $index1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, $index2));
@@ -384,7 +384,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, $groupBy)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, null, null, $groupBy));
         $this->assertSame($view, $this->factory->createView($list, null, null, null, $groupBy));
@@ -401,11 +401,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, null, null, $groupBy1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, null, null, $groupBy2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, $groupBy1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, $groupBy2));
@@ -420,7 +420,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, null, $attr)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, null, null, null, $attr));
         $this->assertSame($view, $this->factory->createView($list, null, null, null, null, $attr));
@@ -437,11 +437,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, null, null, null, $attr1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, null, null, null, $attr2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, null, $attr1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, null, $attr2));
@@ -456,7 +456,7 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, null, $attr)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $this->factory->createView($list, null, null, null, null, $attr));
         $this->assertSame($view, $this->factory->createView($list, null, null, null, null, $attr));
@@ -473,11 +473,11 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
             ->with($list, null, null, null, null, $attr1)
-            ->will($this->returnValue($view1));
+            ->willReturn($view1);
         $this->decoratedFactory->expects($this->at(1))
             ->method('createView')
             ->with($list, null, null, null, null, $attr2)
-            ->will($this->returnValue($view2));
+            ->willReturn($view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, null, $attr1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, null, $attr2));

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
@@ -43,9 +43,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($choices, $callback) {
+            ->willReturnCallback(function ($choices, $callback) {
                 return array_map($callback, $choices);
-            }));
+            });
 
         $this->assertSame(['value'], $this->factory->createListFromChoices($choices, 'property'));
     }
@@ -57,9 +57,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($choices, $callback) {
+            ->willReturnCallback(function ($choices, $callback) {
                 return array_map($callback, $choices);
-            }));
+            });
 
         $this->assertSame(['value'], $this->factory->createListFromChoices($choices, new PropertyPath('property')));
     }
@@ -86,9 +86,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($loader, $callback) {
+            ->willReturnCallback(function ($loader, $callback) {
                 return $callback((object) ['property' => 'value']);
-            }));
+            });
 
         $this->assertSame('value', $this->factory->createListFromLoader($loader, 'property'));
     }
@@ -116,9 +116,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($choices, $callback) {
+            ->willReturnCallback(function ($choices, $callback) {
                 return array_map($callback, $choices);
-            }));
+            });
 
         $this->assertSame([null], $this->factory->createListFromChoices($choices, 'property'));
     }
@@ -131,9 +131,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($loader, $callback) {
+            ->willReturnCallback(function ($loader, $callback) {
                 return $callback(null);
-            }));
+            });
 
         $this->assertNull($this->factory->createListFromLoader($loader, 'property'));
     }
@@ -145,9 +145,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($loader, $callback) {
+            ->willReturnCallback(function ($loader, $callback) {
                 return $callback((object) ['property' => 'value']);
-            }));
+            });
 
         $this->assertSame('value', $this->factory->createListFromLoader($loader, new PropertyPath('property')));
     }
@@ -159,9 +159,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred) {
+            ->willReturnCallback(function ($list, $preferred) {
                 return $preferred((object) ['property' => true]);
-            }));
+            });
 
         $this->assertTrue($this->factory->createView(
             $list,
@@ -194,9 +194,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred) {
+            ->willReturnCallback(function ($list, $preferred) {
                 return $preferred((object) ['property' => true]);
-            }));
+            });
 
         $this->assertTrue($this->factory->createView(
             $list,
@@ -212,9 +212,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred) {
+            ->willReturnCallback(function ($list, $preferred) {
                 return $preferred((object) ['category' => null]);
-            }));
+            });
 
         $this->assertFalse($this->factory->createView(
             $list,
@@ -229,9 +229,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label) {
+            ->willReturnCallback(function ($list, $preferred, $label) {
                 return $label((object) ['property' => 'label']);
-            }));
+            });
 
         $this->assertSame('label', $this->factory->createView(
             $list,
@@ -266,9 +266,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label) {
+            ->willReturnCallback(function ($list, $preferred, $label) {
                 return $label((object) ['property' => 'label']);
-            }));
+            });
 
         $this->assertSame('label', $this->factory->createView(
             $list,
@@ -284,9 +284,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index) {
                 return $index((object) ['property' => 'index']);
-            }));
+            });
 
         $this->assertSame('index', $this->factory->createView(
             $list,
@@ -323,9 +323,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index) {
                 return $index((object) ['property' => 'index']);
-            }));
+            });
 
         $this->assertSame('index', $this->factory->createView(
             $list,
@@ -342,9 +342,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
                 return $groupBy((object) ['property' => 'group']);
-            }));
+            });
 
         $this->assertSame('group', $this->factory->createView(
             $list,
@@ -383,9 +383,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
                 return $groupBy((object) ['property' => 'group']);
-            }));
+            });
 
         $this->assertSame('group', $this->factory->createView(
             $list,
@@ -404,9 +404,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
                 return $groupBy((object) ['group' => null]);
-            }));
+            });
 
         $this->assertNull($this->factory->createView(
             $list,
@@ -424,9 +424,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
                 return $attr((object) ['property' => 'attr']);
-            }));
+            });
 
         $this->assertSame('attr', $this->factory->createView(
             $list,
@@ -467,9 +467,9 @@ class PropertyAccessDecoratorTest extends TestCase
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
             ->with($list, null, null, null, null, $this->isInstanceOf('\Closure'))
-            ->will($this->returnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
+            ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
                 return $attr((object) ['property' => 'attr']);
-            }));
+            });
 
         $this->assertSame('attr', $this->factory->createView(
             $list,

--- a/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
@@ -50,12 +50,12 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getChoices')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getChoices());
         $this->assertSame('RESULT', $this->list->getChoices());
@@ -79,7 +79,7 @@ class LazyChoiceListTest extends TestCase
         // The same list is returned by the lazy choice list
         $this->loadedList->expects($this->exactly(2))
             ->method('getChoices')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getChoices());
         $this->assertSame('RESULT', $this->list->getChoices());
@@ -90,12 +90,12 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getValues')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getValues());
         $this->assertSame('RESULT', $this->list->getValues());
@@ -106,12 +106,12 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getStructuredValues')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getStructuredValues());
         $this->assertSame('RESULT', $this->list->getStructuredValues());
@@ -122,12 +122,12 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getOriginalKeys')
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getOriginalKeys());
         $this->assertSame('RESULT', $this->list->getOriginalKeys());
@@ -138,7 +138,7 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoicesForValues')
             ->with(['a', 'b'])
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getChoicesForValues(['a', 'b']));
         $this->assertSame('RESULT', $this->list->getChoicesForValues(['a', 'b']));
@@ -151,7 +151,7 @@ class LazyChoiceListTest extends TestCase
             ->with($this->value)
             // For BC, the same choice loaded list is returned 3 times
             // It should only twice in 4.0
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         $this->loader->expects($this->never())
             ->method('loadChoicesForValues');
@@ -159,7 +159,7 @@ class LazyChoiceListTest extends TestCase
         $this->loadedList->expects($this->exactly(2))
             ->method('getChoicesForValues')
             ->with(['a', 'b'])
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         // load choice list
         $this->list->getChoices();
@@ -176,7 +176,7 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadValuesForChoices')
             ->with(['a', 'b'])
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         $this->assertSame('RESULT', $this->list->getValuesForChoices(['a', 'b']));
         $this->assertSame('RESULT', $this->list->getValuesForChoices(['a', 'b']));
@@ -189,7 +189,7 @@ class LazyChoiceListTest extends TestCase
             ->with($this->value)
             // For BC, the same choice loaded list is returned 3 times
             // It should only twice in 4.0
-            ->will($this->returnValue($this->loadedList));
+            ->willReturn($this->loadedList);
 
         $this->loader->expects($this->never())
             ->method('loadValuesForChoices');
@@ -197,7 +197,7 @@ class LazyChoiceListTest extends TestCase
         $this->loadedList->expects($this->exactly(2))
             ->method('getValuesForChoices')
             ->with(['a', 'b'])
-            ->will($this->returnValue('RESULT'));
+            ->willReturn('RESULT');
 
         // load choice list
         $this->list->getChoices();

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -179,7 +179,7 @@ class CompoundFormTest extends AbstractFormTest
                 'bar' => 'baz',
                 'auto_initialize' => false,
             ])
-            ->will($this->returnValue($child));
+            ->willReturn($child);
 
         $this->form->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', ['bar' => 'baz']);
 
@@ -198,7 +198,7 @@ class CompoundFormTest extends AbstractFormTest
                 'bar' => 'baz',
                 'auto_initialize' => false,
             ])
-            ->will($this->returnValue($child));
+            ->willReturn($child);
 
         // in order to make casting unnecessary
         $this->form->add(0, 'Symfony\Component\Form\Extension\Core\Type\TextType', ['bar' => 'baz']);
@@ -215,7 +215,7 @@ class CompoundFormTest extends AbstractFormTest
         $this->factory->expects($this->once())
             ->method('createNamed')
             ->with('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->will($this->returnValue($child));
+            ->willReturn($child);
 
         $this->form->add('foo');
 
@@ -236,7 +236,7 @@ class CompoundFormTest extends AbstractFormTest
         $this->factory->expects($this->once())
             ->method('createForProperty')
             ->with('\stdClass', 'foo')
-            ->will($this->returnValue($child));
+            ->willReturn($child);
 
         $this->form->add('foo');
 
@@ -260,7 +260,7 @@ class CompoundFormTest extends AbstractFormTest
                 'bar' => 'baz',
                 'auto_initialize' => false,
             ])
-            ->will($this->returnValue($child));
+            ->willReturn($child);
 
         $this->form->add('foo', null, ['bar' => 'baz']);
 
@@ -352,10 +352,10 @@ class CompoundFormTest extends AbstractFormTest
         $mapper->expects($this->once())
             ->method('mapDataToForms')
             ->with('bar', $this->isInstanceOf('\RecursiveIteratorIterator'))
-            ->will($this->returnCallback(function ($data, \RecursiveIteratorIterator $iterator) use ($child) {
+            ->willReturnCallback(function ($data, \RecursiveIteratorIterator $iterator) use ($child) {
                 $this->assertInstanceOf('Symfony\Component\Form\Util\InheritDataAwareIterator', $iterator->getInnerIterator());
                 $this->assertSame([$child->getName() => $child], iterator_to_array($iterator));
-            }));
+            });
 
         $form->initialize();
         $form->add($child);
@@ -442,10 +442,10 @@ class CompoundFormTest extends AbstractFormTest
         $mapper->expects($this->once())
             ->method('mapDataToForms')
             ->with('bar', $this->isInstanceOf('\RecursiveIteratorIterator'))
-            ->will($this->returnCallback(function ($data, \RecursiveIteratorIterator $iterator) use ($child1, $child2) {
+            ->willReturnCallback(function ($data, \RecursiveIteratorIterator $iterator) use ($child1, $child2) {
                 $this->assertInstanceOf('Symfony\Component\Form\Util\InheritDataAwareIterator', $iterator->getInnerIterator());
                 $this->assertSame(['firstName' => $child1, 'lastName' => $child2], iterator_to_array($iterator));
-            }));
+            });
 
         $form->setData('foo');
     }
@@ -517,12 +517,12 @@ class CompoundFormTest extends AbstractFormTest
         $mapper->expects($this->once())
             ->method('mapFormsToData')
             ->with($this->isInstanceOf('\RecursiveIteratorIterator'), 'bar')
-            ->will($this->returnCallback(function (\RecursiveIteratorIterator $iterator) use ($child1, $child2) {
+            ->willReturnCallback(function (\RecursiveIteratorIterator $iterator) use ($child1, $child2) {
                 $this->assertInstanceOf('Symfony\Component\Form\Util\InheritDataAwareIterator', $iterator->getInnerIterator());
                 $this->assertSame(['firstName' => $child1, 'lastName' => $child2], iterator_to_array($iterator));
                 $this->assertEquals('Bernhard', $child1->getData());
                 $this->assertEquals('Schussek', $child2->getData());
-            }));
+            });
 
         $form->submit([
             'firstName' => 'Bernhard',
@@ -589,10 +589,10 @@ class CompoundFormTest extends AbstractFormTest
         $mapper->expects($this->once())
             ->method('mapFormsToData')
             ->with($this->isInstanceOf('\RecursiveIteratorIterator'), $object)
-            ->will($this->returnCallback(function (\RecursiveIteratorIterator $iterator) use ($child) {
+            ->willReturnCallback(function (\RecursiveIteratorIterator $iterator) use ($child) {
                 $this->assertInstanceOf('Symfony\Component\Form\Util\InheritDataAwareIterator', $iterator->getInnerIterator());
                 $this->assertSame(['name' => $child], iterator_to_array($iterator));
-            }));
+            });
 
         $form->submit([
             'name' => 'Bernhard',
@@ -912,11 +912,11 @@ class CompoundFormTest extends AbstractFormTest
         $field1View = new FormView();
         $type1
             ->method('createView')
-            ->will($this->returnValue($field1View));
+            ->willReturn($field1View);
         $field2View = new FormView();
         $type2
             ->method('createView')
-            ->will($this->returnValue($field2View));
+            ->willReturn($field2View);
 
         $this->form = $this->getBuilder('form', null, null, $options)
             ->setCompound(true)
@@ -935,13 +935,13 @@ class CompoundFormTest extends AbstractFormTest
         // First create the view
         $type->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         // Then build it for the form itself
         $type->expects($this->once())
             ->method('buildView')
             ->with($view, $this->form, $options)
-            ->will($this->returnCallback($assertChildViewsEqual([])));
+            ->willReturnCallback($assertChildViewsEqual([]));
 
         $this->assertSame($view, $this->form->createView());
         $this->assertSame(['foo' => $field1View, 'bar' => $field2View], $view->children);
@@ -961,7 +961,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $button->expects($this->any())
             ->method('isClicked')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $parentForm = $this->getBuilder('parent')->getForm();
         $nestedForm = $this->getBuilder('nested')->getForm();
@@ -983,7 +983,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $button->expects($this->any())
             ->method('isClicked')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->form->add($button);
         $this->form->submit([]);
@@ -1002,7 +1002,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $nestedForm->expects($this->any())
             ->method('getClickedButton')
-            ->will($this->returnValue($button));
+            ->willReturn($button);
 
         $this->form->add($nestedForm);
         $this->form->submit([]);
@@ -1021,7 +1021,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $parentForm->expects($this->any())
             ->method('getClickedButton')
-            ->will($this->returnValue($button));
+            ->willReturn($button);
 
         $this->form->setParent($parentForm);
         $this->form->submit([]);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DataTransformerChainTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DataTransformerChainTest.php
@@ -22,12 +22,12 @@ class DataTransformerChainTest extends TestCase
         $transformer1->expects($this->once())
             ->method('transform')
             ->with($this->identicalTo('foo'))
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar');
         $transformer2 = $this->getMockBuilder('Symfony\Component\Form\DataTransformerInterface')->getMock();
         $transformer2->expects($this->once())
             ->method('transform')
             ->with($this->identicalTo('bar'))
-            ->will($this->returnValue('baz'));
+            ->willReturn('baz');
 
         $chain = new DataTransformerChain([$transformer1, $transformer2]);
 
@@ -40,12 +40,12 @@ class DataTransformerChainTest extends TestCase
         $transformer2->expects($this->once())
             ->method('reverseTransform')
             ->with($this->identicalTo('foo'))
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar');
         $transformer1 = $this->getMockBuilder('Symfony\Component\Form\DataTransformerInterface')->getMock();
         $transformer1->expects($this->once())
             ->method('reverseTransform')
             ->with($this->identicalTo('bar'))
-            ->will($this->returnValue('baz'));
+            ->willReturn('baz');
 
         $chain = new DataTransformerChain([$transformer1, $transformer2]);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -122,7 +122,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('getToken')
             ->with('TOKEN_ID')
-            ->will($this->returnValue(new CsrfToken('TOKEN_ID', 'token')));
+            ->willReturn(new CsrfToken('TOKEN_ID', 'token'));
 
         $view = $this->factory
             ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
@@ -141,7 +141,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('getToken')
             ->with('FORM_NAME')
-            ->will($this->returnValue('token'));
+            ->willReturn('token');
 
         $view = $this->factory
             ->createNamed('FORM_NAME', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
@@ -159,7 +159,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('getToken')
             ->with('Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->will($this->returnValue('token'));
+            ->willReturn('token');
 
         $view = $this->factory
             ->createNamed('', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
@@ -188,7 +188,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('isTokenValid')
             ->with(new CsrfToken('TOKEN_ID', 'token'))
-            ->will($this->returnValue($valid));
+            ->willReturn($valid);
 
         $form = $this->factory
             ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
@@ -220,7 +220,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('isTokenValid')
             ->with(new CsrfToken('FORM_NAME', 'token'))
-            ->will($this->returnValue($valid));
+            ->willReturn($valid);
 
         $form = $this->factory
             ->createNamedBuilder('FORM_NAME', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
@@ -251,7 +251,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('isTokenValid')
             ->with(new CsrfToken('Symfony\Component\Form\Extension\Core\Type\FormType', 'token'))
-            ->will($this->returnValue($valid));
+            ->willReturn($valid);
 
         $form = $this->factory
             ->createNamedBuilder('', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
@@ -366,12 +366,12 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('isTokenValid')
             ->with(new CsrfToken('TOKEN_ID', 'token'))
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->translator->expects($this->once())
              ->method('trans')
              ->with('Foobar')
-             ->will($this->returnValue('[trans]Foobar[/trans]'));
+             ->willReturn('[trans]Foobar[/trans]');
 
         $form = $this->factory
             ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, [

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -84,29 +84,29 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor->expects($this->at(0))
             ->method('extractConfiguration')
             ->with($this->form)
-            ->will($this->returnValue(['config' => 'foo']));
+            ->willReturn(['config' => 'foo']);
         $this->dataExtractor->expects($this->at(1))
             ->method('extractConfiguration')
             ->with($this->childForm)
-            ->will($this->returnValue(['config' => 'bar']));
+            ->willReturn(['config' => 'bar']);
 
         $this->dataExtractor->expects($this->at(2))
             ->method('extractDefaultData')
             ->with($this->form)
-            ->will($this->returnValue(['default_data' => 'foo']));
+            ->willReturn(['default_data' => 'foo']);
         $this->dataExtractor->expects($this->at(3))
             ->method('extractDefaultData')
             ->with($this->childForm)
-            ->will($this->returnValue(['default_data' => 'bar']));
+            ->willReturn(['default_data' => 'bar']);
 
         $this->dataExtractor->expects($this->at(4))
             ->method('extractSubmittedData')
             ->with($this->form)
-            ->will($this->returnValue(['submitted_data' => 'foo']));
+            ->willReturn(['submitted_data' => 'foo']);
         $this->dataExtractor->expects($this->at(5))
             ->method('extractSubmittedData')
             ->with($this->childForm)
-            ->will($this->returnValue(['submitted_data' => 'bar']));
+            ->willReturn(['submitted_data' => 'bar']);
 
         $this->dataCollector->collectConfiguration($this->form);
         $this->dataCollector->collectDefaultData($this->form);
@@ -150,11 +150,11 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor->expects($this->at(0))
             ->method('extractConfiguration')
             ->with($form1)
-            ->will($this->returnValue(['config' => 'foo']));
+            ->willReturn(['config' => 'foo']);
         $this->dataExtractor->expects($this->at(1))
             ->method('extractConfiguration')
             ->with($form2)
-            ->will($this->returnValue(['config' => 'bar']));
+            ->willReturn(['config' => 'bar']);
 
         $this->dataCollector->collectConfiguration($form1);
         $this->dataCollector->collectConfiguration($form2);
@@ -200,12 +200,12 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor->expects($this->at(0))
             ->method('extractConfiguration')
             ->with($this->form)
-            ->will($this->returnValue(['config' => 'foo']));
+            ->willReturn(['config' => 'foo']);
 
         $this->dataExtractor->expects($this->at(1))
             ->method('extractDefaultData')
             ->with($this->form)
-            ->will($this->returnValue(['default_data' => 'foo']));
+            ->willReturn(['default_data' => 'foo']);
 
         $this->dataCollector->collectConfiguration($this->form);
         $this->dataCollector->buildPreliminaryFormTree($this->form);
@@ -272,39 +272,39 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor->expects($this->at(0))
             ->method('extractConfiguration')
             ->with($this->form)
-            ->will($this->returnValue(['config' => 'foo']));
+            ->willReturn(['config' => 'foo']);
         $this->dataExtractor->expects($this->at(1))
             ->method('extractConfiguration')
             ->with($this->childForm)
-            ->will($this->returnValue(['config' => 'bar']));
+            ->willReturn(['config' => 'bar']);
 
         $this->dataExtractor->expects($this->at(2))
             ->method('extractDefaultData')
             ->with($this->form)
-            ->will($this->returnValue(['default_data' => 'foo']));
+            ->willReturn(['default_data' => 'foo']);
         $this->dataExtractor->expects($this->at(3))
             ->method('extractDefaultData')
             ->with($this->childForm)
-            ->will($this->returnValue(['default_data' => 'bar']));
+            ->willReturn(['default_data' => 'bar']);
 
         $this->dataExtractor->expects($this->at(4))
             ->method('extractSubmittedData')
             ->with($this->form)
-            ->will($this->returnValue(['submitted_data' => 'foo']));
+            ->willReturn(['submitted_data' => 'foo']);
         $this->dataExtractor->expects($this->at(5))
             ->method('extractSubmittedData')
             ->with($this->childForm)
-            ->will($this->returnValue(['submitted_data' => 'bar']));
+            ->willReturn(['submitted_data' => 'bar']);
 
         $this->dataExtractor->expects($this->at(6))
             ->method('extractViewVariables')
             ->with($this->view)
-            ->will($this->returnValue(['view_vars' => 'foo']));
+            ->willReturn(['view_vars' => 'foo']);
 
         $this->dataExtractor->expects($this->at(7))
             ->method('extractViewVariables')
             ->with($this->childView)
-            ->will($this->returnValue(['view_vars' => 'bar']));
+            ->willReturn(['view_vars' => 'bar']);
 
         $this->dataCollector->collectConfiguration($this->form);
         $this->dataCollector->collectDefaultData($this->form);
@@ -365,76 +365,76 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor->expects($this->at(0))
             ->method('extractConfiguration')
             ->with($form1)
-            ->will($this->returnValue(['config' => 'foo']));
+            ->willReturn(['config' => 'foo']);
         $this->dataExtractor->expects($this->at(1))
             ->method('extractConfiguration')
             ->with($child1)
-            ->will($this->returnValue(['config' => 'bar']));
+            ->willReturn(['config' => 'bar']);
 
         $this->dataExtractor->expects($this->at(2))
             ->method('extractDefaultData')
             ->with($form1)
-            ->will($this->returnValue(['default_data' => 'foo']));
+            ->willReturn(['default_data' => 'foo']);
         $this->dataExtractor->expects($this->at(3))
             ->method('extractDefaultData')
             ->with($child1)
-            ->will($this->returnValue(['default_data' => 'bar']));
+            ->willReturn(['default_data' => 'bar']);
 
         $this->dataExtractor->expects($this->at(4))
             ->method('extractSubmittedData')
             ->with($form1)
-            ->will($this->returnValue(['submitted_data' => 'foo']));
+            ->willReturn(['submitted_data' => 'foo']);
         $this->dataExtractor->expects($this->at(5))
             ->method('extractSubmittedData')
             ->with($child1)
-            ->will($this->returnValue(['submitted_data' => 'bar']));
+            ->willReturn(['submitted_data' => 'bar']);
 
         $this->dataExtractor->expects($this->at(6))
             ->method('extractViewVariables')
             ->with($form1View)
-            ->will($this->returnValue(['view_vars' => 'foo']));
+            ->willReturn(['view_vars' => 'foo']);
 
         $this->dataExtractor->expects($this->at(7))
             ->method('extractViewVariables')
             ->with($child1View)
-            ->will($this->returnValue(['view_vars' => $child1View->vars]));
+            ->willReturn(['view_vars' => $child1View->vars]);
 
         $this->dataExtractor->expects($this->at(8))
             ->method('extractConfiguration')
             ->with($form2)
-            ->will($this->returnValue(['config' => 'foo']));
+            ->willReturn(['config' => 'foo']);
         $this->dataExtractor->expects($this->at(9))
             ->method('extractConfiguration')
             ->with($child1)
-            ->will($this->returnValue(['config' => 'bar']));
+            ->willReturn(['config' => 'bar']);
 
         $this->dataExtractor->expects($this->at(10))
             ->method('extractDefaultData')
             ->with($form2)
-            ->will($this->returnValue(['default_data' => 'foo']));
+            ->willReturn(['default_data' => 'foo']);
         $this->dataExtractor->expects($this->at(11))
             ->method('extractDefaultData')
             ->with($child1)
-            ->will($this->returnValue(['default_data' => 'bar']));
+            ->willReturn(['default_data' => 'bar']);
 
         $this->dataExtractor->expects($this->at(12))
             ->method('extractSubmittedData')
             ->with($form2)
-            ->will($this->returnValue(['submitted_data' => 'foo']));
+            ->willReturn(['submitted_data' => 'foo']);
         $this->dataExtractor->expects($this->at(13))
             ->method('extractSubmittedData')
             ->with($child1)
-            ->will($this->returnValue(['submitted_data' => 'bar']));
+            ->willReturn(['submitted_data' => 'bar']);
 
         $this->dataExtractor->expects($this->at(14))
             ->method('extractViewVariables')
             ->with($form2View)
-            ->will($this->returnValue(['view_vars' => 'foo']));
+            ->willReturn(['view_vars' => 'foo']);
 
         $this->dataExtractor->expects($this->at(15))
             ->method('extractViewVariables')
             ->with($child1View)
-            ->will($this->returnValue(['view_vars' => $child1View->vars]));
+            ->willReturn(['view_vars' => $child1View->vars]);
 
         $this->dataCollector->collectConfiguration($form1);
         $this->dataCollector->collectDefaultData($form1);
@@ -518,11 +518,11 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor->expects($this->at(0))
             ->method('extractConfiguration')
             ->with($this->form)
-            ->will($this->returnValue(['config' => 'foo']));
+            ->willReturn(['config' => 'foo']);
         $this->dataExtractor->expects($this->at(1))
             ->method('extractConfiguration')
             ->with($this->childForm)
-            ->will($this->returnValue(['config' => 'bar']));
+            ->willReturn(['config' => 'bar']);
 
         // explicitly call collectConfiguration(), since $this->childForm is not
         // contained in the form tree
@@ -566,11 +566,11 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor->expects($this->at(0))
             ->method('extractConfiguration')
             ->with($this->form)
-            ->will($this->returnValue(['config' => 'foo']));
+            ->willReturn(['config' => 'foo']);
         $this->dataExtractor->expects($this->at(1))
             ->method('extractConfiguration')
             ->with($this->childForm)
-            ->will($this->returnValue(['config' => 'bar']));
+            ->willReturn(['config' => 'bar']);
 
         // explicitly call collectConfiguration(), since $this->childForm is not
         // contained in the form tree
@@ -611,22 +611,22 @@ class FormDataCollectorTest extends TestCase
         $form1->add($childForm1);
         $this->dataExtractor
              ->method('extractConfiguration')
-             ->will($this->returnValue([]));
+             ->willReturn([]);
         $this->dataExtractor
              ->method('extractDefaultData')
-             ->will($this->returnValue([]));
+             ->willReturn([]);
         $this->dataExtractor->expects($this->at(4))
             ->method('extractSubmittedData')
             ->with($form1)
-            ->will($this->returnValue(['errors' => ['foo']]));
+            ->willReturn(['errors' => ['foo']]);
         $this->dataExtractor->expects($this->at(5))
             ->method('extractSubmittedData')
             ->with($childForm1)
-            ->will($this->returnValue(['errors' => ['bar', 'bam']]));
+            ->willReturn(['errors' => ['bar', 'bam']]);
         $this->dataExtractor->expects($this->at(8))
             ->method('extractSubmittedData')
             ->with($form2)
-            ->will($this->returnValue(['errors' => ['baz']]));
+            ->willReturn(['errors' => ['baz']]);
 
         $this->dataCollector->collectSubmittedData($form1);
 
@@ -653,30 +653,30 @@ class FormDataCollectorTest extends TestCase
 
         $this->dataExtractor
             ->method('extractConfiguration')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
         $this->dataExtractor
             ->method('extractDefaultData')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
         $this->dataExtractor->expects($this->at(10))
             ->method('extractSubmittedData')
             ->with($this->form)
-            ->will($this->returnValue(['errors' => []]));
+            ->willReturn(['errors' => []]);
         $this->dataExtractor->expects($this->at(11))
             ->method('extractSubmittedData')
             ->with($child1Form)
-            ->will($this->returnValue(['errors' => []]));
+            ->willReturn(['errors' => []]);
         $this->dataExtractor->expects($this->at(12))
             ->method('extractSubmittedData')
             ->with($child11Form)
-            ->will($this->returnValue(['errors' => ['foo']]));
+            ->willReturn(['errors' => ['foo']]);
         $this->dataExtractor->expects($this->at(13))
             ->method('extractSubmittedData')
             ->with($child2Form)
-            ->will($this->returnValue(['errors' => []]));
+            ->willReturn(['errors' => []]);
         $this->dataExtractor->expects($this->at(14))
             ->method('extractSubmittedData')
             ->with($child21Form)
-            ->will($this->returnValue(['errors' => []]));
+            ->willReturn(['errors' => []]);
 
         $this->dataCollector->collectSubmittedData($this->form);
         $this->dataCollector->buildPreliminaryFormTree($this->form);
@@ -701,14 +701,14 @@ class FormDataCollectorTest extends TestCase
 
         $this->dataExtractor->expects($this->any())
             ->method('extractConfiguration')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
         $this->dataExtractor->expects($this->any())
             ->method('extractDefaultData')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
         $this->dataExtractor->expects($this->any())
             ->method('extractSubmittedData')
             ->with($form)
-            ->will($this->returnValue(['errors' => ['baz']]));
+            ->willReturn(['errors' => ['baz']]);
 
         $this->dataCollector->buildPreliminaryFormTree($form);
         $this->dataCollector->collectSubmittedData($form);

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -56,7 +56,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $form = $this->createBuilder('name')
             ->setType($type)
@@ -77,7 +77,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $options = [
             'b' => 'foo',
@@ -111,7 +111,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $options = [
             'b' => 'foo',
@@ -142,7 +142,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $grandParent = $this->createBuilder('grandParent')
             ->setCompound(true)

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -42,7 +42,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
         $this->validator->expects($this->once())
             ->method('validate')
             ->with($this->equalTo($form))
-            ->will($this->returnValue(new ConstraintViolationList()));
+            ->willReturn(new ConstraintViolationList());
 
         // specific data is irrelevant
         $form->submit([]);

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -91,7 +91,7 @@ class FormBuilderTest extends TestCase
         $this->factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->will($this->returnValue(new FormBuilder('foo', null, $this->dispatcher, $this->factory)));
+            ->willReturn(new FormBuilder('foo', null, $this->dispatcher, $this->factory));
 
         $this->assertCount(0, $this->builder->all());
         $this->assertFalse($this->builder->has('foo'));
@@ -186,7 +186,7 @@ class FormBuilderTest extends TestCase
         $this->factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with($expectedName, $expectedType, null, $expectedOptions)
-            ->will($this->returnValue($this->getFormBuilder()));
+            ->willReturn($this->getFormBuilder());
 
         $this->builder->add($expectedName, $expectedType, $expectedOptions);
         $builder = $this->builder->get($expectedName);
@@ -202,7 +202,7 @@ class FormBuilderTest extends TestCase
         $this->factory->expects($this->once())
             ->method('createBuilderForProperty')
             ->with('stdClass', $expectedName, null, $expectedOptions)
-            ->will($this->returnValue($this->getFormBuilder()));
+            ->willReturn($this->getFormBuilder());
 
         $this->builder = new FormBuilder('name', 'stdClass', $this->dispatcher, $this->factory);
         $this->builder->add($expectedName, null, $expectedOptions);
@@ -236,7 +236,7 @@ class FormBuilderTest extends TestCase
 
         $mock->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name));
+            ->willReturn($name);
 
         return $mock;
     }

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -58,10 +58,10 @@ class FormFactoryTest extends TestCase
 
         $this->registry->expects($this->any())
             ->method('getTypeGuesser')
-            ->will($this->returnValue(new FormTypeGuesserChain([
+            ->willReturn(new FormTypeGuesserChain([
                 $this->guesser1,
                 $this->guesser2,
-            ])));
+            ]));
     }
 
     public function testCreateNamedBuilderWithTypeName()
@@ -73,16 +73,16 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->once())
             ->method('getType')
             ->with('type')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
             ->with($this->factory, 'name', $options)
-            ->will($this->returnValue($this->builder));
+            ->willReturn($this->builder);
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -101,16 +101,16 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->once())
             ->method('getType')
             ->with('type')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
             ->with($this->factory, 'name', $expectedOptions)
-            ->will($this->returnValue($this->builder));
+            ->willReturn($this->builder);
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -128,16 +128,16 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->once())
             ->method('getType')
             ->with('type')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
             ->with($this->factory, 'name', $options)
-            ->will($this->returnValue($this->builder));
+            ->willReturn($this->builder);
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -181,16 +181,16 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->any())
             ->method('getType')
             ->with('TYPE')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
             ->with($this->factory, 'TYPE_PREFIX', $options)
-            ->will($this->returnValue($this->builder));
+            ->willReturn($this->builder);
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -198,7 +198,7 @@ class FormFactoryTest extends TestCase
 
         $this->builder->expects($this->once())
             ->method('getForm')
-            ->will($this->returnValue('FORM'));
+            ->willReturn('FORM');
 
         $this->assertSame('FORM', $this->factory->create('TYPE', null, $options));
     }
@@ -212,16 +212,16 @@ class FormFactoryTest extends TestCase
         $this->registry->expects($this->once())
             ->method('getType')
             ->with('type')
-            ->will($this->returnValue($resolvedType));
+            ->willReturn($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
             ->with($this->factory, 'name', $options)
-            ->will($this->returnValue($this->builder));
+            ->willReturn($this->builder);
 
         $this->builder->expects($this->any())
             ->method('getOptions')
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $resolvedType->expects($this->once())
             ->method('buildForm')
@@ -229,7 +229,7 @@ class FormFactoryTest extends TestCase
 
         $this->builder->expects($this->once())
             ->method('getForm')
-            ->will($this->returnValue('FORM'));
+            ->willReturn('FORM');
 
         $this->assertSame('FORM', $this->factory->createNamed('name', 'type', null, $options));
     }
@@ -245,7 +245,7 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [])
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
 
@@ -257,27 +257,27 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessType')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new TypeGuess(
+            ->willReturn(new TypeGuess(
                 'Symfony\Component\Form\Extension\Core\Type\TextType',
                 ['attr' => ['maxlength' => 10]],
                 Guess::MEDIUM_CONFIDENCE
-            )));
+            ));
 
         $this->guesser2->expects($this->once())
             ->method('guessType')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new TypeGuess(
+            ->willReturn(new TypeGuess(
                 'Symfony\Component\Form\Extension\Core\Type\PasswordType',
                 ['attr' => ['maxlength' => 7]],
                 Guess::HIGH_CONFIDENCE
-            )));
+            ));
 
         $factory = $this->getMockFactory(['createNamedBuilder']);
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', null, ['attr' => ['maxlength' => 7]])
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
 
@@ -289,14 +289,14 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessType')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $factory = $this->getMockFactory(['createNamedBuilder']);
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
 
@@ -308,18 +308,18 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessType')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new TypeGuess(
+            ->willReturn(new TypeGuess(
                 'Symfony\Component\Form\Extension\Core\Type\TextType',
                 ['attr' => ['class' => 'foo', 'maxlength' => 10]],
                 Guess::MEDIUM_CONFIDENCE
-            )));
+            ));
 
         $factory = $this->getMockFactory(['createNamedBuilder']);
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['attr' => ['class' => 'foo', 'maxlength' => 11]])
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
@@ -336,25 +336,25 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessMaxLength')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     15,
                     Guess::MEDIUM_CONFIDENCE
-                )));
+                ));
 
         $this->guesser2->expects($this->once())
             ->method('guessMaxLength')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     20,
                     Guess::HIGH_CONFIDENCE
-                )));
+                ));
 
         $factory = $this->getMockFactory(['createNamedBuilder']);
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['attr' => ['maxlength' => 20]])
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
@@ -369,25 +369,25 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessMaxLength')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                 20,
                 Guess::HIGH_CONFIDENCE
-            )));
+            ));
 
         $this->guesser2->expects($this->once())
             ->method('guessPattern')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                 '.{5,}',
                 Guess::HIGH_CONFIDENCE
-            )));
+            ));
 
         $factory = $this->getMockFactory(['createNamedBuilder']);
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['attr' => ['maxlength' => 20, 'pattern' => '.{5,}', 'class' => 'tinymce']])
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
@@ -404,25 +404,25 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessRequired')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     true,
                     Guess::MEDIUM_CONFIDENCE
-                )));
+                ));
 
         $this->guesser2->expects($this->once())
             ->method('guessRequired')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     false,
                     Guess::HIGH_CONFIDENCE
-                )));
+                ));
 
         $factory = $this->getMockFactory(['createNamedBuilder']);
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['required' => false])
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
@@ -437,25 +437,25 @@ class FormFactoryTest extends TestCase
         $this->guesser1->expects($this->once())
             ->method('guessPattern')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     '[a-z]',
                     Guess::MEDIUM_CONFIDENCE
-                )));
+                ));
 
         $this->guesser2->expects($this->once())
             ->method('guessPattern')
             ->with('Application\Author', 'firstName')
-            ->will($this->returnValue(new ValueGuess(
+            ->willReturn(new ValueGuess(
                     '[a-zA-Z]',
                     Guess::HIGH_CONFIDENCE
-                )));
+                ));
 
         $factory = $this->getMockFactory(['createNamedBuilder']);
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['attr' => ['pattern' => '[a-zA-Z]']])
-            ->will($this->returnValue('builderInstance'));
+            ->willReturn('builderInstance');
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -99,21 +99,21 @@ class ResolvedFormTypeTest extends TestCase
         // First the default options are generated for the super type
         $this->parentType->expects($this->once())
             ->method('configureOptions')
-            ->will($this->returnCallback($assertIndexAndAddOption(0, 'a', 'a_default')));
+            ->willReturnCallback($assertIndexAndAddOption(0, 'a', 'a_default'));
 
         // The form type itself
         $this->type->expects($this->once())
             ->method('configureOptions')
-            ->will($this->returnCallback($assertIndexAndAddOption(1, 'b', 'b_default')));
+            ->willReturnCallback($assertIndexAndAddOption(1, 'b', 'b_default'));
 
         // And its extensions
         $this->extension1->expects($this->once())
             ->method('configureOptions')
-            ->will($this->returnCallback($assertIndexAndAddOption(2, 'c', 'c_default')));
+            ->willReturnCallback($assertIndexAndAddOption(2, 'c', 'c_default'));
 
         $this->extension2->expects($this->once())
             ->method('configureOptions')
-            ->will($this->returnCallback($assertIndexAndAddOption(3, 'd', 'd_default')));
+            ->willReturnCallback($assertIndexAndAddOption(3, 'd', 'd_default'));
 
         $givenOptions = ['a' => 'a_custom', 'c' => 'c_custom'];
         $resolvedOptions = ['a' => 'a_custom', 'b' => 'b_default', 'c' => 'c_custom', 'd' => 'd_default'];
@@ -136,12 +136,12 @@ class ResolvedFormTypeTest extends TestCase
 
         $this->resolvedType->expects($this->once())
             ->method('getOptionsResolver')
-            ->will($this->returnValue($optionsResolver));
+            ->willReturn($optionsResolver);
 
         $optionsResolver->expects($this->once())
             ->method('resolve')
             ->with($givenOptions)
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $factory = $this->getMockFormFactory();
         $builder = $this->resolvedType->createBuilder($factory, 'name', $givenOptions);
@@ -164,12 +164,12 @@ class ResolvedFormTypeTest extends TestCase
 
         $this->resolvedType->expects($this->once())
             ->method('getOptionsResolver')
-            ->will($this->returnValue($optionsResolver));
+            ->willReturn($optionsResolver);
 
         $optionsResolver->expects($this->once())
             ->method('resolve')
             ->with($givenOptions)
-            ->will($this->returnValue($resolvedOptions));
+            ->willReturn($resolvedOptions);
 
         $factory = $this->getMockFormFactory();
         $builder = $this->resolvedType->createBuilder($factory, 'name', $givenOptions);
@@ -198,24 +198,24 @@ class ResolvedFormTypeTest extends TestCase
         $this->parentType->expects($this->once())
             ->method('buildForm')
             ->with($builder, $options)
-            ->will($this->returnCallback($assertIndex(0)));
+            ->willReturnCallback($assertIndex(0));
 
         // Then the type itself
         $this->type->expects($this->once())
             ->method('buildForm')
             ->with($builder, $options)
-            ->will($this->returnCallback($assertIndex(1)));
+            ->willReturnCallback($assertIndex(1));
 
         // Then its extensions
         $this->extension1->expects($this->once())
             ->method('buildForm')
             ->with($builder, $options)
-            ->will($this->returnCallback($assertIndex(2)));
+            ->willReturnCallback($assertIndex(2));
 
         $this->extension2->expects($this->once())
             ->method('buildForm')
             ->with($builder, $options)
-            ->will($this->returnCallback($assertIndex(3)));
+            ->willReturnCallback($assertIndex(3));
 
         $this->resolvedType->buildForm($builder, $options);
     }
@@ -261,24 +261,24 @@ class ResolvedFormTypeTest extends TestCase
         $this->parentType->expects($this->once())
             ->method('buildView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(0)));
+            ->willReturnCallback($assertIndex(0));
 
         // Then the type itself
         $this->type->expects($this->once())
             ->method('buildView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(1)));
+            ->willReturnCallback($assertIndex(1));
 
         // Then its extensions
         $this->extension1->expects($this->once())
             ->method('buildView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(2)));
+            ->willReturnCallback($assertIndex(2));
 
         $this->extension2->expects($this->once())
             ->method('buildView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(3)));
+            ->willReturnCallback($assertIndex(3));
 
         $this->resolvedType->buildView($view, $form, $options);
     }
@@ -303,24 +303,24 @@ class ResolvedFormTypeTest extends TestCase
         $this->parentType->expects($this->once())
             ->method('finishView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(0)));
+            ->willReturnCallback($assertIndex(0));
 
         // Then the type itself
         $this->type->expects($this->once())
             ->method('finishView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(1)));
+            ->willReturnCallback($assertIndex(1));
 
         // Then its extensions
         $this->extension1->expects($this->once())
             ->method('finishView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(2)));
+            ->willReturnCallback($assertIndex(2));
 
         $this->extension2->expects($this->once())
             ->method('finishView')
             ->with($view, $form, $options)
-            ->will($this->returnCallback($assertIndex(3)));
+            ->willReturnCallback($assertIndex(3));
 
         $this->resolvedType->finishView($view, $form, $options);
     }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -731,7 +731,7 @@ class SimpleFormTest extends AbstractFormTest
         $type->expects($this->once())
             ->method('createView')
             ->with($form)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $form->createView());
     }
@@ -748,12 +748,12 @@ class SimpleFormTest extends AbstractFormTest
 
         $parentType->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($parentView));
+            ->willReturn($parentView);
 
         $type->expects($this->once())
             ->method('createView')
             ->with($form, $parentView)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $form->createView());
     }
@@ -768,7 +768,7 @@ class SimpleFormTest extends AbstractFormTest
         $type->expects($this->once())
             ->method('createView')
             ->with($form, $parentView)
-            ->will($this->returnValue($view));
+            ->willReturn($view);
 
         $this->assertSame($view, $form->createView($parentView));
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -172,7 +172,7 @@ class FileTest extends TestCase
             ->expects($this->once())
             ->method('guess')
             ->with($this->equalTo($path))
-            ->will($this->returnValue($mimeType))
+            ->willReturn($mimeType)
         ;
 
         return $guesser;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcacheSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcacheSessionHandlerTest.php
@@ -79,7 +79,7 @@ class MemcacheSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('set')
             ->with(self::PREFIX.'id', 'data', 0, $this->equalTo(time() + self::TTL, 2))
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($this->storage->write('id', 'data'));
@@ -91,7 +91,7 @@ class MemcacheSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('delete')
             ->with(self::PREFIX.'id')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($this->storage->destroy('id'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -66,7 +66,7 @@ class MemcachedSessionHandlerTest extends TestCase
         $this->memcached
             ->expects($this->once())
             ->method('quit')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($this->storage->close());
@@ -89,7 +89,7 @@ class MemcachedSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('set')
             ->with(self::PREFIX.'id', 'data', $this->equalTo(time() + self::TTL, 2))
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($this->storage->write('id', 'data'));
@@ -101,7 +101,7 @@ class MemcachedSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('delete')
             ->with(self::PREFIX.'id')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($this->storage->destroy('id'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -95,7 +95,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         // defining the timeout before the actual method call
         // allows to test for "greater than" values in the $criteria
@@ -103,7 +103,7 @@ class MongoDbSessionHandlerTest extends TestCase
 
         $collection->expects($this->once())
             ->method('findOne')
-            ->will($this->returnCallback(function ($criteria) use ($testTimeout) {
+            ->willReturnCallback(function ($criteria) use ($testTimeout) {
                 $this->assertArrayHasKey($this->options['id_field'], $criteria);
                 $this->assertEquals($criteria[$this->options['id_field']], 'foo');
 
@@ -131,7 +131,7 @@ class MongoDbSessionHandlerTest extends TestCase
                 }
 
                 return $fields;
-            }));
+            });
 
         $this->assertEquals('bar', $this->storage->read('foo'));
     }
@@ -143,7 +143,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $data = [];
 
@@ -151,7 +151,7 @@ class MongoDbSessionHandlerTest extends TestCase
 
         $collection->expects($this->once())
             ->method($methodName)
-            ->will($this->returnCallback(function ($criteria, $updateData, $options) use (&$data) {
+            ->willReturnCallback(function ($criteria, $updateData, $options) use (&$data) {
                 $this->assertEquals([$this->options['id_field'] => 'foo'], $criteria);
 
                 if (phpversion('mongodb')) {
@@ -161,7 +161,7 @@ class MongoDbSessionHandlerTest extends TestCase
                 }
 
                 $data = $updateData['$set'];
-            }));
+            });
 
         $expectedExpiry = time() + (int) ini_get('session.gc_maxlifetime');
         $this->assertTrue($this->storage->write('foo', 'bar'));
@@ -197,7 +197,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $data = [];
 
@@ -205,7 +205,7 @@ class MongoDbSessionHandlerTest extends TestCase
 
         $collection->expects($this->once())
             ->method($methodName)
-            ->will($this->returnCallback(function ($criteria, $updateData, $options) use (&$data) {
+            ->willReturnCallback(function ($criteria, $updateData, $options) use (&$data) {
                 $this->assertEquals([$this->options['id_field'] => 'foo'], $criteria);
 
                 if (phpversion('mongodb')) {
@@ -215,7 +215,7 @@ class MongoDbSessionHandlerTest extends TestCase
                 }
 
                 $data = $updateData['$set'];
-            }));
+            });
 
         $this->assertTrue($this->storage->write('foo', 'bar'));
 
@@ -237,7 +237,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $data = [];
 
@@ -245,9 +245,9 @@ class MongoDbSessionHandlerTest extends TestCase
 
         $collection->expects($this->exactly(2))
             ->method($methodName)
-            ->will($this->returnCallback(function ($criteria, $updateData, $options) use (&$data) {
+            ->willReturnCallback(function ($criteria, $updateData, $options) use (&$data) {
                 $data = $updateData;
-            }));
+            });
 
         $this->storage->write('foo', 'bar');
         $this->storage->write('foo', 'foobar');
@@ -266,7 +266,7 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $methodName = phpversion('mongodb') ? 'deleteOne' : 'remove';
 
@@ -284,13 +284,13 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->mongo->expects($this->once())
             ->method('selectCollection')
             ->with($this->options['database'], $this->options['collection'])
-            ->will($this->returnValue($collection));
+            ->willReturn($collection);
 
         $methodName = phpversion('mongodb') ? 'deleteMany' : 'remove';
 
         $collection->expects($this->once())
             ->method($methodName)
-            ->will($this->returnCallback(function ($criteria) {
+            ->willReturnCallback(function ($criteria) {
                 if (phpversion('mongodb')) {
                     $this->assertInstanceOf('MongoDB\BSON\UTCDateTime', $criteria[$this->options['expiry_field']]['$lt']);
                     $this->assertGreaterThanOrEqual(time() - 1, round((string) $criteria[$this->options['expiry_field']]['$lt'] / 1000));
@@ -298,7 +298,7 @@ class MongoDbSessionHandlerTest extends TestCase
                     $this->assertInstanceOf('MongoDate', $criteria[$this->options['expiry_field']]['$lt']);
                     $this->assertGreaterThanOrEqual(time() - 1, $criteria[$this->options['expiry_field']]['$lt']->sec);
                 }
-            }));
+            });
 
         $this->assertTrue($this->storage->gc(1));
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -147,7 +147,7 @@ class PdoSessionHandlerTest extends TestCase
         $stream = $this->createStream($content);
 
         $pdo->prepareResult->expects($this->once())->method('fetchAll')
-            ->will($this->returnValue([[$stream, 42, time()]]));
+            ->willReturn([[$stream, 42, time()]]);
 
         $storage = new PdoSessionHandler($pdo);
         $result = $storage->read('foo');
@@ -177,14 +177,14 @@ class PdoSessionHandlerTest extends TestCase
         $exception = null;
 
         $selectStmt->expects($this->atLeast(2))->method('fetchAll')
-            ->will($this->returnCallback(function () use (&$exception, $stream) {
+            ->willReturnCallback(function () use (&$exception, $stream) {
                 return $exception ? [[$stream, 42, time()]] : [];
-            }));
+            });
 
         $insertStmt->expects($this->once())->method('execute')
-            ->will($this->returnCallback(function () use (&$exception) {
+            ->willReturnCallback(function () use (&$exception) {
                 throw $exception = new \PDOException('', '23');
-            }));
+            });
 
         $storage = new PdoSessionHandler($pdo);
         $result = $storage->read('foo');

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/WriteCheckSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/WriteCheckSessionHandlerTest.php
@@ -30,7 +30,7 @@ class WriteCheckSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('close')
             ->with()
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($writeCheckSessionHandler->close());
@@ -45,7 +45,7 @@ class WriteCheckSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('write')
             ->with('foo', 'bar')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertTrue($writeCheckSessionHandler->write('foo', 'bar'));
@@ -60,7 +60,7 @@ class WriteCheckSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('read')
             ->with('foo')
-            ->will($this->returnValue('bar'))
+            ->willReturn('bar')
         ;
 
         $wrappedSessionHandlerMock
@@ -81,14 +81,14 @@ class WriteCheckSessionHandlerTest extends TestCase
             ->expects($this->once())
             ->method('read')
             ->with('foo')
-            ->will($this->returnValue('bar'))
+            ->willReturn('bar')
         ;
 
         $wrappedSessionHandlerMock
             ->expects($this->once())
             ->method('write')
             ->with('foo', 'baZZZ')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $this->assertEquals('bar', $writeCheckSessionHandler->read('foo'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -50,7 +50,7 @@ class SessionHandlerProxyTest extends TestCase
     {
         $this->mock->expects($this->once())
             ->method('open')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->assertFalse($this->proxy->isActive());
         $this->proxy->open('name', 'id');
@@ -61,7 +61,7 @@ class SessionHandlerProxyTest extends TestCase
     {
         $this->mock->expects($this->once())
             ->method('open')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->assertFalse($this->proxy->isActive());
         $this->proxy->open('name', 'id');
@@ -72,7 +72,7 @@ class SessionHandlerProxyTest extends TestCase
     {
         $this->mock->expects($this->once())
             ->method('close')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->assertFalse($this->proxy->isActive());
         $this->proxy->close();
@@ -83,7 +83,7 @@ class SessionHandlerProxyTest extends TestCase
     {
         $this->mock->expects($this->once())
             ->method('close')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->assertFalse($this->proxy->isActive());
         $this->proxy->close();

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
@@ -87,7 +87,7 @@ class CacheWarmerAggregateTest extends TestCase
         $warmer
             ->expects($this->once())
             ->method('isOptional')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $warmer
             ->expects($this->never())
             ->method('warmUp');

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -157,7 +157,7 @@ class ClientTest extends TestCase
 
         $file->expects($this->once())
             ->method('getSize')
-            ->will($this->returnValue(INF))
+            ->willReturn(INF)
         ;
 
         $client->request('POST', '/', [], [$file]);

--- a/src/Symfony/Component/HttpKernel/Tests/Config/FileLocatorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Config/FileLocatorTest.php
@@ -23,7 +23,7 @@ class FileLocatorTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('locateResource')
             ->with('@BundleName/some/path', null, true)
-            ->will($this->returnValue('/bundle-name/some/path'));
+            ->willReturn('/bundle-name/some/path');
         $locator = new FileLocator($kernel);
         $this->assertEquals('/bundle-name/some/path', $locator->locate('@BundleName/some/path'));
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
@@ -26,11 +26,11 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->once())
             ->method('has')
             ->with('foo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $container->expects($this->once())
             ->method('get')
             ->with('foo')
-            ->will($this->returnValue($this))
+            ->willReturn($this)
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -51,12 +51,12 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->once())
             ->method('has')
             ->with('foo')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $container->expects($this->once())
             ->method('get')
             ->with('foo')
-            ->will($this->returnValue($invokableController))
+            ->willReturn($invokableController)
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -77,12 +77,12 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->once())
             ->method('has')
             ->with($className)
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $container->expects($this->once())
             ->method('get')
             ->with($className)
-            ->will($this->returnValue($invokableController))
+            ->willReturn($invokableController)
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -100,7 +100,7 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->once())
             ->method('has')
             ->with(NonInstantiableController::class)
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -122,19 +122,19 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->at(0))
             ->method('has')
             ->with(ImpossibleConstructController::class)
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $container->expects($this->at(1))
             ->method('has')
             ->with(ImpossibleConstructController::class)
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $container->expects($this->atLeastOnce())
             ->method('getRemovedIds')
             ->with()
-            ->will($this->returnValue([ImpossibleConstructController::class => true]))
+            ->willReturn([ImpossibleConstructController::class => true])
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -162,12 +162,12 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->atLeastOnce())
             ->method('has')
             ->with(NonInstantiableController::class)
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $container->expects($this->atLeastOnce())
             ->method('get')
             ->with(NonInstantiableController::class)
-            ->will($this->returnValue($service))
+            ->willReturn($service)
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -189,13 +189,13 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->at(0))
             ->method('has')
             ->with('app.my_controller')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $container->expects($this->atLeastOnce())
             ->method('getRemovedIds')
             ->with()
-            ->will($this->returnValue(['app.my_controller' => true]))
+            ->willReturn(['app.my_controller' => true])
         ;
 
         $resolver = $this->createControllerResolver(null, $container);
@@ -215,12 +215,12 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $container->expects($this->once())
             ->method('has')
             ->with('app.my_controller')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $container->expects($this->once())
             ->method('get')
             ->with('app.my_controller')
-            ->will($this->returnValue(new ImpossibleConstructController('toto', 'controller')))
+            ->willReturn(new ImpossibleConstructController('toto', 'controller'))
         ;
 
         $resolver = $this->createControllerResolver(null, $container);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -226,7 +226,7 @@ class ControllerResolverTest extends TestCase
     public function testCreateControllerCanReturnAnyCallable()
     {
         $mock = $this->getMockBuilder('Symfony\Component\HttpKernel\Controller\ControllerResolver')->setMethods(['createController'])->getMock();
-        $mock->expects($this->once())->method('createController')->will($this->returnValue('Symfony\Component\HttpKernel\Tests\Controller\some_controller_function'));
+        $mock->expects($this->once())->method('createController')->willReturn('Symfony\Component\HttpKernel\Tests\Controller\some_controller_function');
 
         $request = Request::create('/');
         $request->attributes->set('_controller', 'foobar');

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -23,8 +23,8 @@ class LoggerDataCollectorTest extends TestCase
             ->getMockBuilder('Symfony\Component\HttpKernel\Log\DebugLoggerInterface')
             ->setMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
-        $logger->expects($this->once())->method('countErrors')->will($this->returnValue('foo'));
-        $logger->expects($this->exactly(2))->method('getLogs')->will($this->returnValue([]));
+        $logger->expects($this->once())->method('countErrors')->willReturn('foo');
+        $logger->expects($this->exactly(2))->method('getLogs')->willReturn([]);
 
         $c = new LoggerDataCollector($logger, __DIR__.'/');
         $c->lateCollect();
@@ -50,8 +50,8 @@ class LoggerDataCollectorTest extends TestCase
             ->getMockBuilder('Symfony\Component\HttpKernel\Log\DebugLoggerInterface')
             ->setMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
-        $logger->expects($this->once())->method('countErrors')->will($this->returnValue($nb));
-        $logger->expects($this->exactly(2))->method('getLogs')->will($this->returnValue($logs));
+        $logger->expects($this->once())->method('countErrors')->willReturn($nb);
+        $logger->expects($this->exactly(2))->method('getLogs')->willReturn($logs);
 
         $c = new LoggerDataCollector($logger);
         $c->lateCollect();

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
@@ -44,7 +44,7 @@ class TimeDataCollectorTest extends TestCase
         $this->assertEquals(0, $c->getStartTime());
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
-        $kernel->expects($this->once())->method('getStartTime')->will($this->returnValue(123456));
+        $kernel->expects($this->once())->method('getStartTime')->willReturn(123456);
 
         $c = new TimeDataCollector($kernel);
         $request = new Request();

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -49,7 +49,7 @@ class TraceableEventDispatcherTest extends TestCase
             ->getMock();
         $stopwatch->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch);
 
@@ -65,7 +65,7 @@ class TraceableEventDispatcherTest extends TestCase
             ->getMock();
         $stopwatch->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $stopwatch->expects($this->once())
             ->method('stop');
         $stopwatch->expects($this->once())
@@ -112,9 +112,9 @@ class TraceableEventDispatcherTest extends TestCase
     protected function getHttpKernel($dispatcher, $controller)
     {
         $controllerResolver = $this->getMockBuilder('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface')->getMock();
-        $controllerResolver->expects($this->once())->method('getController')->will($this->returnValue($controller));
+        $controllerResolver->expects($this->once())->method('getController')->willReturn($controller);
         $argumentResolver = $this->getMockBuilder('Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface')->getMock();
-        $argumentResolver->expects($this->once())->method('getArguments')->will($this->returnValue([]));
+        $argumentResolver->expects($this->once())->method('getArguments')->willReturn([]);
 
         return new HttpKernel($dispatcher, $controllerResolver, new RequestStack(), $argumentResolver);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
@@ -25,14 +25,14 @@ class LazyLoadingFragmentHandlerTest extends TestCase
     public function testRenderWithLegacyMapping()
     {
         $renderer = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface')->getMock();
-        $renderer->expects($this->once())->method('getName')->will($this->returnValue('foo'));
-        $renderer->expects($this->any())->method('render')->will($this->returnValue(new Response()));
+        $renderer->expects($this->once())->method('getName')->willReturn('foo');
+        $renderer->expects($this->any())->method('render')->willReturn(new Response());
 
         $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
-        $requestStack->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $requestStack->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $container->expects($this->once())->method('get')->will($this->returnValue($renderer));
+        $container->expects($this->once())->method('get')->willReturn($renderer);
 
         $handler = new LazyLoadingFragmentHandler($container, $requestStack, false);
         $handler->addRendererService('foo', 'foo');
@@ -46,15 +46,15 @@ class LazyLoadingFragmentHandlerTest extends TestCase
     public function testRender()
     {
         $renderer = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface')->getMock();
-        $renderer->expects($this->once())->method('getName')->will($this->returnValue('foo'));
-        $renderer->expects($this->any())->method('render')->will($this->returnValue(new Response()));
+        $renderer->expects($this->once())->method('getName')->willReturn('foo');
+        $renderer->expects($this->any())->method('render')->willReturn(new Response());
 
         $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
-        $requestStack->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $requestStack->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         $container = $this->getMockBuilder('Psr\Container\ContainerInterface')->getMock();
         $container->expects($this->once())->method('has')->with('foo')->willReturn(true);
-        $container->expects($this->once())->method('get')->will($this->returnValue($renderer));
+        $container->expects($this->once())->method('get')->willReturn($renderer);
 
         $handler = new LazyLoadingFragmentHandler($container, $requestStack, false);
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
@@ -77,7 +77,7 @@ class AddRequestFormatsListenerTest extends TestCase
 
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
 
         return $event;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -94,7 +94,7 @@ class DebugHandlersListenerTest extends TestCase
         $dispatcher = new EventDispatcher();
         $listener = new DebugHandlersListener(null);
         $app = $this->getMockBuilder('Symfony\Component\Console\Application')->getMock();
-        $app->expects($this->once())->method('getHelperSet')->will($this->returnValue(new HelperSet()));
+        $app->expects($this->once())->method('getHelperSet')->willReturn(new HelperSet());
         $command = new Command(__FUNCTION__);
         $command->setApplication($app);
         $event = new ConsoleEvent($command, new ArgvInput(), new ConsoleOutput());

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -112,9 +112,9 @@ class ExceptionListenerTest extends TestCase
         $listener = new ExceptionListener('foo', $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock());
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+        $kernel->expects($this->once())->method('handle')->willReturnCallback(function (Request $request) {
             return new Response($request->getRequestFormat());
-        }));
+        });
 
         $request = Request::create('/');
         $request->setRequestFormat('xml');
@@ -130,9 +130,9 @@ class ExceptionListenerTest extends TestCase
     {
         $dispatcher = new EventDispatcher();
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+        $kernel->expects($this->once())->method('handle')->willReturnCallback(function (Request $request) {
             return new Response($request->getRequestFormat());
-        }));
+        });
 
         $listener = new ExceptionListener('foo', $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock(), true);
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -55,7 +55,7 @@ class LocaleListenerTest extends TestCase
         $context->expects($this->once())->method('setParameter')->with('_locale', 'es');
 
         $router = $this->getMockBuilder('Symfony\Component\Routing\Router')->setMethods(['getContext'])->disableOriginalConstructor()->getMock();
-        $router->expects($this->once())->method('getContext')->will($this->returnValue($context));
+        $router->expects($this->once())->method('getContext')->willReturn($context);
 
         $request = Request::create('/');
 
@@ -71,12 +71,12 @@ class LocaleListenerTest extends TestCase
         $context->expects($this->once())->method('setParameter')->with('_locale', 'es');
 
         $router = $this->getMockBuilder('Symfony\Component\Routing\Router')->setMethods(['getContext'])->disableOriginalConstructor()->getMock();
-        $router->expects($this->once())->method('getContext')->will($this->returnValue($context));
+        $router->expects($this->once())->method('getContext')->willReturn($context);
 
         $parentRequest = Request::create('/');
         $parentRequest->setLocale('es');
 
-        $this->requestStack->expects($this->once())->method('getParentRequest')->will($this->returnValue($parentRequest));
+        $this->requestStack->expects($this->once())->method('getParentRequest')->willReturn($parentRequest);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\FinishRequestEvent')->disableOriginalConstructor()->getMock();
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
@@ -36,7 +36,7 @@ class ProfilerListenerTest extends TestCase
 
         $profiler->expects($this->once())
             ->method('collect')
-            ->will($this->returnValue($profile));
+            ->willReturn($profile);
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -49,7 +49,7 @@ class RouterListenerTest extends TestCase
         $context->setHttpsPort($defaultHttpsPort);
         $urlMatcher->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($context));
+            ->willReturn($context);
 
         $listener = new RouterListener($urlMatcher, $this->requestStack);
         $event = $this->createGetResponseEventForUri($uri);
@@ -102,7 +102,7 @@ class RouterListenerTest extends TestCase
         $requestMatcher->expects($this->once())
                        ->method('matchRequest')
                        ->with($this->isInstanceOf('Symfony\Component\HttpFoundation\Request'))
-                       ->will($this->returnValue([]));
+                       ->willReturn([]);
 
         $listener = new RouterListener($requestMatcher, $this->requestStack, new RequestContext());
         $listener->onKernelRequest($event);
@@ -118,7 +118,7 @@ class RouterListenerTest extends TestCase
         $requestMatcher->expects($this->any())
                        ->method('matchRequest')
                        ->with($this->isInstanceOf('Symfony\Component\HttpFoundation\Request'))
-                       ->will($this->returnValue([]));
+                       ->willReturn([]);
 
         $context = new RequestContext();
 
@@ -143,7 +143,7 @@ class RouterListenerTest extends TestCase
         $requestMatcher = $this->getMockBuilder('Symfony\Component\Routing\Matcher\RequestMatcherInterface')->getMock();
         $requestMatcher->expects($this->once())
             ->method('matchRequest')
-            ->will($this->returnValue($parameter));
+            ->willReturn($parameter);
 
         $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $logger->expects($this->once())

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -47,7 +47,7 @@ class TestSessionListenerTest extends TestCase
         $this->session = $this->getSession();
         $this->listener->expects($this->any())
              ->method('getSession')
-             ->will($this->returnValue($this->session));
+             ->willReturn($this->session);
     }
 
     public function testShouldSaveMasterRequestSession()
@@ -183,28 +183,28 @@ class TestSessionListenerTest extends TestCase
     {
         $this->session->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
     }
 
     private function sessionHasNotBeenStarted()
     {
         $this->session->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
     }
 
     private function sessionIsEmpty()
     {
         $this->session->expects($this->once())
             ->method('isEmpty')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
     }
 
     private function fixSessionId($sessionId)
     {
         $this->session->expects($this->any())
             ->method('getId')
-            ->will($this->returnValue($sessionId));
+            ->willReturn($sessionId);
     }
 
     private function getSession()
@@ -214,7 +214,7 @@ class TestSessionListenerTest extends TestCase
             ->getMock();
 
         // set return value for getName()
-        $mock->expects($this->any())->method('getName')->will($this->returnValue('MOCKSESSID'));
+        $mock->expects($this->any())->method('getName')->willReturn('MOCKSESSID');
 
         return $mock;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
@@ -113,6 +113,6 @@ class TranslatorListenerTest extends TestCase
         $this->requestStack
             ->expects($this->any())
             ->method('getParentRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -32,7 +32,7 @@ class FragmentHandlerTest extends TestCase
         $this->requestStack
             ->expects($this->any())
             ->method('getCurrentRequest')
-            ->will($this->returnValue(Request::create('/')))
+            ->willReturn(Request::create('/'))
         ;
     }
 
@@ -79,7 +79,7 @@ class FragmentHandlerTest extends TestCase
         $renderer
             ->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $e = $renderer
             ->expects($this->any())

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -64,9 +64,9 @@ class InlineFragmentRendererTest extends TestCase
         $resolver
             ->expects($this->once())
             ->method('getController')
-            ->will($this->returnValue(function (\stdClass $object, Bar $object1) {
+            ->willReturn(function (\stdClass $object, Bar $object1) {
                 return new Response($object1->getBar());
-            }))
+            })
         ;
 
         $kernel = new HttpKernel(new EventDispatcher(), $resolver, new RequestStack());
@@ -85,9 +85,9 @@ class InlineFragmentRendererTest extends TestCase
         $resolver
             ->expects($this->once())
             ->method('getController')
-            ->will($this->returnValue(function (\stdClass $object, Bar $object1) {
+            ->willReturn(function (\stdClass $object, Bar $object1) {
                 return new Response($object1->getBar());
-            }))
+            })
         ;
 
         $kernel = new HttpKernel(new EventDispatcher(), $resolver, new RequestStack(), new ArgumentResolver());
@@ -162,18 +162,18 @@ class InlineFragmentRendererTest extends TestCase
         $controllerResolver
             ->expects($this->once())
             ->method('getController')
-            ->will($this->returnValue(function () {
+            ->willReturn(function () {
                 ob_start();
                 echo 'bar';
                 throw new \RuntimeException();
-            }))
+            })
         ;
 
         $argumentResolver = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface')->getMock();
         $argumentResolver
             ->expects($this->once())
             ->method('getArguments')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $kernel = new HttpKernel(new EventDispatcher(), $controllerResolver, new RequestStack(), $argumentResolver);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -229,7 +229,7 @@ class EsiTest extends TestCase
         $cache = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpCache\HttpCache')->setMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();
         $cache->expects($this->any())
               ->method('getRequest')
-              ->will($this->returnValue($request))
+              ->willReturn($request)
         ;
         if (\is_array($response)) {
             $cache->expects($this->any())
@@ -239,7 +239,7 @@ class EsiTest extends TestCase
         } else {
             $cache->expects($this->any())
                   ->method('handle')
-                  ->will($this->returnValue($response))
+                  ->willReturn($response)
             ;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -196,7 +196,7 @@ class SsiTest extends TestCase
         $cache = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpCache\HttpCache')->setMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();
         $cache->expects($this->any())
               ->method('getRequest')
-              ->will($this->returnValue($request))
+              ->willReturn($request)
         ;
         if (\is_array($response)) {
             $cache->expects($this->any())
@@ -206,7 +206,7 @@ class SsiTest extends TestCase
         } else {
             $cache->expects($this->any())
                   ->method('handle')
-                  ->will($this->returnValue($response))
+                  ->willReturn($response)
             ;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -363,13 +363,13 @@ class HttpKernelTest extends TestCase
         $controllerResolver
             ->expects($this->any())
             ->method('getController')
-            ->will($this->returnValue($controller));
+            ->willReturn($controller);
 
         $argumentResolver = $this->getMockBuilder(ArgumentResolverInterface::class)->getMock();
         $argumentResolver
             ->expects($this->any())
             ->method('getArguments')
-            ->will($this->returnValue($arguments));
+            ->willReturn($arguments);
 
         return new HttpKernel($eventDispatcher, $controllerResolver, $requestStack, $argumentResolver);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -110,7 +110,7 @@ class KernelTest extends TestCase
         $kernel = $this->getKernel(['initializeBundles', 'initializeContainer', 'getBundles']);
         $kernel->expects($this->once())
             ->method('getBundles')
-            ->will($this->returnValue([$bundle]));
+            ->willReturn([$bundle]);
 
         $kernel->boot();
     }
@@ -167,16 +167,16 @@ class KernelTest extends TestCase
             ->getMock();
         $kernel->expects($this->any())
             ->method('getContainerBuilder')
-            ->will($this->returnValue($container));
+            ->willReturn($container);
         $kernel->expects($this->any())
             ->method('prepareContainer')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $kernel->expects($this->any())
             ->method('getCacheDir')
-            ->will($this->returnValue(sys_get_temp_dir()));
+            ->willReturn(sys_get_temp_dir());
         $kernel->expects($this->any())
             ->method('getLogDir')
-            ->will($this->returnValue(sys_get_temp_dir()));
+            ->willReturn(sys_get_temp_dir());
 
         $reflection = new \ReflectionClass(\get_class($kernel));
         $method = $reflection->getMethod('buildContainer');
@@ -226,7 +226,7 @@ class KernelTest extends TestCase
         $kernel = $this->getKernel(['getBundles']);
         $kernel->expects($this->any())
             ->method('getBundles')
-            ->will($this->returnValue([$bundle]));
+            ->willReturn([$bundle]);
 
         $kernel->boot();
         $kernel->shutdown();
@@ -249,7 +249,7 @@ class KernelTest extends TestCase
         $kernel = $this->getKernel(['getHttpKernel']);
         $kernel->expects($this->once())
             ->method('getHttpKernel')
-            ->will($this->returnValue($httpKernelMock));
+            ->willReturn($httpKernelMock);
 
         $kernel->handle($request, $type, $catch);
     }
@@ -267,7 +267,7 @@ class KernelTest extends TestCase
         $kernel = $this->getKernel(['getHttpKernel', 'boot']);
         $kernel->expects($this->once())
             ->method('getHttpKernel')
-            ->will($this->returnValue($httpKernelMock));
+            ->willReturn($httpKernelMock);
 
         $kernel->expects($this->once())
             ->method('boot');
@@ -421,7 +421,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('getBundle')
-            ->will($this->returnValue([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle')]))
+            ->willReturn([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle')])
         ;
 
         $kernel->locateResource('@Bundle1Bundle/config/routing.xml');
@@ -433,7 +433,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('getBundle')
-            ->will($this->returnValue([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle')]))
+            ->willReturn([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle')])
         ;
 
         $this->assertEquals(__DIR__.'/Fixtures/Bundle1Bundle/foo.txt', $kernel->locateResource('@Bundle1Bundle/foo.txt'));
@@ -451,7 +451,7 @@ EOF;
         $kernel
             ->expects($this->exactly(2))
             ->method('getBundle')
-            ->will($this->returnValue([$child, $parent]))
+            ->willReturn([$child, $parent])
         ;
 
         $this->assertEquals(__DIR__.'/Fixtures/Bundle2Bundle/foo.txt', $kernel->locateResource('@ParentAABundle/foo.txt'));
@@ -470,7 +470,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('getBundle')
-            ->will($this->returnValue([$child, $parent]))
+            ->willReturn([$child, $parent])
         ;
 
         $this->assertEquals([
@@ -488,10 +488,10 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('getBundle')
-            ->will($this->returnValue([
+            ->willReturn([
                 $this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle'),
                 $this->getBundle(__DIR__.'/Foobar'),
-            ]))
+            ])
         ;
 
         $this->assertEquals(
@@ -506,7 +506,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('getBundle')
-            ->will($this->returnValue([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle')]))
+            ->willReturn([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle')])
         ;
 
         $this->assertEquals(
@@ -521,7 +521,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('getBundle')
-            ->will($this->returnValue([$this->getBundle(__DIR__.'/Fixtures/FooBundle', null, null, 'FooBundle')]))
+            ->willReturn([$this->getBundle(__DIR__.'/Fixtures/FooBundle', null, null, 'FooBundle')])
         ;
 
         $this->assertEquals(
@@ -539,7 +539,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('getBundle')
-            ->will($this->returnValue([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle', null, null, 'Bundle1Bundle')]))
+            ->willReturn([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle', null, null, 'Bundle1Bundle')])
         ;
 
         $this->assertEquals([
@@ -561,7 +561,7 @@ EOF;
         $kernel
             ->expects($this->exactly(4))
             ->method('getBundle')
-            ->will($this->returnValue([$child, $parent]))
+            ->willReturn([$child, $parent])
         ;
 
         $this->assertEquals([
@@ -596,7 +596,7 @@ EOF;
         $kernel
             ->expects($this->exactly(2))
             ->method('getBundle')
-            ->will($this->returnValue([$this->getBundle(__DIR__.'/Fixtures/FooBundle', null, null, 'FooBundle')]))
+            ->willReturn([$this->getBundle(__DIR__.'/Fixtures/FooBundle', null, null, 'FooBundle')])
         ;
 
         $this->assertEquals(
@@ -612,7 +612,7 @@ EOF;
         $kernel
             ->expects($this->exactly(2))
             ->method('getBundle')
-            ->will($this->returnValue([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle', null, null, 'Bundle1Bundle')]))
+            ->willReturn([$this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle', null, null, 'Bundle1Bundle')])
         ;
 
         $this->assertEquals(
@@ -638,7 +638,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('registerBundles')
-            ->will($this->returnValue([$parent, $child]))
+            ->willReturn([$parent, $child])
         ;
         $kernel->boot();
 
@@ -660,7 +660,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('registerBundles')
-            ->will($this->returnValue([$grandparent, $parent, $child]))
+            ->willReturn([$grandparent, $parent, $child])
         ;
         $kernel->boot();
 
@@ -696,7 +696,7 @@ EOF;
         $kernel
             ->expects($this->once())
             ->method('registerBundles')
-            ->will($this->returnValue([$parent, $grandparent, $child]))
+            ->willReturn([$parent, $grandparent, $child])
         ;
         $kernel->boot();
 
@@ -785,7 +785,7 @@ EOF;
         $kernel = $this->getKernel(['getHttpKernel']);
         $kernel->expects($this->exactly(2))
             ->method('getHttpKernel')
-            ->will($this->returnValue($httpKernelMock));
+            ->willReturn($httpKernelMock);
 
         $kernel->boot();
         $kernel->terminate(Request::create('/'), new Response());
@@ -938,19 +938,19 @@ EOF;
         $bundle
             ->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue(null === $bundleName ? \get_class($bundle) : $bundleName))
+            ->willReturn(null === $bundleName ? \get_class($bundle) : $bundleName)
         ;
 
         $bundle
             ->expects($this->any())
             ->method('getPath')
-            ->will($this->returnValue($dir))
+            ->willReturn($dir)
         ;
 
         $bundle
             ->expects($this->any())
             ->method('getParent')
-            ->will($this->returnValue($parent))
+            ->willReturn($parent)
         ;
 
         return $bundle;
@@ -976,7 +976,7 @@ EOF;
         ;
         $kernel->expects($this->any())
             ->method('registerBundles')
-            ->will($this->returnValue($bundles))
+            ->willReturn($bundles)
         ;
         $p = new \ReflectionProperty($kernel, 'rootDir');
         $p->setAccessible(true);

--- a/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
@@ -149,7 +149,7 @@ class LoggerTest extends TestCase
         }
         $dummy->expects($this->atLeastOnce())
             ->method('__toString')
-            ->will($this->returnValue('DUMMY'));
+            ->willReturn('DUMMY');
 
         $this->logger->warning($dummy);
 

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -72,7 +72,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->assertSame(self::$data, $this->reader->read(self::RES_DIR, 'root'));
     }
@@ -82,12 +82,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$fallbackData));
+            ->willReturn(self::$fallbackData);
 
         $this->assertSame(self::$mergedData, $this->reader->readEntry(self::RES_DIR, 'en', []));
     }
@@ -97,7 +97,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->assertSame('Bar', $this->reader->readEntry(self::RES_DIR, 'root', ['Entries', 'Foo']));
     }
@@ -110,7 +110,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->reader->readEntry(self::RES_DIR, 'root', ['Entries', 'NonExisting']);
     }
@@ -120,12 +120,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$fallbackData));
+            ->willReturn(self::$fallbackData);
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
@@ -138,7 +138,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(self::$data));
+            ->willReturn(self::$data);
 
         $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam'], false);
     }
@@ -153,7 +153,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$fallbackData));
+            ->willReturn(self::$fallbackData);
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
@@ -193,17 +193,17 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue($childData));
+                ->willReturn($childData);
 
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'root')
-                ->will($this->returnValue($parentData));
+                ->willReturn($parentData);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue($childData));
+                ->willReturn($childData);
         }
 
         $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en', [], true));
@@ -217,7 +217,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue($childData));
+            ->willReturn($childData);
 
         $this->assertSame($childData, $this->reader->readEntry(self::RES_DIR, 'en_GB', [], false));
     }
@@ -231,17 +231,17 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue(['Foo' => ['Bar' => $childData]]));
+                ->willReturn(['Foo' => ['Bar' => $childData]]);
 
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'root')
-                ->will($this->returnValue(['Foo' => ['Bar' => $parentData]]));
+                ->willReturn(['Foo' => ['Bar' => $parentData]]);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue(['Foo' => ['Bar' => $childData]]));
+                ->willReturn(['Foo' => ['Bar' => $childData]]);
         }
 
         $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en', ['Foo', 'Bar'], true));
@@ -255,12 +255,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(['Foo' => 'Baz']));
+            ->willReturn(['Foo' => 'Baz']);
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(['Foo' => ['Bar' => $parentData]]));
+            ->willReturn(['Foo' => ['Bar' => $parentData]]);
 
         $this->assertSame($parentData, $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
     }
@@ -274,17 +274,17 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
-                ->will($this->returnValue(['Foo' => ['Bar' => $childData]]));
+                ->willReturn(['Foo' => ['Bar' => $childData]]);
 
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue(['Foo' => 'Bar']));
+                ->willReturn(['Foo' => 'Bar']);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
-                ->will($this->returnValue(['Foo' => ['Bar' => $childData]]));
+                ->willReturn(['Foo' => ['Bar' => $childData]]);
         }
 
         $this->assertSame($childData, $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
@@ -298,12 +298,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(['Foo' => 'Baz']));
+            ->willReturn(['Foo' => 'Baz']);
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(['Foo' => 'Bar']));
+            ->willReturn(['Foo' => 'Bar']);
 
         $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true);
     }
@@ -320,17 +320,17 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
-                ->will($this->returnValue(['Foo' => ['Bar' => $childData]]));
+                ->willReturn(['Foo' => ['Bar' => $childData]]);
 
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
-                ->will($this->returnValue(['Foo' => ['Bar' => $parentData]]));
+                ->willReturn(['Foo' => ['Bar' => $parentData]]);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
-                ->will($this->returnValue(['Foo' => ['Bar' => $childData]]));
+                ->willReturn(['Foo' => ['Bar' => $childData]]);
         }
 
         $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
@@ -347,18 +347,18 @@ class BundleEntryReaderTest extends TestCase
             $this->readerImpl->expects($this->at(0))
                 ->method('read')
                 ->with(self::RES_DIR, 'ro_MD')
-                ->will($this->returnValue(['Foo' => ['Bar' => $childData]]));
+                ->willReturn(['Foo' => ['Bar' => $childData]]);
 
             // Read fallback locale of aliased locale ("ro_MD" -> "ro")
             $this->readerImpl->expects($this->at(1))
                 ->method('read')
                 ->with(self::RES_DIR, 'ro')
-                ->will($this->returnValue(['Foo' => ['Bar' => $parentData]]));
+                ->willReturn(['Foo' => ['Bar' => $parentData]]);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'ro_MD')
-                ->will($this->returnValue(['Foo' => ['Bar' => $childData]]));
+                ->willReturn(['Foo' => ['Bar' => $childData]]);
         }
 
         $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'mo', ['Foo', 'Bar'], true));

--- a/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
@@ -70,7 +70,7 @@ class LdapClientTest extends LdapTestCase
         $collection
             ->expects($this->once())
             ->method('getIterator')
-            ->will($this->returnValue(new \ArrayIterator([
+            ->willReturn(new \ArrayIterator([
                 new Entry('cn=qux,dc=foo,dc=com', [
                     'cn' => ['qux'],
                     'dc' => ['com', 'foo'],
@@ -81,13 +81,13 @@ class LdapClientTest extends LdapTestCase
                     'dc' => ['com', 'foo'],
                     'givenName' => ['Baz'],
                 ]),
-            ])))
+            ]))
         ;
         $query = $this->getMockBuilder(QueryInterface::class)->getMock();
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($collection))
+            ->willReturn($collection)
         ;
         $this->ldap
             ->expects($this->once())

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -42,7 +42,7 @@ class LdapTest extends TestCase
         $this->adapter
             ->expects($this->once())
             ->method('getConnection')
-            ->will($this->returnValue($connection))
+            ->willReturn($connection)
         ;
         $this->ldap->bind('foo', 'bar');
     }

--- a/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
@@ -27,7 +27,7 @@ class ProcessFailedExceptionTest extends TestCase
         $process = $this->getMockBuilder('Symfony\Component\Process\Process')->setMethods(['isSuccessful'])->setConstructorArgs(['php'])->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         if (method_exists($this, 'expectException')) {
             $this->expectException(\InvalidArgumentException::class);
@@ -55,31 +55,31 @@ class ProcessFailedExceptionTest extends TestCase
         $process = $this->getMockBuilder('Symfony\Component\Process\Process')->setMethods(['isSuccessful', 'getOutput', 'getErrorOutput', 'getExitCode', 'getExitCodeText', 'isOutputDisabled', 'getWorkingDirectory'])->setConstructorArgs([$cmd])->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $process->expects($this->once())
             ->method('getOutput')
-            ->will($this->returnValue($output));
+            ->willReturn($output);
 
         $process->expects($this->once())
             ->method('getErrorOutput')
-            ->will($this->returnValue($errorOutput));
+            ->willReturn($errorOutput);
 
         $process->expects($this->once())
             ->method('getExitCode')
-            ->will($this->returnValue($exitCode));
+            ->willReturn($exitCode);
 
         $process->expects($this->once())
             ->method('getExitCodeText')
-            ->will($this->returnValue($exitText));
+            ->willReturn($exitText);
 
         $process->expects($this->once())
             ->method('isOutputDisabled')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $process->expects($this->once())
             ->method('getWorkingDirectory')
-            ->will($this->returnValue($workingDirectory));
+            ->willReturn($workingDirectory);
 
         $exception = new ProcessFailedException($process);
 
@@ -103,7 +103,7 @@ class ProcessFailedExceptionTest extends TestCase
         $process = $this->getMockBuilder('Symfony\Component\Process\Process')->setMethods(['isSuccessful', 'isOutputDisabled', 'getExitCode', 'getExitCodeText', 'getOutput', 'getErrorOutput', 'getWorkingDirectory'])->setConstructorArgs([$cmd])->getMock();
         $process->expects($this->once())
             ->method('isSuccessful')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $process->expects($this->never())
             ->method('getOutput');
@@ -113,19 +113,19 @@ class ProcessFailedExceptionTest extends TestCase
 
         $process->expects($this->once())
             ->method('getExitCode')
-            ->will($this->returnValue($exitCode));
+            ->willReturn($exitCode);
 
         $process->expects($this->once())
             ->method('getExitCodeText')
-            ->will($this->returnValue($exitText));
+            ->willReturn($exitText);
 
         $process->expects($this->once())
             ->method('isOutputDisabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $process->expects($this->once())
             ->method('getWorkingDirectory')
-            ->will($this->returnValue($workingDirectory));
+            ->willReturn($workingDirectory);
 
         $exception = new ProcessFailedException($process);
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -128,11 +128,11 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
         $car->expects($this->any())
             ->method('getStructure')
-            ->will($this->returnValue($structure));
+            ->willReturn($structure);
 
         $structure->expects($this->at(0))
             ->method('getAxes')
-            ->will($this->returnValue($axesBefore));
+            ->willReturn($axesBefore);
         $structure->expects($this->at(1))
             ->method('removeAxis')
             ->with('fourth');
@@ -158,7 +158,7 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
         $car->expects($this->any())
             ->method('getAxes')
-            ->will($this->returnValue($axesBefore));
+            ->willReturn($axesBefore);
 
         $this->propertyAccessor->setValue($car, 'axes', $axesAfter);
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -119,7 +119,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([$this->getAnnotatedRoute($routeData)]))
+            ->willReturn([$this->getAnnotatedRoute($routeData)])
         ;
 
         $routeCollection = $this->loader->load($className);
@@ -165,12 +165,12 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->once())
             ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
+            ->willReturn($this->getAnnotatedRoute($classRouteData))
         ;
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([$this->getAnnotatedRoute($methodRouteData)]))
+            ->willReturn([$this->getAnnotatedRoute($methodRouteData)])
         ;
 
         $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass');
@@ -193,12 +193,12 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->exactly(1))
             ->method('getClassAnnotations')
-            ->will($this->returnValue([$this->getAnnotatedRoute($classRouteData)]))
+            ->willReturn([$this->getAnnotatedRoute($classRouteData)])
         ;
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass');
@@ -221,19 +221,19 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->exactly(1))
             ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
+            ->willReturn($this->getAnnotatedRoute($classRouteData))
         ;
 
         $this->reader
             ->expects($this->exactly(1))
             ->method('getClassAnnotations')
-            ->will($this->returnValue([$this->getAnnotatedRoute($classRouteData)]))
+            ->willReturn([$this->getAnnotatedRoute($classRouteData)])
         ;
 
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass');
@@ -263,12 +263,12 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->exactly(1))
             ->method('getClassAnnotations')
-            ->will($this->returnValue([$this->getAnnotatedRoute($classRouteData1), $this->getAnnotatedRoute($classRouteData2)]))
+            ->willReturn([$this->getAnnotatedRoute($classRouteData1), $this->getAnnotatedRoute($classRouteData2)])
         ;
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass');
@@ -304,12 +304,12 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->once())
             ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
+            ->willReturn($this->getAnnotatedRoute($classRouteData))
         ;
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([$this->getAnnotatedRoute($methodRouteData)]))
+            ->willReturn([$this->getAnnotatedRoute($methodRouteData)])
         ;
 
         $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass');
@@ -336,7 +336,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([$this->getAnnotatedRoute($methodRouteData)]))
+            ->willReturn([$this->getAnnotatedRoute($methodRouteData)])
         ;
 
         $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\EncodingClass');

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -34,13 +34,13 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->any())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $this->reader
             ->expects($this->any())
             ->method('getClassAnnotations')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
@@ -58,13 +58,13 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->any())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $this->reader
             ->expects($this->any())
             ->method('getClassAnnotations')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
@@ -93,7 +93,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
         $this->reader
             ->expects($this->any())
             ->method('getMethodAnnotations')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/FooClass.php');

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -62,7 +62,7 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
         $route = new Route(['path' => '/path/to/{id}']);
         $this->reader->expects($this->once())->method('getClassAnnotation');
         $this->reader->expects($this->once())->method('getMethodAnnotations')
-            ->will($this->returnValue([$route]));
+            ->willReturn([$route]);
 
         $this->loader->load(__DIR__.'/../Fixtures/OtherAnnotatedClasses/VariadicClass.php');
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
@@ -89,7 +89,7 @@ class ObjectRouteLoaderTest extends TestCase
             ->getMock();
         $service->expects($this->once())
             ->method('loadRoutes')
-            ->will($this->returnValue('NOT_A_COLLECTION'));
+            ->willReturn('NOT_A_COLLECTION');
 
         $loader = new ObjectRouteLoaderForTest();
         $loader->loaderMap = ['my_service' => $service];

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -23,7 +23,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $coll->add('foo', new Route('/foo/'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $matcher->expects($this->once())->method('redirect')->will($this->returnValue([]));
+        $matcher->expects($this->once())->method('redirect')->willReturn([]);
         $matcher->match('/foo');
     }
 
@@ -51,7 +51,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
             ->expects($this->once())
             ->method('redirect')
             ->with('/foo', 'foo', 'ftp')
-            ->will($this->returnValue(['_route' => 'foo']))
+            ->willReturn(['_route' => 'foo'])
         ;
         $matcher->match('/foo');
     }
@@ -78,7 +78,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
             ->expects($this->once())
             ->method('redirect')
             ->with('/foo/baz', 'foo', 'https')
-            ->will($this->returnValue(['redirect' => 'value']))
+            ->willReturn(['redirect' => 'value'])
         ;
         $this->assertEquals(['_route' => 'foo', 'bar' => 'baz', 'redirect' => 'value'], $matcher->match('/foo/baz'));
     }
@@ -93,7 +93,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
             ->expects($this->once())
             ->method('redirect')
             ->with('/foo/baz/', 'foo', null)
-            ->will($this->returnValue(['redirect' => 'value']))
+            ->willReturn(['redirect' => 'value'])
         ;
         $this->assertEquals(['_route' => 'foo', 'bar' => 'baz', 'redirect' => 'value'], $matcher->match('/foo/baz'));
     }
@@ -124,7 +124,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $coll->add('bar', new Route('/{name}'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $matcher->expects($this->once())->method('redirect')->with('/foo/')->will($this->returnValue(['_route' => 'foo']));
+        $matcher->expects($this->once())->method('redirect')->with('/foo/')->willReturn(['_route' => 'foo']);
         $this->assertSame(['_route' => 'foo'], $matcher->match('/foo'));
     }
 

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -28,7 +28,7 @@ class RouteCollectionBuilderTest extends TestCase
         $resolver->expects($this->once())
             ->method('resolve')
             ->with('admin_routing.yml', 'yaml')
-            ->will($this->returnValue($resolvedLoader));
+            ->willReturn($resolvedLoader);
 
         $originalRoute = new Route('/foo/path');
         $expectedCollection = new RouteCollection();
@@ -39,12 +39,12 @@ class RouteCollectionBuilderTest extends TestCase
             ->expects($this->once())
             ->method('load')
             ->with('admin_routing.yml', 'yaml')
-            ->will($this->returnValue($expectedCollection));
+            ->willReturn($expectedCollection);
 
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
         $loader->expects($this->any())
             ->method('getResolver')
-            ->will($this->returnValue($resolver));
+            ->willReturn($resolver);
 
         // import the file!
         $routes = new RouteCollectionBuilder($loader);
@@ -107,11 +107,11 @@ class RouteCollectionBuilderTest extends TestCase
         // make this loader able to do the import - keeps mocking simple
         $loader->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $loader
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($importedCollection));
+            ->willReturn($importedCollection);
 
         $routes = new RouteCollectionBuilder($loader);
 
@@ -296,11 +296,11 @@ class RouteCollectionBuilderTest extends TestCase
         // make this loader able to do the import - keeps mocking simple
         $loader->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $loader
             ->expects($this->any())
             ->method('load')
-            ->will($this->returnValue($importedCollection));
+            ->willReturn($importedCollection);
         // import this from the /admin route builder
         $adminRoutes->import('admin.yml', '/imported');
 
@@ -347,11 +347,11 @@ class RouteCollectionBuilderTest extends TestCase
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
         $loader->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $loader
             ->expects($this->any())
             ->method('load')
-            ->will($this->returnValue([$firstCollection, $secondCollection]));
+            ->willReturn([$firstCollection, $secondCollection]);
 
         $routeCollectionBuilder = new RouteCollectionBuilder($loader);
         $routeCollectionBuilder->import('/directory/recurse/*', '/other/', 'glob');

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -88,7 +88,7 @@ class RouterTest extends TestCase
 
         $this->loader->expects($this->once())
             ->method('load')->with('routing.yml', 'ResourceType')
-            ->will($this->returnValue($routeCollection));
+            ->willReturn($routeCollection);
 
         $this->assertSame($routeCollection, $this->router->getRouteCollection());
     }
@@ -102,7 +102,7 @@ class RouterTest extends TestCase
 
         $this->loader->expects($this->once())
             ->method('load')->with('routing.yml', null)
-            ->will($this->returnValue(new RouteCollection()));
+            ->willReturn(new RouteCollection());
 
         $this->assertInstanceOf('Symfony\\Component\\Routing\\Matcher\\UrlMatcher', $this->router->getMatcher());
     }
@@ -124,7 +124,7 @@ class RouterTest extends TestCase
 
         $this->loader->expects($this->once())
             ->method('load')->with('routing.yml', null)
-            ->will($this->returnValue(new RouteCollection()));
+            ->willReturn(new RouteCollection());
 
         $this->assertInstanceOf('Symfony\\Component\\Routing\\Generator\\UrlGenerator', $this->router->getGenerator());
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -177,13 +177,13 @@ class AuthenticationProviderManagerTest extends TestCase
         $provider = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface')->getMock();
         $provider->expects($this->once())
                  ->method('supports')
-                 ->will($this->returnValue($supports))
+                 ->willReturn($supports)
         ;
 
         if (null !== $token) {
             $provider->expects($this->once())
                      ->method('authenticate')
-                     ->will($this->returnValue($token))
+                     ->willReturn($token)
             ;
         } elseif (null !== $exception) {
             $provider->expects($this->once())

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
@@ -58,7 +58,7 @@ class AnonymousAuthenticationProviderTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setMethods(['getSecret'])->disableOriginalConstructor()->getMock();
         $token->expects($this->any())
               ->method('getSecret')
-              ->will($this->returnValue($secret))
+              ->willReturn($secret)
         ;
 
         return $token;

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -77,7 +77,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $token = $this->getSupportedToken();
         $token->expects($this->once())
               ->method('getUser')
-              ->will($this->returnValue($user))
+              ->willReturn($user)
         ;
 
         $provider = new DaoAuthenticationProvider($userProvider, $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface')->getMock(), 'key', $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface')->getMock());
@@ -95,7 +95,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $userProvider = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface')->getMock();
         $userProvider->expects($this->once())
                      ->method('loadUserByUsername')
-                     ->will($this->returnValue($user))
+                     ->willReturn($user)
         ;
 
         $provider = new DaoAuthenticationProvider($userProvider, $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface')->getMock(), 'key', $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface')->getMock());
@@ -124,7 +124,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(''))
+            ->willReturn('')
         ;
 
         $method->invoke(
@@ -140,7 +140,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $encoder
             ->expects($this->once())
             ->method('isPasswordValid')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $provider = $this->getProvider(null, null, $encoder);
@@ -151,7 +151,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue('0'))
+            ->willReturn('0')
         ;
 
         $method->invoke(
@@ -169,7 +169,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $encoder = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\PasswordEncoderInterface')->getMock();
         $encoder->expects($this->once())
                 ->method('isPasswordValid')
-                ->will($this->returnValue(false))
+                ->willReturn(false)
         ;
 
         $provider = $this->getProvider(null, null, $encoder);
@@ -179,7 +179,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $token = $this->getSupportedToken();
         $token->expects($this->once())
               ->method('getCredentials')
-              ->will($this->returnValue('foo'))
+              ->willReturn('foo')
         ;
 
         $method->invoke($provider, $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock(), $token);
@@ -193,18 +193,18 @@ class DaoAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getPassword')
-             ->will($this->returnValue('foo'))
+             ->willReturn('foo')
         ;
 
         $token = $this->getSupportedToken();
         $token->expects($this->once())
               ->method('getUser')
-              ->will($this->returnValue($user));
+              ->willReturn($user);
 
         $dbUser = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $dbUser->expects($this->once())
                ->method('getPassword')
-               ->will($this->returnValue('newFoo'))
+               ->willReturn('newFoo')
         ;
 
         $provider = $this->getProvider();
@@ -218,18 +218,18 @@ class DaoAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getPassword')
-             ->will($this->returnValue('foo'))
+             ->willReturn('foo')
         ;
 
         $token = $this->getSupportedToken();
         $token->expects($this->once())
               ->method('getUser')
-              ->will($this->returnValue($user));
+              ->willReturn($user);
 
         $dbUser = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $dbUser->expects($this->once())
                ->method('getPassword')
-               ->will($this->returnValue('foo'))
+               ->willReturn('foo')
         ;
 
         $provider = $this->getProvider();
@@ -243,7 +243,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $encoder = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\PasswordEncoderInterface')->getMock();
         $encoder->expects($this->once())
                 ->method('isPasswordValid')
-                ->will($this->returnValue(true))
+                ->willReturn(true)
         ;
 
         $provider = $this->getProvider(null, null, $encoder);
@@ -253,7 +253,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $token = $this->getSupportedToken();
         $token->expects($this->once())
               ->method('getCredentials')
-              ->will($this->returnValue('foo'))
+              ->willReturn('foo')
         ;
 
         $method->invoke($provider, $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock(), $token);
@@ -265,7 +265,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $mock
             ->expects($this->any())
             ->method('getProviderKey')
-            ->will($this->returnValue('key'))
+            ->willReturn('key')
         ;
 
         return $mock;
@@ -277,7 +277,7 @@ class DaoAuthenticationProviderTest extends TestCase
         if (null !== $user) {
             $userProvider->expects($this->once())
                          ->method('loadUserByUsername')
-                         ->will($this->returnValue($user))
+                         ->willReturn($user)
             ;
         }
 
@@ -293,7 +293,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $encoderFactory
             ->expects($this->any())
             ->method('getEncoder')
-            ->will($this->returnValue($passwordEncoder))
+            ->willReturn($passwordEncoder)
         ;
 
         return new DaoAuthenticationProvider($userProvider, $userChecker, 'key', $encoderFactory);

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
@@ -113,7 +113,7 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($collection))
+            ->willReturn($collection)
         ;
 
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
@@ -121,13 +121,13 @@ class LdapBindAuthenticationProviderTest extends TestCase
             ->expects($this->once())
             ->method('escape')
             ->with('foo', '')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
             ->with('{username}', 'foobar')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
         $userChecker = $this->getMockBuilder(UserCheckerInterface::class)->getMock();
 
@@ -153,14 +153,14 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($collection))
+            ->willReturn($collection)
         ;
 
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
         $userChecker = $this->getMockBuilder(UserCheckerInterface::class)->getMock();
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -31,7 +31,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getProviderKey')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $this->assertFalse($provider->supports($token));
     }
@@ -62,7 +62,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
         $provider = $this->getProvider($user);
 
@@ -99,20 +99,20 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         if (false !== $user) {
             $token->expects($this->once())
                   ->method('getUser')
-                  ->will($this->returnValue($user))
+                  ->willReturn($user)
             ;
         }
         if (false !== $credentials) {
             $token->expects($this->once())
                   ->method('getCredentials')
-                  ->will($this->returnValue($credentials))
+                  ->willReturn($credentials)
             ;
         }
 
         $token
             ->expects($this->any())
             ->method('getProviderKey')
-            ->will($this->returnValue('key'))
+            ->willReturn('key')
         ;
 
         $token->setAttributes(['foo' => 'bar']);
@@ -126,7 +126,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         if (null !== $user) {
             $userProvider->expects($this->once())
                          ->method('loadUserByUsername')
-                         ->will($this->returnValue($user))
+                         ->willReturn($user)
             ;
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -69,7 +69,7 @@ class RememberMeAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $user->expects($this->exactly(2))
              ->method('getRoles')
-             ->will($this->returnValue(['ROLE_FOO']));
+             ->willReturn(['ROLE_FOO']);
 
         $provider = $this->getProvider();
 
@@ -89,14 +89,14 @@ class RememberMeAuthenticationProviderTest extends TestCase
             $user
                 ->expects($this->any())
                 ->method('getRoles')
-                ->will($this->returnValue([]));
+                ->willReturn([]);
         }
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(['getProviderKey'])->setConstructorArgs([$user, 'foo', $secret])->getMock();
         $token
             ->expects($this->once())
             ->method('getProviderKey')
-            ->will($this->returnValue('foo'));
+            ->willReturn('foo');
 
         return $token;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
@@ -29,7 +29,7 @@ class SimpleAuthenticationProviderTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
         $userChecker->expects($this->once())
@@ -39,7 +39,7 @@ class SimpleAuthenticationProviderTest extends TestCase
         $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
         $authenticator->expects($this->once())
             ->method('authenticateToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $provider = $this->getProvider($authenticator, null, $userChecker);
 
@@ -56,7 +56,7 @@ class SimpleAuthenticationProviderTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
         $userChecker->expects($this->once())
@@ -66,7 +66,7 @@ class SimpleAuthenticationProviderTest extends TestCase
         $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
         $authenticator->expects($this->once())
             ->method('authenticateToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $provider = $this->getProvider($authenticator, null, $userChecker);
 
@@ -78,11 +78,11 @@ class SimpleAuthenticationProviderTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue('string-user'));
+            ->willReturn('string-user');
         $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
         $authenticator->expects($this->once())
             ->method('authenticateToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $this->assertSame($token, $this->getProvider($authenticator, null, new UserChecker())->authenticate($token));
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -76,7 +76,7 @@ class UserAuthenticationProviderTest extends TestCase
         $provider = $this->getProvider(false, true);
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->returnValue(null))
+                 ->willReturn(null)
         ;
 
         $provider->authenticate($this->getSupportedToken());
@@ -96,7 +96,7 @@ class UserAuthenticationProviderTest extends TestCase
         $provider = $this->getProvider($userChecker);
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock()))
+                 ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock())
         ;
 
         $provider->authenticate($this->getSupportedToken());
@@ -116,7 +116,7 @@ class UserAuthenticationProviderTest extends TestCase
         $provider = $this->getProvider($userChecker);
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock()))
+                 ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock())
         ;
 
         $provider->authenticate($this->getSupportedToken());
@@ -131,7 +131,7 @@ class UserAuthenticationProviderTest extends TestCase
         $provider = $this->getProvider();
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock()))
+                 ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock())
         ;
         $provider->expects($this->once())
                  ->method('checkAuthentication')
@@ -150,7 +150,7 @@ class UserAuthenticationProviderTest extends TestCase
         $provider = $this->getProvider(false, false);
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock()))
+                 ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock())
         ;
         $provider->expects($this->once())
                  ->method('checkAuthentication')
@@ -165,24 +165,24 @@ class UserAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getRoles')
-             ->will($this->returnValue(['ROLE_FOO']))
+             ->willReturn(['ROLE_FOO'])
         ;
 
         $provider = $this->getProvider();
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->returnValue($user))
+                 ->willReturn($user)
         ;
 
         $token = $this->getSupportedToken();
         $token->expects($this->once())
               ->method('getCredentials')
-              ->will($this->returnValue('foo'))
+              ->willReturn('foo')
         ;
 
         $token->expects($this->once())
               ->method('getRoles')
-              ->will($this->returnValue([]))
+              ->willReturn([])
         ;
 
         $authToken = $provider->authenticate($token);
@@ -199,25 +199,25 @@ class UserAuthenticationProviderTest extends TestCase
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getRoles')
-             ->will($this->returnValue(['ROLE_FOO']))
+             ->willReturn(['ROLE_FOO'])
         ;
 
         $provider = $this->getProvider();
         $provider->expects($this->once())
                  ->method('retrieveUser')
-                 ->will($this->returnValue($user))
+                 ->willReturn($user)
         ;
 
         $token = $this->getSupportedToken();
         $token->expects($this->once())
               ->method('getCredentials')
-              ->will($this->returnValue('foo'))
+              ->willReturn('foo')
         ;
 
         $switchUserRole = new SwitchUserRole('foo', $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
         $token->expects($this->once())
               ->method('getRoles')
-              ->will($this->returnValue([$switchUserRole]))
+              ->willReturn([$switchUserRole])
         ;
 
         $authToken = $provider->authenticate($token);
@@ -236,7 +236,7 @@ class UserAuthenticationProviderTest extends TestCase
         $mock
             ->expects($this->any())
             ->method('getProviderKey')
-            ->will($this->returnValue('key'))
+            ->willReturn('key')
         ;
 
         $mock->setAttributes(['foo' => 'bar']);

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -77,7 +77,7 @@ class AbstractTokenTest extends TestCase
         $this->assertEquals('fabien', $token->getUsername());
 
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
-        $user->expects($this->once())->method('getUsername')->will($this->returnValue('fabien'));
+        $user->expects($this->once())->method('getUsername')->willReturn('fabien');
         $token->setUser($user);
         $this->assertEquals('fabien', $token->getUsername());
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -59,7 +59,7 @@ class RememberMeTokenTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue($roles))
+            ->willReturn($roles)
         ;
 
         return $user;

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -72,10 +72,10 @@ class AccessDecisionManagerTest extends TestCase
         $voter = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface')->getMock();
         $voter->expects($this->any())
               ->method('vote')
-              ->will($this->returnValueMap([
+              ->willReturnMap([
                   [$token, null, ['ROLE_FOO'], $vote1],
                   [$token, null, ['ROLE_BAR'], $vote2],
-              ]))
+              ])
         ;
 
         return $voter;
@@ -137,7 +137,7 @@ class AccessDecisionManagerTest extends TestCase
         $voter = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface')->getMock();
         $voter->expects($this->any())
               ->method('vote')
-              ->will($this->returnValue($vote));
+              ->willReturn($vote);
 
         return $voter;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -46,7 +46,7 @@ class AuthorizationCheckerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($token))
-            ->will($this->returnValue($newToken));
+            ->willReturn($newToken);
 
         // default with() isn't a strict check
         $tokenComparison = function ($value) use ($newToken) {
@@ -58,7 +58,7 @@ class AuthorizationCheckerTest extends TestCase
             ->expects($this->once())
             ->method('decide')
             ->with($this->callback($tokenComparison))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         // first run the token has not been re-authenticated yet, after isGranted is called, it should be equal
         $this->assertNotSame($newToken, $this->tokenStorage->getToken());
@@ -83,12 +83,12 @@ class AuthorizationCheckerTest extends TestCase
         $token
             ->expects($this->once())
             ->method('isAuthenticated')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->accessDecisionManager
             ->expects($this->once())
             ->method('decide')
-            ->will($this->returnValue($decide));
+            ->willReturn($decide);
         $this->tokenStorage->setToken($token);
         $this->assertSame($decide, $this->authorizationChecker->isGranted('ROLE_FOO'));
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
@@ -51,7 +51,7 @@ class ExpressionVoterTest extends TestCase
         if ($tokenExpectsGetRoles) {
             $token->expects($this->once())
                 ->method('getRoles')
-                ->will($this->returnValue($roles));
+                ->willReturn($roles);
         }
 
         return $token;
@@ -64,7 +64,7 @@ class ExpressionVoterTest extends TestCase
         if ($expressionLanguageExpectsEvaluate) {
             $mock->expects($this->once())
                 ->method('evaluate')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         }
 
         return $mock;

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
@@ -54,7 +54,7 @@ class RoleVoterTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token->expects($this->once())
               ->method('getRoles')
-              ->will($this->returnValue($roles));
+              ->willReturn($roles);
 
         return $token;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
@@ -21,19 +21,19 @@ class UserPasswordEncoderTest extends TestCase
         $userMock = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $userMock->expects($this->any())
             ->method('getSalt')
-            ->will($this->returnValue('userSalt'));
+            ->willReturn('userSalt');
 
         $mockEncoder = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')->getMock();
         $mockEncoder->expects($this->any())
             ->method('encodePassword')
             ->with($this->equalTo('plainPassword'), $this->equalTo('userSalt'))
-            ->will($this->returnValue('encodedPassword'));
+            ->willReturn('encodedPassword');
 
         $mockEncoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
         $mockEncoderFactory->expects($this->any())
             ->method('getEncoder')
             ->with($this->equalTo($userMock))
-            ->will($this->returnValue($mockEncoder));
+            ->willReturn($mockEncoder);
 
         $passwordEncoder = new UserPasswordEncoder($mockEncoderFactory);
 
@@ -46,22 +46,22 @@ class UserPasswordEncoderTest extends TestCase
         $userMock = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $userMock->expects($this->any())
             ->method('getSalt')
-            ->will($this->returnValue('userSalt'));
+            ->willReturn('userSalt');
         $userMock->expects($this->any())
             ->method('getPassword')
-            ->will($this->returnValue('encodedPassword'));
+            ->willReturn('encodedPassword');
 
         $mockEncoder = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')->getMock();
         $mockEncoder->expects($this->any())
             ->method('isPasswordValid')
             ->with($this->equalTo('encodedPassword'), $this->equalTo('plainPassword'), $this->equalTo('userSalt'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $mockEncoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
         $mockEncoderFactory->expects($this->any())
             ->method('getEncoder')
             ->with($this->equalTo($userMock))
-            ->will($this->returnValue($mockEncoder));
+            ->willReturn($mockEncoder);
 
         $passwordEncoder = new UserPasswordEncoder($mockEncoderFactory);
 

--- a/src/Symfony/Component/Security/Core/Tests/SecurityTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/SecurityTest.php
@@ -29,7 +29,7 @@ class SecurityTest extends TestCase
 
         $tokenStorage->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $container = $this->createContainer('security.token_storage', $tokenStorage);
 
@@ -45,12 +45,12 @@ class SecurityTest extends TestCase
         $token = $this->getMockBuilder(TokenInterface::class)->getMock();
         $token->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($userInToken));
+            ->willReturn($userInToken);
         $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
 
         $tokenStorage->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $container = $this->createContainer('security.token_storage', $tokenStorage);
 
@@ -75,7 +75,7 @@ class SecurityTest extends TestCase
         $authorizationChecker->expects($this->once())
             ->method('isGranted')
             ->with('SOME_ATTRIBUTE', 'SOME_SUBJECT')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $container = $this->createContainer('security.authorization_checker', $authorizationChecker);
 
@@ -90,7 +90,7 @@ class SecurityTest extends TestCase
         $container->expects($this->atLeastOnce())
             ->method('get')
             ->with($serviceId)
-            ->will($this->returnValue($serviceObject));
+            ->willReturn($serviceObject);
 
         return $container;
     }

--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -33,7 +33,7 @@ class ChainUserProviderTest extends TestCase
             ->expects($this->once())
             ->method('loadUserByUsername')
             ->with($this->equalTo('foo'))
-            ->will($this->returnValue($account = $this->getAccount()))
+            ->willReturn($account = $this->getAccount())
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2]);
@@ -78,7 +78,7 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('refreshUser')
-            ->will($this->returnValue($account = $this->getAccount()))
+            ->willReturn($account = $this->getAccount())
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2]);
@@ -98,7 +98,7 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('refreshUser')
-            ->will($this->returnValue($account = $this->getAccount()))
+            ->willReturn($account = $this->getAccount())
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2]);
@@ -135,7 +135,7 @@ class ChainUserProviderTest extends TestCase
             ->expects($this->once())
             ->method('supportsClass')
             ->with($this->equalTo('foo'))
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $provider2 = $this->getProvider();
@@ -143,7 +143,7 @@ class ChainUserProviderTest extends TestCase
             ->expects($this->once())
             ->method('supportsClass')
             ->with($this->equalTo('foo'))
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2]);
@@ -157,7 +157,7 @@ class ChainUserProviderTest extends TestCase
             ->expects($this->once())
             ->method('supportsClass')
             ->with($this->equalTo('foo'))
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $provider2 = $this->getProvider();
@@ -165,7 +165,7 @@ class ChainUserProviderTest extends TestCase
             ->expects($this->once())
             ->method('supportsClass')
             ->with($this->equalTo('foo'))
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2]);
@@ -185,7 +185,7 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('refreshUser')
-            ->will($this->returnValue($account = $this->getAccount()))
+            ->willReturn($account = $this->getAccount())
         ;
 
         $provider = new ChainUserProvider(new \ArrayObject([$provider1, $provider2]));

--- a/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
@@ -50,23 +50,23 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(0))
+            ->willReturn(0)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
@@ -83,23 +83,23 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(2))
+            ->willReturn(2)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
@@ -116,33 +116,33 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', [
+            ->willReturn(new Entry('foo', [
                     'sAMAccountName' => ['foo'],
                     'userpassword' => ['bar', 'baz'],
                 ]
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword');
@@ -159,29 +159,29 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', [])))
+            ->willReturn(new Entry('foo', []))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})');
@@ -201,32 +201,32 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', [
+            ->willReturn(new Entry('foo', [
                     'sAMAccountName' => ['foo'],
                 ]
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword');
@@ -243,32 +243,32 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', [
+            ->willReturn(new Entry('foo', [
                     'sAMAccountName' => ['foo'],
                 ]
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
@@ -285,32 +285,32 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', [
+            ->willReturn(new Entry('foo', [
                     'sAMAccountName' => ['foo'],
                 ]
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('Foo'))
+            ->willReturn('Foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
@@ -324,33 +324,33 @@ class LdapUserProviderTest extends TestCase
         $query
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->will($this->returnValue(new Entry('foo', [
+            ->willReturn(new Entry('foo', [
                     'sAMAccountName' => ['foo'],
                     'userpassword' => ['bar'],
                 ]
-            )))
+            ))
         ;
         $result
             ->expects($this->once())
             ->method('count')
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
         $ldap
             ->expects($this->once())
             ->method('escape')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $ldap
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($query))
+            ->willReturn($query)
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword');

--- a/src/Symfony/Component/Security/Core/Tests/User/UserCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/UserCheckerTest.php
@@ -28,7 +28,7 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isCredentialsNonExpired')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isCredentialsNonExpired')->willReturn(true);
 
         $this->assertNull($checker->checkPostAuth($account));
     }
@@ -41,7 +41,7 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isCredentialsNonExpired')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isCredentialsNonExpired')->willReturn(false);
 
         $checker->checkPostAuth($account);
     }
@@ -58,9 +58,9 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isEnabled')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isAccountNonExpired')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isAccountNonLocked')->willReturn(true);
+        $account->expects($this->once())->method('isEnabled')->willReturn(true);
+        $account->expects($this->once())->method('isAccountNonExpired')->willReturn(true);
 
         $this->assertNull($checker->checkPreAuth($account));
     }
@@ -73,7 +73,7 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isAccountNonLocked')->willReturn(false);
 
         $checker->checkPreAuth($account);
     }
@@ -86,8 +86,8 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isEnabled')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isAccountNonLocked')->willReturn(true);
+        $account->expects($this->once())->method('isEnabled')->willReturn(false);
 
         $checker->checkPreAuth($account);
     }
@@ -100,9 +100,9 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isEnabled')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isAccountNonExpired')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isAccountNonLocked')->willReturn(true);
+        $account->expects($this->once())->method('isEnabled')->willReturn(true);
+        $account->expects($this->once())->method('isAccountNonExpired')->willReturn(false);
 
         $checker->checkPreAuth($account);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
@@ -65,7 +65,7 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         $this->encoder->expects($this->once())
             ->method('isPasswordValid')
             ->with(static::PASSWORD, 'secret', static::SALT)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->validator->validate('secret', $constraint);
 
@@ -81,7 +81,7 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         $this->encoder->expects($this->once())
             ->method('isPasswordValid')
             ->with(static::PASSWORD, 'secret', static::SALT)
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->validator->validate('secret', $constraint);
 
@@ -133,13 +133,13 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         $mock
             ->expects($this->any())
             ->method('getPassword')
-            ->will($this->returnValue(static::PASSWORD))
+            ->willReturn(static::PASSWORD)
         ;
 
         $mock
             ->expects($this->any())
             ->method('getSalt')
-            ->will($this->returnValue(static::SALT))
+            ->willReturn(static::SALT)
         ;
 
         return $mock;
@@ -157,7 +157,7 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         $mock
             ->expects($this->any())
             ->method('getEncoder')
-            ->will($this->returnValue($encoder))
+            ->willReturn($encoder)
         ;
 
         return $mock;
@@ -171,7 +171,7 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         $mock
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         return $mock;
@@ -183,7 +183,7 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         $mock
             ->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($user))
+            ->willReturn($user)
         ;
 
         return $mock;

--- a/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
@@ -30,11 +30,11 @@ class CsrfTokenManagerTest extends TestCase
         $storage->expects($this->once())
             ->method('hasToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $generator->expects($this->once())
             ->method('generateToken')
-            ->will($this->returnValue('TOKEN'));
+            ->willReturn('TOKEN');
 
         $storage->expects($this->once())
             ->method('setToken')
@@ -55,12 +55,12 @@ class CsrfTokenManagerTest extends TestCase
         $storage->expects($this->once())
             ->method('hasToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $storage->expects($this->once())
             ->method('getToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue('TOKEN'));
+            ->willReturn('TOKEN');
 
         $token = $manager->getToken('token_id');
 
@@ -79,7 +79,7 @@ class CsrfTokenManagerTest extends TestCase
 
         $generator->expects($this->once())
             ->method('generateToken')
-            ->will($this->returnValue('TOKEN'));
+            ->willReturn('TOKEN');
 
         $storage->expects($this->once())
             ->method('setToken')
@@ -100,12 +100,12 @@ class CsrfTokenManagerTest extends TestCase
         $storage->expects($this->once())
             ->method('hasToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $storage->expects($this->once())
             ->method('getToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue('TOKEN'));
+            ->willReturn('TOKEN');
 
         $this->assertTrue($manager->isTokenValid(new CsrfToken('token_id', 'TOKEN')));
     }
@@ -118,12 +118,12 @@ class CsrfTokenManagerTest extends TestCase
         $storage->expects($this->once())
             ->method('hasToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $storage->expects($this->once())
             ->method('getToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue('TOKEN'));
+            ->willReturn('TOKEN');
 
         $this->assertFalse($manager->isTokenValid(new CsrfToken('token_id', 'FOOBAR')));
     }
@@ -136,7 +136,7 @@ class CsrfTokenManagerTest extends TestCase
         $storage->expects($this->once())
             ->method('hasToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $storage->expects($this->never())
             ->method('getToken');
@@ -152,7 +152,7 @@ class CsrfTokenManagerTest extends TestCase
         $storage->expects($this->once())
             ->method('removeToken')
             ->with($namespace.'token_id')
-            ->will($this->returnValue('REMOVED_TOKEN'));
+            ->willReturn('REMOVED_TOKEN');
 
         $this->assertSame('REMOVED_TOKEN', $manager->removeToken('token_id'));
     }

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -77,7 +77,7 @@ class FormLoginAuthenticatorTest extends TestCase
         $this->requestWithSession->getSession()
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $redirectResponse = $this->authenticator->onAuthenticationSuccess($this->requestWithSession, $token, 'providerkey');
 
@@ -96,7 +96,7 @@ class FormLoginAuthenticatorTest extends TestCase
         $this->requestWithSession->getSession()
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue(self::CUSTOM_SUCCESS_URL));
+            ->willReturn(self::CUSTOM_SUCCESS_URL);
 
         $redirectResponse = $this->authenticator->onAuthenticationSuccess($this->requestWithSession, $token, 'providerkey');
 

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -51,7 +51,7 @@ class GuardAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('getCredentials')
             ->with($this->equalTo($this->request))
-            ->will($this->returnValue($credentials));
+            ->willReturn($credentials);
 
         // a clone of the token that should be created internally
         $uniqueGuardKey = 'my_firewall_0';
@@ -61,7 +61,7 @@ class GuardAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($nonAuthedToken))
-            ->will($this->returnValue($authenticateToken));
+            ->willReturn($authenticateToken);
 
         $this->guardAuthenticatorHandler
             ->expects($this->once())
@@ -139,18 +139,18 @@ class GuardAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('getCredentials')
             ->with($this->equalTo($this->request))
-            ->will($this->returnValue(['username' => 'anything_not_empty']));
+            ->willReturn(['username' => 'anything_not_empty']);
 
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
-            ->will($this->returnValue($authenticateToken));
+            ->willReturn($authenticateToken);
 
         $successResponse = new Response('Success!');
         $this->guardAuthenticatorHandler
             ->expects($this->once())
             ->method('handleAuthenticationSuccess')
-            ->will($this->returnValue($successResponse));
+            ->willReturn($successResponse);
 
         $listener = new GuardAuthenticationListener(
             $this->guardAuthenticatorHandler,
@@ -163,7 +163,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $listener->setRememberMeServices($this->rememberMeServices);
         $authenticator->expects($this->once())
             ->method('supportsRememberMe')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         // should be called - we do have a success Response
         $this->rememberMeServices
             ->expects($this->once())
@@ -219,7 +219,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticatorA
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         // this is not called
         $this->authenticationManager
@@ -256,7 +256,7 @@ class GuardAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('getCredentials')
             ->with($this->equalTo($this->request))
-            ->will($this->returnValue($credentials));
+            ->willReturn($credentials);
 
         // a clone of the token that should be created internally
         $uniqueGuardKey = 'my_firewall_0';
@@ -266,7 +266,7 @@ class GuardAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($nonAuthedToken))
-            ->will($this->returnValue($authenticateToken));
+            ->willReturn($authenticateToken);
 
         $this->guardAuthenticatorHandler
             ->expects($this->once())
@@ -307,11 +307,11 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticatorA
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $authenticatorB
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         // this is not called
         $this->authenticationManager
@@ -341,7 +341,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('supports')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         // this is not called
         $authenticator
@@ -370,13 +370,13 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         // this will raise exception
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $listener = new GuardAuthenticationListener(
             $this->guardAuthenticatorHandler,
@@ -401,13 +401,13 @@ class GuardAuthenticationListenerTest extends TestCase
         $authenticator
             ->expects($this->once())
             ->method('supports')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         // this will raise exception
         $authenticator
             ->expects($this->once())
             ->method('getCredentials')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $listener = new GuardAuthenticationListener(
             $this->guardAuthenticatorHandler,
@@ -439,7 +439,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $this->event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($this->request));
+            ->willReturn($this->request);
 
         $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $this->rememberMeServices = $this->getMockBuilder('Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface')->getMock();

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -54,7 +54,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $this->guardAuthenticator->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token, $providerKey)
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $handler = new GuardAuthenticatorHandler($this->tokenStorage, $this->dispatcher);
         $actualResponse = $handler->handleAuthenticationSuccess($this->token, $this->request, $this->guardAuthenticator, $providerKey);
@@ -73,7 +73,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $this->guardAuthenticator->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $authException)
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $handler = new GuardAuthenticatorHandler($this->tokenStorage, $this->dispatcher);
         $actualResponse = $handler->handleAuthenticationFailure($authException, $this->request, $this->guardAuthenticator, 'firewall_provider_key');
@@ -90,7 +90,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
             ->getMock();
         $token->expects($this->any())
             ->method('getProviderKey')
-            ->will($this->returnValue($tokenProviderKey));
+            ->willReturn($tokenProviderKey);
 
         $this->tokenStorage->expects($this->never())
             ->method('setToken')
@@ -101,7 +101,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $this->guardAuthenticator->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $authException)
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $handler = new GuardAuthenticatorHandler($this->tokenStorage, $this->dispatcher);
         $actualResponse = $handler->handleAuthenticationFailure($authException, $this->request, $this->guardAuthenticator, $actualProviderKey);

--- a/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
@@ -41,7 +41,7 @@ class GuardAuthenticationProviderTest extends TestCase
         $this->preAuthenticationToken->expects($this->exactly(2))
             ->method('getGuardProviderKey')
             // it will return the "1" index, which will match authenticatorB
-            ->will($this->returnValue('my_cool_firewall_1'));
+            ->willReturn('my_cool_firewall_1');
 
         $enteredCredentials = [
             'username' => '_weaverryan_test_user',
@@ -49,7 +49,7 @@ class GuardAuthenticationProviderTest extends TestCase
         ];
         $this->preAuthenticationToken->expects($this->atLeastOnce())
             ->method('getCredentials')
-            ->will($this->returnValue($enteredCredentials));
+            ->willReturn($enteredCredentials);
 
         // authenticators A and C are never called
         $authenticatorA->expects($this->never())
@@ -61,18 +61,18 @@ class GuardAuthenticationProviderTest extends TestCase
         $authenticatorB->expects($this->once())
             ->method('getUser')
             ->with($enteredCredentials, $this->userProvider)
-            ->will($this->returnValue($mockedUser));
+            ->willReturn($mockedUser);
         // checkCredentials is called
         $authenticatorB->expects($this->once())
             ->method('checkCredentials')
             ->with($enteredCredentials, $mockedUser)
             // authentication works!
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $authedToken = $this->getMockBuilder(TokenInterface::class)->getMock();
         $authenticatorB->expects($this->once())
             ->method('createAuthenticatedToken')
             ->with($mockedUser, $providerKey)
-            ->will($this->returnValue($authedToken));
+            ->willReturn($authedToken);
 
         // user checker should be called
         $this->userChecker->expects($this->once())
@@ -103,7 +103,7 @@ class GuardAuthenticationProviderTest extends TestCase
         $this->preAuthenticationToken->expects($this->exactly(2))
             ->method('getGuardProviderKey')
             // it will return the "1" index, which will match authenticatorB
-            ->will($this->returnValue('my_cool_firewall_1'));
+            ->willReturn('my_cool_firewall_1');
 
         $enteredCredentials = [
             'username' => '_weaverryan_test_user',
@@ -111,7 +111,7 @@ class GuardAuthenticationProviderTest extends TestCase
         ];
         $this->preAuthenticationToken->expects($this->atLeastOnce())
             ->method('getCredentials')
-            ->will($this->returnValue($enteredCredentials));
+            ->willReturn($enteredCredentials);
 
         // authenticators A and C are never called
         $authenticatorA->expects($this->never())
@@ -123,18 +123,18 @@ class GuardAuthenticationProviderTest extends TestCase
         $authenticatorB->expects($this->once())
             ->method('getUser')
             ->with($enteredCredentials, $this->userProvider)
-            ->will($this->returnValue($mockedUser));
+            ->willReturn($mockedUser);
         // checkCredentials is called
         $authenticatorB->expects($this->once())
             ->method('checkCredentials')
             ->with($enteredCredentials, $mockedUser)
             // authentication works!
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $authedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $authenticatorB->expects($this->once())
             ->method('createAuthenticatedToken')
             ->with($mockedUser, $providerKey)
-            ->will($this->returnValue($authedToken));
+            ->willReturn($authedToken);
 
         // user checker should be called
         $this->userChecker->expects($this->once())
@@ -162,21 +162,21 @@ class GuardAuthenticationProviderTest extends TestCase
         $this->preAuthenticationToken->expects($this->any())
             ->method('getGuardProviderKey')
             // the 0 index, to match the only authenticator
-            ->will($this->returnValue('my_uncool_firewall_0'));
+            ->willReturn('my_uncool_firewall_0');
 
         $this->preAuthenticationToken->expects($this->atLeastOnce())
             ->method('getCredentials')
-            ->will($this->returnValue('non-null-value'));
+            ->willReturn('non-null-value');
 
         $mockedUser = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $authenticator->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($mockedUser));
+            ->willReturn($mockedUser);
         // checkCredentials is called
         $authenticator->expects($this->once())
             ->method('checkCredentials')
             // authentication fails :(
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $provider = new GuardAuthenticationProvider([$authenticator], $this->userProvider, $providerKey, $this->userChecker);
         $provider->authenticate($this->preAuthenticationToken);

--- a/src/Symfony/Component/Security/Http/Tests/AccessMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessMapTest.php
@@ -45,7 +45,7 @@ class AccessMapTest extends TestCase
         $requestMatcher = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestMatcherInterface')->getMock();
         $requestMatcher->expects($this->once())
             ->method('matches')->with($request)
-            ->will($this->returnValue($matches));
+            ->willReturn($matches);
 
         return $requestMatcher;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -34,7 +34,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
         $this->session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
         $this->request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
-        $this->request->expects($this->any())->method('getSession')->will($this->returnValue($this->session));
+        $this->request->expects($this->any())->method('getSession')->willReturn($this->session);
         $this->exception = $this->getMockBuilder('Symfony\Component\Security\Core\Exception\AuthenticationException')->setMethods(['getMessage'])->getMock();
     }
 
@@ -47,12 +47,12 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
             ->method('set')->with(Security::AUTHENTICATION_ERROR, $this->exception);
         $this->httpUtils->expects($this->once())
             ->method('createRequest')->with($this->request, '/login')
-            ->will($this->returnValue($subRequest));
+            ->willReturn($subRequest);
 
         $response = new Response();
         $this->httpKernel->expects($this->once())
             ->method('handle')->with($subRequest, HttpKernelInterface::SUB_REQUEST)
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
         $result = $handler->onAuthenticationFailure($this->request, $this->exception);
@@ -65,7 +65,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
         $response = new Response();
         $this->httpUtils->expects($this->once())
             ->method('createRedirectResponse')->with($this->request, '/login')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, [], $this->logger);
         $result = $handler->onAuthenticationFailure($this->request, $this->exception);
@@ -92,7 +92,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
         $this->httpUtils->expects($this->once())
             ->method('createRequest')->with($this->request, '/login')
-            ->will($this->returnValue($subRequest));
+            ->willReturn($subRequest);
 
         $this->session->expects($this->never())->method('set');
 
@@ -117,7 +117,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
         $this->httpUtils->expects($this->once())
             ->method('createRequest')->with($this->request, '/login')
-            ->will($this->returnValue($this->getRequest()));
+            ->willReturn($this->getRequest());
 
         $this->logger
             ->expects($this->once())
@@ -143,7 +143,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     {
         $this->request->expects($this->once())
             ->method('get')->with('_failure_path')
-            ->will($this->returnValue('/auth/login'));
+            ->willReturn('/auth/login');
 
         $this->httpUtils->expects($this->once())
             ->method('createRedirectResponse')->with($this->request, '/auth/login');
@@ -156,7 +156,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     {
         $this->request->expects($this->once())
             ->method('get')->with('_failure_path')
-            ->will($this->returnValue(['value' => '/auth/login']));
+            ->willReturn(['value' => '/auth/login']);
 
         $this->httpUtils->expects($this->once())
             ->method('createRedirectResponse')->with($this->request, '/auth/login');
@@ -171,7 +171,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
         $this->request->expects($this->once())
             ->method('get')->with('_my_failure_path')
-            ->will($this->returnValue('/auth/login'));
+            ->willReturn('/auth/login');
 
         $this->httpUtils->expects($this->once())
             ->method('createRedirectResponse')->with($this->request, '/auth/login');

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -24,7 +24,7 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     public function testRequestRedirections(Request $request, $options, $redirectedUrl)
     {
         $urlGenerator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
-        $urlGenerator->expects($this->any())->method('generate')->will($this->returnValue('http://localhost/login'));
+        $urlGenerator->expects($this->any())->method('generate')->willReturn('http://localhost/login');
         $httpUtils = new HttpUtils($urlGenerator);
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $handler = new DefaultAuthenticationSuccessHandler($httpUtils, $options);
@@ -37,7 +37,7 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     public function getRequestRedirections()
     {
         $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
-        $session->expects($this->once())->method('get')->with('_security.admin.target_path')->will($this->returnValue('/admin/dashboard'));
+        $session->expects($this->once())->method('get')->with('_security.admin.target_path')->willReturn('/admin/dashboard');
         $session->expects($this->once())->method('remove')->with('_security.admin.target_path');
         $requestWithSession = Request::create('/');
         $requestWithSession->setSession($session);

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -53,7 +53,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->successHandler->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token)
-            ->will($this->returnValue($this->response));
+            ->willReturn($this->response);
 
         $handler = new SimpleAuthenticationHandler($authenticator, $this->successHandler, $this->failureHandler);
         $result = $handler->onAuthenticationSuccess($this->request, $this->token);
@@ -70,7 +70,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $authenticator->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token)
-            ->will($this->returnValue($this->response));
+            ->willReturn($this->response);
 
         $handler = new SimpleAuthenticationHandler($authenticator, $this->successHandler, $this->failureHandler);
         $result = $handler->onAuthenticationSuccess($this->request, $this->token);
@@ -91,7 +91,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $authenticator->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token)
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $handler = new SimpleAuthenticationHandler($authenticator, $this->successHandler, $this->failureHandler);
         $handler->onAuthenticationSuccess($this->request, $this->token);
@@ -102,13 +102,13 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->successHandler->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token)
-            ->will($this->returnValue($this->response));
+            ->willReturn($this->response);
 
         $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\TestSuccessHandlerInterface');
         $authenticator->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token)
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $handler = new SimpleAuthenticationHandler($authenticator, $this->successHandler, $this->failureHandler);
         $result = $handler->onAuthenticationSuccess($this->request, $this->token);
@@ -123,7 +123,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->failureHandler->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $this->authenticationException)
-            ->will($this->returnValue($this->response));
+            ->willReturn($this->response);
 
         $handler = new SimpleAuthenticationHandler($authenticator, $this->successHandler, $this->failureHandler);
         $result = $handler->onAuthenticationFailure($this->request, $this->authenticationException);
@@ -140,7 +140,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $authenticator->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $this->authenticationException)
-            ->will($this->returnValue($this->response));
+            ->willReturn($this->response);
 
         $handler = new SimpleAuthenticationHandler($authenticator, $this->successHandler, $this->failureHandler);
         $result = $handler->onAuthenticationFailure($this->request, $this->authenticationException);
@@ -161,7 +161,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $authenticator->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $this->authenticationException)
-            ->will($this->returnValue(new \stdClass()));
+            ->willReturn(new \stdClass());
 
         $handler = new SimpleAuthenticationHandler($authenticator, $this->successHandler, $this->failureHandler);
         $handler->onAuthenticationFailure($this->request, $this->authenticationException);
@@ -172,13 +172,13 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->failureHandler->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $this->authenticationException)
-            ->will($this->returnValue($this->response));
+            ->willReturn($this->response);
 
         $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\TestFailureHandlerInterface');
         $authenticator->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $this->authenticationException)
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $handler = new SimpleAuthenticationHandler($authenticator, $this->successHandler, $this->failureHandler);
         $result = $handler->onAuthenticationFailure($this->request, $this->authenticationException);

--- a/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
@@ -29,7 +29,7 @@ class FormAuthenticationEntryPointTest extends TestCase
             ->expects($this->once())
             ->method('createRedirectResponse')
             ->with($this->equalTo($request), $this->equalTo('/the/login/path'))
-            ->will($this->returnValue($response))
+            ->willReturn($response)
         ;
 
         $entryPoint = new FormAuthenticationEntryPoint($httpKernel, $httpUtils, '/the/login/path', false);
@@ -48,7 +48,7 @@ class FormAuthenticationEntryPointTest extends TestCase
             ->expects($this->once())
             ->method('createRequest')
             ->with($this->equalTo($request), $this->equalTo('/the/login/path'))
-            ->will($this->returnValue($subRequest))
+            ->willReturn($subRequest)
         ;
 
         $httpKernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
@@ -56,7 +56,7 @@ class FormAuthenticationEntryPointTest extends TestCase
             ->expects($this->once())
             ->method('handle')
             ->with($this->equalTo($subRequest), $this->equalTo(HttpKernelInterface::SUB_REQUEST))
-            ->will($this->returnValue($response))
+            ->willReturn($response)
         ;
 
         $entryPoint = new FormAuthenticationEntryPoint($httpKernel, $httpUtils, '/the/login/path', true);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AbstractPreAuthenticatedListenerTest.php
@@ -31,7 +31,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->once())
@@ -44,7 +44,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken'))
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $listener = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener', [
@@ -55,13 +55,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -77,7 +77,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->never())
@@ -101,13 +101,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -125,7 +125,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
         $tokenStorage
             ->expects($this->never())
@@ -149,13 +149,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -173,7 +173,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -190,13 +190,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -214,7 +214,7 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
         $tokenStorage
             ->expects($this->once())
@@ -239,13 +239,13 @@ class AbstractPreAuthenticatedListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getPreAuthenticatedData')
-            ->will($this->returnValue($userCredentials));
+            ->willReturn($userCredentials);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -28,21 +28,21 @@ class AccessListenerTest extends TestCase
             ->expects($this->any())
             ->method('getPatterns')
             ->with($this->equalTo($request))
-            ->will($this->returnValue([['foo' => 'bar'], null]))
+            ->willReturn([['foo' => 'bar'], null])
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $accessDecisionManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock();
@@ -50,7 +50,7 @@ class AccessListenerTest extends TestCase
             ->expects($this->once())
             ->method('decide')
             ->with($this->equalTo($token), $this->equalTo(['foo' => 'bar']), $this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $listener = new AccessListener(
@@ -64,7 +64,7 @@ class AccessListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -79,21 +79,21 @@ class AccessListenerTest extends TestCase
             ->expects($this->any())
             ->method('getPatterns')
             ->with($this->equalTo($request))
-            ->will($this->returnValue([['foo' => 'bar'], null]))
+            ->willReturn([['foo' => 'bar'], null])
         ;
 
         $notAuthenticatedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $notAuthenticatedToken
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $authenticatedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $authenticatedToken
             ->expects($this->any())
             ->method('isAuthenticated')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $authManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -101,14 +101,14 @@ class AccessListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($notAuthenticatedToken))
-            ->will($this->returnValue($authenticatedToken))
+            ->willReturn($authenticatedToken)
         ;
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($notAuthenticatedToken))
+            ->willReturn($notAuthenticatedToken)
         ;
         $tokenStorage
             ->expects($this->once())
@@ -121,7 +121,7 @@ class AccessListenerTest extends TestCase
             ->expects($this->once())
             ->method('decide')
             ->with($this->equalTo($authenticatedToken), $this->equalTo(['foo' => 'bar']), $this->equalTo($request))
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $listener = new AccessListener(
@@ -135,7 +135,7 @@ class AccessListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -150,7 +150,7 @@ class AccessListenerTest extends TestCase
             ->expects($this->any())
             ->method('getPatterns')
             ->with($this->equalTo($request))
-            ->will($this->returnValue([null, null]))
+            ->willReturn([null, null])
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
@@ -163,7 +163,7 @@ class AccessListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $listener = new AccessListener(
@@ -177,7 +177,7 @@ class AccessListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -192,7 +192,7 @@ class AccessListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $listener = new AccessListener(

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -23,7 +23,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock())
         ;
         $tokenStorage
             ->expects($this->never())
@@ -46,7 +46,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $anonymousToken = new AnonymousToken('TheSecret', 'anon.', []);
@@ -58,7 +58,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
             ->with($this->callback(function ($token) {
                 return 'TheSecret' === $token->getSecret();
             }))
-            ->will($this->returnValue($anonymousToken))
+            ->willReturn($anonymousToken)
         ;
 
         $tokenStorage

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
@@ -34,7 +34,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->once())
@@ -47,7 +47,7 @@ class BasicAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken'))
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -61,7 +61,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -80,7 +80,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->never())
@@ -94,7 +94,7 @@ class BasicAuthenticationListenerTest extends TestCase
             ->expects($this->any())
             ->method('start')
             ->with($this->equalTo($request), $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
-            ->will($this->returnValue($response))
+            ->willReturn($response)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -108,7 +108,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())
@@ -140,7 +140,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -156,7 +156,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
@@ -176,7 +176,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -209,7 +209,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
         $tokenStorage
             ->expects($this->never())
@@ -223,7 +223,7 @@ class BasicAuthenticationListenerTest extends TestCase
             ->expects($this->any())
             ->method('start')
             ->with($this->equalTo($request), $this->isInstanceOf('Symfony\Component\Security\Core\Exception\AuthenticationException'))
-            ->will($this->returnValue($response))
+            ->willReturn($response)
         ;
 
         $listener = new BasicAuthenticationListener(
@@ -237,7 +237,7 @@ class BasicAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
@@ -23,7 +23,7 @@ class ChannelListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('isSecure')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
@@ -31,7 +31,7 @@ class ChannelListenerTest extends TestCase
             ->expects($this->any())
             ->method('getPatterns')
             ->with($this->equalTo($request))
-            ->will($this->returnValue([[], 'http']))
+            ->willReturn([[], 'http'])
         ;
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
@@ -44,7 +44,7 @@ class ChannelListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->never())
@@ -61,7 +61,7 @@ class ChannelListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('isSecure')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
@@ -69,7 +69,7 @@ class ChannelListenerTest extends TestCase
             ->expects($this->any())
             ->method('getPatterns')
             ->with($this->equalTo($request))
-            ->will($this->returnValue([[], 'https']))
+            ->willReturn([[], 'https'])
         ;
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
@@ -82,7 +82,7 @@ class ChannelListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->never())
@@ -99,7 +99,7 @@ class ChannelListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('isSecure')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $response = new Response();
@@ -109,7 +109,7 @@ class ChannelListenerTest extends TestCase
             ->expects($this->any())
             ->method('getPatterns')
             ->with($this->equalTo($request))
-            ->will($this->returnValue([[], 'https']))
+            ->willReturn([[], 'https'])
         ;
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
@@ -117,14 +117,14 @@ class ChannelListenerTest extends TestCase
             ->expects($this->once())
             ->method('start')
             ->with($this->equalTo($request))
-            ->will($this->returnValue($response))
+            ->willReturn($response)
         ;
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())
@@ -142,7 +142,7 @@ class ChannelListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('isSecure')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $response = new Response();
@@ -152,7 +152,7 @@ class ChannelListenerTest extends TestCase
             ->expects($this->any())
             ->method('getPatterns')
             ->with($this->equalTo($request))
-            ->will($this->returnValue([[], 'http']))
+            ->willReturn([[], 'http'])
         ;
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
@@ -160,14 +160,14 @@ class ChannelListenerTest extends TestCase
             ->expects($this->once())
             ->method('start')
             ->with($this->equalTo($request))
-            ->will($this->returnValue($response))
+            ->willReturn($response)
         ;
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
         $event
             ->expects($this->once())

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -151,17 +151,17 @@ class ContextListenerTest extends TestCase
 
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
         $request->expects($this->any())
             ->method('hasPreviousSession')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $request->expects($this->any())
             ->method('getSession')
-            ->will($this->returnValue($session));
+            ->willReturn($session);
         $session->expects($this->any())
             ->method('get')
             ->with('_security_key123')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
         $tokenStorage->expects($this->once())
             ->method('setToken')
             ->with(null);
@@ -193,10 +193,10 @@ class ContextListenerTest extends TestCase
 
         $event->expects($this->any())
             ->method('isMasterRequest')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock()));
+            ->willReturn($this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock());
 
         $dispatcher->expects($this->once())
             ->method('addListener')
@@ -218,14 +218,14 @@ class ContextListenerTest extends TestCase
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
         $request->expects($this->any())
             ->method('hasSession')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $event->expects($this->any())
             ->method('isMasterRequest')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
 
         $dispatcher->expects($this->once())
             ->method('removeListener')
@@ -237,12 +237,12 @@ class ContextListenerTest extends TestCase
     public function testHandleRemovesTokenIfNoPreviousSessionWasFound()
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
-        $request->expects($this->any())->method('hasPreviousSession')->will($this->returnValue(false));
+        $request->expects($this->any())->method('hasPreviousSession')->willReturn(false);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
             ->disableOriginalConstructor()
             ->getMock();
-        $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
+        $event->expects($this->any())->method('getRequest')->willReturn($request);
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage->expects($this->once())->method('setToken')->with(null);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/DigestAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/DigestAuthenticationListenerTest.php
@@ -47,7 +47,7 @@ class DigestAuthenticationListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $tokenStorage
             ->expects($this->once())
@@ -64,7 +64,7 @@ class DigestAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -77,7 +77,7 @@ class ExceptionListenerTest extends TestCase
         $event = $this->createEvent(new AuthenticationException());
 
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
-        $entryPoint->expects($this->once())->method('start')->will($this->returnValue('NOT A RESPONSE'));
+        $entryPoint->expects($this->once())->method('start')->willReturn('NOT A RESPONSE');
 
         $listener = $this->createExceptionListener(null, null, null, $entryPoint);
         $listener->onKernelException($event);
@@ -106,12 +106,12 @@ class ExceptionListenerTest extends TestCase
     public function testAccessDeniedExceptionFullFledgedAndWithoutAccessDeniedHandlerAndWithErrorPage(\Exception $exception, \Exception $eventException = null)
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnValue(new Response('Unauthorized', 401)));
+        $kernel->expects($this->once())->method('handle')->willReturn(new Response('Unauthorized', 401));
 
         $event = $this->createEvent($exception, $kernel);
 
         $httpUtils = $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')->getMock();
-        $httpUtils->expects($this->once())->method('createRequest')->will($this->returnValue(Request::create('/error')));
+        $httpUtils->expects($this->once())->method('createRequest')->willReturn(Request::create('/error'));
 
         $listener = $this->createExceptionListener(null, $this->createTrustResolver(true), $httpUtils, null, '/error');
         $listener->onKernelException($event);
@@ -131,7 +131,7 @@ class ExceptionListenerTest extends TestCase
         $event = $this->createEvent($exception);
 
         $accessDeniedHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface')->getMock();
-        $accessDeniedHandler->expects($this->once())->method('handle')->will($this->returnValue(new Response('error')));
+        $accessDeniedHandler->expects($this->once())->method('handle')->willReturn(new Response('error'));
 
         $listener = $this->createExceptionListener(null, $this->createTrustResolver(true), null, null, null, $accessDeniedHandler);
         $listener->onKernelException($event);
@@ -148,7 +148,7 @@ class ExceptionListenerTest extends TestCase
         $event = $this->createEvent($exception);
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
-        $tokenStorage->expects($this->once())->method('getToken')->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()));
+        $tokenStorage->expects($this->once())->method('getToken')->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
 
         $listener = $this->createExceptionListener($tokenStorage, $this->createTrustResolver(false), null, $this->createEntryPoint());
         $listener->onKernelException($event);
@@ -171,7 +171,7 @@ class ExceptionListenerTest extends TestCase
     private function createEntryPoint(Response $response = null)
     {
         $entryPoint = $this->getMockBuilder('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface')->getMock();
-        $entryPoint->expects($this->once())->method('start')->will($this->returnValue($response ?: new Response('OK')));
+        $entryPoint->expects($this->once())->method('start')->willReturn($response ?: new Response('OK'));
 
         return $entryPoint;
     }
@@ -179,7 +179,7 @@ class ExceptionListenerTest extends TestCase
     private function createTrustResolver($fullFledged)
     {
         $trustResolver = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface')->getMock();
-        $trustResolver->expects($this->once())->method('isFullFledged')->will($this->returnValue($fullFledged));
+        $trustResolver->expects($this->once())->method('isFullFledged')->willReturn($fullFledged);
 
         return $trustResolver;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -30,7 +30,7 @@ class LogoutListenerTest extends TestCase
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
             ->with($request, $options['logout_path'])
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $listener->handle($event);
     }
@@ -49,20 +49,20 @@ class LogoutListenerTest extends TestCase
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
             ->with($request, $options['logout_path'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $tokenManager->expects($this->once())
             ->method('isTokenValid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $successHandler->expects($this->once())
             ->method('onLogoutSuccess')
             ->with($request)
-            ->will($this->returnValue($response = new Response()));
+            ->willReturn($response = new Response());
 
         $tokenStorage->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token = $this->getToken()));
+            ->willReturn($token = $this->getToken());
 
         $handler = $this->getHandler();
         $handler->expects($this->once())
@@ -93,16 +93,16 @@ class LogoutListenerTest extends TestCase
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
             ->with($request, $options['logout_path'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $successHandler->expects($this->once())
             ->method('onLogoutSuccess')
             ->with($request)
-            ->will($this->returnValue($response = new Response()));
+            ->willReturn($response = new Response());
 
         $tokenStorage->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($token = $this->getToken()));
+            ->willReturn($token = $this->getToken());
 
         $handler = $this->getHandler();
         $handler->expects($this->once())
@@ -136,12 +136,12 @@ class LogoutListenerTest extends TestCase
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
             ->with($request, $options['logout_path'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $successHandler->expects($this->once())
             ->method('onLogoutSuccess')
             ->with($request)
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $listener->handle($event);
     }
@@ -162,11 +162,11 @@ class LogoutListenerTest extends TestCase
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
             ->with($request, $options['logout_path'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $tokenManager->expects($this->once())
             ->method('isTokenValid')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $listener->handle($event);
     }
@@ -189,7 +189,7 @@ class LogoutListenerTest extends TestCase
 
         $event->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request = new Request()));
+            ->willReturn($request = new Request());
 
         return [$event, $request];
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -26,7 +26,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock())
         ;
 
         $tokenStorage
@@ -44,20 +44,20 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $service
             ->expects($this->once())
             ->method('autoLogin')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $event = $this->getGetResponseEvent();
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue(new Request()))
+            ->willReturn(new Request())
         ;
 
         $this->assertNull($listener->handle($event));
@@ -72,13 +72,13 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $service
             ->expects($this->once())
             ->method('autoLogin')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock())
         ;
 
         $service
@@ -97,7 +97,7 @@ class RememberMeListenerTest extends TestCase
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -114,13 +114,13 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $service
             ->expects($this->once())
             ->method('autoLogin')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock())
         ;
 
         $service
@@ -139,7 +139,7 @@ class RememberMeListenerTest extends TestCase
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue(new Request()))
+            ->willReturn(new Request())
         ;
 
         $listener->handle($event);
@@ -152,7 +152,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $exception = new AuthenticationException('Authentication failed.');
@@ -176,7 +176,7 @@ class RememberMeListenerTest extends TestCase
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue(new Request()))
+            ->willReturn(new Request())
         ;
 
         $listener->handle($event);
@@ -189,14 +189,14 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $service
             ->expects($this->once())
             ->method('autoLogin')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $tokenStorage
@@ -208,14 +208,14 @@ class RememberMeListenerTest extends TestCase
         $manager
             ->expects($this->once())
             ->method('authenticate')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $event = $this->getGetResponseEvent();
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue(new Request()))
+            ->willReturn(new Request())
         ;
 
         $listener->handle($event);
@@ -228,14 +228,14 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $service
             ->expects($this->once())
             ->method('autoLogin')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $tokenStorage
@@ -247,40 +247,40 @@ class RememberMeListenerTest extends TestCase
         $manager
             ->expects($this->once())
             ->method('authenticate')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $session = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
         $session
             ->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $request = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Request')->getMock();
         $request
             ->expects($this->once())
             ->method('hasSession')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $request
             ->expects($this->once())
             ->method('getSession')
-            ->will($this->returnValue($session))
+            ->willReturn($session)
         ;
 
         $event = $this->getGetResponseEvent();
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $sessionStrategy
             ->expects($this->once())
             ->method('onAuthentication')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $listener->handle($event);
@@ -293,14 +293,14 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $service
             ->expects($this->once())
             ->method('autoLogin')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $tokenStorage
@@ -312,14 +312,14 @@ class RememberMeListenerTest extends TestCase
         $manager
             ->expects($this->once())
             ->method('authenticate')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $session = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
         $session
             ->expects($this->once())
             ->method('isStarted')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $session
             ->expects($this->once())
@@ -330,20 +330,20 @@ class RememberMeListenerTest extends TestCase
         $request
             ->expects($this->any())
             ->method('hasSession')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $request
             ->expects($this->any())
             ->method('getSession')
-            ->will($this->returnValue($session))
+            ->willReturn($session)
         ;
 
         $event = $this->getGetResponseEvent();
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -356,14 +356,14 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $service
             ->expects($this->once())
             ->method('autoLogin')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $tokenStorage
@@ -375,7 +375,7 @@ class RememberMeListenerTest extends TestCase
         $manager
             ->expects($this->once())
             ->method('authenticate')
-            ->will($this->returnValue($token))
+            ->willReturn($token)
         ;
 
         $event = $this->getGetResponseEvent();
@@ -383,7 +383,7 @@ class RememberMeListenerTest extends TestCase
         $event
             ->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $dispatcher

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -40,7 +40,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($this->token))
-            ->will($this->returnValue($this->token))
+            ->willReturn($this->token)
         ;
 
         $simpleAuthenticator = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface')->getMock();
@@ -48,7 +48,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('createToken')
             ->with($this->equalTo($this->request), $this->equalTo('secured_area'))
-            ->will($this->returnValue($this->token))
+            ->willReturn($this->token)
         ;
 
         $loginEvent = new InteractiveLoginEvent($this->request, $this->token);
@@ -85,7 +85,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('createToken')
             ->with($this->equalTo($this->request), $this->equalTo('secured_area'))
-            ->will($this->returnValue($this->token))
+            ->willReturn($this->token)
         ;
 
         $listener = new SimplePreAuthenticationListener($this->tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
@@ -108,7 +108,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $this->event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($this->request))
+            ->willReturn($this->request)
         ;
 
         $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -167,7 +167,7 @@ class SwitchUserListenerTest extends TestCase
 
         $this->accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
@@ -183,11 +183,11 @@ class SwitchUserListenerTest extends TestCase
 
         $this->accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->userProvider->expects($this->once())
             ->method('loadUserByUsername')->with('kuba')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
         $this->userChecker->expects($this->once())
             ->method('checkPostAuth')->with($user);
 
@@ -213,11 +213,11 @@ class SwitchUserListenerTest extends TestCase
 
         $this->accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->userProvider->expects($this->once())
             ->method('loadUserByUsername')->with('kuba')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
         $this->userChecker->expects($this->once())
             ->method('checkPostAuth')->with($user);
 
@@ -241,11 +241,11 @@ class SwitchUserListenerTest extends TestCase
 
         $this->accessDecisionManager->expects($this->any())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->userProvider->expects($this->any())
             ->method('loadUserByUsername')->with('kuba')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $dispatcher
@@ -288,11 +288,11 @@ class SwitchUserListenerTest extends TestCase
 
         $this->accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->userProvider->expects($this->once())
             ->method('loadUserByUsername')->with('kuba')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
         $this->userChecker->expects($this->once())
             ->method('checkPostAuth')->with($user);
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
@@ -38,21 +38,21 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
         $httpUtils
             ->expects($this->any())
             ->method('checkRequestPath')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $failureHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface')->getMock();
         $failureHandler
             ->expects($ok ? $this->never() : $this->once())
             ->method('onAuthenticationFailure')
-            ->will($this->returnValue(new Response()))
+            ->willReturn(new Response())
         ;
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager')->disableOriginalConstructor()->getMock();
         $authenticationManager
             ->expects($ok ? $this->once() : $this->never())
             ->method('authenticate')
-            ->will($this->returnValue(new Response()))
+            ->willReturn(new Response())
         ;
 
         $listener = new UsernamePasswordFormAuthenticationListener(
@@ -70,7 +70,7 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
         $event
             ->expects($this->any())
             ->method('getRequest')
-            ->will($this->returnValue($request))
+            ->willReturn($request)
         ;
 
         $listener->handle($event);
@@ -154,7 +154,7 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
         $usernameClass
             ->expects($this->atLeastOnce())
             ->method('__toString')
-            ->will($this->returnValue('someUsername'));
+            ->willReturn('someUsername');
 
         $request = Request::create('/login_check', 'POST', ['_username' => $usernameClass]);
         $request->setSession($this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock());

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordJsonAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordJsonAuthenticationListenerTest.php
@@ -43,7 +43,7 @@ class UsernamePasswordJsonAuthenticationListenerTest extends TestCase
         $httpUtils
             ->expects($this->any())
             ->method('checkRequestPath')
-            ->will($this->returnValue($matchCheckPath))
+            ->willReturn($matchCheckPath)
         ;
         $authenticationManager = $this->getMockBuilder(AuthenticationManagerInterface::class)->getMock();
 

--- a/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
@@ -28,7 +28,7 @@ class FirewallMapTest extends TestCase
             ->expects($this->once())
             ->method('matches')
             ->with($this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $map->add($notMatchingMatcher, [$this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock()]);
@@ -38,7 +38,7 @@ class FirewallMapTest extends TestCase
             ->expects($this->once())
             ->method('matches')
             ->with($this->equalTo($request))
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
         $theListener = $this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock();
         $theException = $this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ExceptionListener')->disableOriginalConstructor()->getMock();
@@ -70,7 +70,7 @@ class FirewallMapTest extends TestCase
             ->expects($this->once())
             ->method('matches')
             ->with($this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $map->add($notMatchingMatcher, [$this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock()]);
@@ -105,7 +105,7 @@ class FirewallMapTest extends TestCase
             ->expects($this->once())
             ->method('matches')
             ->with($this->equalTo($request))
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $map->add($notMatchingMatcher, [$this->getMockBuilder('Symfony\Component\Security\Http\Firewall\ListenerInterface')->getMock()]);

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -37,7 +37,7 @@ class FirewallTest extends TestCase
             ->expects($this->once())
             ->method('getListeners')
             ->with($this->equalTo($request))
-            ->will($this->returnValue([[], $listener]))
+            ->willReturn([[], $listener])
         ;
 
         $event = new GetResponseEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $request, HttpKernelInterface::MASTER_REQUEST);
@@ -66,7 +66,7 @@ class FirewallTest extends TestCase
         $map
             ->expects($this->once())
             ->method('getListeners')
-            ->will($this->returnValue([[$first, $second], null]))
+            ->willReturn([[$first, $second], null])
         ;
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
@@ -81,7 +81,7 @@ class FirewallTest extends TestCase
         $event
             ->expects($this->at(0))
             ->method('hasResponse')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $firewall = new Firewall($map, $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock());

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -92,12 +92,12 @@ class HttpUtilsTest extends TestCase
             ->expects($this->any())
             ->method('generate')
             ->with('foobar', [], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->will($this->returnValue('http://localhost/foo/bar'))
+            ->willReturn('http://localhost/foo/bar')
         ;
         $urlGenerator
             ->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock())
         ;
 
         $response = $utils->createRedirectResponse($this->getRequest(), 'foobar');
@@ -125,12 +125,12 @@ class HttpUtilsTest extends TestCase
         $urlGenerator
             ->expects($this->once())
             ->method('generate')
-            ->will($this->returnValue('/foo/bar'))
+            ->willReturn('/foo/bar')
         ;
         $urlGenerator
             ->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock()))
+            ->willReturn($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock())
         ;
 
         $subRequest = $utils->createRequest($this->getRequest(), 'foobar');
@@ -229,7 +229,7 @@ class HttpUtilsTest extends TestCase
             ->expects($this->any())
             ->method('match')
             ->with('/foo/bar')
-            ->will($this->returnValue(['_route' => 'foobar']))
+            ->willReturn(['_route' => 'foobar'])
         ;
 
         $utils = new HttpUtils(null, $urlMatcher);
@@ -244,7 +244,7 @@ class HttpUtilsTest extends TestCase
             ->expects($this->any())
             ->method('matchRequest')
             ->with($request)
-            ->will($this->returnValue(['_route' => 'foobar']))
+            ->willReturn(['_route' => 'foobar'])
         ;
 
         $utils = new HttpUtils(null, $urlMatcher);
@@ -323,7 +323,7 @@ class HttpUtilsTest extends TestCase
         $urlGenerator
             ->expects($this->any())
             ->method('generate')
-            ->will($this->returnValue($generatedUrl))
+            ->willReturn($generatedUrl)
         ;
 
         return $urlGenerator;

--- a/src/Symfony/Component/Security/Http/Tests/Logout/DefaultLogoutSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/DefaultLogoutSuccessHandlerTest.php
@@ -26,7 +26,7 @@ class DefaultLogoutSuccessHandlerTest extends TestCase
         $httpUtils->expects($this->once())
             ->method('createRedirectResponse')
             ->with($request, '/dashboard')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $handler = new DefaultLogoutSuccessHandler($httpUtils, '/dashboard');
         $result = $handler->onLogoutSuccess($request);

--- a/src/Symfony/Component/Security/Http/Tests/Logout/SessionLogoutHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/SessionLogoutHandlerTest.php
@@ -28,7 +28,7 @@ class SessionLogoutHandlerTest extends TestCase
         $request
             ->expects($this->once())
             ->method('getSession')
-            ->will($this->returnValue($session))
+            ->willReturn($session)
         ;
 
         $session

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -51,7 +51,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $service
             ->expects($this->once())
             ->method('processAutoLoginCookie')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $service->autoLogin($request);
@@ -67,13 +67,13 @@ class AbstractRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue([]))
+            ->willReturn([])
         ;
 
         $service
             ->expects($this->once())
             ->method('processAutoLoginCookie')
-            ->will($this->returnValue($user))
+            ->willReturn($user)
         ;
 
         $returnedToken = $service->autoLogin($request);
@@ -131,7 +131,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
 
         $service
@@ -154,13 +154,13 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $service
             ->expects($this->never())
             ->method('onLoginSuccess')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $this->assertFalse($request->request->has('foo'));
@@ -178,13 +178,13 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $service
             ->expects($this->once())
             ->method('onLoginSuccess')
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $service->loginSuccess($request, $response, $token);
@@ -205,13 +205,13 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $service
             ->expects($this->once())
             ->method('onLoginSuccess')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $service->loginSuccess($request, $response, $token);
@@ -232,13 +232,13 @@ class AbstractRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $service
             ->expects($this->once())
             ->method('onLoginSuccess')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $service->loginSuccess($request, $response, $token);
@@ -296,7 +296,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $provider
             ->expects($this->any())
             ->method('supportsClass')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         return $provider;

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -84,7 +84,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('loadTokenBySeries')
-            ->will($this->returnValue(new PersistentToken('fooclass', 'fooname', 'fooseries', 'foovalue', new \DateTime())))
+            ->willReturn(new PersistentToken('fooclass', 'fooname', 'fooseries', 'foovalue', new \DateTime()))
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -111,14 +111,14 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $tokenProvider
             ->expects($this->once())
             ->method('loadTokenBySeries')
-            ->will($this->returnValue(new PersistentToken('fooclass', 'foouser', 'fooseries', 'anotherFooValue', new \DateTime())))
+            ->willReturn(new PersistentToken('fooclass', 'foouser', 'fooseries', 'anotherFooValue', new \DateTime()))
         ;
 
         $tokenProvider
             ->expects($this->once())
             ->method('deleteTokenBySeries')
             ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         try {
@@ -141,7 +141,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
             ->expects($this->once())
             ->method('loadTokenBySeries')
             ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(new PersistentToken('fooclass', 'username', 'fooseries', 'foovalue', new \DateTime('yesterday'))))
+            ->willReturn(new PersistentToken('fooclass', 'username', 'fooseries', 'foovalue', new \DateTime('yesterday')))
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -155,7 +155,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue(['ROLE_FOO']))
+            ->willReturn(['ROLE_FOO'])
         ;
 
         $userProvider = $this->getProvider();
@@ -163,7 +163,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
             ->expects($this->once())
             ->method('loadUserByUsername')
             ->with($this->equalTo('foouser'))
-            ->will($this->returnValue($user))
+            ->willReturn($user)
         ;
 
         $service = $this->getService($userProvider, ['name' => 'foo', 'path' => null, 'domain' => null, 'secure' => false, 'httponly' => false, 'always_remember_me' => true, 'lifetime' => 3600]);
@@ -175,7 +175,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
             ->expects($this->once())
             ->method('loadTokenBySeries')
             ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(new PersistentToken('fooclass', 'foouser', 'fooseries', 'foovalue', new \DateTime())))
+            ->willReturn(new PersistentToken('fooclass', 'foouser', 'fooseries', 'foovalue', new \DateTime()))
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -200,7 +200,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
             ->expects($this->once())
             ->method('deleteTokenBySeries')
             ->with($this->equalTo('fooseries'))
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
         $service->setTokenProvider($tokenProvider);
 
@@ -276,13 +276,13 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $account
             ->expects($this->once())
             ->method('getUsername')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token
             ->expects($this->any())
             ->method('getUser')
-            ->will($this->returnValue($account))
+            ->willReturn($account)
         ;
 
         $tokenProvider = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface')->getMock();
@@ -331,7 +331,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         $provider
             ->expects($this->any())
             ->method('supportsClass')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         return $provider;

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
@@ -95,9 +95,9 @@ class ResponseListenerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
-        $event->expects($this->any())->method('isMasterRequest')->will($this->returnValue(HttpKernelInterface::MASTER_REQUEST === $type));
-        $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
+        $event->expects($this->any())->method('getRequest')->willReturn($request);
+        $event->expects($this->any())->method('isMasterRequest')->willReturn(HttpKernelInterface::MASTER_REQUEST === $type);
+        $event->expects($this->any())->method('getResponse')->willReturn($response);
 
         return $event;
     }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -67,14 +67,14 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
 
         $userProvider
             ->expects($this->once())
             ->method('loadUserByUsername')
             ->with($this->equalTo('foouser'))
-            ->will($this->returnValue($user))
+            ->willReturn($user)
         ;
 
         $this->assertNull($service->autoLogin($request));
@@ -92,14 +92,14 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
 
         $userProvider
             ->expects($this->once())
             ->method('loadUserByUsername')
             ->with($this->equalTo('foouser'))
-            ->will($this->returnValue($user))
+            ->willReturn($user)
         ;
 
         $this->assertNull($service->autoLogin($request));
@@ -117,12 +117,12 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue(['ROLE_FOO']))
+            ->willReturn(['ROLE_FOO'])
         ;
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
 
         $userProvider = $this->getProvider();
@@ -130,7 +130,7 @@ class TokenBasedRememberMeServicesTest extends TestCase
             ->expects($this->once())
             ->method('loadUserByUsername')
             ->with($this->equalTo($username))
-            ->will($this->returnValue($user))
+            ->willReturn($user)
         ;
 
         $service = $this->getService($userProvider, ['name' => 'foo', 'always_remember_me' => true, 'lifetime' => 3600]);
@@ -191,7 +191,7 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
 
         $cookies = $response->headers->getCookies();
@@ -214,17 +214,17 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $user
             ->expects($this->once())
             ->method('getPassword')
-            ->will($this->returnValue('foopass'))
+            ->willReturn('foopass')
         ;
         $user
             ->expects($this->once())
             ->method('getUsername')
-            ->will($this->returnValue('foouser'))
+            ->willReturn('foouser')
         ;
         $token
             ->expects($this->atLeastOnce())
             ->method('getUser')
-            ->will($this->returnValue($user))
+            ->willReturn($user)
         ;
 
         $cookies = $response->headers->getCookies();
@@ -277,7 +277,7 @@ class TokenBasedRememberMeServicesTest extends TestCase
         $provider
             ->expects($this->any())
             ->method('supportsClass')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         return $provider;

--- a/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
@@ -61,7 +61,7 @@ class SessionAuthenticationStrategyTest extends TestCase
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
 
         if (null !== $session) {
-            $request->expects($this->any())->method('getSession')->will($this->returnValue($session));
+            $request->expects($this->any())->method('getSession')->willReturn($session);
         }
 
         return $request;

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -32,12 +32,12 @@ class ChainDecoderTest extends TestCase
 
         $this->decoder1
             ->method('supportsDecoding')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [self::FORMAT_1, [], true],
                 [self::FORMAT_2, [], false],
                 [self::FORMAT_3, [], false],
                 [self::FORMAT_3, ['foo' => 'bar'], true],
-            ]));
+            ]);
 
         $this->decoder2 = $this
             ->getMockBuilder('Symfony\Component\Serializer\Encoder\DecoderInterface')
@@ -45,11 +45,11 @@ class ChainDecoderTest extends TestCase
 
         $this->decoder2
             ->method('supportsDecoding')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [self::FORMAT_1, [], false],
                 [self::FORMAT_2, [], true],
                 [self::FORMAT_3, [], false],
-            ]));
+            ]);
 
         $this->chainDecoder = new ChainDecoder([$this->decoder1, $this->decoder2]);
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -34,12 +34,12 @@ class ChainEncoderTest extends TestCase
 
         $this->encoder1
             ->method('supportsEncoding')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [self::FORMAT_1, [], true],
                 [self::FORMAT_2, [], false],
                 [self::FORMAT_3, [], false],
                 [self::FORMAT_3, ['foo' => 'bar'], true],
-            ]));
+            ]);
 
         $this->encoder2 = $this
             ->getMockBuilder('Symfony\Component\Serializer\Encoder\EncoderInterface')
@@ -47,11 +47,11 @@ class ChainEncoderTest extends TestCase
 
         $this->encoder2
             ->method('supportsEncoding')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [self::FORMAT_1, [], false],
                 [self::FORMAT_2, [], true],
                 [self::FORMAT_3, [], false],
-            ]));
+            ]);
 
         $this->chainEncoder = new ChainEncoder([$this->encoder1, $this->encoder2]);
     }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
@@ -31,7 +31,7 @@ class CacheMetadataFactoryTest extends TestCase
         $decorated
             ->expects($this->once())
             ->method('getMetadataFor')
-            ->will($this->returnValue($metadata))
+            ->willReturn($metadata)
         ;
 
         $factory = new CacheClassMetadataFactory($decorated, new ArrayAdapter());
@@ -47,7 +47,7 @@ class CacheMetadataFactoryTest extends TestCase
         $decorated
             ->expects($this->once())
             ->method('hasMetadataFor')
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $factory = new CacheClassMetadataFactory($decorated, new ArrayAdapter());

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryTest.php
@@ -55,7 +55,7 @@ class ClassMetadataFactoryTest extends TestCase
         $cache
             ->expects($this->once())
             ->method('fetch')
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
 
         $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()), $cache);
@@ -68,7 +68,7 @@ class ClassMetadataFactoryTest extends TestCase
     public function testCacheNotExists()
     {
         $cache = $this->getMockBuilder('Doctrine\Common\Cache\Cache')->getMock();
-        $cache->method('fetch')->will($this->returnValue(false));
+        $cache->method('fetch')->willReturn(false);
         $cache->method('save');
 
         $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()), $cache);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -39,12 +39,12 @@ class ArrayDenormalizerTest extends TestCase
         $this->serializer->expects($this->at(0))
             ->method('denormalize')
             ->with(['foo' => 'one', 'bar' => 'two'])
-            ->will($this->returnValue(new ArrayDummy('one', 'two')));
+            ->willReturn(new ArrayDummy('one', 'two'));
 
         $this->serializer->expects($this->at(1))
             ->method('denormalize')
             ->with(['foo' => 'three', 'bar' => 'four'])
-            ->will($this->returnValue(new ArrayDummy('three', 'four')));
+            ->willReturn(new ArrayDummy('three', 'four'));
 
         $result = $this->denormalizer->denormalize(
             [
@@ -68,7 +68,7 @@ class ArrayDenormalizerTest extends TestCase
         $this->serializer->expects($this->once())
             ->method('supportsDenormalization')
             ->with($this->anything(), __NAMESPACE__.'\ArrayDummy', $this->anything())
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->assertTrue(
             $this->denormalizer->supportsDenormalization(
@@ -85,7 +85,7 @@ class ArrayDenormalizerTest extends TestCase
     {
         $this->serializer->expects($this->any())
             ->method('supportsDenormalization')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->assertFalse(
             $this->denormalizer->supportsDenormalization(

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -63,7 +63,7 @@ class GetSetMethodNormalizerTest extends TestCase
             ->expects($this->once())
             ->method('normalize')
             ->with($object, 'any')
-            ->will($this->returnValue('string_object'))
+            ->willReturn('string_object')
         ;
 
         $this->assertEquals(

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
@@ -50,11 +50,11 @@ class JsonSerializableNormalizerTest extends TestCase
         $this->serializer
             ->expects($this->once())
             ->method('normalize')
-            ->will($this->returnCallback(function ($data) {
+            ->willReturnCallback(function ($data) {
                 $this->assertArraySubset(['foo' => 'a', 'bar' => 'b', 'baz' => 'c'], $data);
 
                 return 'string_object';
-            }))
+            })
         ;
 
         $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
@@ -70,11 +70,11 @@ class JsonSerializableNormalizerTest extends TestCase
         $this->serializer
             ->expects($this->once())
             ->method('normalize')
-            ->will($this->returnCallback(function ($data, $format, $context) {
+            ->willReturnCallback(function ($data, $format, $context) {
                 $this->normalizer->normalize($data['qux'], $format, $context);
 
                 return 'string_object';
-            }))
+            })
         ;
 
         $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -65,7 +65,7 @@ class ObjectNormalizerTest extends TestCase
             ->expects($this->once())
             ->method('normalize')
             ->with($object, 'any')
-            ->will($this->returnValue('string_object'))
+            ->willReturn('string_object')
         ;
 
         $this->assertEquals(

--- a/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
@@ -26,7 +26,7 @@ class DelegatingEngineTest extends TestCase
         $secondEngine->expects($this->once())
             ->method('render')
             ->with('template.php', ['foo' => 'bar'])
-            ->will($this->returnValue('<html />'));
+            ->willReturn('<html />');
 
         $delegatingEngine = new DelegatingEngine([$firstEngine, $secondEngine]);
         $result = $delegatingEngine->render('template.php', ['foo' => 'bar']);
@@ -53,7 +53,7 @@ class DelegatingEngineTest extends TestCase
         $streamingEngine->expects($this->once())
             ->method('stream')
             ->with('template.php', ['foo' => 'bar'])
-            ->will($this->returnValue('<html />'));
+            ->willReturn('<html />');
 
         $delegatingEngine = new DelegatingEngine([$streamingEngine]);
         $result = $delegatingEngine->stream('template.php', ['foo' => 'bar']);
@@ -77,7 +77,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('exists')
             ->with('template.php')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $delegatingEngine = new DelegatingEngine([$engine]);
 
@@ -132,7 +132,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('supports')
             ->with($template)
-            ->will($this->returnValue($supports));
+            ->willReturn($supports);
 
         return $engine;
     }
@@ -144,7 +144,7 @@ class DelegatingEngineTest extends TestCase
         $engine->expects($this->once())
             ->method('supports')
             ->with($template)
-            ->will($this->returnValue($supports));
+            ->willReturn($supports);
 
         return $engine;
     }

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -27,7 +27,7 @@ class TranslationDataCollectorTest extends TestCase
     public function testCollectEmptyMessages()
     {
         $translator = $this->getTranslator();
-        $translator->expects($this->any())->method('getCollectedMessages')->will($this->returnValue([]));
+        $translator->expects($this->any())->method('getCollectedMessages')->willReturn([]);
 
         $dataCollector = new TranslationDataCollector($translator);
         $dataCollector->lateCollect();
@@ -125,7 +125,7 @@ class TranslationDataCollectorTest extends TestCase
         ];
 
         $translator = $this->getTranslator();
-        $translator->expects($this->any())->method('getCollectedMessages')->will($this->returnValue($collectedMessages));
+        $translator->expects($this->any())->method('getCollectedMessages')->willReturn($collectedMessages);
 
         $dataCollector = new TranslationDataCollector($translator);
         $dataCollector->lateCollect();

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -84,10 +84,10 @@ class MessageCatalogueTest extends TestCase
     public function testAddCatalogue()
     {
         $r = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
+        $r->expects($this->any())->method('__toString')->willReturn('r');
 
         $r1 = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
+        $r1->expects($this->any())->method('__toString')->willReturn('r1');
 
         $catalogue = new MessageCatalogue('en', ['domain1' => ['foo' => 'foo'], 'domain2' => ['bar' => 'bar']]);
         $catalogue->addResource($r);
@@ -106,13 +106,13 @@ class MessageCatalogueTest extends TestCase
     public function testAddFallbackCatalogue()
     {
         $r = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
+        $r->expects($this->any())->method('__toString')->willReturn('r');
 
         $r1 = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
+        $r1->expects($this->any())->method('__toString')->willReturn('r1');
 
         $r2 = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r2->expects($this->any())->method('__toString')->will($this->returnValue('r2'));
+        $r2->expects($this->any())->method('__toString')->willReturn('r2');
 
         $catalogue = new MessageCatalogue('fr_FR', ['domain1' => ['foo' => 'foo'], 'domain2' => ['bar' => 'bar']]);
         $catalogue->addResource($r);
@@ -171,11 +171,11 @@ class MessageCatalogueTest extends TestCase
     {
         $catalogue = new MessageCatalogue('en');
         $r = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
+        $r->expects($this->any())->method('__toString')->willReturn('r');
         $catalogue->addResource($r);
         $catalogue->addResource($r);
         $r1 = $this->getMockBuilder('Symfony\Component\Config\Resource\ResourceInterface')->getMock();
-        $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
+        $r1->expects($this->any())->method('__toString')->willReturn('r1');
         $catalogue->addResource($r1);
 
         $this->assertEquals([$r, $r1], $catalogue->getResources());

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -100,7 +100,7 @@ class TranslatorCacheTest extends TestCase
         $loader
             ->expects($this->exactly(2))
             ->method('load')
-            ->will($this->returnValue($catalogue))
+            ->willReturn($catalogue)
         ;
 
         // 1st pass
@@ -242,11 +242,11 @@ class TranslatorCacheTest extends TestCase
     {
         $resource = $this->getMockBuilder('Symfony\Component\Config\Resource\SelfCheckingResourceInterface')->getMock();
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')->getMock();
-        $resource->method('isFresh')->will($this->returnValue(false));
+        $resource->method('isFresh')->willReturn(false);
         $loader
             ->expects($this->exactly(2))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('fr', [], [$resource])));
+            ->willReturn($this->getCatalogue('fr', [], [$resource]));
 
         // prime the cache
         $translator = new Translator('fr', null, $this->tmpDir, true);

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -109,7 +109,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $validator->expects($this->any())
             ->method('inContext')
             ->with($context)
-            ->will($this->returnValue($contextualValidator));
+            ->willReturn($contextualValidator);
 
         return $context;
     }
@@ -174,7 +174,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $validator->expects($this->at(2 * $i))
             ->method('atPath')
             ->with($propertyPath)
-            ->will($this->returnValue($validator));
+            ->willReturn($validator);
         $validator->expects($this->at(2 * $i + 1))
             ->method('validate')
             ->with($value, $this->logicalOr(null, [], $this->isInstanceOf('\Symfony\Component\Validator\Constraints\Valid')), $group);
@@ -186,7 +186,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $contextualValidator->expects($this->at(2 * $i))
             ->method('atPath')
             ->with($propertyPath)
-            ->will($this->returnValue($contextualValidator));
+            ->willReturn($contextualValidator);
         $contextualValidator->expects($this->at(2 * $i + 1))
             ->method('validate')
             ->with($value, $constraints, $group);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -258,11 +258,11 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
         $used = false;
 
         $expressionLanguage->method('evaluate')
-            ->will($this->returnCallback(function () use (&$used) {
+            ->willReturnCallback(function () use (&$used) {
                 $used = true;
 
                 return true;
-            }));
+            });
 
         $validator = new ExpressionValidator(null, $expressionLanguage);
         $validator->initialize($this->createContext());

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -291,11 +291,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $file
             ->expects($this->once())
             ->method('getPathname')
-            ->will($this->returnValue($this->path));
+            ->willReturn($this->path);
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue('image/jpg'));
+            ->willReturn('image/jpg');
 
         $constraint = new File([
             'mimeTypes' => ['image/png', 'image/jpg'],
@@ -315,11 +315,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $file
             ->expects($this->once())
             ->method('getPathname')
-            ->will($this->returnValue($this->path));
+            ->willReturn($this->path);
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue('image/jpg'));
+            ->willReturn('image/jpg');
 
         $constraint = new File([
             'mimeTypes' => ['image/*'],
@@ -339,11 +339,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $file
             ->expects($this->once())
             ->method('getPathname')
-            ->will($this->returnValue($this->path));
+            ->willReturn($this->path);
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue('application/pdf'));
+            ->willReturn('application/pdf');
 
         $constraint = new File([
             'mimeTypes' => ['image/png', 'image/jpg'],
@@ -369,11 +369,11 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $file
             ->expects($this->once())
             ->method('getPathname')
-            ->will($this->returnValue($this->path));
+            ->willReturn($this->path);
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue('application/pdf'));
+            ->willReturn('application/pdf');
 
         $constraint = new File([
             'mimeTypes' => ['image/*', 'image/jpg'],

--- a/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
@@ -54,7 +54,7 @@ class ContainerConstraintValidatorFactoryTest extends TestCase
         $constraint
             ->expects($this->once())
             ->method('validatedBy')
-            ->will($this->returnValue('Fully\\Qualified\\ConstraintValidator\\Class\\Name'));
+            ->willReturn('Fully\\Qualified\\ConstraintValidator\\Class\\Name');
 
         $factory = new ContainerConstraintValidatorFactory(new Container());
         $factory->getInstance($constraint);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
@@ -31,7 +31,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->cache->write($meta);
 
@@ -51,7 +51,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->assertFalse($this->cache->has('Foo\\Bar'), 'has() returns false when there is no entry');
 
@@ -68,7 +68,7 @@ abstract class AbstractCacheTest extends TestCase
 
         $meta->expects($this->once())
             ->method('getClassName')
-            ->will($this->returnValue('Foo\\Bar'));
+            ->willReturn('Foo\\Bar');
 
         $this->assertFalse($this->cache->read('Foo\\Bar'), 'read() returns false when there is no entry');
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -97,7 +97,7 @@ class LazyLoadingMetadataFactoryTest extends TestCase
                   [$this->equalTo(self::PARENT_CLASS)],
                   [$this->equalTo(self::INTERFACE_A_CLASS)]
               )
-              ->will($this->returnValue(false));
+              ->willReturn(false);
         $cache->expects($this->exactly(2))
               ->method('write')
               ->withConsecutive(
@@ -172,12 +172,12 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $cache
             ->expects($this->any())
             ->method('write')
-            ->will($this->returnCallback(function ($metadata) { serialize($metadata); }))
+            ->willReturnCallback(function ($metadata) { serialize($metadata); })
         ;
 
         $cache->expects($this->any())
             ->method('read')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
         $metadata->addConstraint(new Callback(function () {}));

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/LoaderChainTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/LoaderChainTest.php
@@ -46,12 +46,12 @@ class LoaderChainTest extends TestCase
         $loader1 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader1->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $loader2 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader2->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $chain = new LoaderChain([
             $loader1,
@@ -68,12 +68,12 @@ class LoaderChainTest extends TestCase
         $loader1 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader1->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $loader2 = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $loader2->expects($this->any())
             ->method('loadClassMetadata')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $chain = new LoaderChain([
             $loader1,

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
@@ -610,9 +610,9 @@ abstract class AbstractTest extends AbstractValidatorTest
         $initializer1->expects($this->once())
             ->method('initialize')
             ->with($entity)
-            ->will($this->returnCallback(function ($object) {
+            ->willReturnCallback(function ($object) {
                 $object->initialized = true;
-            }));
+            });
 
         $initializer2->expects($this->once())
             ->method('initialize')

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -92,9 +92,9 @@ class RegistryTest extends TestCase
     {
         $strategy = $this->getMockBuilder(SupportStrategyInterface::class)->getMock();
         $strategy->expects($this->any())->method('supports')
-            ->will($this->returnCallback(function ($workflow, $subject) use ($supportedClassName) {
+            ->willReturnCallback(function ($workflow, $subject) use ($supportedClassName) {
                 return $subject instanceof $supportedClassName;
-            }));
+            });
 
         return $strategy;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

In a recent PR, fabbot complained about the usage of will(returnValue()) in test cases that I haven't changed. In this PR, I've applied the PHP CS Fixer's `php_unit_mock_short_will_return` fixer on the whole codebase.