### PR TITLE
Several components are incompatible with HttpKernel 5.0

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "symfony/config": "^4.2|^5.0",
         "symfony/dependency-injection": "^4.2|^5.0",
-        "symfony/http-kernel": "^4.3|^5.0",
+        "symfony/http-kernel": "^4.3",
         "symfony/security-core": "^4.3",
         "symfony/security-csrf": "^4.2|^5.0",
         "symfony/security-guard": "^4.2|^5.0",

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/config": "^4.2|^5.0",
-        "symfony/http-kernel": "^4.3|^5.0",
+        "symfony/http-kernel": "^4.3",
         "symfony/routing": "^3.4|^4.0|^5.0",
         "symfony/twig-bundle": "^4.2|^5.0",
         "symfony/var-dumper": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1.3",
         "symfony/security-core": "^4.3",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
-        "symfony/http-kernel": "^4.3|^5.0",
+        "symfony/http-kernel": "^4.3",
         "symfony/property-access": "^3.4|^4.0|^5.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1.3",
         "symfony/event-dispatcher-contracts": "^1.1",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
-        "symfony/http-kernel": "^4.3|^5.0",
+        "symfony/http-kernel": "^4.3",
         "symfony/property-access": "^3.4|^4.0|^5.0",
         "symfony/service-contracts": "^1.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This will help to finish the HttpKernel dead code removal (#31672) as this conflict with the component since the type-hint of several listener has been updated.