### PR TITLE
[Lock] prune PdoStorage table on each save according to gcProbability

### DIFF
--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -127,6 +127,7 @@ class PdoStore implements StoreInterface
                 throw new LockExpiredException(sprintf('Failed to put off the expiration of the "%s" lock within the specified time.', $key));
             }
             $this->prune();
+
             return;
         } catch (DBALException $e) {
             // the lock is already acquired. It could be us. Let's try to put off.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I expected the `\Symfony\Component\Lock\Store\PdoStore::prune` method to be called according to `gcProbability` every time I interact with a lock. But `\Symfony\Component\Lock\Store\PdoStore::save` returns early on success. As I see it, this means that expired locks are pruned much less often than specified by `gcProbability`.

This PR fixes that by calling prune before the early return.

I'm not so sure if checking the probability **inside** the `prune` method is a good solution. Maybe it would be nicer to have a separate function (`randomPrune`).