### PR TITLE
[Form] add missing symfony/service-contracts dependency

### DIFF
--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -22,7 +22,8 @@
         "symfony/options-resolver": "~4.3",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/property-access": "~3.4|~4.0"
+        "symfony/property-access": "~3.4|~4.0",
+        "symfony/service-contracts": "~1.1"
     },
     "require-dev": {
         "doctrine/collections": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31844
| License       | MIT
| Doc PR        | -

`ResetInterface` is needed by `CachingFactoryDecorator`, which is used in `CoreExtension`, so this is a mandatory dep.