### PR TITLE
[Form][DX] Improved error message on create a form builder with invalid options

### DIFF
--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -92,7 +93,11 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      */
     public function createBuilder(FormFactoryInterface $factory, $name, array $options = [])
     {
-        $options = $this->getOptionsResolver()->resolve($options);
+        try {
+            $options = $this->getOptionsResolver()->resolve($options);
+        } catch (ExceptionInterface $e) {
+            throw new $e(sprintf('An error has occurred resolving the options of the form "%s": %s', \get_class($this->getInnerType()), $e->getMessage()), $e->getCode(), $e);
+        }
 
         // Should be decoupled from the specific option at some point
         $dataClass = isset($options['data_class']) ? $options['data_class'] : null;

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -179,6 +179,33 @@ class ResolvedFormTypeTest extends TestCase
         $this->assertSame('\stdClass', $builder->getDataClass());
     }
 
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     * @expectedExceptionMessage An error has occurred resolving the options of the form "stdClass": The required option "foo" is missing.
+     */
+    public function testFailsCreateBuilderOnInvalidFormOptionsResolution()
+    {
+        $optionsResolver = (new OptionsResolver())
+            ->setRequired('foo')
+        ;
+        $this->resolvedType = $this->getMockBuilder(ResolvedFormType::class)
+            ->setConstructorArgs([$this->type, [$this->extension1, $this->extension2], $this->parentResolvedType])
+            ->setMethods(['getOptionsResolver', 'getInnerType'])
+            ->getMock()
+        ;
+        $this->resolvedType->expects($this->once())
+            ->method('getOptionsResolver')
+            ->willReturn($optionsResolver)
+        ;
+        $this->resolvedType->expects($this->once())
+            ->method('getInnerType')
+            ->willReturn(new \stdClass())
+        ;
+        $factory = $this->getMockFormFactory();
+
+        $this->resolvedType->createBuilder($factory, 'name');
+    }
+
     public function testBuildForm()
     {
         $i = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

**before**
> The required option "class" is missing.

**after**
> An error has occurred resolving the options of the form "App\Form\MyEntityType": The required option "class" is missing.