### PR TITLE
[DependencyInjection] fix from merge on ValidateEnvPlaceholdersPassTest

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -399,7 +399,7 @@ class ConfigurationWithArrayNodeRequiringOneElement implements ConfigurationInte
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('env_extension');
-        $treeBuilder
+        $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('nodes')
                     ->isRequired()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

@xabbuh Even if it's not called this need to be fixed, but as speaking with @nicolas-grekas, we found out that there are something strange in here:

- `ConfigurationWithArrayNodeRequiringOneElement::getConfigTreeBuilder` is never called
- EnvExtension::load has an 
```php 
if(!array_filter($config)) {return;}
```
and in the test using `ConfigurationWithArrayNodeRequiringOneElement`, the `$config` array is empty.
So maybe we have more to do in here than just fixing the merge. (we have the same issue with `EnvConfigurationWithoutRootNode`)
