### PR TITLE
[FrameworkBundle] Fixed replace argument of `routing.loader` service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -780,7 +780,7 @@ class FrameworkExtension extends Extension
         $loader->load('routing.xml');
 
         if ($config['utf8']) {
-            $container->getDefinition('routing.loader')->replaceArgument(2, ['utf8' => true]);
+            $container->getDefinition('routing.loader')->replaceArgument(1, ['utf8' => true]);
         }
 
         $container->setParameter('router.resource', $config['resource']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fix https://github.com/symfony/symfony/pull/31702
> (1/1) OutOfBoundsException
The index "2" is not in the range [0, 1].

https://github.com/symfony/symfony/blob/bd8d8a2cfd50dffb4aa07908865931fb82a9e7bf/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php#L33