### PR TITLE
[HttpClient] add $response->cancel()

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -25,6 +25,11 @@ DependencyInjection
        factory: ['@factory_service', method]
    ```
 
+HttpClient
+----------
+
+ * Added method `cancel()` to `ResponseInterface`
+
 Messenger
 ---------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -220,6 +220,11 @@ FrameworkBundle
  * Support for the legacy directory structure in `translation:update` and `debug:translation` commands has been removed.
  * Removed the "Psr\SimpleCache\CacheInterface" / "cache.app.simple" service, use "Symfony\Contracts\Cache\CacheInterface" / "cache.app" instead.
 
+HttpClient
+----------
+
+ * Added method `cancel()` to `ResponseInterface`
+
 HttpFoundation
 --------------
 

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added `$response->cancel()`
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -170,6 +170,15 @@ trait ResponseTrait
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function cancel(): void
+    {
+        $this->info['error'] = 'Response has been canceled.';
+        $this->close();
+    }
+
+    /**
      * Closes the response and all its network handles.
      */
     abstract protected function close(): void;

--- a/src/Symfony/Contracts/HttpClient/ResponseInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ResponseInterface.php
@@ -72,6 +72,11 @@ interface ResponseInterface
     public function toArray(bool $throw = true): array;
 
     /**
+     * Cancels the response.
+     */
+    public function cancel(): void;
+
+    /**
      * Returns info coming from the transport layer.
      *
      * This method SHOULD NOT throw any ExceptionInterface and SHOULD be non-blocking.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

(BC break allowed by the `@experimental` annotation)

Canceling a response is already possible but requires registering a progress function and throwing an exception from it. This new method aims at making this much simpler.

/cc @jderusse as we discussed this on Slack.