### PR TITLE
[WIP][PhpUnitBridge] Don't use classes from vendors on unit tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -14,6 +14,8 @@ namespace Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerFor;
 
 /**
+ * Test change on Deprecation !!
+ *
  * @internal
  */
 class Deprecation

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -16,6 +16,13 @@ use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\Deprecation;
 
 class DeprecationTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        $reflection = new \ReflectionClass(Deprecation::class);
+        printf("filename: %s\n", $reflection->getFileName());
+        echo file_get_contents($reflection->getFileName());
+    }
+
     public function testItCanDetermineTheClassWhereTheDeprecationHappened()
     {
         $deprecation = new Deprecation('💩', $this->debugBacktrace(), __FILE__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This is a test; please don't review :)

When the CI runs the unit tests, the composer autoload system uses the tested classes from the vendor directory of PHPUnitBridge (instead of using the repository ones). But if a PR modifies these tested classes, the classes in the vendor are not up-to-date ! This PR aims to fix this.