### PR TITLE
[OptionsResolver] Add $triggerDeprecation arg to offsetGet() method in Options interface

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.0.0
+-----
+
+ * added `offsetGet()` method to the `Options` interface with a new boolean argument `$triggerDeprecation`
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -11,14 +11,34 @@
 
 namespace Symfony\Component\OptionsResolver;
 
+use Symfony\Component\OptionsResolver\Exception\AccessException;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\NoSuchOptionException;
+use Symfony\Component\OptionsResolver\Exception\OptionDefinitionException;
+
 /**
  * Contains resolved option values.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Tobias Schultze <http://tobion.de>
- *
- * @method mixed offsetGet(string $option, bool $triggerDeprecation = true)
  */
 interface Options extends \ArrayAccess, \Countable
 {
+    /**
+     * Returns the resolved value of an option.
+     *
+     * @param string $option             The option name
+     * @param bool   $triggerDeprecation Whether to trigger the deprecation or not
+     *
+     * @return mixed The option value
+     *
+     * @throws AccessException           If accessing this method outside of
+     *                                   {@link resolve()}
+     * @throws NoSuchOptionException     If the option is not set
+     * @throws InvalidOptionsException   If the option doesn't fulfill the
+     *                                   specified validation rules
+     * @throws OptionDefinitionException If there is a cyclic dependency between
+     *                                   lazy options and/or normalizers
+     */
+    public function offsetGet($option, bool $triggerDeprecation = true);
 }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -825,28 +825,13 @@ class OptionsResolver implements Options
     }
 
     /**
-     * Returns the resolved value of an option.
-     *
-     * @param string $option             The option name
-     * @param bool   $triggerDeprecation Whether to trigger the deprecation or not (true by default)
-     *
-     * @return mixed The option value
-     *
-     * @throws AccessException           If accessing this method outside of
-     *                                   {@link resolve()}
-     * @throws NoSuchOptionException     If the option is not set
-     * @throws InvalidOptionsException   If the option doesn't fulfill the
-     *                                   specified validation rules
-     * @throws OptionDefinitionException If there is a cyclic dependency between
-     *                                   lazy options and/or normalizers
+     * {@inheritdoc}
      */
-    public function offsetGet($option/*, bool $triggerDeprecation = true*/)
+    public function offsetGet($option, bool $triggerDeprecation = true)
     {
         if (!$this->locked) {
             throw new AccessException('Array access is only supported within closures of lazy options and normalizers.');
         }
-
-        $triggerDeprecation = 1 === \func_num_args() || \func_get_arg(1);
 
         // Shortcut for resolved options
         if (isset($this->resolved[$option]) || \array_key_exists($option, $this->resolved)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Ref: https://github.com/symfony/symfony/pull/28878