### PR TITLE
[Form] Fix wrong DateTime on outdated ICU library

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -162,11 +162,8 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
     {
         $dateFormat = $this->dateFormat;
         $timeFormat = $this->timeFormat;
-        $timezone = $ignoreTimezone ? 'UTC' : $this->outputTimezone;
-        if (class_exists('IntlTimeZone', false)) {
-            // see https://bugs.php.net/bug.php?id=66323
-            $timezone = \IntlTimeZone::createTimeZone($timezone);
-        }
+        $timezone = new \DateTimeZone($ignoreTimezone ? 'UTC' : $this->outputTimezone);
+
         $calendar = $this->calendar;
         $pattern = $this->pattern;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.4 |
| Bug fix? | Yes |
| New feature? | No |
| BC breaks? | No |
| Deprecations? | No |
| Tests pass? | Yes |
| Fixed tickets | --- |
| License | MIT |

There is a problem, when server uses outdated version of ICU (php-intl).

It throws no exeption or debug message on unexisting Timezone. So sometimes you can get wrong DateTime in Forms, because Intl uses 'Etc/Unknown' (UTC+0) instead correct Timezone. And it happens very unobvious.

I added `\IntlExeption` for that cases.