### PR TITLE
[DomCrawler] fixed return annotation

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -90,7 +90,7 @@ abstract class FormField
     /**
      * Gets the value of the field.
      *
-     * @return string|array The value of the field
+     * @return string|array|null The value of the field
      */
     public function getValue()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4  <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I am almost ashamed to send this in as "luxury" PR, but it is blocking me.

The return annotation of the method does not reflect all possible cases, which causes some static code analysis tools (e.g. PHPStan level 4 or Scrutinizer) to error out on test like this:
```
self::assertNull($form->get('myCheckbox')->getValue());
```
complaining something like :
```
Call to method PHPUnit\Framework\Assert::assertNull() with array|string will always evaluate to false.
```
Null values can happen in `DomCrawler/Field/ChoiceFormField.php` [here](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php#L124) and [here](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php#L213)