### PR TITLE
[HttpFoundation] work around PHP 7.3 bug related to json_encode()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -185,6 +185,12 @@ class JsonDescriptor extends Descriptor
     private function writeData(array $data, array $options)
     {
         $flags = isset($options['json_encoding']) ? $options['json_encoding'] : 0;
+
+        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $flags)) {
+            // Work around https://bugs.php.net/77997
+            json_encode(null);
+        }
+
         $this->write(json_encode($data, $flags | JSON_PRETTY_PRINT)."\n");
     }
 

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -97,7 +97,14 @@ class JsonDescriptor extends Descriptor
      */
     private function writeData(array $data, array $options)
     {
-        $this->write(json_encode($data, isset($options['json_encoding']) ? $options['json_encoding'] : 0));
+        $flags = isset($options['json_encoding']) ? $options['json_encoding'] : 0;
+
+        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $flags)) {
+            // Work around https://bugs.php.net/77997
+            json_encode(null);
+        }
+
+        $this->write(json_encode($data, $flags));
     }
 
     /**

--- a/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
@@ -82,6 +82,12 @@ class JsonDescriptor extends Descriptor
     private function writeData(array $data, array $options)
     {
         $flags = isset($options['json_encoding']) ? $options['json_encoding'] : 0;
+
+        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $flags)) {
+            // Work around https://bugs.php.net/77997
+            json_encode(null);
+        }
+
         $this->output->write(json_encode($data, $flags | JSON_PRETTY_PRINT)."\n");
     }
 

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -153,6 +153,11 @@ class JsonResponse extends Response
                     restore_error_handler();
                 }
             } else {
+                if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $this->encodingOptions)) {
+                    // Work around https://bugs.php.net/77997
+                    json_encode(null);
+                }
+
                 try {
                     $data = json_encode($data, $this->encodingOptions);
                 } catch (\Exception $e) {

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -36,6 +36,11 @@ class JsonEncode implements EncoderInterface
     {
         $context = $this->resolveContext($context);
 
+        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $context['json_encode_options'])) {
+            // Work around https://bugs.php.net/77997
+            json_encode(null);
+        }
+
         $encodedJson = json_encode($data, $context['json_encode_options']);
 
         if (JSON_ERROR_NONE !== json_last_error() && (false === $encodedJson || !($context['json_encode_options'] & JSON_PARTIAL_OUTPUT_ON_ERROR))) {

--- a/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
@@ -31,6 +31,11 @@ class JsonFileDumper extends FileDumper
             $flags = \defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
         }
 
+        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $flags)) {
+            // Work around https://bugs.php.net/77997
+            json_encode(null);
+        }
+
         return json_encode($messages->all($domain), $flags);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31447
| License       | MIT
| Doc PR        | -

I know, this doesn't make any sense.
`json_encode` embeds global state behind the scene :(

For reference, I asked on php-internals what they think about this:
https://externals.io/message/105653#105838