### PR TITLE
[Messenger] Deprecate passing a bus locator to ConsumeMessagesCommand's constructor

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -4,7 +4,7 @@ UPGRADE FROM 4.3 to 4.4
 HttpKernel
 ----------
 
-* The `DebugHandlersListener` class has been marked as `final`
+ * The `DebugHandlersListener` class has been marked as `final`
 
 DependencyInjection
 -------------------
@@ -25,10 +25,16 @@ DependencyInjection
        factory: ['@factory_service', method]
    ```
 
+Messenger
+---------
+
+ * Deprecated passing a `ContainerInterface` instance as first argument of the `ConsumeMessagesCommand` constructor,
+   pass a `RoutableMessageBus`  instance instead.
+
 MonologBridge
 --------------
 
-* The `RouteProcessor` has been marked final.
+ * The `RouteProcessor` has been marked final.
 
 TwigBridge
 ----------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -269,6 +269,8 @@ Messenger
 ---------
 
  * The `LoggingMiddleware` class has been removed, pass a logger to `SendMessageMiddleware` instead.
+ * Passing a `ContainerInterface` instance as first argument of the `ConsumeMessagesCommand` constructor now
+   throws as `\TypeError`, pass a `RoutableMessageBus`  instance instead.
 
 Monolog
 -------

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * Deprecated passing a `ContainerInterface` instance as first argument of the `ConsumeMessagesCommand` constructor,
+   pass a `RoutableMessageBus`  instance instead.
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -54,8 +54,8 @@ class ConsumeMessagesCommand extends Command
      */
     public function __construct($routableBus, ContainerInterface $receiverLocator, LoggerInterface $logger = null, array $receiverNames = [], /* ContainerInterface */ $retryStrategyLocator = null, EventDispatcherInterface $eventDispatcher = null)
     {
-        // to be deprecated in 4.4
         if ($routableBus instanceof ContainerInterface) {
+            @trigger_error(sprintf('Passing a "%s" instance as first argument to "%s()" is deprecated since Symfony 4.4, pass a "%s" instance instead.', ContainerInterface::class, __METHOD__, RoutableMessageBus::class), E_USER_DEPRECATED);
             $routableBus = new RoutableMessageBus($routableBus);
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -27,7 +27,7 @@ class ConsumeMessagesCommandTest extends TestCase
 {
     public function testConfigurationWithDefaultReceiver()
     {
-        $command = new ConsumeMessagesCommand($this->createMock(ServiceLocator::class), $this->createMock(ServiceLocator::class), null, ['amqp']);
+        $command = new ConsumeMessagesCommand($this->createMock(RoutableMessageBus::class), $this->createMock(ServiceLocator::class), null, ['amqp']);
         $inputArgument = $command->getDefinition()->getArgument('receivers');
         $this->assertFalse($inputArgument->isRequired());
         $this->assertSame(['amqp'], $inputArgument->getDefault());
@@ -98,6 +98,10 @@ class ConsumeMessagesCommandTest extends TestCase
         $this->assertContains('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a "Psr\Container\ContainerInterface" instance as first argument to "Symfony\Component\Messenger\Command\ConsumeMessagesCommand::__construct()" is deprecated since Symfony 4.4, pass a "Symfony\Component\Messenger\RoutableMessageBus" instance instead.
+     */
     public function testBasicRunWithBusLocator()
     {
         $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
@@ -130,6 +134,10 @@ class ConsumeMessagesCommandTest extends TestCase
         $this->assertContains('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a "Psr\Container\ContainerInterface" instance as first argument to "Symfony\Component\Messenger\Command\ConsumeMessagesCommand::__construct()" is deprecated since Symfony 4.4, pass a "Symfony\Component\Messenger\RoutableMessageBus" instance instead.
+     */
     public function testRunWithBusOptionAndBusLocator()
     {
         $envelope = new Envelope(new \stdClass());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Continuation of #31748 