### PR TITLE
[Console] Add check for Konsole/Yakuake to disable hyperlinks

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -187,7 +187,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         $unsetCodes = [];
 
         if (null === $this->handlesHrefGracefully) {
-            $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR');
+            $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR') && !getenv('KONSOLE_VERSION');
         }
 
         if (null !== $this->foreground) {

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -435,7 +435,7 @@ class CliDumper extends AbstractDumper
         }
 
         if (null === $this->handlesHrefGracefully) {
-            $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR');
+            $this->handlesHrefGracefully = 'JetBrains-JediTerm' !== getenv('TERMINAL_EMULATOR') && !getenv('KONSOLE_VERSION');
         }
 
         if (isset($attr['ellipsis'], $attr['ellipsis-type'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31809
| License       | MIT
| Doc PR        | 

Added check for environment variable set by Konsole and other relateds terminal emulators. 

A ticket has been opened to Konsole team to support this feature someday: https://bugs.kde.org/show_bug.cgi?id=408288
