### PR TITLE
[HTTP Foundation] Fixed path info issue

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1864,6 +1864,10 @@ class Request
         if (null === ($baseUrl = $this->getBaseUrl())) {
             return $requestUri;
         }
+        
+        if (0 !== strpos($requestUri, $baseUrl)) {
+            return $requestUri;
+        }
 
         $pathInfo = substr($requestUri, \strlen($baseUrl));
         if (false === $pathInfo || '' === $pathInfo) {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1864,7 +1864,6 @@ class Request
         if (null === ($baseUrl = $this->getBaseUrl())) {
             return $requestUri;
         }
-        
         if (0 !== strpos($requestUri, $baseUrl)) {
             return $requestUri;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Hello,
I fixed some issue when preparePathInfo() function.

In the case:
when $requestUri is '/xxx/yyy/index.php' and $baseUrl is '/aaa/index.php', preparePathInfo return '.php' not '/xxx/yyy/index.php'.

add if to check request URI start from base URL string.