### PR TITLE
[TwigBundle] mark TemplateIterator as internal

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * marked the `TemplateIterator` as `internal`
+
 4.2.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
@@ -28,7 +28,7 @@ class TemplateCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInte
     private $twig;
     private $iterator;
 
-    public function __construct(ContainerInterface $container, \Traversable $iterator)
+    public function __construct(ContainerInterface $container, iterable $iterator)
     {
         // As this cache warmer is optional, dependencies should be lazy-loaded, that's why a container should be injected.
         $this->container = $container;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This class is an implementation detail and should not be relied on as an extension point. This is also why TemplateCacheWarmer does not typhint this class but iterable. By making it internal we can remove the rootDir argument in #31823