### PR TITLE
[HttpKernel] deprecate the usage of the deprecated events to ease deleting them

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/EventListener/FirewallListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/EventListener/FirewallListener.php
@@ -15,6 +15,8 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\Security\Http\FirewallMapInterface;
@@ -41,8 +43,12 @@ class FirewallListener extends Firewall
     /**
      * @internal
      */
-    public function configureLogoutUrlGenerator(GetResponseEvent $event)
+    public function configureLogoutUrlGenerator(KernelEvent $event)
     {
+        if (GetResponseEvent::class === \get_class($event)) {
+            @trigger_error(sprintf('The %s event has been deprecated since Symfony 4.3 and will be replaced by %s event in Symfony 5.0.', GetResponseEvent::class, RequestEvent::class), E_USER_DEPRECATED);
+        }
+
         if (!$event->isMasterRequest()) {
             return;
         }

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
@@ -60,8 +62,12 @@ class WebDebugToolbarListener implements EventSubscriberInterface
         return self::DISABLED !== $this->mode;
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(KernelEvent $event)
     {
+        if (FilterResponseEvent::class === \get_class($event)) {
+            @trigger_error(sprintf('The %s event has been deprecated since Symfony 4.3 and will be replaced by %s event in Symfony 5.0.', FilterResponseEvent::class, ResponseEvent::class), E_USER_DEPRECATED);
+        }
+
         $response = $event->getResponse();
         $request = $event->getRequest();
 

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -17,7 +17,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -41,8 +43,12 @@ class ExceptionListener implements EventSubscriberInterface
         $this->debug = $debug;
     }
 
-    public function logKernelException(GetResponseForExceptionEvent $event)
+    public function logKernelException(KernelEvent $event)
     {
+        if (GetResponseForExceptionEvent::class === \get_class($event)) {
+            @trigger_error(sprintf('The %s event has been deprecated since Symfony 4.3 and will be replaced by %s event in Symfony 5.0.', GetResponseForExceptionEvent::class, ExceptionEvent::class), E_USER_DEPRECATED);
+        }
+
         $e = FlattenException::create($event->getException());
 
         $this->logException($event->getException(), sprintf('Uncaught PHP Exception %s: "%s" at %s line %s', $e->getClass(), $e->getMessage(), $e->getFile(), $e->getLine()));
@@ -52,8 +58,12 @@ class ExceptionListener implements EventSubscriberInterface
      * @param string                   $eventName
      * @param EventDispatcherInterface $eventDispatcher
      */
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(KernelEvent $event)
     {
+        if (GetResponseForExceptionEvent::class === \get_class($event)) {
+            @trigger_error(sprintf('The %s event has been deprecated since Symfony 4.3 and will be replaced by %s event in Symfony 5.0.', GetResponseForExceptionEvent::class, ExceptionEvent::class), E_USER_DEPRECATED);
+        }
+
         if (null === $this->controller) {
             return;
         }

--- a/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -34,8 +36,12 @@ class ResponseListener implements EventSubscriberInterface
     /**
      * Filters the Response.
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(KernelEvent $event)
     {
+        if (FilterResponseEvent::class === \get_class($event)) {
+            @trigger_error(sprintf('The %s event has been deprecated since Symfony 4.3 and will be replaced by %s event in Symfony 5.0.', FilterResponseEvent::class, ResponseEvent::class), E_USER_DEPRECATED);
+        }
+
         if (!$event->isMasterRequest()) {
             return;
         }

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Security\Http\Firewall;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
@@ -123,8 +125,12 @@ class ContextListener implements ListenerInterface
     /**
      * Writes the security token into the session.
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(KernelEvent $event)
     {
+        if (FilterResponseEvent::class === \get_class($event)) {
+            @trigger_error(sprintf('The %s class has been deprecated since Symfony 4.3 and will be replaced by %s in Symfony 5.0.', FilterResponseEvent::class, ResponseEvent::class), E_USER_DEPRECATED);
+        }
+
         if (!$event->isMasterRequest()) {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |  none  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |<!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This is needed to fix the tests in #31672, since all the class has been made final since 4.3, we don't have any problem changing the type hint in 4.4 and then using the right type hint in 5.0.