### PR TITLE
[OptionsResolver] fix adding $triggerDeprecation to Options::offsetGet()

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -16,8 +16,6 @@ namespace Symfony\Component\OptionsResolver;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Tobias Schultze <http://tobion.de>
- *
- * @method mixed offsetGet(string $option, bool $triggerDeprecation = true)
  */
 interface Options extends \ArrayAccess, \Countable
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This has been added by @yceruto in #28878 but it doesn't make sense to me: the interface has no concept if deprecation (`OptionsResolver` has!)