### PR TITLE
[HttpClient] work around PHP 7.3 bug related to json_encode()

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -301,7 +301,13 @@ trait HttpClientTrait
         }
 
         try {
-            $value = json_encode($value, $flags | (\PHP_VERSION_ID >= 70300 ? JSON_THROW_ON_ERROR : 0), $maxDepth);
+            if (\PHP_VERSION_ID >= 70300) {
+                // Work around https://bugs.php.net/77997
+                json_encode(null);
+                $flags |= JSON_THROW_ON_ERROR;
+            }
+
+            $value = json_encode($value, $flags, $maxDepth);
         } catch (\JsonException $e) {
             throw new InvalidArgumentException(sprintf('Invalid value for "json" option: %s.', $e->getMessage()));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is the remaining of ##31860 for upper branches.