### PR TITLE
[Translation] Fixed case sensitivity of lint:xliff command

### DIFF
--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -124,7 +124,9 @@ EOF
             $normalizedLocale = preg_quote(str_replace('-', '_', $targetLanguage), '/');
             // strict file names require translation files to be named '____.locale.xlf'
             // otherwise, both '____.locale.xlf' and 'locale.____.xlf' are allowed
-            $expectedFilenamePattern = $this->requireStrictFileNames ? sprintf('/^.*\.%s\.xlf/', $normalizedLocale) : sprintf('/^(.*\.%s\.xlf|%s\..*\.xlf)/', $normalizedLocale, $normalizedLocale);
+            // also, the regexp matching must be case-insensitive, as defined for 'target-language' values
+            // http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#target-language
+            $expectedFilenamePattern = $this->requireStrictFileNames ? sprintf('/^.*\.(?i:%s)\.xlf/', $normalizedLocale) : sprintf('/^(.*\.(?i:%s)\.xlf|(?i:%s)\..*\.xlf)/', $normalizedLocale, $normalizedLocale);
 
             if (0 === preg_match($expectedFilenamePattern, basename($file))) {
                 $errors[] = [

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -94,6 +94,17 @@ class XliffLintCommandTest extends TestCase
         $this->assertContains('There is a mismatch between the language included in the file name ("messages.en.xlf") and the "es" value used in the "target-language" attribute of the file.', trim($tester->getDisplay()));
     }
 
+    public function testLintTargetLanguageIsCaseInsensitive()
+    {
+        $tester = $this->createCommandTester();
+        $filename = $this->createFile('note', 'zh-cn', 'messages.zh_CN.xlf');
+
+        $tester->execute(['filename' => $filename], ['decorated' => false]);
+
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertContains('[OK] All 1 XLIFF files contain valid syntax.', trim($tester->getDisplay()));
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -
| License       | MIT
| Doc PR        | (not needed)

I was checking some errors of `lint:xliff` (https://travis-ci.org/EasyCorp/EasyAdminBundle/jobs/540053551#L657) and saw this:

```
ERROR  in src/Resources/translations/EasyAdminBundle.sr_RS.xlf
 * There is a mismatch between the language included in the file name ("EasyAdminBundle.sr_RS.xlf") and the "sr-rs" value used in the "target-language" attribute of the file.

ERROR  in src/Resources/translations/EasyAdminBundle.zh_CN.xlf
 * There is a mismatch between the language included in the file name ("EasyAdminBundle.zh_CN.xlf") and the "zh-cn" value used in the "target-language" attribute of the file.
```

This was suspicious, so I checked the XLIFF standard and it says (http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#target-language):

```
target-language:
  Unlike the other XLIFF attributes, the values are not case-sensitive.
```

So, it's valid that `zh-cn` is the target language and `zh-CN` is the file extension. This PR fixes that.