### PR TITLE
[WIP][PhpUnitBridge] Don't use classes from vendors on unit tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
@@ -31,8 +31,18 @@ class ClockMockTest extends TestCase
         ClockMock::withClockMock(1234567890.125);
     }
 
+    public function testFail()
+    {
+        $this->assertTrue(false, "test test test");
+    }
+
     public function testTime()
     {
+        echo "test time\n";
+
+        //$reflection = new \ReflectionClass(ClockMock::class);
+        //printf("ClockMock file: %s\n", $reflection->getFileName());
+
         $this->assertSame(1234567890, time());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When the CI runs the unit tests, the composer autoload system uses the tested classes from the vendor directory of PHPUnitBridge (instead of using the repository ones). But if a PR modifies these tested classes, the classes in the vendor are not up-to-date ! This PR aims to fix this.