### PR TITLE
[Security\Core] Make SodiumPasswordEncoder validate BCrypt-ed passwords

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -84,6 +84,11 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
             return false;
         }
 
+        if (72 >= \strlen($raw) && 0 === strpos($encoded, '$2')) {
+            // Accept validating BCrypt passwords for seamless migrations
+            return password_verify($raw, $encoded);
+        }
+
         if (\function_exists('sodium_crypto_pwhash_str_verify')) {
             return \sodium_crypto_pwhash_str_verify($encoded, $raw);
         }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
@@ -31,6 +31,12 @@ class SodiumPasswordEncoderTest extends TestCase
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));
     }
 
+    public function testBCryptValidation()
+    {
+        $encoder = new SodiumPasswordEncoder();
+        $this->assertTrue($encoder->isPasswordValid('$2y$04$M8GDODMoGQLQRpkYCdoJh.lbiZPee3SZI32RcYK49XYTolDGwoRMm', 'abc', null));
+    }
+
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31758
| License       | MIT
| Doc PR        | -

Otherwise, the promise of the "auto" mode doesn't work.