### PR TITLE
PropertyInfoLoader should not try to add validation to non-existent property

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
@@ -60,6 +60,10 @@ final class PropertyInfoLoader implements LoaderInterface
                 continue;
             }
 
+            if (!property_exists($className, $property)) {
+                continue;
+            }
+
             $types = $this->typeExtractor->getTypes($className, $property);
             if (null === $types) {
                 continue;

--- a/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderEntity.php
@@ -48,4 +48,8 @@ class PropertyInfoLoaderEntity
     public $alreadyPartiallyMappedCollection;
 
     public $readOnly;
+
+    public function setNonExistentField()
+    {
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -46,6 +46,7 @@ class PropertyInfoLoaderTest extends TestCase
                 'alreadyMappedNotBlank',
                 'alreadyPartiallyMappedCollection',
                 'readOnly',
+                'nonExistentField',
             ])
         ;
         $propertyInfoStub


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31796 (see https://github.com/symfony/symfony/issues/31796#issuecomment-499924238)
| License       | MIT
| Doc PR        | not needed

With auto-validation, if a class has a setter (e.g. `setFoo()`) but there is no `foo` property, it still tries to add validation to that property, resulting in a:

> Property "foo" does not exist in class "App\Entity\Bar

This fixes that. I believe it's "just this simple", but I don't have any experience with the code in this area yet.

Cheers!