### PR TITLE
[Config] remove the root method and the nullable name

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.0.0
+-----
+ * Dropped support for constructing a `TreeBuilder` without passing root node information.
+ * Removed the `root()` method in `TreeBuilder`, pass the root node information to the constructor instead
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -24,36 +24,10 @@ class TreeBuilder implements NodeParentInterface
     protected $tree;
     protected $root;
 
-    public function __construct(string $name = null, string $type = 'array', NodeBuilder $builder = null)
+    public function __construct(string $name, string $type = 'array', NodeBuilder $builder = null)
     {
-        if (null === $name) {
-            @trigger_error('A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.', E_USER_DEPRECATED);
-        } else {
-            $builder = $builder ?: new NodeBuilder();
-            $this->root = $builder->node($name, $type)->setParent($this);
-        }
-    }
-
-    /**
-     * Creates the root node.
-     *
-     * @param string      $name    The name of the root node
-     * @param string      $type    The type of the root node
-     * @param NodeBuilder $builder A custom node builder instance
-     *
-     * @return ArrayNodeDefinition|NodeDefinition The root node (as an ArrayNodeDefinition when the type is 'array')
-     *
-     * @throws \RuntimeException When the node type is not supported
-     *
-     * @deprecated since Symfony 4.3, pass the root name to the constructor instead
-     */
-    public function root($name, $type = 'array', NodeBuilder $builder = null)
-    {
-        @trigger_error(sprintf('The "%s()" method called for the "%s" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.', __METHOD__, $name), E_USER_DEPRECATED);
-
         $builder = $builder ?: new NodeBuilder();
-
-        return $this->root = $builder->node($name, $type)->setParent($this);
+        $this->root = $builder->node($name, $type)->setParent($this);
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
@@ -188,23 +188,4 @@ class TreeBuilderTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\Config\Definition\BaseNode', $childChildren['foo']);
         $this->assertSame('propagation/child/foo', $childChildren['foo']->getPath());
     }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
-     */
-    public function testInitializingTreeBuildersWithoutRootNode()
-    {
-        new TreeBuilder();
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "foo" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.
-     */
-    public function testRoot()
-    {
-        $builder = new TreeBuilder('foo');
-        $builder->root('foo');
-    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -390,7 +390,7 @@ class EnvConfigurationWithoutRootNode implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        return new TreeBuilder();
+        return new TreeBuilder('env_extension');
     }
 }
 
@@ -398,8 +398,8 @@ class ConfigurationWithArrayNodeRequiringOneElement implements ConfigurationInte
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('env_extension')
+        $treeBuilder = new TreeBuilder('env_extension');
+        $treeBuilder
             ->children()
                 ->arrayNode('nodes')
                     ->isRequired()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->


This PR allows to remove the both deprecated path of the `TreeBuilder` and update tests accordingly.