### PR TITLE
[HttpClient] revert bad logic around JSON_THROW_ON_ERROR

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -301,13 +301,7 @@ trait HttpClientTrait
         }
 
         try {
-            if (\PHP_VERSION_ID >= 70300) {
-                // Work around https://bugs.php.net/77997
-                json_encode(null);
-                $flags |= JSON_THROW_ON_ERROR;
-            }
-
-            $value = json_encode($value, $flags, $maxDepth);
+            $value = json_encode($value, $flags | (\PHP_VERSION_ID >= 70300 ? \JSON_THROW_ON_ERROR : 0), $maxDepth);
         } catch (\JsonException $e) {
             throw new InvalidArgumentException(sprintf('Invalid value for "json" option: %s.', $e->getMessage()));
         }

--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -148,7 +148,7 @@ trait ResponseTrait
         }
 
         try {
-            $content = json_decode($content, true, 512, JSON_BIGINT_AS_STRING | (\PHP_VERSION_ID >= 70300 ? JSON_THROW_ON_ERROR : 0));
+            $content = json_decode($content, true, 512, JSON_BIGINT_AS_STRING | (\PHP_VERSION_ID >= 70300 ? \JSON_THROW_ON_ERROR : 0));
         } catch (\JsonException $e) {
             throw new JsonException($e->getMessage(), $e->getCode());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Same as #31869, reverts #31861