### PR TITLE
Allow custom transports for mailer component

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * Added the ability to specify a custom mailer `transport_id`
  * Deprecated support for `templating` engine in `TemplateController`, use Twig instead
  * Deprecated the `$parser` argument of `ControllerResolver::__construct()` and `DelegatingLoader::__construct()`
  * Deprecated the `controller_name_converter` and `resolve_controller_name_subscriber` services

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1523,8 +1523,18 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('mailer')
                     ->info('Mailer configuration')
                     ->{!class_exists(FullStack::class) && class_exists(Mailer::class) ? 'canBeDisabled' : 'canBeEnabled'}()
+                    ->beforeNormalization()
+                        ->always(function ($v) {
+                            if (isset($v['dsn']) && isset($v['transport_id'])) {
+                                throw new LogicException('You must set the mailer "dsn" to null, to use a custom transport service.');
+                            }
+
+                            return $v;
+                        })
+                    ->end()
                     ->children()
                         ->scalarNode('dsn')->defaultValue('smtp://null')->end()
+                        ->scalarNode('transport_id')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1916,7 +1916,12 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('mailer.xml');
-        $container->getDefinition('mailer.default_transport')->setArgument(0, $config['dsn']);
+
+        if (null === $config['transport_id']) {
+            $container->getDefinition('mailer.default_transport')->setArgument(0, $config['dsn']);
+        } else {
+            $container->getDefinition('mailer.mailer')->setArgument(0, new Reference($config['transport_id']));
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1920,7 +1920,8 @@ class FrameworkExtension extends Extension
         if (null === $config['transport_id']) {
             $container->getDefinition('mailer.default_transport')->setArgument(0, $config['dsn']);
         } else {
-            $container->getDefinition('mailer.mailer')->setArgument(0, new Reference($config['transport_id']));
+            $container->removeDefinition('mailer.default_transport');
+            $container->setAlias('mailer.default_transport', $config['transport_id']);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -375,6 +375,7 @@ class ConfigurationTest extends TestCase
             'mailer' => [
                 'dsn' => 'smtp://null',
                 'enabled' => !class_exists(FullStack::class) && class_exists(Mailer::class),
+                'transport_id' => null,
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31385 
| License       | MIT
| Doc PR        | TBD symfony/symfony-docs#...

This PR allows to define a custom transport for mailer component.
To enable it, set the `framework.mailer.dsn` key to `null` and the new `framework.mailer.transport_id` key to the transport service id you want to inject into the default mailer instance.
