### PR TITLE
[DIC] Add a split env var processor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * deprecated support for short factories and short configurators in Yaml
  * deprecated `tagged` in favor of `tagged_iterator`
+ * added `%env(split:...)%` processor to `split` a string into an array
 
 4.3.0
 -----

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -48,6 +48,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             'string' => 'string',
             'trim' => 'string',
             'require' => 'bool|int|float|string|array',
+            'split' => 'array',
         ];
     }
 
@@ -241,6 +242,10 @@ class EnvVarProcessor implements EnvVarProcessorInterface
 
         if ('trim' === $prefix) {
             return trim($env);
+        }
+
+        if ('split' === $prefix) {
+            return explode(',', $env);
         }
 
         throw new RuntimeException(sprintf('Unsupported env var prefix "%s".', $prefix));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -46,6 +46,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'string' => ['string'],
             'trim' => ['string'],
             'require' => ['bool', 'int', 'float', 'string', 'array'],
+            'split' => ['array'],
         ];
 
         $this->assertSame($expected, $container->getParameterBag()->getProvidedTypes());

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -486,4 +486,17 @@ class EnvVarProcessorTest extends TestCase
 
         $this->assertEquals('foo', $result);
     }
+
+    public function testGetEnvSplit()
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $result = $processor->getEnv('split', 'foo', function ($name) {
+            $this->assertSame('foo', $name);
+
+            return 'one,two,three';
+        });
+
+        $this->assertSame(['one', 'two', 'three'], $result);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#11674

This adds a new `explode` processor that will explode a `string` to a `PHP array`
