### PR TITLE
[Routing] revert deprecation of Serializable in routing

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -121,8 +121,9 @@ Routing
 
  * The `generator_base_class`, `generator_cache_class`, `matcher_base_class`, and `matcher_cache_class` router
    options have been deprecated.
- * Implementing `Serializable` for `Route` and `CompiledRoute` is deprecated; if you serialize them, please
-   ensure your unserialization logic can recover from a failure related to an updated serialization format
+ * `Serializable` implementing methods for `Route` and `CompiledRoute` are marked as `@internal` and `@final`.
+   Instead of overwriting them, use `__serialize` and `__unserialize` as extension points which are forward compatible
+   with the new serialization methods in PHP 7.4.
 
 Security
 --------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -282,8 +282,9 @@ Routing
 
  * The `generator_base_class`, `generator_cache_class`, `matcher_base_class`, and `matcher_cache_class` router
    options have been removed.
- * `Route` and `CompiledRoute` don't implement `Serializable` anymore; if you serialize them, please
-   ensure your unserialization logic can recover from a failure related to an updated serialization format
+ * `Serializable` implementing methods for `Route` and `CompiledRoute` are final.
+   Instead of overwriting them, use `__serialize` and `__unserialize` as extension points which are forward compatible
+   with the new serialization methods in PHP 7.4.
 
 Security
 --------

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -8,8 +8,9 @@ CHANGELOG
  * added `CompiledUrlGenerator` and `CompiledUrlGeneratorDumper`
  * deprecated `PhpGeneratorDumper` and `PhpMatcherDumper`
  * deprecated `generator_base_class`, `generator_cache_class`, `matcher_base_class` and `matcher_cache_class` router options
- * deprecated implementing `Serializable` for `Route` and `CompiledRoute`; if you serialize them, please
-   ensure your unserialization logic can recover from a failure related to an updated serialization format
+ * `Serializable` implementing methods for `Route` and `CompiledRoute` are marked as `@internal` and `@final`.
+   Instead of overwriting them, use `__serialize` and `__unserialize` as extension points which are forward compatible
+   with the new serialization methods in PHP 7.4.
  * exposed `utf8` Route option, defaults "locale" and "format" in configuration loaders and configurators
  * added support for invokable route loader services
 

--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -64,7 +64,8 @@ class CompiledRoute implements \Serializable
     }
 
     /**
-     * @internal since Symfony 4.3, will be removed in Symfony 5 as the class won't implement Serializable anymore
+     * @internal since Symfony 4.3
+     * @final since Symfony 4.3
      */
     public function serialize()
     {
@@ -84,7 +85,8 @@ class CompiledRoute implements \Serializable
     }
 
     /**
-     * @internal since Symfony 4.3, will be removed in Symfony 5 as the class won't implement Serializable anymore
+     * @internal since Symfony 4.3
+     * @final since Symfony 4.3
      */
     public function unserialize($serialized)
     {

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -78,7 +78,8 @@ class Route implements \Serializable
     }
 
     /**
-     * @internal since Symfony 4.3, will be removed in Symfony 5 as the class won't implement Serializable anymore
+     * @internal since Symfony 4.3
+     * @final since Symfony 4.3
      */
     public function serialize()
     {
@@ -104,7 +105,8 @@ class Route implements \Serializable
     }
 
     /**
-     * @internal since Symfony 4.3, will be removed in Symfony 5 as the class won't implement Serializable anymore
+     * @internal since Symfony 4.3
+     * @final since Symfony 4.3
      */
     public function unserialize($serialized)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

we still need to implement Serializable as long as we support PHP < 7.4. otherwise serialized data in php 7.2 would not work anymore when people upgrade to php 7.4. see discussion in https://github.com/symfony/symfony/pull/31792#discussion_r289626274
partly reverts #30286
