### PR TITLE
[HttpFoundation] Fixed case-sensitive handling of cache-control header in RedirectResponse constructor

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -42,7 +42,7 @@ class RedirectResponse extends Response
             throw new \InvalidArgumentException(sprintf('The HTTP status code is not a redirect ("%s" given).', $status));
         }
 
-        if (301 == $status && !\array_key_exists('cache-control', $headers)) {
+        if (301 == $status && !\array_key_exists('cache-control', array_change_key_case($headers, \CASE_LOWER))) {
             $this->headers->remove('cache-control');
         }
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -91,6 +91,10 @@ class RedirectResponseTest extends TestCase
         $this->assertFalse($response->headers->hasCacheControlDirective('no-cache'));
         $this->assertTrue($response->headers->hasCacheControlDirective('max-age'));
 
+        $response = new RedirectResponse('foo.bar', 301, ['Cache-Control' => 'max-age=86400']);
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-cache'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('max-age'));
+
         $response = new RedirectResponse('foo.bar', 302);
         $this->assertTrue($response->headers->hasCacheControlDirective('no-cache'));
     }


### PR DESCRIPTION
…r in RedirectResponse constructor.

| Q             | A
| ------------- | ---
| Branch?       |  3.4
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31862  <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Perform a case-insensitive check on `$headers` in \Symfony\Component\HttpFoundation\RedirectResponse::__construct()