### PR TITLE
[Mailer][FrameworkBundle] Add a way to use a custom transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1525,6 +1525,7 @@ class Configuration implements ConfigurationInterface
                     ->{!class_exists(FullStack::class) && class_exists(Mailer::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                     ->children()
                         ->scalarNode('dsn')->defaultValue('smtp://null')->end()
+                        ->scalarNode('transport')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1918,9 +1918,7 @@ class FrameworkExtension extends Extension
         $loader->load('mailer.xml');
         $transport = $container->getDefinition('mailer.default_transport');
         $transport->setArgument(0, $config['dsn']);
-        if (null !== $config['transport']) {
-            $transport->setArgument(4, new Reference($config['transport']));
-        }
+        $transport->setArgument(4, $config['transport']);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1916,7 +1916,11 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('mailer.xml');
-        $container->getDefinition('mailer.default_transport')->setArgument(0, $config['dsn']);
+        $transport = $container->getDefinition('mailer.default_transport');
+        $transport->setArgument(0, $config['dsn']);
+        if (null !== $config['transport']) {
+            $transport->setArgument(4, new Reference($config['transport']));
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -374,6 +374,7 @@ class ConfigurationTest extends TestCase
             ],
             'mailer' => [
                 'dsn' => 'smtp://null',
+                'transport' => null,
                 'enabled' => !class_exists(FullStack::class) && class_exists(Mailer::class),
             ],
         ];

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -31,14 +31,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class Transport
 {
-    public static function fromDsn(string $dsn, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null, TransportInterface $customTransport = null): TransportInterface
+    public static function fromDsn(string $dsn, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null, string $customTransportClass = null): TransportInterface
     {
         // failover?
         $dsns = preg_split('/\s++\|\|\s++/', $dsn);
         if (\count($dsns) > 1) {
             $transports = [];
             foreach ($dsns as $dsn) {
-                $transports[] = self::createTransport($dsn, $dispatcher, $client, $logger, $customTransport);
+                $transports[] = self::createTransport($dsn, $dispatcher, $client, $logger, $customTransportClass);
             }
 
             return new Transport\FailoverTransport($transports);
@@ -49,16 +49,16 @@ class Transport
         if (\count($dsns) > 1) {
             $transports = [];
             foreach ($dsns as $dsn) {
-                $transports[] = self::createTransport($dsn, $dispatcher, $client, $logger, $customTransport);
+                $transports[] = self::createTransport($dsn, $dispatcher, $client, $logger, $customTransportClass);
             }
 
             return new Transport\RoundRobinTransport($transports);
         }
 
-        return self::createTransport($dsn, $dispatcher, $client, $logger, $customTransport);
+        return self::createTransport($dsn, $dispatcher, $client, $logger, $customTransportClass);
     }
 
-    private static function createTransport(string $dsn, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null, TransportInterface $customTransport = null): TransportInterface
+    private static function createTransport(string $dsn, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null, string $customTransportClass = null): TransportInterface
     {
         if (false === $parsedDsn = parse_url($dsn)) {
             throw new InvalidArgumentException(sprintf('The "%s" mailer DSN is invalid.', $dsn));
@@ -170,11 +170,17 @@ class Transport
 
                 throw new LogicException(sprintf('The "%s" scheme is not supported for mailer "%s".', $parsedDsn['scheme'], $parsedDsn['host']));
             case 'custom':
-                if (!$customTransport) {
+                if (!$customTransportClass) {
                     throw new \LogicException('You must specify the transport class when using the "custom" provider.');
                 }
 
-                return new $customTransport($user, $pass, $query, $client, $dispatcher, $logger);
+                $customTransport = new $customTransportClass($user, $pass, $query, $client, $dispatcher, $logger);
+
+                if (!$customTransport instanceof TransportInterface) {
+                    throw new \LogicException(sprintf('The transport class must implements "%s".', TransportInterface::class));
+                }
+
+                return $customTransport;
             default:
                 if ('smtp' === $parsedDsn['scheme']) {
                     $transport = new Transport\Smtp\EsmtpTransport($parsedDsn['host'], $parsedDsn['port'] ?? 25, $query['encryption'] ?? null, $query['auth_mode'] ?? null, $dispatcher, $logger);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | todo
| Fixed tickets | #31385 
| License       | MIT
| Doc PR        | todo

Add a "custom" provider, to allow using a custom transport class.

`MAILER_DSN=http://user:pass@custom`

can fix https://github.com/symfony/symfony/issues/31385