### PR TITLE
[Monolog] adding the new `$request` argument and remove deprecation

### DIFF
--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.0.0
+-----
+
+ * The methods `DebugProcessor::getLogs()`, `DebugProcessor::countErrors()`, `Logger::getLogs()` and `Logger::countErrors()` have a new `$request` argument.
+
 4.4.0
 -----
 

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -24,17 +24,11 @@ class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @param Request|null $request
      */
-    public function getLogs(/* Request $request = null */)
+    public function getLogs(Request $request = null)
     {
-        if (\func_num_args() < 1 && __CLASS__ !== \get_class($this) && __CLASS__ !== (new \ReflectionMethod($this, __FUNCTION__))->getDeclaringClass()->getName() && !$this instanceof \PHPUnit\Framework\MockObject\MockObject && !$this instanceof \Prophecy\Prophecy\ProphecySubjectInterface) {
-            @trigger_error(sprintf('The "%s()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
-        }
-
         if ($logger = $this->getDebugLogger()) {
-            return $logger->getLogs(...\func_get_args());
+            return $logger->getLogs($request);
         }
 
         return [];
@@ -42,17 +36,11 @@ class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param Request|null $request
      */
-    public function countErrors(/* Request $request = null */)
+    public function countErrors(Request $request = null)
     {
-        if (\func_num_args() < 1 && __CLASS__ !== \get_class($this) && __CLASS__ !== (new \ReflectionMethod($this, __FUNCTION__))->getDeclaringClass()->getName() && !$this instanceof \PHPUnit\Framework\MockObject\MockObject && !$this instanceof \Prophecy\Prophecy\ProphecySubjectInterface) {
-            @trigger_error(sprintf('The "%s()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
-        }
-
         if ($logger = $this->getDebugLogger()) {
-            return $logger->countErrors(...\func_get_args());
+            return $logger->countErrors($request);
         }
 
         return 0;

--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -58,16 +58,10 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param Request|null $request
      */
-    public function getLogs(/* Request $request = null */)
+    public function getLogs(Request $request = null)
     {
-        if (\func_num_args() < 1 && __CLASS__ !== \get_class($this) && __CLASS__ !== (new \ReflectionMethod($this, __FUNCTION__))->getDeclaringClass()->getName() && !$this instanceof \PHPUnit\Framework\MockObject\MockObject && !$this instanceof \Prophecy\Prophecy\ProphecySubjectInterface) {
-            @trigger_error(sprintf('The "%s()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
-        }
-
-        if (1 <= \func_num_args() && null !== $request = \func_get_arg(0)) {
+        if (null !== $request) {
             return $this->records[spl_object_hash($request)] ?? [];
         }
 
@@ -80,16 +74,10 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param Request|null $request
      */
-    public function countErrors(/* Request $request = null */)
+    public function countErrors(Request $request = null)
     {
-        if (\func_num_args() < 1 && __CLASS__ !== \get_class($this) && __CLASS__ !== (new \ReflectionMethod($this, __FUNCTION__))->getDeclaringClass()->getName() && !$this instanceof \PHPUnit\Framework\MockObject\MockObject && !$this instanceof \Prophecy\Prophecy\ProphecySubjectInterface) {
-            @trigger_error(sprintf('The "%s()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
-        }
-
-        if (1 <= \func_num_args() && null !== $request = \func_get_arg(0)) {
+        if (null !== $request) {
             return $this->errorCount[spl_object_hash($request)] ?? 0;
         }
 

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -125,36 +125,28 @@ class LoggerTest extends TestCase
         }
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The "Symfony\Bridge\Monolog\Logger::getLogs()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
-     */
     public function testInheritedClassCallGetLogsWithoutArgument()
     {
         $loggerChild = new ClassThatInheritLogger('test');
-        $loggerChild->getLogs();
+        $this->assertNull($loggerChild->getLogs());
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The "Symfony\Bridge\Monolog\Logger::countErrors()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
-     */
     public function testInheritedClassCallCountErrorsWithoutArgument()
     {
         $loggerChild = new ClassThatInheritLogger('test');
-        $loggerChild->countErrors();
+        $this->assertEquals(0, $loggerChild->countErrors());
     }
 }
 
 class ClassThatInheritLogger extends Logger
 {
-    public function getLogs()
+    public function getLogs(Request $request = null)
     {
-        parent::getLogs();
+        parent::getLogs($request);
     }
 
-    public function countErrors()
+    public function countErrors(Request $request = null)
     {
-        parent::countErrors();
+        parent::countErrors($request);
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
@@ -63,24 +63,16 @@ class DebugProcessorTest extends TestCase
         $this->assertSame(0, $processor->countErrors(new Request()));
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The "Symfony\Bridge\Monolog\Processor\DebugProcessor::getLogs()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
-     */
     public function testInheritedClassCallGetLogsWithoutArgument()
     {
         $debugProcessorChild = new ClassThatInheritDebugProcessor();
-        $debugProcessorChild->getLogs();
+        $this->assertNull($debugProcessorChild->getLogs());
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The "Symfony\Bridge\Monolog\Processor\DebugProcessor::countErrors()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
-     */
     public function testInheritedClassCallCountErrorsWithoutArgument()
     {
         $debugProcessorChild = new ClassThatInheritDebugProcessor();
-        $debugProcessorChild->countErrors();
+        $this->assertEquals(0, $debugProcessorChild->countErrors());
     }
 
     private function getRecord($level = Logger::WARNING, $message = 'test')
@@ -99,13 +91,13 @@ class DebugProcessorTest extends TestCase
 
 class ClassThatInheritDebugProcessor extends DebugProcessor
 {
-    public function getLogs()
+    public function getLogs(Request $request = null)
     {
-        parent::getLogs();
+        parent::getLogs($request);
     }
 
-    public function countErrors()
+    public function countErrors(Request $request = null)
     {
-        parent::countErrors();
+        parent::countErrors($request);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerInterface.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerInterface.php
@@ -27,20 +27,16 @@ interface DebugLoggerInterface
      * timestamp, message, priority, and priorityName.
      * It can also have an optional context key containing an array.
      *
-     * @param Request|null $request The request to get logs for
-     *
      * @return array An array of logs
      */
-    public function getLogs(/* Request $request = null */);
+    public function getLogs(Request $request = null);
 
     /**
      * Returns the number of errors.
      *
-     * @param Request|null $request The request to count logs for
-     *
      * @return int The number of errors
      */
-    public function countErrors(/* Request $request = null */);
+    public function countErrors(Request $request = null);
 
     /**
      * Removes all log records.

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -178,7 +178,7 @@ class ExceptionListenerTest extends TestCase
 
 class TestLogger extends Logger implements DebugLoggerInterface
 {
-    public function countErrors()
+    public function countErrors(Request $request = null)
     {
         return \count($this->logs['critical']);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This removed the one and only deprecated codes from monolog from 4.x to 5.0.
