### PR TITLE
[Cache] Pass  arg to get callback everywhere

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -59,7 +59,8 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
 
         // ArrayAdapter works in memory, we don't care about stampede protection
         if (INF === $beta || !$item->isHit()) {
-            $this->save($item->set($callback($item)));
+            $save = true;
+            $this->save($item->set($callback($item, $save)));
         }
 
         return $item->get();

--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -42,7 +42,9 @@ class NullAdapter implements AdapterInterface, CacheInterface
      */
     public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
     {
-        return $callback(($this->createCacheItem)($key));
+        $save = true;
+
+        return $callback(($this->createCacheItem)($key), $save);
     }
 
     /**

--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -103,9 +103,9 @@ class ProxyAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
             return $this->doGet($this, $key, $callback, $beta, $metadata);
         }
 
-        return $this->pool->get($this->getId($key), function ($innerItem) use ($key, $callback) {
+        return $this->pool->get($this->getId($key), function ($innerItem, bool &$save) use ($key, $callback) {
             $item = ($this->createCacheItem)($key, $innerItem);
-            $item->set($value = $callback($item));
+            $item->set($value = $callback($item, $save));
             ($this->setInnerItem)($innerItem, (array) $item);
 
             return $value;

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -45,10 +45,10 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, PruneableInt
         }
 
         $isHit = true;
-        $callback = function (CacheItem $item) use ($callback, &$isHit) {
+        $callback = function (CacheItem $item, bool &$save) use ($callback, &$isHit) {
             $isHit = $item->isHit();
 
-            return $callback($item);
+            return $callback($item, $save);
         };
 
         $event = $this->start(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Some adapters does not pass an useless "save" bool arg. However, that makes a `CallbackInterface` callable unusable with them since the arg is required in the interface.