### PR TITLE
[HttpClient] fix unregistering the debug buffer when using curl

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -167,6 +167,7 @@ final class CurlResponse implements ResponseInterface
             if (!\in_array(curl_getinfo($this->handle, CURLINFO_PRIVATE), ['headers', 'content'], true)) {
                 rewind($this->debugBuffer);
                 $info['debug'] = stream_get_contents($this->debugBuffer);
+                curl_setopt($this->handle, CURLOPT_VERBOSE, false);
                 fclose($this->debugBuffer);
                 $this->debugBuffer = null;
                 $this->finalInfo = $info;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31803
| License       | MIT
| Doc PR        | -