### PR TITLE
[Translator] Collect locale details earlier in the process

### DIFF
--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -36,11 +36,8 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
     {
         $messages = $this->sanitizeCollectedMessages($this->translator->getCollectedMessages());
 
-        $this->data = $this->computeCount($messages);
+        $this->data += $this->computeCount($messages);
         $this->data['messages'] = $messages;
-
-        $this->data['locale'] = $this->translator->getLocale();
-        $this->data['fallback_locales'] = $this->translator->getFallbackLocales();
 
         $this->data = $this->cloneVar($this->data);
     }
@@ -50,6 +47,8 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
+        $this->data['locale'] = $this->translator->getLocale();
+        $this->data['fallback_locales'] = $this->translator->getFallbackLocales();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31600 
| License       | MIT
| Doc PR        | N/A

The [LocaleAwareListener](https://github.com/symfony/symfony/blob/4.3/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php) class reverts the locale back to the default locale when the request has finished. But the `TranslationDataCollector` only collects the locale in `lateCollect`, which only happens when the kernel terminates. This means the locale is reverted back to the default by the time the collector runs.

The PR moves the `locale` and `fallback_locales` from `lateCollect` to `collect`, so that the information can be captured earlier, before the `LocaleAwareListener` is run.