### PR TITLE
[Cache] Fixed undefined variable in ArrayTrait

### DIFF
--- a/src/Symfony/Component/Cache/Traits/ArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ArrayTrait.php
@@ -129,7 +129,7 @@ trait ArrayTrait
             } catch (\Exception $e) {
                 $type = \is_object($value) ? \get_class($value) : \gettype($value);
                 $message = sprintf('Failed to save key "{key}" of type %s: %s', $type, $e->getMessage());
-                CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->namespace)), 'exception' => $e]);
+                CacheItem::log($this->logger, $message, ['key' => $key, 'exception' => $e]);
 
                 return;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

So once again (see https://github.com/symfony/symfony/pull/29591) my test suite managed to find an error in ArrayTrait in cache. This time it was this PR: https://github.com/symfony/symfony/pull/31395 later improved by https://github.com/symfony/symfony/pull/31590 that introduced `$id` to logging, which I guess should be `$key`? So this PR changes it to `$key`, ~but my tests **still fail** as there is no `$this->namespace` in `ArrayAdapter` (is this the only class that uses this ArrayTrait?). But I don't know what to do about it. Maybe @nicolas-grekas has some answers?~