### PR TITLE
[SecurityBundle] Fix profiler dump for non-invokable security listeners

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
@@ -39,10 +39,6 @@ final class WrappedListener implements ListenerInterface
     public function __construct($listener)
     {
         $this->listener = $listener;
-
-        if (null === self::$hasVarDumper) {
-            self::$hasVarDumper = class_exists(ClassStub::class);
-        }
     }
 
     /**
@@ -76,8 +72,25 @@ final class WrappedListener implements ListenerInterface
 
     public function getInfo(): array
     {
-        if (null === $this->stub) {
-            $this->stub = self::$hasVarDumper ? new ClassStub(\get_class($this->listener)) : \get_class($this->listener);
+        if (null !== $this->stub) {
+            // no-op
+        } elseif (self::$hasVarDumper ?? self::$hasVarDumper = class_exists(ClassStub::class)) {
+            $this->stub = ClassStub::wrapCallable($this->listener);
+        } elseif (\is_array($this->listener)) {
+            $this->stub = (\is_object($this->listener[0]) ? \get_class($this->listener[0]) : $this->listener[0]).'::'.$this->listener[1];
+        } elseif ($this->listener instanceof \Closure) {
+            $r = new \ReflectionFunction($this->listener);
+            if (false !== strpos($r->name, '{closure}')) {
+                $this->stub = 'closure';
+            } elseif ($class = $r->getClosureScopeClass()) {
+                $this->stub = $class->name.'::'.$r->name;
+            } else {
+                $this->stub = $r->name;
+            }
+        } elseif (\is_string($this->listener)) {
+            $this->stub = $this->listener;
+        } else {
+            $this->stub = \get_class($this->listener).'::__invoke';
         }
 
         return [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
-use Symfony\Component\VarDumper\Caster\ClassStub;
 
 /**
  * @group time-sensitive
@@ -56,9 +55,6 @@ class TraceableFirewallListenerTest extends TestCase
 
         $listeners = $firewall->getWrappedListeners();
         $this->assertCount(1, $listeners);
-        $this->assertSame($response, $listeners[0]['response']);
-        $this->assertInstanceOf(ClassStub::class, $listeners[0]['stub']);
-        $this->assertSame(\get_class($listener), (string) $listeners[0]['stub']);
-        $this->assertSame(1, $listenerCalled);
+        $this->assertSame($listener, $listeners[0]['stub']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Listeners can be any callable since 4.3.
