### PR TITLE
Add check for Konsole to disable hyperlinks

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -175,6 +175,22 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
+     * Check for known terminal emulators who don't support hyperlinks
+     * @return bool
+     */
+    private function checkHrefSupport():bool
+    {
+        if ('JetBrains-JediTerm' === getenv('TERMINAL_EMULATOR')) {
+            return false;
+        }
+        if (getenv('KONSOLE_VERSION')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Applies the style to a given text.
      *
      * @param string $text The text to style
@@ -187,7 +203,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         $unsetCodes = [];
 
         if (null === $this->handlesHrefGracefully) {
-            $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR');
+            $this->handlesHrefGracefully = $this->checkHrefSupport();
         }
 
         if (null !== $this->foreground) {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -175,10 +175,11 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
-     * Check for known terminal emulators who don't support hyperlinks
+     * Check for known terminal emulators who don't support hyperlinks.
+     *
      * @return bool
      */
-    private function checkHrefSupport():bool
+    private function checkHrefSupport(): bool
     {
         if ('JetBrains-JediTerm' === getenv('TERMINAL_EMULATOR')) {
             return false;


### PR DESCRIPTION
Referring to issue https://github.com/symfony/symfony/issues/31809

Added check for environment variable set by Konsole and other relateds terminal emulators. Today I'll also open a feature request to Konsole team to support this feature someday.

As it's possible than a more complex logic will be used in future, I've put the checks in a new private method `checkHrefSupport().`