### PR TITLE
[HttpKernel] Fix handling non-catchable fatal errors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -721,9 +721,6 @@ class FrameworkExtension extends Extension
             $container->setParameter('debug.error_handler.throw_at', 0);
         }
 
-        $definition->replaceArgument(4, $debug);
-        $definition->replaceArgument(6, $debug);
-
         if ($debug && class_exists(DebugProcessor::class)) {
             $definition = new Definition(DebugProcessor::class);
             $definition->setPublic(false);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -18,9 +18,10 @@
             <argument type="service" id="logger" on-invalid="null" />
             <argument>null</argument><!-- Log levels map for enabled error levels -->
             <argument>%debug.error_handler.throw_at%</argument>
-            <argument>true</argument>
+            <argument>%kernel.debug%</argument>
             <argument type="service" id="debug.file_link_formatter"></argument>
-            <argument>true</argument>
+            <argument>%kernel.debug%</argument>
+            <argument>%kernel.charset%</argument>
         </service>
 
         <service id="debug.file_link_formatter" class="Symfony\Component\HttpKernel\Debug\FileLinkFormatter">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -67,16 +67,6 @@
             <argument type="service" id="router" on-invalid="ignore" />
         </service>
 
-        <service id="http_exception_listener" class="Symfony\Component\HttpKernel\EventListener\ExceptionListener">
-            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-2048" />
-            <tag name="kernel.reset" method="reset" />
-            <argument>null</argument>
-            <argument>null</argument>
-            <argument>%kernel.debug%</argument>
-            <argument>%kernel.charset%</argument>
-            <argument>%debug.file_link_format%</argument>
-        </service>
-
         <service id="validate_request_listener" class="Symfony\Component\HttpKernel\EventListener\ValidateRequestListener">
             <tag name="kernel.event_subscriber" />
         </service>

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -104,6 +104,7 @@ class DebugHandlersListenerTest extends TestCase
         $xListeners = [
             KernelEvents::REQUEST => [[$listener, 'configure']],
             ConsoleEvents::COMMAND => [[$listener, 'configure']],
+            KernelEvents::EXCEPTION => [[$listener, 'onKernelException']],
         ];
         $this->assertSame($xListeners, $dispatcher->getListeners());
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -155,25 +155,6 @@ class ExceptionListenerTest extends TestCase
         $this->assertFalse($response->headers->has('content-security-policy'), 'CSP header has been removed');
         $this->assertFalse($dispatcher->hasListeners(KernelEvents::RESPONSE), 'CSP removal listener has been removed');
     }
-
-    public function testNullController()
-    {
-        $listener = new ExceptionListener(null);
-        $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
-        $kernel->expects($this->once())->method('handle')->willReturnCallback(function (Request $request) {
-            $controller = $request->attributes->get('_controller');
-
-            return $controller();
-        });
-        $request = Request::create('/');
-        $event = new GetResponseForExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, new \Exception('foo'));
-
-        $listener->onKernelException($event);
-        $this->assertNull($event->getResponse());
-
-        $listener->onKernelException($event);
-        $this->assertContains('Whoops, looks like something went wrong.', $event->getResponse()->getContent());
-    }
 }
 
 class TestLogger extends Logger implements DebugLoggerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This reverts PR #27519 this commit 18c2dde08e52714666ff3a06ff9aa604fa80bfb0,
reversing changes made to ac1189a61e74b83be17787473d1aa9ceabd050c9.

Right now, the listener is skipped on fatal errors.