### PR TITLE
[HttpClient] Don't throw InvalidArgumentException on bad Location header

### DIFF
--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\NativeClientState;
 use Symfony\Component\HttpClient\Response\NativeResponse;
@@ -352,7 +353,15 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
                 return null;
             }
 
-            $url = self::resolveUrl(self::parseUrl($location), $info['url']);
+            try {
+                $url = self::parseUrl($location);
+            } catch (InvalidArgumentException $e) {
+                $info['redirect_url'] = null;
+
+                return null;
+            }
+
+            $url = self::resolveUrl($url, $info['url']);
             $info['redirect_url'] = implode('', $url);
 
             if ($info['redirect_count'] >= $maxRedirects) {

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -55,6 +55,10 @@ switch ($vars['REQUEST_URI']) {
         header('Location: http://foo.example.', true, 301);
         break;
 
+    case '/301/invalid':
+        header('Location: //?foo=bar', true, 301);
+        break;
+
     case '/302':
         if (!isset($vars['HTTP_AUTHORIZATION'])) {
             header('Location: http://localhost:8057/', true, 302);

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -259,6 +259,20 @@ abstract class HttpClientTestCase extends TestCase
         $this->assertSame($expected, $filteredHeaders);
     }
 
+    public function testInvalidRedirect()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/301/invalid');
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame(['//?foo=bar'], $response->getHeaders(false)['location']);
+        $this->assertSame(0, $response->getInfo('redirect_count'));
+        $this->assertNull($response->getInfo('redirect_url'));
+
+        $this->expectException(RedirectionExceptionInterface::class);
+        $response->getHeaders();
+    }
+
     public function testRelativeRedirects()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31776
| License       | MIT
| Doc PR        | -

Instead, just stop following redirections and throw a `RedirectionExceptionInterface` as usual when throwing is not disabled.