### PR TITLE
[Doctrine Bridge] Check field type before adding Length constraint

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderEntity.php
@@ -60,4 +60,13 @@ class DoctrineLoaderEntity extends DoctrineLoaderParentEntity
      * @ORM\Embedded(class=DoctrineLoaderEmbed::class)
      */
     public $embedded;
+
+    /** @ORM\Column(type="text", nullable=true, length=1000) */
+    public $textField;
+
+    /** @ORM\Id @ORM\Column(type="guid", length=50) */
+    protected $guidField;
+
+    /** @ORM\Column(type="simple_array", length=100) */
+    public $simpleArrayField = [];
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -108,6 +108,16 @@ class DoctrineLoaderTest extends TestCase
         $this->assertCount(1, $embeddedMaxLengthConstraints);
         $this->assertInstanceOf(Length::class, $embeddedMaxLengthConstraints[0]);
         $this->assertSame(25, $embeddedMaxLengthConstraints[0]->max);
+
+        $this->assertCount(0, $classMetadata->getPropertyMetadata('guidField'));
+        $this->assertCount(0, $classMetadata->getPropertyMetadata('simpleArrayField'));
+
+        $textFieldMetadata = $classMetadata->getPropertyMetadata('textField');
+        $this->assertCount(1, $textFieldMetadata);
+        $textFieldConstraints = $textFieldMetadata[0]->getConstraints();
+        $this->assertCount(1, $textFieldConstraints);
+        $this->assertInstanceOf(Length::class, $textFieldConstraints[0]);
+        $this->assertSame(1000, $textFieldConstraints[0]->max);
     }
 
     public function testFieldMappingsConfiguration()

--- a/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
@@ -73,7 +73,7 @@ final class DoctrineLoader implements LoaderInterface
                 $metadata->addConstraint(new UniqueEntity(['fields' => $mapping['fieldName']]));
             }
 
-            if (null === ($mapping['length'] ?? null)) {
+            if (null === ($mapping['length'] ?? null) || !\in_array($mapping['type'], ['string', 'text'], true)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #31855
| License       | MIT
| Doc PR        | 

Validator\DoctrineLoader now add a Length constraint only on field of type string, text and guid; for any other type the mapping length is just ignored