### PR TITLE
Add a missing quote in PropertyAccessorInterface::getValue() DocBlock

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -58,7 +58,7 @@ interface PropertyAccessorInterface
      *
      *     $propertyAccessor = PropertyAccess::createPropertyAccessor();
      *
-     *     echo $propertyAccessor->getValue($object, 'child.name);
+     *     echo $propertyAccessor->getValue($object, 'child.name');
      *     // equals echo $object->getChild()->getName();
      *
      * This method first tries to find a public getter for each property in the


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

This typo is [here](https://github.com/symfony/symfony/commit/1bae7b242c37760b809b653a177ad61fc5b47984#diff-9814357bc1a81a8e3c8e38de9ccc69d0R63) for almost 7 years now :smile: 
This won't change the face of the world, but it will be my first PR for Symfony.