### PR TITLE
[Serializer] Fix DataUriNormalizer deprecation (MIME type guesser is optional)

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -39,7 +39,7 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
     private $mimeTypeGuesser;
 
     /**
-     * @param MimeTypeGuesserInterface
+     * @param MimeTypeGuesserInterface|null $mimeTypeGuesser
      */
     public function __construct($mimeTypeGuesser = null)
     {
@@ -48,8 +48,8 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
         } elseif (null === $mimeTypeGuesser) {
             if (class_exists(MimeTypes::class)) {
                 $mimeTypeGuesser = MimeTypes::getDefault();
-            } else {
-                @trigger_error(sprintf('Passing null to "%s()" without symfony/mime installed is deprecated since Symfony 4.3, install symfony/mime.', __METHOD__), E_USER_DEPRECATED);
+            } elseif (class_exists(MimeTypeGuesser::class)) {
+                @trigger_error(sprintf('Passing null to "%s()" to use a default MIME type guesser without Symfony Mime installed is deprecated since Symfony 4.3. Try running "composer require symfony/mime".', __METHOD__), E_USER_DEPRECATED);
                 $mimeTypeGuesser = MimeTypeGuesser::getInstance();
             }
         } elseif (!$mimeTypeGuesser instanceof MimeTypes) {
@@ -156,7 +156,9 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
 
         if ($this->mimeTypeGuesser instanceof DeprecatedMimeTypeGuesserInterface && $mimeType = $this->mimeTypeGuesser->guess($object->getPathname())) {
             return $mimeType;
-        } elseif ($this->mimeTypeGuesser && $mimeType = $this->mimeTypeGuesser->guessMimeType($object->getPathname())) {
+        }
+
+        if ($this->mimeTypeGuesser && $mimeType = $this->mimeTypeGuesser->guessMimeType($object->getPathname())) {
             return $mimeType;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Relates to https://github.com/symfony/symfony/pull/31771#discussion_r289604657 : 

The deprecation isn't fundamentally wrong, but if none of the Mime nor HttpFoundation components are installed, the DataUriNormalizer can be used, and the MIME type used will always be `'application/octet-stream'`

https://github.com/symfony/symfony/blob/9691519ca46511005bc701ca93c2973923952034/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php#L39-L46

https://github.com/symfony/symfony/blob/9691519ca46511005bc701ca93c2973923952034/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php#L135-L139

So this completes the deprecation message, as well as allowing `null` again when no default MIME type guesser is available at all.