### PR TITLE
Rename the Symfony Mailer service implementation to avoid conflict with SwitMailer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
@@ -5,11 +5,12 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="mailer" class="Symfony\Component\Mailer\Mailer">
+        <service id="mailer.mailer" class="Symfony\Component\Mailer\Mailer">
             <argument type="service" id="mailer.transport" />
             <argument type="service" id="messenger.default_bus" on-invalid="ignore" />
         </service>
-        <service id="Symfony\Component\Mailer\MailerInterface" alias="mailer" />
+        <service id="mailer" alias="mailer.mailer" />
+        <service id="Symfony\Component\Mailer\MailerInterface" alias="mailer.mailer" />
 
         <service id="mailer.transport" class="Symfony\Component\Mailer\Transport\TransportInterface">
             <factory class="Symfony\Component\Mailer\Transport" method="fromDsn" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When you install Symfony Mailer as well as SwitMailer and try to typehint MailerInterface, the autowiring alias is aliased to the "mailer" service which is overriden by SwitMailer, thus making the injection fail.