### PR TITLE
Fix json-encoding when JSON_THROW_ON_ERROR is used

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -186,11 +186,6 @@ class JsonDescriptor extends Descriptor
     {
         $flags = isset($options['json_encoding']) ? $options['json_encoding'] : 0;
 
-        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $flags)) {
-            // Work around https://bugs.php.net/77997
-            json_encode(null);
-        }
-
         $this->write(json_encode($data, $flags | JSON_PRETTY_PRINT)."\n");
     }
 

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -99,11 +99,6 @@ class JsonDescriptor extends Descriptor
     {
         $flags = isset($options['json_encoding']) ? $options['json_encoding'] : 0;
 
-        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $flags)) {
-            // Work around https://bugs.php.net/77997
-            json_encode(null);
-        }
-
         $this->write(json_encode($data, $flags));
     }
 

--- a/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
@@ -83,11 +83,6 @@ class JsonDescriptor extends Descriptor
     {
         $flags = isset($options['json_encoding']) ? $options['json_encoding'] : 0;
 
-        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $flags)) {
-            // Work around https://bugs.php.net/77997
-            json_encode(null);
-        }
-
         $this->output->write(json_encode($data, $flags | JSON_PRETTY_PRINT)."\n");
     }
 

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -153,11 +153,6 @@ class JsonResponse extends Response
                     restore_error_handler();
                 }
             } else {
-                if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $this->encodingOptions)) {
-                    // Work around https://bugs.php.net/77997
-                    json_encode(null);
-                }
-
                 try {
                     $data = json_encode($data, $this->encodingOptions);
                 } catch (\Exception $e) {
@@ -165,6 +160,10 @@ class JsonResponse extends Response
                         throw $e->getPrevious() ?: $e;
                     }
                     throw $e;
+                }
+
+                if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $this->encodingOptions)) {
+                    return $this->setJson($data);
                 }
             }
         }

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -72,7 +72,15 @@ class JsonDecode implements DecoderInterface
         $recursionDepth = $context['json_decode_recursion_depth'];
         $options = $context['json_decode_options'];
 
-        $decodedData = json_decode($data, $associative, $recursionDepth, $options);
+        try {
+            $decodedData = json_decode($data, $associative, $recursionDepth, $options);
+        } catch (\JsonException $e) {
+            throw new NotEncodableValueException($e->getMessage(), 0, $e);
+        }
+
+        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $options)) {
+            return $decodedData;
+        }
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new NotEncodableValueException(json_last_error_msg());

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -36,12 +36,11 @@ class JsonEncode implements EncoderInterface
     {
         $context = $this->resolveContext($context);
 
-        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $context['json_encode_options'])) {
-            // Work around https://bugs.php.net/77997
-            json_encode(null);
-        }
-
         $encodedJson = json_encode($data, $context['json_encode_options']);
+
+        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $context['json_encode_options'])) {
+            return $encodedJson;
+        }
 
         if (JSON_ERROR_NONE !== json_last_error() && (false === $encodedJson || !($context['json_encode_options'] & JSON_PARTIAL_OUTPUT_ON_ERROR))) {
             throw new NotEncodableValueException(json_last_error_msg());

--- a/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
@@ -31,11 +31,6 @@ class JsonFileDumper extends FileDumper
             $flags = \defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
         }
 
-        if (\PHP_VERSION_ID >= 70300 && (JSON_THROW_ON_ERROR & $flags)) {
-            // Work around https://bugs.php.net/77997
-            json_encode(null);
-        }
-
         return json_encode($messages->all($domain), $flags);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As hinted in #31860 by @lt