### PR TITLE
[Messenger] set amqp content_type based on serialization format

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -55,7 +55,8 @@ class SerializerTest extends TestCase
         $this->assertArrayHasKey('body', $encoded);
         $this->assertArrayHasKey('headers', $encoded);
         $this->assertArrayHasKey('type', $encoded['headers']);
-        $this->assertEquals(DummyMessage::class, $encoded['headers']['type']);
+        $this->assertSame(DummyMessage::class, $encoded['headers']['type']);
+        $this->assertSame('application/json', $encoded['headers']['Content-Type']);
     }
 
     public function testUsesTheCustomFormatAndContext()

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -101,7 +101,7 @@ class Serializer implements SerializerInterface
 
         $envelope = $envelope->withoutStampsOfType(NonSendableStampInterface::class);
 
-        $headers = ['type' => \get_class($envelope->getMessage())] + $this->encodeStamps($envelope);
+        $headers = ['type' => \get_class($envelope->getMessage())] + $this->encodeStamps($envelope) + $this->getContentTypeHeader();
 
         return [
             'body' => $this->serializer->serialize($envelope->getMessage(), $this->format, $context),
@@ -153,6 +153,30 @@ class Serializer implements SerializerInterface
             if ($stamp instanceof SerializerStamp) {
                 return $stamp;
             }
+        }
+
+        return null;
+    }
+
+    private function getContentTypeHeader(): array
+    {
+        $mimeType = $this->getMimeTypeForFormat();
+
+        return null === $mimeType ? [] : ['Content-Type' => $mimeType];
+    }
+
+    private function getMimeTypeForFormat(): ?string
+    {
+        switch ($this->format) {
+            case 'json':
+                return 'application/json';
+            case 'xml':
+                return 'application/xml';
+            case 'yml':
+            case 'yaml':
+                return 'application/x-yaml';
+            case 'csv':
+                return 'text/csv';
         }
 
         return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31736
| License       | MIT
| Doc PR        | 
