### PR TITLE
[HttpClient] add $response->cancel()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr/container": "^1.0",
         "psr/link": "^1.0",
         "psr/log": "~1.0",
-        "symfony/contracts": "^1.1.1",
+        "symfony/contracts": "^1.1.3",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-intl-idn": "^1.10",

--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -170,6 +170,15 @@ trait ResponseTrait
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function cancel(): void
+    {
+        $this->info['error'] = 'Response has been canceled.';
+        $this->close();
+    }
+
+    /**
      * Closes the response and all its network handles.
      */
     abstract protected function close(): void;

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.1.3",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^1.1",
+        "symfony/http-client-contracts": "^1.1.3",
         "symfony/polyfill-php73": "^1.11"
     },
     "require-dev": {

--- a/src/Symfony/Contracts/HttpClient/ResponseInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ResponseInterface.php
@@ -72,6 +72,11 @@ interface ResponseInterface
     public function toArray(bool $throw = true): array;
 
     /**
+     * Cancels the response.
+     */
+    public function cancel(): void;
+
+    /**
      * Returns info coming from the transport layer.
      *
      * This method SHOULD NOT throw any ExceptionInterface and SHOULD be non-blocking.

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -481,6 +481,16 @@ abstract class HttpClientTestCase extends TestCase
         $this->assertSame(['foo' => '0123456789', 'REQUEST_METHOD' => 'POST'], $response->toArray());
     }
 
+    public function testCancel()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/timeout-header');
+
+        $response->cancel();
+        $this->expectException(TransportExceptionInterface::class);
+        $response->getHeaders();
+    }
+
     public function testOnProgressCancel()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11668

An alternative to #31845 and #31842.
Same as  #31831 but considered as a bug fix (at the Contracts level), thus for 4.3.
I think we're early enough since 4.3/1.1 to do it.
That will save us some headaches in the short term.
