### PR TITLE
[FrameworkBundle] Add missing BC layer for deprecated ControllerNameParser injections

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -25,6 +25,14 @@ DependencyInjection
        factory: ['@factory_service', method]
    ```
 
+FrameworkBundle
+---------------
+
+* The `$parser` argument of `ControllerResolver::__construct()` and `DelegatingLoader::__construct()`
+  has been deprecated.
+* The `ControllerResolver` and `DelegatingLoader` classes have been marked as `final`.
+* The `controller_name_converter` and `resolve_controller_name_subscriber` services have been deprecated.
+
 Messenger
 ---------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -219,6 +219,11 @@ FrameworkBundle
  * Removed support for legacy translations directories `src/Resources/translations/` and `src/Resources/<BundleName>/translations/`, use `translations/` instead.
  * Support for the legacy directory structure in `translation:update` and `debug:translation` commands has been removed.
  * Removed the "Psr\SimpleCache\CacheInterface" / "cache.app.simple" service, use "Symfony\Contracts\Cache\CacheInterface" / "cache.app" instead.
+ * The `$parser` argument of `ControllerResolver::__construct()` and `DelegatingLoader::__construct()`
+   has been removed.
+ * The `ControllerResolver` and `DelegatingLoader` classes have been made `final`.
+ * The `controller_name_converter` and `resolve_controller_name_subscriber` services have been removed.
+
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+* Deprecated the `$parser` argument of `ControllerResolver::__construct()` and `DelegatingLoader::__construct()`
+* Deprecated the `controller_name_converter` and `resolve_controller_name_subscriber` services
+* The `ControllerResolver` and `DelegatingLoader` classes have been marked as `final`
+
 4.3.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -27,9 +27,13 @@ class ControllerNameParser
 {
     protected $kernel;
 
-    public function __construct(KernelInterface $kernel)
+    public function __construct(KernelInterface $kernel, bool $triggerDeprecation = true)
     {
         $this->kernel = $kernel;
+
+        if ($triggerDeprecation) {
+            @trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.1.', __CLASS__), E_USER_DEPRECATED);
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
@@ -27,8 +27,12 @@ class ResolveControllerNameSubscriber implements EventSubscriberInterface
 {
     private $parser;
 
-    public function __construct(ControllerNameParser $parser)
+    public function __construct(ControllerNameParser $parser, bool $triggerDeprecation = true)
     {
+        if ($triggerDeprecation) {
+            @trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.1.', __CLASS__), E_USER_DEPRECATED);
+        }
+
         $this->parser = $parser;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -46,9 +46,9 @@
         </service>
 
         <service id="routing.loader" class="Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader" public="true">
-            <argument type="service" id="controller_name_converter" />
             <argument type="service" id="routing.resolver" />
             <argument type="collection" />
+            <argument type="service" id=".legacy_controller_name_converter" /> <!-- deprecated since Symfony 4.4 -->
         </service>
 
         <service id="router.default" class="Symfony\Bundle\FrameworkBundle\Routing\Router">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -7,16 +7,21 @@
     <services>
         <defaults public="false" />
 
-        <service id="controller_name_converter" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser">
+        <service id=".legacy_controller_name_converter" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser">
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="kernel" />
+            <argument>false</argument>
+        </service>
+
+        <service id="controller_name_converter" alias=".legacy_controller_name_converter">
+            <deprecated>The "%alias_id%" service is deprecated since Symfony 4.3.</deprecated>
         </service>
 
         <service id="controller_resolver" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver">
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="service_container" />
-            <argument type="service" id="controller_name_converter" />
             <argument type="service" id="logger" on-invalid="ignore" />
+            <argument type="service" id=".legacy_controller_name_converter" />
         </service>
 
         <service id="argument_metadata_factory" class="Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory" />
@@ -81,10 +86,15 @@
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="resolve_controller_name_subscriber" class="Symfony\Bundle\FrameworkBundle\EventListener\ResolveControllerNameSubscriber">
-            <argument type="service" id="controller_name_converter" />
+        <service id=".legacy_resolve_controller_name_subscriber" class="Symfony\Bundle\FrameworkBundle\EventListener\ResolveControllerNameSubscriber">
+            <argument type="service" id=".legacy_controller_name_converter" />
+            <argument>false</argument>
             <tag name="kernel.event_subscriber" />
         </service>
+        <service id="resolve_controller_name_subscriber" alias=".legacy_resolve_controller_name_subscriber">
+            <deprecated>The "%alias_id%" service is deprecated since Symfony 4.3.</deprecated>
+        </service>
+
         <service id="disallow_search_engine_index_response_listener" class="Symfony\Component\HttpKernel\EventListener\DisallowRobotsIndexingListener">
             <tag name="kernel.event_subscriber" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -63,7 +63,7 @@ class ControllerResolverTest extends ContainerControllerResolverTest
             ->willReturn('Symfony\Bundle\FrameworkBundle\Tests\Controller\ContainerAwareController::testAction')
         ;
 
-        $resolver = $this->createControllerResolver(null, null, $parser);
+        $resolver = $this->createLegacyControllerResolver(null, null, $parser);
         $request = Request::create('/');
         $request->attributes->set('_controller', $shortName);
 
@@ -105,7 +105,7 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         $container = new Container();
         $container->set(TestAbstractController::class, $controller);
 
-        $resolver = $this->createControllerResolver(null, $container);
+        $resolver = $this->createLegacyControllerResolver(null, $container);
 
         $request = Request::create('/');
         $request->attributes->set('_controller', TestAbstractController::class.'::fooAction');
@@ -127,7 +127,7 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         $container = new Container();
         $container->set(DummyController::class, $controller);
 
-        $resolver = $this->createControllerResolver(null, $container);
+        $resolver = $this->createLegacyControllerResolver(null, $container);
 
         $request = Request::create('/');
         $request->attributes->set('_controller', DummyController::class.'::fooAction');
@@ -176,7 +176,7 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         $this->assertSame($controllerContainer, $controller->getContainer());
     }
 
-    protected function createControllerResolver(LoggerInterface $logger = null, Psr11ContainerInterface $container = null, ControllerNameParser $parser = null)
+    protected function createLegacyControllerResolver(LoggerInterface $logger = null, Psr11ContainerInterface $container = null, ControllerNameParser $parser = null)
     {
         if (!$parser) {
             $parser = $this->createMockParser();
@@ -187,6 +187,15 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         }
 
         return new ControllerResolver($container, $parser, $logger);
+    }
+
+    protected function createControllerResolver(LoggerInterface $logger = null, Psr11ContainerInterface $container = null)
+    {
+        if (!$container) {
+            $container = $this->createMockContainer();
+        }
+
+        return new ControllerResolver($container, $logger);
     }
 
     protected function createMockParser()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/EventListener/ResolveControllerNameSubscriberTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/EventListener/ResolveControllerNameSubscriberTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+/**
+ * @group legacy
+ */
 class ResolveControllerNameSubscriberTest extends TestCase
 {
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/DelegatingLoaderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/DelegatingLoaderTest.php
@@ -13,6 +13,10 @@ use Symfony\Component\Routing\RouteCollection;
 
 class DelegatingLoaderTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a "Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser" instance as first argument to "Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader::__construct()" is deprecated since Symfony 4.4, pass a "Symfony\Component\Config\Loader\LoaderResolverInterface" instance instead.
+     */
     public function testConstructorApi()
     {
         $controllerNameParser = $this->getMockBuilder(ControllerNameParser::class)
@@ -24,10 +28,6 @@ class DelegatingLoaderTest extends TestCase
 
     public function testLoadDefaultOptions()
     {
-        $controllerNameParser = $this->getMockBuilder(ControllerNameParser::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $loaderResolver = $this->getMockBuilder(LoaderResolverInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -46,7 +46,7 @@ class DelegatingLoaderTest extends TestCase
             ->method('load')
             ->willReturn($routeCollection);
 
-        $delegatingLoader = new DelegatingLoader($controllerNameParser, $loaderResolver, ['utf8' => true]);
+        $delegatingLoader = new DelegatingLoader($loaderResolver, ['utf8' => true]);
 
         $loadedRouteCollection = $delegatingLoader->load('foo');
         $this->assertCount(2, $loadedRouteCollection);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Allows removing the `ControllerNameParser` class and corresponding `controller_name_converter` service in 5.0. 
Should have been done in 4.1, better late than never.