### PR TITLE
[DependencyInjection] Define default priority inside service class

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -22,14 +22,16 @@ class TaggedIteratorArgument extends IteratorArgument
     private $indexAttribute;
     private $defaultIndexMethod;
     private $needsIndexes = false;
+    private $defaultPriorityMethod;
 
     /**
-     * @param string      $tag                The name of the tag identifying the target services
-     * @param string|null $indexAttribute     The name of the attribute that defines the key referencing each service in the tagged collection
-     * @param string|null $defaultIndexMethod The static method that should be called to get each service's key when their tag doesn't define the previous attribute
-     * @param bool        $needsIndexes       Whether indexes are required and should be generated when computing the map
+     * @param string      $tag                   The name of the tag identifying the target services
+     * @param string|null $indexAttribute        The name of the attribute that defines the key referencing each service in the tagged collection
+     * @param string|null $defaultIndexMethod    The static method that should be called to get each service's key when their tag doesn't define the previous attribute
+     * @param bool        $needsIndexes          Whether indexes are required and should be generated when computing the map
+     * @param string|null $defaultPriorityMethod The static method that should be called to get the default priority of the service
      */
-    public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $needsIndexes = false)
+    public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $needsIndexes = false, string $defaultPriorityMethod = null)
     {
         parent::__construct([]);
 
@@ -41,6 +43,7 @@ class TaggedIteratorArgument extends IteratorArgument
         $this->indexAttribute = $indexAttribute;
         $this->defaultIndexMethod = $defaultIndexMethod ?: ('getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute ?? ''))).'Name');
         $this->needsIndexes = $needsIndexes;
+        $this->defaultPriorityMethod = $defaultPriorityMethod;
     }
 
     public function getTag()
@@ -61,5 +64,10 @@ class TaggedIteratorArgument extends IteratorArgument
     public function needsIndexes(): bool
     {
         return $this->needsIndexes;
+    }
+
+    public function getDefaultPriorityMethod(): ?string
+    {
+        return $this->defaultPriorityMethod;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * deprecated support for short factories and short configurators in Yaml
  * deprecated `tagged` in favor of `tagged_iterator`
- * added ability to define an priority method for a tagged collection
+ * added ability to define a priority method for a tagged collection
 
 4.3.0
 -----

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * deprecated support for short factories and short configurators in Yaml
+ * added ability to define an priority method for a tagged collection
 
 4.3.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -66,7 +66,7 @@ trait PriorityTaggedServiceTrait
                 if (!($rpm = $r->getMethod($defaultPriorityMethod))->isStatic()) {
                     throw new InvalidArgumentException(
                         sprintf(
-                            'Method "%s::%s()" should be static: tag "%s" on service "%s" is missing default priority method.',
+                            'Default priority method "%s::%s()" of the "%s"-tagged collection on service "%s" must be static.',
                             $class,
                             $defaultPriorityMethod,
                             $tagName,

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -68,13 +68,13 @@ trait PriorityTaggedServiceTrait
                 }
 
                 if (!$priorityReflMethod->isPublic()) {
-                    throw new InvalidArgumentException(sprintf('Method "%s::%s()" should be public: tag "%s" on service "%s" is missing default priority method.', $class, $defaultPriorityMethod, $tagName, $serviceId));
+                    throw new InvalidArgumentException(sprintf('Default priority method "%s::%s()" of the "%s"-tagged collection on service "%s" should be public.', $class, $defaultPriorityMethod, $tagName, $serviceId));
                 }
 
                 $priority = $priorityReflMethod->invoke(null);
 
                 if (!\is_int($priority)) {
-                    throw new InvalidArgumentException(sprintf('Method "%s::%s()" should return an integer, got %s: tag "%s" on service "%s" is missing default priority method.', $class, $defaultPriorityMethod, \gettype($priority), $tagName, $serviceId));
+                    throw new InvalidArgumentException(sprintf('Default priority method "%s::%s()" of the "%s"-tagged collection on service "%s" should return an integer, got %s.', $class, $defaultPriorityMethod, \gettype($priority), $tagName, $serviceId));
                 }
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -63,43 +63,18 @@ trait PriorityTaggedServiceTrait
 
             $priority = 0;
             if ($defaultPriorityMethod && $r->hasMethod($defaultPriorityMethod)) {
-                if (!($rpm = $r->getMethod($defaultPriorityMethod))->isStatic()) {
-                    throw new InvalidArgumentException(
-                        sprintf(
-                            'Default priority method "%s::%s()" of the "%s"-tagged collection on service "%s" must be static.',
-                            $class,
-                            $defaultPriorityMethod,
-                            $tagName,
-                            $serviceId
-                        )
-                    );
+                if (!($priorityReflMethod = $r->getMethod($defaultPriorityMethod))->isStatic()) {
+                    throw new InvalidArgumentException(sprintf('Default priority method "%s::%s()" of the "%s"-tagged collection on service "%s" must be static.', $class, $defaultPriorityMethod, $tagName, $serviceId));
                 }
 
-                if (!$rpm->isPublic()) {
-                    throw new InvalidArgumentException(
-                        sprintf(
-                            'Method "%s::%s()" should be public: tag "%s" on service "%s" is missing default priority method.',
-                            $class,
-                            $defaultPriorityMethod,
-                            $tagName,
-                            $serviceId
-                        )
-                    );
+                if (!$priorityReflMethod->isPublic()) {
+                    throw new InvalidArgumentException(sprintf('Method "%s::%s()" should be public: tag "%s" on service "%s" is missing default priority method.', $class, $defaultPriorityMethod, $tagName, $serviceId));
                 }
 
-                $priority = $rpm->invoke(null);
+                $priority = $priorityReflMethod->invoke(null);
 
                 if (!\is_int($priority)) {
-                    throw new InvalidArgumentException(
-                        sprintf(
-                            'Method "%s::%s()" should return an integer, got %s: tag "%s" on service "%s" is missing default priority method.',
-                            $class,
-                            $defaultPriorityMethod,
-                            \gettype($priority),
-                            $tagName,
-                            $serviceId
-                        )
-                    );
+                    throw new InvalidArgumentException(sprintf('Method "%s::%s()" should return an integer, got %s: tag "%s" on service "%s" is missing default priority method.', $class, $defaultPriorityMethod, \gettype($priority), $tagName, $serviceId));
                 }
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -74,7 +74,7 @@ trait PriorityTaggedServiceTrait
                 $priority = $priorityReflMethod->invoke(null);
 
                 if (!\is_int($priority)) {
-                    throw new InvalidArgumentException(sprintf('Default priority method "%s::%s()" of the "%s"-tagged collection on service "%s" should return an integer, got %s.', $class, $defaultPriorityMethod, \gettype($priority), $tagName, $serviceId));
+                    throw new InvalidArgumentException(sprintf('Default priority method "%s::%s()" of the "%s"-tagged collection on service "%s" should return an integer, got %s.', $class, $defaultPriorityMethod, $tagName, $serviceId, \gettype($priority)));
                 }
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -58,7 +58,7 @@ trait PriorityTaggedServiceTrait
             $class = $container->getParameterBag()->resolveValue($class) ?: null;
 
             if (!$r = $container->getReflectionClass($class)) {
-                throw new InvalidArgumentException( sprintf('Class "%s" used for service "%s" cannot be found.', $class, $serviceId));
+                throw new InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $serviceId));
             }
 
             $priority = 0;
@@ -89,7 +89,7 @@ trait PriorityTaggedServiceTrait
 
                 $priority = $rpm->invoke(null);
 
-                if (!\is_integer($priority)) {
+                if (!\is_int($priority)) {
                     throw new InvalidArgumentException(
                         sprintf(
                             'Method "%s::%s()" should return an integer, got %s: tag "%s" on service "%s" is missing default priority method.',

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -53,7 +53,7 @@ trait PriorityTaggedServiceTrait
         $services = [];
 
         foreach ($container->findTaggedServiceIds($tagName, true) as $serviceId => $attributes) {
-            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : (method_exists($serviceId, 'getDefaultPriority') ? $serviceId::getDefaultPriority() : 0);
 
             if (null === $indexAttribute && !$needsIndexes) {
                 $services[$priority][] = new Reference($serviceId);

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -57,7 +57,7 @@ trait PriorityTaggedServiceTrait
             $class = $container->getDefinition($serviceId)->getClass();
             $class = $container->getParameterBag()->resolveValue($class) ?: null;
 
-            if (!$r = $container->getReflectionClass($class)) {
+            if (null !== $r = $container->getReflectionClass($class)) {
                 throw new InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $serviceId));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -297,6 +297,10 @@ class XmlDumper extends Dumper
                         $element->setAttribute('default-index-method', $tag->getDefaultIndexMethod());
                     }
                 }
+
+                if (null !== $tag->getDefaultPriorityMethod()) {
+                    $element->setAttribute('default-priority-method', $tag->getDefaultPriorityMethod());
+                }
             } elseif ($value instanceof IteratorArgument) {
                 $element->setAttribute('type', 'iterator');
                 $this->convertParameters($value->getValues(), $type, $element, 'key');

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -235,17 +235,22 @@ class YamlDumper extends Dumper
             $tag = $value;
 
             if ($value instanceof TaggedIteratorArgument || ($value instanceof ServiceLocatorArgument && $tag = $value->getTaggedIteratorArgument())) {
-                if (null === $tag->getIndexAttribute()) {
-                    $content = $tag->getTag();
-                } else {
-                    $content = [
-                        'tag' => $tag->getTag(),
-                        'index_by' => $tag->getIndexAttribute(),
-                    ];
+                $content = ['tag' => $tag->getTag()];
+
+                if (null !== $tag->getIndexAttribute()) {
+                    $content['index_by'] = $tag->getIndexAttribute();
 
                     if (null !== $tag->getDefaultIndexMethod()) {
                         $content['default_index_method'] = $tag->getDefaultIndexMethod();
                     }
+                }
+
+                if (null !== $tag->getDefaultPriorityMethod()) {
+                    $content['default_priority_method'] = $tag->getDefaultPriorityMethod();
+                }
+
+                if (count($content) === 1) {
+                    $content = $tag->getTag();
                 }
 
                 return new TaggedValue($value instanceof TaggedIteratorArgument ? 'tagged' : 'tagged_locator', $content);

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -244,15 +244,15 @@ class YamlDumper extends Dumper
                         $content['default_index_method'] = $tag->getDefaultIndexMethod();
                     }
                 }
-              
+
                 if (null !== $tag->getDefaultPriorityMethod()) {
                     $content['default_priority_method'] = $tag->getDefaultPriorityMethod();
                 }
 
-                if (count($content) === 1) {
+                if (1 === \count($content)) {
                     $content = $tag->getTag();
                 }
-              
+
                 return new TaggedValue($value instanceof TaggedIteratorArgument ? 'tagged_iterator' : 'tagged_locator', $content);
             }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -128,11 +128,12 @@ function tagged(string $tag, string $indexAttribute = null, string $defaultIndex
 /**
  * Creates a lazy iterator by tag name.
  *
- * @param string $tag
+ * @param string      $tag
  * @param string|null $indexAttribute
  * @param string|null $defaultIndexMethod
- * @param bool $needsIndexes
+ * @param bool        $needsIndexes
  * @param string|null $defaultPriorityMethod
+ *
  * @return TaggedIteratorArgument
  */
 function tagged_iterator(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $needsIndexes = false, string $defaultPriorityMethod = null): TaggedIteratorArgument
@@ -143,11 +144,12 @@ function tagged_iterator(string $tag, string $indexAttribute = null, string $def
 /**
  * Creates a service locator by tag name.
  *
- * @param string $tag
- * @param string $indexAttribute
+ * @param string      $tag
+ * @param string      $indexAttribute
  * @param string|null $defaultIndexMethod
- * @param bool $needsIndexes
+ * @param bool        $needsIndexes
  * @param string|null $defaultPriorityMethod
+ *
  * @return ServiceLocatorArgument
  */
 function tagged_locator(string $tag, string $indexAttribute, string $defaultIndexMethod = null, bool $needsIndexes = true, string $defaultPriorityMethod = null): ServiceLocatorArgument
@@ -159,6 +161,7 @@ function tagged_locator(string $tag, string $indexAttribute, string $defaultInde
  * Creates an expression.
  *
  * @param string $expression
+ *
  * @return Expression
  */
 function expr(string $expression): Expression

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -115,22 +115,39 @@ function iterator(array $values): IteratorArgument
 
 /**
  * Creates a lazy iterator by tag name.
+ *
+ * @param string $tag
+ * @param string|null $indexAttribute
+ * @param string|null $defaultIndexMethod
+ * @param bool $needsIndexes
+ * @param string|null $defaultPriorityMethod
+ * @return TaggedIteratorArgument
  */
-function tagged(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null): TaggedIteratorArgument
+function tagged(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $needsIndexes = false, string $defaultPriorityMethod = null): TaggedIteratorArgument
 {
-    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod);
+    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod,$needsIndexes, $defaultPriorityMethod);
 }
 
 /**
  * Creates a service locator by tag name.
+ *
+ * @param string $tag
+ * @param string $indexAttribute
+ * @param string|null $defaultIndexMethod
+ * @param bool $needsIndexes
+ * @param string|null $defaultPriorityMethod
+ * @return ServiceLocatorArgument
  */
-function tagged_locator(string $tag, string $indexAttribute, string $defaultIndexMethod = null): ServiceLocatorArgument
+function tagged_locator(string $tag, string $indexAttribute, string $defaultIndexMethod = null, bool $needsIndexes = true, string $defaultPriorityMethod = null): ServiceLocatorArgument
 {
-    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true));
+    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, $needsIndexes, $defaultPriorityMethod));
 }
 
 /**
  * Creates an expression.
+ *
+ * @param string $expression
+ * @return Expression
  */
 function expr(string $expression): Expression
 {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -127,14 +127,6 @@ function tagged(string $tag, string $indexAttribute = null, string $defaultIndex
 
 /**
  * Creates a lazy iterator by tag name.
- *
- * @param string      $tag
- * @param string|null $indexAttribute
- * @param string|null $defaultIndexMethod
- * @param bool        $needsIndexes
- * @param string|null $defaultPriorityMethod
- *
- * @return TaggedIteratorArgument
  */
 function tagged_iterator(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null, bool $needsIndexes = false, string $defaultPriorityMethod = null): TaggedIteratorArgument
 {
@@ -143,14 +135,6 @@ function tagged_iterator(string $tag, string $indexAttribute = null, string $def
 
 /**
  * Creates a service locator by tag name.
- *
- * @param string      $tag
- * @param string      $indexAttribute
- * @param string|null $defaultIndexMethod
- * @param bool        $needsIndexes
- * @param string|null $defaultPriorityMethod
- *
- * @return ServiceLocatorArgument
  */
 function tagged_locator(string $tag, string $indexAttribute, string $defaultIndexMethod = null, bool $needsIndexes = true, string $defaultPriorityMethod = null): ServiceLocatorArgument
 {
@@ -159,10 +143,6 @@ function tagged_locator(string $tag, string $indexAttribute, string $defaultInde
 
 /**
  * Creates an expression.
- *
- * @param string $expression
- *
- * @return Expression
  */
 function expr(string $expression): Expression
 {

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -553,7 +553,7 @@ class XmlFileLoader extends FileLoader
                         throw new InvalidArgumentException(sprintf('Tag "<%s>" with type="%s" has no or empty "tag" attribute in "%s".', $name, $type, $file));
                     }
 
-                    $arguments[$key] = new TaggedIteratorArgument($arg->getAttribute('tag'), $arg->getAttribute('index-by') ?: null, $arg->getAttribute('default-index-method') ?: null, $forLocator);
+                    $arguments[$key] = new TaggedIteratorArgument($arg->getAttribute('tag'), $arg->getAttribute('index-by') ?: null, $arg->getAttribute('default-index-method') ?: null, $forLocator, $arg->getAttribute('default-priority-method') ?: null);
 
                     if ($forLocator) {
                         $arguments[$key] = new ServiceLocatorArgument($arguments[$key]);

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -737,7 +737,7 @@ class YamlFileLoader extends FileLoader
                         throw new InvalidArgumentException(sprintf('"!%s" tag contains unsupported key "%s"; supported ones are "tag", "index_by" and "default_index_method".', $value->getTag(), implode('"", "', $diff)));
                     }
 
-                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'], $argument['default_index_method'] ?? null, $forLocator);
+                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null, $forLocator);
 
                     if ($forLocator) {
                         $argument = new ServiceLocatorArgument($argument);

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -733,11 +733,11 @@ class YamlFileLoader extends FileLoader
                 }
 
                 if (\is_array($argument) && isset($argument['tag']) && $argument['tag']) {
-                    if ($diff = array_diff(array_keys($argument), ['tag', 'index_by', 'default_index_method'])) {
-                        throw new InvalidArgumentException(sprintf('"!%s" tag contains unsupported key "%s"; supported ones are "tag", "index_by" and "default_index_method".', $value->getTag(), implode('"", "', $diff)));
+                    if ($diff = array_diff(array_keys($argument), ['tag', 'index_by', 'default_index_method', 'default_priority_method'])) {
+                        throw new InvalidArgumentException(sprintf('"!%s" tag contains unsupported key "%s"; supported ones are "tag", "index_by", "default_index_method" and "default_priority_method".', $value->getTag(), implode('"", "', $diff)));
                     }
 
-                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null, $forLocator);
+                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null, $forLocator, $argument['default_priority_method'] ?? null);
 
                     if ($forLocator) {
                         $argument = new ServiceLocatorArgument($argument);

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -236,6 +236,7 @@
     <xsd:attribute name="tag" type="xsd:string" />
     <xsd:attribute name="index-by" type="xsd:string" />
     <xsd:attribute name="default-index-method" type="xsd:string" />
+    <xsd:attribute name="default-priority-method" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="call">

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -402,6 +402,30 @@ class IntegrationTest extends TestCase
         ];
         $this->assertSame($expected, ['baz' => $serviceLocator->get('baz')]);
     }
+
+    public function testTaggedServiceWithPriorityMethod()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar', ['priority' => 10])
+        ;
+        $container->register(FooTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar')
+        ;
+        $container->register(FooBarTaggedClass::class)
+            ->addArgument(new TaggedIteratorArgument('foo_bar', null, null, false, 'getDefaultPriority'))
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        $s = $container->get(FooBarTaggedClass::class);
+
+        $param = iterator_to_array($s->getParam()->getIterator());
+        $this->assertSame([0 => $container->get(FooTagClass::class), 1 => $container->get(BarTagClass::class)], $param);
+    }
 }
 
 class ServiceSubscriberStub implements ServiceSubscriberInterface

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -220,6 +220,24 @@ class XmlDumperTest extends TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_with_tagged_arguments.xml', $dumper->dump());
     }
 
+    public function testTaggedWithDefaultPriorityMethod()
+    {
+        $taggedIterator = new TaggedIteratorArgument('foo_tag', null, null, false, 'foopriority');
+        $container = new ContainerBuilder();
+        $container->register('foo', 'Foo')->addTag('foo_tag');
+        $container->register('foo_tagged_iterator', 'Bar')
+            ->setPublic(true)
+            ->addArgument($taggedIterator)
+        ;
+        $container->register('foo_tagged_locator', 'Bar')
+            ->setPublic(true)
+            ->addArgument(new ServiceLocatorArgument($taggedIterator))
+        ;
+
+        $dumper = new XmlDumper($container);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_with_tagged_priority_method.xml', $dumper->dump());
+    }
+
     public function testDumpAbstractServices()
     {
         $container = include self::$fixturesPath.'/containers/container_abstract.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -109,6 +109,18 @@ class YamlDumperTest extends TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_tagged_argument.yml', $dumper->dump());
     }
 
+    public function testTaggedWithDefaultPriorityMethod()
+    {
+        $taggedIterator = new TaggedIteratorArgument('foo', null, null, false, 'foopriority');
+        $container = new ContainerBuilder();
+        $container->register('foo_service', 'Foo')->addTag('foo');
+        $container->register('foo_service_tagged_iterator', 'Bar')->addArgument($taggedIterator);
+        $container->register('foo_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator));
+
+        $dumper = new YamlDumper($container);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_tagged_priority_method.yml', $dumper->dump());
+    }
+
     private function assertEqualYamlStructure($expected, $yaml, $message = '')
     {
         $parser = new Parser();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTagClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTagClass.php
@@ -8,4 +8,9 @@ class FooTagClass
     {
         return 'foo_tag_class';
     }
+
+    public static function getDefaultPriority()
+    {
+        return 20;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_priority_method.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_priority_method.xml
@@ -6,7 +6,7 @@
       <tag name="foo_tag"/>
     </service>
     <service id="foo_tagged_iterator" class="Bar" public="true">
-      <argument type="tagged" tag="foo_tag" default-priority-method="foopriority"/>
+      <argument type="tagged_iterator" tag="foo_tag" default-priority-method="foopriority"/>
     </service>
     <service id="foo_tagged_locator" class="Bar" public="true">
       <argument type="tagged_locator" tag="foo_tag" default-priority-method="foopriority"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_priority_method.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_priority_method.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="foo" class="Foo">
+      <tag name="foo_tag"/>
+    </service>
+    <service id="foo_tagged_iterator" class="Bar" public="true">
+      <argument type="tagged" tag="foo_tag" default-priority-method="foopriority"/>
+    </service>
+    <service id="foo_tagged_locator" class="Bar" public="true">
+      <argument type="tagged_locator" tag="foo_tag" default-priority-method="foopriority"/>
+    </service>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_priority_method.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_priority_method.yml
@@ -10,7 +10,7 @@ services:
             - { name: foo }
     foo_service_tagged_iterator:
         class: Bar
-        arguments: [!tagged { tag: foo, default_priority_method: foopriority }]
+        arguments: [!tagged_iterator { tag: foo, default_priority_method: foopriority }]
     foo_service_tagged_locator:
         class: Bar
         arguments: [!tagged_locator { tag: foo, default_priority_method: foopriority }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_priority_method.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_priority_method.yml
@@ -1,0 +1,22 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo_service:
+        class: Foo
+        tags:
+            - { name: foo }
+    foo_service_tagged_iterator:
+        class: Bar
+        arguments: [!tagged { tag: foo, default_priority_method: foopriority }]
+    foo_service_tagged_locator:
+        class: Bar
+        arguments: [!tagged_locator { tag: foo, default_priority_method: foopriority }]
+    Psr\Container\ContainerInterface:
+        alias: service_container
+        public: false
+    Symfony\Component\DependencyInjection\ContainerInterface:
+        alias: service_container
+        public: false

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -336,6 +336,23 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_tagged_locator')->getArgument(0));
     }
 
+    public function testParseTaggedArgumentsWithPriority()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_with_tagged_priority_method.xml');
+
+        $this->assertCount(1, $container->getDefinition('foo')->getTag('foo_tag'));
+        $this->assertCount(1, $container->getDefinition('foo_tagged_iterator')->getArguments());
+        $this->assertCount(1, $container->getDefinition('foo_tagged_locator')->getArguments());
+
+        $taggedIterator = new TaggedIteratorArgument('foo_tag', null, null, false, 'foopriority');
+        $this->assertEquals($taggedIterator, $container->getDefinition('foo_tagged_iterator')->getArgument(0));
+
+        $taggedIterator = new TaggedIteratorArgument('foo_tag', null, null, true, 'foopriority');
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_tagged_locator')->getArgument(0));
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -317,6 +317,23 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_service_tagged_locator')->getArgument(0));
     }
 
+    public function testParseTaggedArgumentsWithPriority()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_tagged_priority_method.yml');
+
+        $this->assertCount(1, $container->getDefinition('foo_service')->getTag('foo'));
+        $this->assertCount(1, $container->getDefinition('foo_service_tagged_iterator')->getArguments());
+        $this->assertCount(1, $container->getDefinition('foo_service_tagged_locator')->getArguments());
+
+        $taggedIterator = new TaggedIteratorArgument('foo', null, null, false, 'foopriority');
+        $this->assertEquals($taggedIterator, $container->getDefinition('foo_service_tagged_iterator')->getArgument(0));
+
+        $taggedIterator = new TaggedIteratorArgument('foo', null, null, true, 'foopriority');
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_service_tagged_locator')->getArgument(0));
+    }
+
     public function testNameOnlyTagsAreAllowedAsString()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     
| Deprecations? | no
| Tests pass?   | yes   
| Fixed tickets | #...   
| License       | MIT

With autoconfigure functions we don't have to do much to inject tagged services into a collector using interfaces, using `!tagged` is the easy way. But if we need some order we have to use priority, the problem is that priority only can be set by configuration file when it is a simple value.
This PR take a look if the static method `getDefaultPriority` exists in the service class and return its default value for the service instead of current 0 by defualt.

Example of a service with default priority:

    <?php
    namespace App;
    use App\ServiceTagged;
    class Service implement ServiceTagged
    {
        public static function getDefaultPriority(): int
        {
            return 50; //This will be the default priority if it's not defined in a configuration file
        }
    }
    ?>

PD: First PR please by nice!