### PR TITLE
[WIP][Security] OAuth2 component

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/OAuthClientFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/OAuthClientFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class OAuthClientFactory implements UserProviderFactoryInterface
+{
+    public function create(ContainerBuilder $container, $id, $config)
+    {
+        $container
+            ->setDefinition($id, new ChildDefinition('security.user.provider.oauth'))
+        ;
+    }
+
+    public function getKey()
+    {
+        return 'oauth';
+    }
+
+    public function addConfiguration(NodeDefinition $builder)
+    {
+        $builder
+            ->children()
+                ->enumNode('type')
+                    ->info('The type of OAuth client needed: authorization_code, implicit, client_credentials, resource_owner')
+                    ->values(['authorization_code', 'implicit', 'client_credentials', 'resource_owner'])
+                        ->isRequired()
+                        ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('client_id')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                    ->defaultValue('12345678')
+                ->end()
+                ->scalarNode('client_secret')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                    ->defaultValue('12345678')
+                ->end()
+                ->scalarNode('authorization_url')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                    ->defaultValue('https://foo.com/authenticate')
+                ->end()
+                ->scalarNode('redirect_uri')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                    ->defaultValue('https://myapp.com/oauth')
+                ->end()
+                ->scalarNode('access_token_url')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                    ->defaultValue('https://foo.com/token')
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Symfony/Component/Security/Core/User/OauthUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/OauthUserProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\User;
+
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+
+/**
+ * OauthUserProvider is a provider built on top of the Oauth component.
+ *
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class OauthUserProvider implements UserProviderInterface
+{
+    private const USER_ROLES = ['ROLE_USER', 'ROLE_OAUTH_USER'];
+
+    public function loadUserByUsername($username)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        if (!$user instanceof User) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
+        }
+
+        return new User($user->getUsername(), null, $user->getRoles());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        return 'Symfony\Component\Security\Core\User\User' === $class;
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/.gitignore
+++ b/src/Symfony/Component/Security/OAuth2Client/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Security/OAuth2Client/Authorization/AuthorizationCodeResponse.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Authorization/AuthorizationCodeResponse.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Authorization;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationCodeResponse
+{
+    private $code;
+    private $state;
+    public const TYPE = 'code';
+
+    public function __construct(string $code, string $state)
+    {
+        $this->code = $code;
+        $this->state = $state;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getState(): string
+    {
+        return $this->state;
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Event/AccessTokenFetchEvent.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Event/AccessTokenFetchEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Event;
+
+use Symfony\Component\Security\OAuth2Client\Token\AbstractToken;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AccessTokenFetchEvent extends Event
+{
+    private $token;
+
+    public function __construct(AbstractToken $token)
+    {
+        $this->token = $token;
+    }
+
+    public function getToken(): AbstractToken
+    {
+        return $this->token;
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Event/RefreshTokenFetchEvent.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Event/RefreshTokenFetchEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Event;
+
+use Symfony\Component\Security\OAuth2Client\Token\AbstractToken;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class RefreshTokenFetchEvent extends Event
+{
+    private $token;
+
+    public function __construct(AbstractToken $token)
+    {
+        $this->token = $token;
+    }
+
+    public function getToken(): AbstractToken
+    {
+        return $this->token;
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Exception/InvalidJWTAuthorizationOptions.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Exception/InvalidJWTAuthorizationOptions.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Exception;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class InvalidJWTAuthorizationOptions extends \LogicException
+{
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Exception/InvalidJWTTokenTypeException.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Exception/InvalidJWTTokenTypeException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Exception;
+
+/**
+ * Represent an error linked to the usage of an invalid JWT token.
+ *
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class InvalidJWTTokenTypeException extends \LogicException
+{
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Exception/InvalidRequestException.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Exception/InvalidRequestException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Exception;
+
+/**
+ * Represent an error linked to the request (can be for an authentication code, access_token or refresh_token).
+ *
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class InvalidRequestException extends \LogicException
+{
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Exception/InvalidUrlException.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Exception/InvalidUrlException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Exception;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class InvalidUrlException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Exception/MissingOptionsException.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Exception/MissingOptionsException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Exception;
+
+/**
+ * Thrown if the provider does not receive all the required options.
+ *
+ * {@see GenericProvider::defineOptions}
+ *
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class MissingOptionsException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Helper/TokenIntrospectionHelper.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Helper/TokenIntrospectionHelper.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Helper;
+
+use Symfony\Component\Security\OAuth2Client\Token\IntrospectedToken;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @see https://tools.ietf.org/html/rfc7662
+ *
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class TokenIntrospectionHelper
+{
+    private $client;
+
+    public function __construct(HttpClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    public function introspecte(string $introspectionEndpointURI, string $token, array $headers = [], array $extraQuery = [], string $tokenTypeHint = null, string $method = 'POST'): IntrospectedToken
+    {
+        $defaultHeaders = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $defaultQuery = ['token' => $token];
+
+        if ($tokenTypeHint) {
+            $defaultQuery['token_type_hint'] = $tokenTypeHint;
+        }
+
+        $finalHeaders = array_unique(array_merge($defaultHeaders, $headers));
+        $finalQuery = array_unique(array_merge($defaultQuery, $extraQuery));
+
+        $response = $this->client->request($method, $introspectionEndpointURI, [
+            'headers' => $finalHeaders,
+            'query' => $finalQuery,
+        ]);
+
+        $body = $response->toArray();
+
+        return new IntrospectedToken($body);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/LICENCE
+++ b/src/Symfony/Component/Security/OAuth2Client/LICENCE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2019 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Security/OAuth2Client/Loader/ClientProfile.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Loader/ClientProfile.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Loader;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+class ClientProfile
+{
+    private $content = [];
+
+    public function __construct(array $content = [])
+    {
+        $this->content = $content;
+    }
+
+    public function getContent(): array
+    {
+        return $this->content;
+    }
+
+    public function get(string $key, $default = null)
+    {
+        return \array_key_exists($key, $this->content) ? $this->content[$key] : $default;
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Loader/ClientProfileLoader.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Loader/ClientProfileLoader.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Loader;
+
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ClientProfileLoader
+{
+    private $client;
+    private $clientProfileUrl;
+
+    public function __construct(HttpClientInterface $client, string $clientProfileUrl)
+    {
+        $this->client = $client;
+        $this->clientProfileUrl = $clientProfileUrl;
+    }
+
+    /**
+     * Allow to fetch the client profile using the url and an access token.
+     *
+     * @param string $method  the HTTP method used to fetch the profile
+     * @param array  $headers an array of headers used to fetch the profile
+     *
+     * @return ClientProfile the client data
+     *
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function fetchClientProfile(string $method = 'GET', array $headers = []): ClientProfile
+    {
+        $response = $this->client->request($method, $this->clientProfileUrl, [
+            'headers' => $headers,
+        ]);
+
+        return new ClientProfile($response->toArray());
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/AuthorizationCodeProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/AuthorizationCodeProvider.php
@@ -66,9 +66,7 @@ final class AuthorizationCodeProvider extends GenericProvider
     public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET', bool $secured = false)
     {
         if (!isset($options['code'])) {
-            throw new MissingOptionsException(
-                \sprintf('The required options code is missing')
-            );
+            throw new MissingOptionsException(sprintf('The required options code is missing'));
         }
 
         $defaultHeaders = [

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/AuthorizationCodeProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/AuthorizationCodeProvider.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Provider;
+
+use Symfony\Component\Security\OAuth2Client\Authorization\AuthorizationCodeResponse;
+use Symfony\Component\Security\OAuth2Client\Exception\MissingOptionsException;
+use Symfony\Component\Security\OAuth2Client\Token\AuthorizationCodeGrantAccessToken;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationCodeProvider extends GenericProvider
+{
+    /**
+     * The following options: redirect_uri, scope and state are optional or recommended https://tools.ietf.org/html/rfc6749#section-4.1.
+     */
+    public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'GET', bool $secured = false)
+    {
+        $query = [
+            'response_type' => 'code',
+            'client_id' => $this->options['client_id'],
+        ];
+
+        if (isset($options['redirect_uri'])) {
+            $query['redirect_uri'] = $options['redirect_uri'];
+        }
+
+        if (isset($options['scope'])) {
+            $query['scope'] = $options['scope'];
+        }
+
+        if (isset($options['state'])) {
+            $query['state'] = $options['state'];
+        }
+
+        $defaultHeaders = [
+            'Accept' => 'application/x-www-form-urlencoded',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $finalHeaders = $this->mergeRequestArguments($defaultHeaders, $headers);
+        $finalQuery = $this->mergeRequestArguments($query, $options);
+
+        $response = $this->client->request($method, $this->options['authorization_url'], [
+            'headers' => $finalHeaders,
+            'query' => $finalQuery,
+        ]);
+
+        $matches = $this->parseResponse($response);
+
+        return new AuthorizationCodeResponse($matches['code'], $matches['state']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET', bool $secured = false)
+    {
+        if (!isset($options['code'])) {
+            throw new MissingOptionsException(
+                \sprintf('The required options code is missing')
+            );
+        }
+
+        $defaultHeaders = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $finalHeaders = $this->mergeRequestArguments($defaultHeaders, $headers);
+
+        $response = $this->client->request($method, $this->options['access_token_url'], [
+            'headers' => $finalHeaders,
+            'query' => [
+                'grant_type' => 'authorization_code',
+                'code' => $options['code'],
+                'redirect_uri' => $this->options['redirect_uri'],
+                'client_id' => $this->options['client_id'],
+            ],
+        ]);
+
+        $this->parseResponse($response);
+
+        $this->checkResponseIsCacheable($response);
+
+        return new AuthorizationCodeGrantAccessToken($response->toArray());
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/ClientCredentialsProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/ClientCredentialsProvider.php
@@ -28,10 +28,7 @@ final class ClientCredentialsProvider extends GenericProvider
      */
     public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'GET')
     {
-        throw new \RuntimeException(\sprintf(
-            'The %s does not support the authorization process, the credentials should be obtained by the client, please refer to https://tools.ietf.org/html/rfc6749#section-4.4.1',
-            self::class
-        ));
+        throw new \RuntimeException(sprintf('The %s does not support the authorization process, the credentials should be obtained by the client, please refer to https://tools.ietf.org/html/rfc6749#section-4.4.1', self::class));
     }
 
     /**

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/ClientCredentialsProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/ClientCredentialsProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Provider;
+
+use Symfony\Component\Security\OAuth2Client\Token\ClientGrantToken;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ClientCredentialsProvider extends GenericProvider
+{
+    /**
+     * {@inheritdoc}
+     *
+     * The ClientGrantProvider isn't suitable to fetch an authorization code
+     * as the credentials should be obtained by the client.
+     *
+     * More informations on https://tools.ietf.org/html/rfc6749#section-4.4.1
+     */
+    public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'GET')
+    {
+        throw new \RuntimeException(\sprintf(
+            'The %s does not support the authorization process, the credentials should be obtained by the client, please refer to https://tools.ietf.org/html/rfc6749#section-4.4.1',
+            self::class
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * The scope option is optional as explained https://tools.ietf.org/html/rfc6749#section-4.4.2
+     *
+     * The response headers are checked as the response should not be cacheable https://tools.ietf.org/html/rfc6749#section-5.1
+     */
+    public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET')
+    {
+        $query = [
+            'grant_type' => 'client_credentials',
+        ];
+
+        if ($options['scope']) {
+            $query['scope'] = $options['scope'];
+        } else {
+            if ($this->logger) {
+                $this->logger->warning('The scope option isn\'t defined, the expected behaviour can vary');
+
+                $query = array_unique(array_merge($query, $options));
+            }
+        }
+
+        $defaultHeaders = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $finalHeaders = $this->mergeRequestArguments($defaultHeaders, $headers);
+        $finalQuery = $this->mergeRequestArguments($query, $options);
+
+        $response = $this->client->request($method, $this->options['access_token_url'], [
+            'headers' => $finalHeaders,
+            'query' => $finalQuery,
+        ]);
+
+        $this->parseResponse($response);
+
+        $this->checkResponseIsCacheable($response);
+
+        return new ClientGrantToken($response->toArray());
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/GenericProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/GenericProvider.php
@@ -77,7 +77,7 @@ abstract class GenericProvider implements ProviderInterface
         foreach ($urls as $key => $url) {
             if (\in_array($key, self::URL_OPTIONS)) {
                 if (!preg_match('~^{http|https}|[\w+.-]+://~', $url)) {
-                    throw new InvalidUrlException(\sprintf('The given URL %s isn\'t a valid one.', $url));
+                    throw new InvalidUrlException(sprintf('The given URL %s isn\'t a valid one.', $url));
                 }
             }
         }
@@ -120,9 +120,7 @@ abstract class GenericProvider implements ProviderInterface
 
         foreach ($matches as $keys => $value) {
             if (\in_array($keys, self::ERROR_OPTIONS)) {
-                throw new InvalidRequestException(
-                    \sprintf('It seems that the request encounter an error %s', $value)
-                );
+                throw new InvalidRequestException(sprintf('It seems that the request encounter an error %s', $value));
             }
         }
 

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/GenericProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/GenericProvider.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Provider;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidRequestException;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidUrlException;
+use Symfony\Component\Security\OAuth2Client\Loader\ClientProfileLoader;
+use Symfony\Component\Security\OAuth2Client\Token\RefreshToken;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+abstract class GenericProvider implements ProviderInterface
+{
+    private const DEFAULT_OPTIONS = [
+        'client_id' => ['null', 'string'],
+        'client_secret' => ['null', 'string'],
+        'redirect_uri' => ['null', 'string'],
+        'authorization_url' => ['null', 'string'],
+        'access_token_url' => ['null', 'string'],
+        'user_details_url' => ['null', 'string'],
+    ];
+
+    private const ERROR_OPTIONS = [
+        'error',
+        'error_description',
+        'error_uri',
+    ];
+
+    private const URL_OPTIONS = [
+        'redirect_uri',
+        'authorization_url',
+        'access_token_url',
+        'userDetails_url',
+    ];
+
+    protected $client;
+    protected $logger;
+    protected $options = [];
+
+    public function __construct(HttpClientInterface $client, array $options = [], LoggerInterface $logger = null)
+    {
+        $resolver = new OptionsResolver();
+        $this->defineOptions($resolver);
+
+        $this->options = $resolver->resolve($options);
+
+        $this->validateUrls($this->options);
+
+        $this->client = $client;
+        $this->logger = $logger;
+    }
+
+    private function defineOptions(OptionsResolver $resolver): void
+    {
+        foreach (self::DEFAULT_OPTIONS as $option => $optionType) {
+            $resolver->setRequired($option);
+            $resolver->setAllowedTypes($option, $optionType);
+        }
+    }
+
+    private function validateUrls(array $urls)
+    {
+        foreach ($urls as $key => $url) {
+            if (\in_array($key, self::URL_OPTIONS)) {
+                if (!preg_match('~^{http|https}|[\w+.-]+://~', $url)) {
+                    throw new InvalidUrlException(\sprintf('The given URL %s isn\'t a valid one.', $url));
+                }
+            }
+        }
+    }
+
+    /**
+     * Allow to add extra arguments to the actual request.
+     *
+     * @param array $defaultArguments the required arguments for the actual request (based on the RFC)
+     * @param array $extraArguments   the extra arguments that can be optionals/recommended
+     *
+     * @return array the final arguments sent to the request
+     */
+    protected function mergeRequestArguments(array $defaultArguments, array $extraArguments = []): array
+    {
+        if (0 < \count($extraArguments)) {
+            $finalArguments = array_unique(array_merge($defaultArguments, $extraArguments));
+        }
+
+        return $finalArguments ?? $defaultArguments;
+    }
+
+    protected function checkResponseIsCacheable(ResponseInterface $response): void
+    {
+        $headers = $response->getInfo('response_headers');
+
+        if (isset($headers['Cache-Control']) && 'no-store' !== $headers['Cache-Control']) {
+            if ($this->logger) {
+                $this->logger->warning('This response is marked as cacheable.');
+            }
+        }
+    }
+
+    public function parseResponse(ResponseInterface $response): array
+    {
+        $content = $response->getContent();
+
+        $parsedUrl = parse_url($content, PHP_URL_QUERY);
+        parse_str($parsedUrl, $matches);
+
+        foreach ($matches as $keys => $value) {
+            if (\in_array($keys, self::ERROR_OPTIONS)) {
+                throw new InvalidRequestException(
+                    \sprintf('It seems that the request encounter an error %s', $value)
+                );
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshToken(string $refreshToken, string $scope = null, array $headers = [], string $method = 'GET'): RefreshToken
+    {
+        $query = [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $refreshToken,
+        ];
+
+        if (null !== $scope) {
+            $query['scope'] = $scope;
+        } else {
+            if ($this->logger) {
+                $this->logger->info('The scope isn\'t defined, the response can vary from the expected behaviour.');
+            }
+        }
+
+        $defaultHeaders = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $finalHeaders = $this->mergeRequestArguments($defaultHeaders, $headers);
+
+        $response = $this->client->request($method, $this->options['access_token_url'], [
+            'headers' => $finalHeaders,
+            'query' => $query,
+        ]);
+
+        $this->parseResponse($response);
+
+        return new RefreshToken($response->toArray());
+    }
+
+    public function prepareClientProfileLoader(): ClientProfileLoader
+    {
+        return new ClientProfileLoader($this->client, $this->options['user_details_url']);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/ImplicitProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/ImplicitProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Provider;
+
+use Symfony\Component\Security\OAuth2Client\Token\ImplicitGrantToken;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ImplicitProvider extends GenericProvider
+{
+    /**
+     * {@inheritdoc}
+     *
+     * The ImplicitGrantProvider cannot fetch an Authorization code
+     * as described in https://tools.ietf.org/html/rfc6749#section-4.2.
+     */
+    public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'GET')
+    {
+        throw new \RuntimeException(\sprintf(
+            'The %s doesn\'t support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.2',
+            self::class
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * The following options: redirect_uri, scope and state are optional or recommended https://tools.ietf.org/html/rfc6749#section-4.2
+     */
+    public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET')
+    {
+        $query = [
+            'response_type' => 'token',
+            'client_id' => $this->options['client_id'],
+        ];
+
+        if (isset($options['redirect_uri'])) {
+            $query['redirect_uri'] = $options['redirect_uri'];
+        }
+
+        if (isset($options['scope'])) {
+            $query['scope'] = $options['scope'];
+        }
+
+        if (isset($options['state'])) {
+            $query['state'] = $options['state'];
+        }
+
+        $defaultHeaders = ['Content-Type' => 'application/x-www-form-urlencoded'];
+
+        $finalHeaders = $this->mergeRequestArguments($defaultHeaders, $headers);
+        $finalQuery = $this->mergeRequestArguments($query, $options);
+
+        $response = $this->client->request($method, $this->options['access_token_url'], [
+            'headers' => $finalHeaders,
+            'query' => $finalQuery,
+        ]);
+
+        $matches = $this->parseResponse($response);
+
+        return new ImplicitGrantToken($matches);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/ImplicitProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/ImplicitProvider.php
@@ -26,10 +26,7 @@ final class ImplicitProvider extends GenericProvider
      */
     public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'GET')
     {
-        throw new \RuntimeException(\sprintf(
-            'The %s doesn\'t support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.2',
-            self::class
-        ));
+        throw new \RuntimeException(sprintf('The %s doesn\'t support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.2', self::class));
     }
 
     /**

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/JWTProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/JWTProvider.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Provider;
+
+use Symfony\Component\Security\OAuth2Client\Authorization\AuthorizationCodeResponse;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidJWTAuthorizationOptions;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidJWTTokenTypeException;
+use Symfony\Component\Security\OAuth2Client\Exception\MissingOptionsException;
+use Symfony\Component\Security\OAuth2Client\Token\AuthorizationCodeGrantAccessToken;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class JWTProvider extends GenericProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'POST')
+    {
+        if (!isset($options['iss'], $options['sub'], $options['aud'], $options['exp'])) {
+            throw new InvalidJWTAuthorizationOptions(\sprintf(''));
+        }
+
+        $body = [
+            'iss' => $options['iss'],
+            'sub' => $options['sub'],
+            'aud' => $options['aud'],
+            'exp' => $options['exp'],
+        ];
+
+        $defaultHeaders = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+        ];
+
+        $finalHeaders = $this->mergeRequestArguments($defaultHeaders, $headers);
+        $finalQuery = $this->mergeRequestArguments($body, $options);
+
+        $response = $this->client->request($method, $this->options['authorization_url'], [
+            'headers' => $finalHeaders,
+            'body' => $finalQuery,
+        ]);
+
+        $matches = $this->parseResponse($response);
+
+        return new AuthorizationCodeResponse($matches['code'], $matches['state']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET')
+    {
+        if (!isset($options['assertion'])) {
+            throw new MissingOptionsException(\sprintf('The assertion query parameters mut be set!'));
+        }
+
+        $query = [
+            'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            'assertion' => $options['assertion'],
+        ];
+
+        if (isset($options['client_id']) && \is_string($options['assertion'])) {
+            $query['client_id'] = $options['client_id'];
+        } elseif (!\is_string($options['assertion'])) {
+            throw new InvalidJWTTokenTypeException(\sprintf(
+                'The given JWT token isn\'t properly typed, given %s', \gettype($options['assertion'])
+            ));
+        }
+
+        if (isset($options['scope'])) {
+            $query['scope'] = $options['scope'];
+        }
+
+        $defaultHeaders = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $finalHeaders = $this->mergeRequestArguments($defaultHeaders, $headers);
+
+        $response = $this->client->request($method, $this->options['access_token_url'], [
+            'headers' => $finalHeaders,
+            'query' => $query,
+        ]);
+
+        $this->parseResponse($response);
+
+        $this->checkResponseIsCacheable($response);
+
+        return new AuthorizationCodeGrantAccessToken($response->toArray());
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/JWTProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/JWTProvider.php
@@ -28,7 +28,7 @@ final class JWTProvider extends GenericProvider
     public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'POST')
     {
         if (!isset($options['iss'], $options['sub'], $options['aud'], $options['exp'])) {
-            throw new InvalidJWTAuthorizationOptions(\sprintf(''));
+            throw new InvalidJWTAuthorizationOptions(sprintf(''));
         }
 
         $body = [
@@ -62,7 +62,7 @@ final class JWTProvider extends GenericProvider
     public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET')
     {
         if (!isset($options['assertion'])) {
-            throw new MissingOptionsException(\sprintf('The assertion query parameters mut be set!'));
+            throw new MissingOptionsException(sprintf('The assertion query parameters mut be set!'));
         }
 
         $query = [
@@ -73,9 +73,7 @@ final class JWTProvider extends GenericProvider
         if (isset($options['client_id']) && \is_string($options['assertion'])) {
             $query['client_id'] = $options['client_id'];
         } elseif (!\is_string($options['assertion'])) {
-            throw new InvalidJWTTokenTypeException(\sprintf(
-                'The given JWT token isn\'t properly typed, given %s', \gettype($options['assertion'])
-            ));
+            throw new InvalidJWTTokenTypeException(sprintf('The given JWT token isn\'t properly typed, given %s', \gettype($options['assertion'])));
         }
 
         if (isset($options['scope'])) {

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/ProviderInterface.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/ProviderInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Provider;
+
+use Symfony\Component\Security\OAuth2Client\Token\RefreshToken;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+interface ProviderInterface
+{
+    /**
+     * Allow to parse the response body and find errors.
+     *
+     * @param ResponseInterface $response
+     */
+    public function parseResponse(ResponseInterface $response);
+
+    /**
+     * This method allows to fetch the authorization informations,
+     * this could be an authentication code as well as the client credentials.
+     *
+     * @param array  $options an array of extra options (scope, state, etc)
+     * @param array  $headers an array of extra/overriding headers
+     * @param string $method  the request http method
+     *
+     * @return mixed The authorization code (stored in a object if possible)
+     */
+    public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'GET');
+
+    /**
+     * @param array  $options an array of extra options (scope, state, etc)
+     * @param array  $headers an array of extra/overriding headers
+     * @param string $method  the request http method
+     *
+     * @return mixed The access_token (stored in a object if possible)
+     */
+    public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET');
+
+    /**
+     * Allow to refresh a token if the provider supports it.
+     *
+     * @param string      $refreshToken the refresh_token received in the access_token request
+     * @param string|null $scope        the scope of the new access_token (must be supported by the provider)
+     * @param array       $headers      an array of extra/overriding headers
+     * @param string      $method       the request http method
+     *
+     * @return RefreshToken The newly token (with a valid refresh_token and scope).
+     *
+     * By default, the RefreshToken structure is similar to the AbstractToken one https://tools.ietf.org/html/rfc6749#section-5.1
+     */
+    public function refreshToken(string $refreshToken, string $scope = null, array $headers = [], string $method = 'GET'): RefreshToken;
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/ProviderInterface.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/ProviderInterface.php
@@ -21,8 +21,6 @@ interface ProviderInterface
 {
     /**
      * Allow to parse the response body and find errors.
-     *
-     * @param ResponseInterface $response
      */
     public function parseResponse(ResponseInterface $response);
 

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/ResourceOwnerCredentialsProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/ResourceOwnerCredentialsProvider.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Provider;
+
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidRequestException;
+use Symfony\Component\Security\OAuth2Client\Token\ResourceOwnerCredentialsGrantToken;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ResourceOwnerCredentialsProvider extends GenericProvider
+{
+    /**
+     * The ResourceOwnerCredentialsGrantProvider isn't suitable to fetch
+     * an authorization code as the credentials should be obtained by the client.
+     *
+     * More informations on https://tools.ietf.org/html/rfc6749#section-4.3.1
+     */
+    public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'GET')
+    {
+        throw new \RuntimeException(\sprintf(
+            'The %s does not support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.3.1',
+            self::class
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * The scope key is optional as explained in https://tools.ietf.org/html/rfc6749#section-4.3.2
+     */
+    public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET')
+    {
+        if (!isset($options['username'], $options['password'])) {
+            throw new InvalidRequestException(\sprintf(
+                'The access_token request requires that you provide a username and a password!'
+            ));
+        }
+
+        $query = [
+            'grant_type' => 'password',
+            'username' => $options['username'],
+            'password' => $options['password'],
+        ];
+
+        if (isset($options['scope'])) {
+            $query['scope'] = $options['scope'];
+        } else {
+            if ($this->logger) {
+                $this->logger->warning('The scope is not provided, the expected behaviour can vary.');
+            }
+        }
+
+        $defaultHeaders = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $finalHeaders = $this->mergeRequestArguments($defaultHeaders, $headers);
+        $finalQuery = $this->mergeRequestArguments($query, $options);
+
+        $response = $this->client->request($method, $this->options['access_token_url'], [
+            'headers' => $finalHeaders,
+            'query' => $finalQuery,
+        ]);
+
+        $this->parseResponse($response);
+
+        $this->checkResponseIsCacheable($response);
+
+        return new ResourceOwnerCredentialsGrantToken($response->toArray());
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Provider/ResourceOwnerCredentialsProvider.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Provider/ResourceOwnerCredentialsProvider.php
@@ -27,10 +27,7 @@ final class ResourceOwnerCredentialsProvider extends GenericProvider
      */
     public function fetchAuthorizationInformations(array $options, array $headers = [], string $method = 'GET')
     {
-        throw new \RuntimeException(\sprintf(
-            'The %s does not support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.3.1',
-            self::class
-        ));
+        throw new \RuntimeException(sprintf('The %s does not support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.3.1', self::class));
     }
 
     /**
@@ -41,9 +38,7 @@ final class ResourceOwnerCredentialsProvider extends GenericProvider
     public function fetchAccessToken(array $options, array $headers = [], string $method = 'GET')
     {
         if (!isset($options['username'], $options['password'])) {
-            throw new InvalidRequestException(\sprintf(
-                'The access_token request requires that you provide a username and a password!'
-            ));
+            throw new InvalidRequestException(sprintf('The access_token request requires that you provide a username and a password!'));
         }
 
         $query = [

--- a/src/Symfony/Component/Security/OAuth2Client/README.md
+++ b/src/Symfony/Component/Security/OAuth2Client/README.md
@@ -1,0 +1,11 @@
+Security Component - OAuth2Client
+================================
+
+Resources
+---------
+
+  * [Documentation](https://symfony.com/doc/current/components/security.html)
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Helper/TokenIntrospectionHelperUnitTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Helper/TokenIntrospectionHelperUnitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\OAuth2Client\Helper\TokenIntrospectionHelper;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class TokenIntrospectionHelperUnitTest extends TestCase
+{
+    public function testValidTokenCanBeIntrospected()
+    {
+        $clientMock = new MockHttpClient([
+            new MockResponse(\json_encode([
+                'active' => false,
+                'scope' => 'test',
+                'client_id' => '1234567',
+                'username' => 'random',
+                'token_type' => 'authorization_code',
+            ])),
+        ]);
+
+        $introspecter = new TokenIntrospectionHelper($clientMock);
+
+        $introspectedToken = $introspecter->introspecte('https://www.bar.com', '123456randomtoken');
+
+        static::assertSame($introspectedToken->getTokenValue('active'), false);
+        static::assertSame($introspectedToken->getTokenValue('scope'), 'test');
+        static::assertSame($introspectedToken->getTokenValue('client_id'), '1234567');
+        static::assertSame($introspectedToken->getTokenValue('username'), 'random');
+        static::assertSame($introspectedToken->getTokenValue('token_type'), 'authorization_code');
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Helper/TokenIntrospectionHelperUnitTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Helper/TokenIntrospectionHelperUnitTest.php
@@ -24,7 +24,7 @@ final class TokenIntrospectionHelperUnitTest extends TestCase
     public function testValidTokenCanBeIntrospected()
     {
         $clientMock = new MockHttpClient([
-            new MockResponse(\json_encode([
+            new MockResponse(json_encode([
                 'active' => false,
                 'scope' => 'test',
                 'client_id' => '1234567',

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Loader/ClientProfileLoaderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Loader/ClientProfileLoaderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Tests\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\OAuth2Client\Loader\ClientProfileLoader;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ClientProfileLoaderTest extends TestCase
+{
+    /**
+     * @dataProvider provideWrongAccessToken
+     */
+    public function testWrongAccessToken(string $clientProfileUrl, string $accessToken)
+    {
+        $client = new MockHttpClient([
+            new MockResponse(\json_encode([
+                'error' => 'This access_token seems expired.',
+            ]), [
+                'response_headers' => [
+                    'Content-Type' => 'application/json',
+                    'http_code' => 401,
+                ],
+            ]),
+        ]);
+
+        $loader = new ClientProfileLoader($client, $clientProfileUrl);
+
+        $clientProfile = $loader->fetchClientProfile('GET', [
+            'Accept' => 'application/json',
+            'Authorization' => 'Bearer '.$accessToken,
+        ]);
+
+        static::assertArrayHasKey('error', $clientProfile->getContent());
+    }
+
+    /**
+     * @dataProvider provideValidAccessToken
+     */
+    public function testValidAccessToken(string $clientProfileUrl, string $accessToken)
+    {
+        $client = new MockHttpClient([
+            new MockResponse(\json_encode([
+                'username' => 'Foo',
+                'email' => 'foo@bar.com',
+                'id' => 123456,
+            ]), [
+                'response_headers' => [
+                    'Content-Type' => 'application/json',
+                    'http_code' => 200,
+                ],
+            ]),
+        ]);
+
+        $loader = new ClientProfileLoader($client, $clientProfileUrl);
+
+        $clientProfile = $loader->fetchClientProfile('GET', [
+            'Accept' => 'application/json',
+            'Authorization' => 'basic '.$accessToken,
+        ]);
+
+        static::assertArrayNotHasKey('error', $clientProfile->getContent());
+        static::assertArrayHasKey('username', $clientProfile->getContent());
+        static::assertSame('Foo', $clientProfile->get('username'));
+        static::assertSame('foo@bar.com', $clientProfile->get('email'));
+    }
+
+    public function provideWrongAccessToken(): \Generator
+    {
+        yield 'Expired access_token' => [
+            'http://api.foo.com/profile/user',
+            \uniqid(),
+        ];
+    }
+
+    public function provideValidAccessToken(): \Generator
+    {
+        yield 'Expired access_token' => [
+            'http://api.foo.com/profile/user',
+            '1234567nialbdodaizbazu7',
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Loader/ClientProfileLoaderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Loader/ClientProfileLoaderTest.php
@@ -27,7 +27,7 @@ final class ClientProfileLoaderTest extends TestCase
     public function testWrongAccessToken(string $clientProfileUrl, string $accessToken)
     {
         $client = new MockHttpClient([
-            new MockResponse(\json_encode([
+            new MockResponse(json_encode([
                 'error' => 'This access_token seems expired.',
             ]), [
                 'response_headers' => [
@@ -53,7 +53,7 @@ final class ClientProfileLoaderTest extends TestCase
     public function testValidAccessToken(string $clientProfileUrl, string $accessToken)
     {
         $client = new MockHttpClient([
-            new MockResponse(\json_encode([
+            new MockResponse(json_encode([
                 'username' => 'Foo',
                 'email' => 'foo@bar.com',
                 'id' => 123456,
@@ -82,7 +82,7 @@ final class ClientProfileLoaderTest extends TestCase
     {
         yield 'Expired access_token' => [
             'http://api.foo.com/profile/user',
-            \uniqid(),
+            uniqid(),
         ];
     }
 

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/AuthorizationCodeProviderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/AuthorizationCodeProviderTest.php
@@ -78,7 +78,7 @@ final class AuthorizationCodeProviderTest extends TestCase
     {
         $clientMock = new MockHttpClient(
             [
-                new MockResponse(\sprintf('https://bar.com/authenticate?code=%s&state=%s', $code, $state), [
+                new MockResponse(sprintf('https://bar.com/authenticate?code=%s&state=%s', $code, $state), [
                     'response_headers' => [
                         'http_method' => 'GET',
                         'http_code' => 200,
@@ -124,19 +124,19 @@ final class AuthorizationCodeProviderTest extends TestCase
     {
         $clientMock = new MockHttpClient(
             [
-                new MockResponse(\json_encode([
+                new MockResponse(json_encode([
                     'access_token' => $code,
                     'token_type' => 'test',
                     'expires_in' => 3600,
-                    'refresh_token' => \uniqid(),
+                    'refresh_token' => uniqid(),
                 ]), [
                     'response_headers' => [
                         'http_method' => 'GET',
                         'http_code' => 200,
                     ],
                 ]),
-                new MockResponse(\json_encode([
-                    'access_token' => \uniqid(),
+                new MockResponse(json_encode([
+                    'access_token' => uniqid(),
                     'token_type' => 'test',
                     'expires_in' => 1200,
                 ]), [
@@ -154,7 +154,7 @@ final class AuthorizationCodeProviderTest extends TestCase
 
         static::assertNotNull($accessToken->getTokenValue('access_token'));
         static::assertNotNull($accessToken->getTokenValue('refresh_token'));
-        static::assertInternalType('int', $accessToken->getTokenValue('expires_in'));
+        static::assertIsInt($accessToken->getTokenValue('expires_in'));
         static::assertSame(3600, $accessToken->getTokenValue('expires_in'));
 
         $refreshedToken = $provider->refreshToken($accessToken->getTokenValue('refresh_token'), 'public');
@@ -171,7 +171,7 @@ final class AuthorizationCodeProviderTest extends TestCase
     {
         $clientMock = new MockHttpClient(
             [
-                new MockResponse(\json_encode([
+                new MockResponse(json_encode([
                     'access_token' => $code,
                     'token_type' => 'test',
                     'expires_in' => 3600,
@@ -190,7 +190,7 @@ final class AuthorizationCodeProviderTest extends TestCase
 
         static::assertNotNull($accessToken->getTokenValue('access_token'));
         static::assertNull($accessToken->getTokenValue('refresh_token'));
-        static::assertInternalType('int', $accessToken->getTokenValue('expires_in'));
+        static::assertIsInt($accessToken->getTokenValue('expires_in'));
     }
 
     public function provideWrongOptions(): \Generator

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/AuthorizationCodeProviderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/AuthorizationCodeProviderTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidRequestException;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidUrlException;
+use Symfony\Component\Security\OAuth2Client\Provider\AuthorizationCodeProvider;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationCodeProviderTest extends TestCase
+{
+    /**
+     * @dataProvider provideWrongOptions
+     */
+    public function testWrongOptionsSent(array $options)
+    {
+        static::expectException(MissingOptionsException::class);
+
+        $clientMock = new MockHttpClient([]);
+
+        new AuthorizationCodeProvider($clientMock, $options);
+    }
+
+    /**
+     * @dataProvider provideWrongUrls
+     */
+    public function testWrongUrls(array $options)
+    {
+        static::expectException(InvalidUrlException::class);
+
+        $clientMock = new MockHttpClient([]);
+
+        new AuthorizationCodeProvider($clientMock, $options);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndInvalidAuthorizationCodeRequest(array $options, string $code, string $state)
+    {
+        static::expectException(InvalidRequestException::class);
+
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse('https://bar.com/authenticate?error=invalid_scope', [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 400,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new AuthorizationCodeProvider($clientMock, $options);
+
+        $provider->fetchAuthorizationInformations(['scope' => 'test', 'state' => $state]);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndValidAuthorizationCodeRequest(array $options, string $code, string $state)
+    {
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse(\sprintf('https://bar.com/authenticate?code=%s&state=%s', $code, $state), [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 200,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new AuthorizationCodeProvider($clientMock, $options);
+
+        $authorizationCode = $provider->fetchAuthorizationInformations(['scope' => 'public', 'state' => $state]);
+
+        static::assertSame($state, $authorizationCode->getState());
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndInvalidAccessTokenRequest(array $options, string $code, string $state)
+    {
+        static::expectException(InvalidRequestException::class);
+
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse('https://bar.com/authenticate?error=invalid_scope', [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 400,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new AuthorizationCodeProvider($clientMock, $options);
+
+        $provider->fetchAccessToken(['code' => $code]);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndValidAccessTokenWithRefreshTokenRequest(array $options, string $code, string $state)
+    {
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse(\json_encode([
+                    'access_token' => $code,
+                    'token_type' => 'test',
+                    'expires_in' => 3600,
+                    'refresh_token' => \uniqid(),
+                ]), [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 200,
+                    ],
+                ]),
+                new MockResponse(\json_encode([
+                    'access_token' => \uniqid(),
+                    'token_type' => 'test',
+                    'expires_in' => 1200,
+                ]), [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 200,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new AuthorizationCodeProvider($clientMock, $options);
+
+        $accessToken = $provider->fetchAccessToken(['code' => $code]);
+
+        static::assertNotNull($accessToken->getTokenValue('access_token'));
+        static::assertNotNull($accessToken->getTokenValue('refresh_token'));
+        static::assertInternalType('int', $accessToken->getTokenValue('expires_in'));
+        static::assertSame(3600, $accessToken->getTokenValue('expires_in'));
+
+        $refreshedToken = $provider->refreshToken($accessToken->getTokenValue('refresh_token'), 'public');
+
+        static::assertNotNull($refreshedToken->getTokenValue('access_token'));
+        static::assertNull($refreshedToken->getTokenValue('refresh_token'));
+        static::assertSame(1200, $refreshedToken->getTokenValue('expires_in'));
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndValidAccessTokenWithoutRefreshTokenRequest(array $options, string $code, string $state)
+    {
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse(\json_encode([
+                    'access_token' => $code,
+                    'token_type' => 'test',
+                    'expires_in' => 3600,
+                ]), [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 200,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new AuthorizationCodeProvider($clientMock, $options);
+
+        $accessToken = $provider->fetchAccessToken(['code' => $code]);
+
+        static::assertNotNull($accessToken->getTokenValue('access_token'));
+        static::assertNull($accessToken->getTokenValue('refresh_token'));
+        static::assertInternalType('int', $accessToken->getTokenValue('expires_in'));
+    }
+
+    public function provideWrongOptions(): \Generator
+    {
+        yield 'Missing client_id option' => [
+            [
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https://bar.com',
+                'authorization_url' => 'https://bar.com/authenticate',
+                'access_token_url' => 'https://bar.com/',
+                'user_details_url' => 'https://bar.com/',
+            ],
+        ];
+    }
+
+    public function provideWrongUrls(): \Generator
+    {
+        yield 'Invalid urls options' => [
+            [
+                'client_id' => 'foo',
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https:/bar.com',
+                'authorization_url' => 'bar.com/authenticate',
+                'access_token_url' => '/bar.com/',
+                'user_details_url' => 'httpsbar.com/',
+            ],
+        ];
+    }
+
+    public function provideValidOptions(): \Generator
+    {
+        yield 'Valid options' => [
+            [
+                'client_id' => 'foo',
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https://bar.com',
+                'authorization_url' => 'https://bar.com/authenticate',
+                'access_token_url' => 'https://bar.com/',
+                'user_details_url' => 'https://bar.com/',
+            ],
+            '1234567nialbdodaizbazu7',
+            '1325267BDZYABA',
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ClientCredentialsProviderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ClientCredentialsProviderTest.php
@@ -41,7 +41,7 @@ final class ClientCredentialsProviderTest extends TestCase
     public function testErrorOnAuthorizationTokenRequest(array $options, string $scope)
     {
         static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage(\sprintf(
+        static::expectExceptionMessage(sprintf(
             'The %s does not support the authorization process, the credentials should be obtained by the client, please refer to https://tools.ietf.org/html/rfc6749#section-4.4.1',
             ClientCredentialsProvider::class
         ));
@@ -83,8 +83,8 @@ final class ClientCredentialsProviderTest extends TestCase
     {
         $clientMock = new MockHttpClient(
             [
-                new MockResponse(\json_encode([
-                    'access_token' => \uniqid(),
+                new MockResponse(json_encode([
+                    'access_token' => uniqid(),
                     'token_type' => 'bearer',
                     'expires_in' => 3600,
                 ]), [
@@ -99,7 +99,7 @@ final class ClientCredentialsProviderTest extends TestCase
 
         $accessToken = $provider->fetchAccessToken([
             'scope' => $scope,
-            'test' => \uniqid(),
+            'test' => uniqid(),
         ]);
 
         static::assertNotNull($accessToken->getTokenValue('access_token'));
@@ -114,8 +114,8 @@ final class ClientCredentialsProviderTest extends TestCase
     {
         $clientMock = new MockHttpClient(
             [
-                new MockResponse(\json_encode([
-                    'access_token' => \uniqid(),
+                new MockResponse(json_encode([
+                    'access_token' => uniqid(),
                     'token_type' => 'bearer',
                     'expires_in' => 3600,
                 ]), [
@@ -131,7 +131,7 @@ final class ClientCredentialsProviderTest extends TestCase
 
         $accessToken = $provider->fetchAccessToken([
             'scope' => $scope,
-            'test' => \uniqid(),
+            'test' => uniqid(),
         ]);
 
         static::assertNotNull($accessToken->getTokenValue('access_token'));

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ClientCredentialsProviderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ClientCredentialsProviderTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidRequestException;
+use Symfony\Component\Security\OAuth2Client\Provider\ClientCredentialsProvider;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ClientCredentialsProviderTest extends TestCase
+{
+    /**
+     * @dataProvider provideWrongOptions
+     */
+    public function testWrongOptionsSent(array $options)
+    {
+        static::expectException(MissingOptionsException::class);
+
+        $clientMock = new MockHttpClient([]);
+
+        new ClientCredentialsProvider($clientMock, $options);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testErrorOnAuthorizationTokenRequest(array $options, string $scope)
+    {
+        static::expectException(\RuntimeException::class);
+        static::expectExceptionMessage(\sprintf(
+            'The %s does not support the authorization process, the credentials should be obtained by the client, please refer to https://tools.ietf.org/html/rfc6749#section-4.4.1',
+            ClientCredentialsProvider::class
+        ));
+
+        $clientMock = new MockHttpClient([new MockResponse()]);
+
+        $provider = new ClientCredentialsProvider($clientMock, $options);
+
+        $provider->fetchAuthorizationInformations(['scope' => $scope]);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndInvalidAccessTokenRequest(array $options, string $scope)
+    {
+        static::expectException(InvalidRequestException::class);
+
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse('https://bar.com/authenticate?error=invalid_scope', [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 400,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new ClientCredentialsProvider($clientMock, $options);
+
+        $provider->fetchAccessToken(['scope' => $scope]);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndValidAccessTokenRequestAndInvalidResponse(array $options, string $scope)
+    {
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse(\json_encode([
+                    'access_token' => \uniqid(),
+                    'token_type' => 'bearer',
+                    'expires_in' => 3600,
+                ]), [
+                    'response_headers' => [
+                        'Cache-Control' => 'public;s-maxage=200',
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new ClientCredentialsProvider($clientMock, $options);
+
+        $accessToken = $provider->fetchAccessToken([
+            'scope' => $scope,
+            'test' => \uniqid(),
+        ]);
+
+        static::assertNotNull($accessToken->getTokenValue('access_token'));
+        static::assertNotNull($accessToken->getTokenValue('token_type'));
+        static::assertNotNull($accessToken->getTokenValue('expires_in'));
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndValidAccessTokenRequestAndValidResponse(array $options, string $scope)
+    {
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse(\json_encode([
+                    'access_token' => \uniqid(),
+                    'token_type' => 'bearer',
+                    'expires_in' => 3600,
+                ]), [
+                    'response_headers' => [
+                        'Cache-Control' => 'no-store',
+                        'Pragma' => 'no-cache',
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new ClientCredentialsProvider($clientMock, $options);
+
+        $accessToken = $provider->fetchAccessToken([
+            'scope' => $scope,
+            'test' => \uniqid(),
+        ]);
+
+        static::assertNotNull($accessToken->getTokenValue('access_token'));
+        static::assertNotNull($accessToken->getTokenValue('token_type'));
+        static::assertNotNull($accessToken->getTokenValue('expires_in'));
+    }
+
+    public function provideWrongOptions(): \Generator
+    {
+        yield 'Missing client_id option' => [
+            [
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https://bar.com',
+                'authorization_url' => 'https://bar.com/authenticate',
+                'access_token_url' => 'https://bar.com/',
+                'user_details_url' => 'https://bar.com/',
+            ],
+        ];
+    }
+
+    public function provideValidOptions(): \Generator
+    {
+        yield 'Valid options' => [
+            [
+                'client_id' => 'foo',
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https://bar.com',
+                'authorization_url' => 'https://bar.com/authenticate',
+                'access_token_url' => 'https://bar.com/',
+                'user_details_url' => 'https://bar.com/',
+            ],
+            'public',
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ImplicitProviderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ImplicitProviderTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidRequestException;
+use Symfony\Component\Security\OAuth2Client\Provider\ImplicitProvider;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ImplicitProviderTest extends TestCase
+{
+    /**
+     * @dataProvider provideWrongOptions
+     */
+    public function testWrongOptionsSent(array $options)
+    {
+        static::expectException(MissingOptionsException::class);
+
+        $clientMock = new MockHttpClient([]);
+
+        new ImplicitProvider($clientMock, $options);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testErrorOnAuthorizationTokenRequest(array $options, string $code, string $state)
+    {
+        static::expectException(\RuntimeException::class);
+        static::expectExceptionMessage(\sprintf(
+            'The %s doesn\'t support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.2',
+            ImplicitProvider::class
+        ));
+
+        $clientMock = new MockHttpClient([new MockResponse()]);
+
+        $provider = new ImplicitProvider($clientMock, $options);
+
+        $provider->fetchAuthorizationInformations(['scope' => 'test', 'state' => $state]);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndInvalidAccessTokenRequest(array $options, string $code, string $state)
+    {
+        static::expectException(InvalidRequestException::class);
+
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse('https://bar.com/authenticate?error=invalid_scope', [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 400,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new ImplicitProvider($clientMock, $options);
+
+        $provider->fetchAccessToken(['scope' => 'public', 'state' => $state]);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndValidAccessTokenRequest(array $options, string $code, string $state)
+    {
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse(\sprintf('https://bar.com/authenticate?access_token=%s&token_type=valid&state=%s', $code, $state), [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 200,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new ImplicitProvider($clientMock, $options);
+
+        $accessToken = $provider->fetchAccessToken(['scope' => 'public', 'state' => $state]);
+
+        static::assertNotNull($accessToken->getTokenValue('access_token'));
+        static::assertNotNull($accessToken->getTokenValue('token_type'));
+        static::assertNotNull($accessToken->getTokenValue('state'));
+    }
+
+    public function provideWrongOptions(): \Generator
+    {
+        yield 'Missing client_id option' => [
+            [
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https://bar.com',
+                'authorization_url' => 'https://bar.com/authenticate',
+                'access_token_url' => 'https://bar.com/',
+                'user_details_url' => 'https://bar.com/',
+            ],
+        ];
+    }
+
+    public function provideValidOptions(): \Generator
+    {
+        yield 'Valid options' => [
+            [
+                'client_id' => 'foo',
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https://bar.com',
+                'authorization_url' => 'https://bar.com/authenticate',
+                'access_token_url' => 'https://bar.com/',
+                'user_details_url' => 'https://bar.com/',
+            ],
+            '1234567nialbdodaizbazu7',
+            '1325267BDZYABA',
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ImplicitProviderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ImplicitProviderTest.php
@@ -41,7 +41,7 @@ final class ImplicitProviderTest extends TestCase
     public function testErrorOnAuthorizationTokenRequest(array $options, string $code, string $state)
     {
         static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage(\sprintf(
+        static::expectExceptionMessage(sprintf(
             'The %s doesn\'t support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.2',
             ImplicitProvider::class
         ));
@@ -83,7 +83,7 @@ final class ImplicitProviderTest extends TestCase
     {
         $clientMock = new MockHttpClient(
             [
-                new MockResponse(\sprintf('https://bar.com/authenticate?access_token=%s&token_type=valid&state=%s', $code, $state), [
+                new MockResponse(sprintf('https://bar.com/authenticate?access_token=%s&token_type=valid&state=%s', $code, $state), [
                     'response_headers' => [
                         'http_method' => 'GET',
                         'http_code' => 200,

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ResourceOwnerCredentialsProviderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ResourceOwnerCredentialsProviderTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\Security\OAuth2Client\Exception\InvalidRequestException;
+use Symfony\Component\Security\OAuth2Client\Provider\ResourceOwnerCredentialsProvider;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ResourceOwnerCredentialsProviderTest extends TestCase
+{
+    /**
+     * @dataProvider provideWrongOptions
+     */
+    public function testWrongOptionsSent(array $options)
+    {
+        static::expectException(MissingOptionsException::class);
+
+        $clientMock = new MockHttpClient([]);
+
+        new ResourceOwnerCredentialsProvider($clientMock, $options);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testErrorOnAuthorizationTokenRequest(array $options, string $code, array $credentials = [])
+    {
+        static::expectException(\RuntimeException::class);
+        static::expectExceptionMessage(\sprintf(
+            'The %s does not support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.3.1',
+            ResourceOwnerCredentialsProvider::class
+        ));
+
+        $clientMock = new MockHttpClient([new MockResponse()]);
+
+        $provider = new ResourceOwnerCredentialsProvider($clientMock, $options);
+
+        $provider->fetchAuthorizationInformations($credentials);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndInvalidAccessTokenRequest(array $options, string $code, array $credentials = [])
+    {
+        static::expectException(InvalidRequestException::class);
+
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse('https://bar.com/authenticate?error=invalid_scope', [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 400,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new ResourceOwnerCredentialsProvider($clientMock, $options);
+
+        $provider->fetchAccessToken($credentials);
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndValidAccessTokenRequest(array $options, string $code, array $credentials = [])
+    {
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse(\json_encode([
+                    'access_token' => $code,
+                    'token_type' => 'test',
+                    'expires_in' => 3600,
+                    'refresh_token' => \uniqid(),
+                ]), [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 200,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new ResourceOwnerCredentialsProvider($clientMock, $options);
+
+        $accessToken = $provider->fetchAccessToken($credentials);
+
+        static::assertNotNull($accessToken->getTokenValue('access_token'));
+        static::assertNotNull($accessToken->getTokenValue('token_type'));
+        static::assertNull($accessToken->getTokenValue('state'));
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testValidOptionsAndValidAccessTokenRequestAndRefreshTokenRequest(array $options, string $code, array $credentials = [])
+    {
+        $clientMock = new MockHttpClient(
+            [
+                new MockResponse(\json_encode([
+                    'access_token' => $code,
+                    'token_type' => 'test',
+                    'expires_in' => 3600,
+                    'refresh_token' => \uniqid(),
+                ]), [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 200,
+                    ],
+                ]),
+                new MockResponse(\json_encode([
+                    'access_token' => $code,
+                    'token_type' => 'test',
+                    'expires_in' => 1200,
+                ]), [
+                    'response_headers' => [
+                        'http_method' => 'GET',
+                        'http_code' => 200,
+                    ],
+                ]),
+            ]
+        );
+
+        $provider = new ResourceOwnerCredentialsProvider($clientMock, $options);
+
+        $accessToken = $provider->fetchAccessToken($credentials);
+
+        static::assertNotNull($accessToken->getTokenValue('access_token'));
+        static::assertNotNull($accessToken->getTokenValue('token_type'));
+        static::assertNull($accessToken->getTokenValue('state'));
+        static::assertSame(3600, $accessToken->getTokenValue('expires_in'));
+
+        $refreshedToken = $provider->refreshToken($accessToken->getTokenValue('refresh_token'), 'public');
+
+        static::assertNotNull($refreshedToken->getTokenValue('access_token'));
+        static::assertNull($refreshedToken->getTokenValue('refresh_token'));
+        static::assertSame(1200, $refreshedToken->getTokenValue('expires_in'));
+    }
+
+    public function provideWrongOptions(): \Generator
+    {
+        yield 'Missing client_id option' => [
+            [
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https://bar.com',
+                'authorization_url' => 'https://bar.com/authenticate',
+                'access_token_url' => 'https://bar.com/',
+                'user_details_url' => 'https://bar.com/',
+            ],
+        ];
+    }
+
+    public function provideValidOptions(): \Generator
+    {
+        yield 'Valid options' => [
+            [
+                'client_id' => 'foo',
+                'client_secret' => 'foo',
+                'redirect_uri' => 'https://bar.com',
+                'authorization_url' => 'https://bar.com/authenticate',
+                'access_token_url' => 'https://bar.com/',
+                'user_details_url' => 'https://bar.com/',
+            ],
+            '1234567nialbdodaizbazu7',
+            [
+                'username' => 'foo',
+                'password' => 'bar',
+                'scope' => 'public',
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ResourceOwnerCredentialsProviderTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Provider/ResourceOwnerCredentialsProviderTest.php
@@ -41,7 +41,7 @@ final class ResourceOwnerCredentialsProviderTest extends TestCase
     public function testErrorOnAuthorizationTokenRequest(array $options, string $code, array $credentials = [])
     {
         static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage(\sprintf(
+        static::expectExceptionMessage(sprintf(
             'The %s does not support the authorization process, please refer to https://tools.ietf.org/html/rfc6749#section-4.3.1',
             ResourceOwnerCredentialsProvider::class
         ));
@@ -83,11 +83,11 @@ final class ResourceOwnerCredentialsProviderTest extends TestCase
     {
         $clientMock = new MockHttpClient(
             [
-                new MockResponse(\json_encode([
+                new MockResponse(json_encode([
                     'access_token' => $code,
                     'token_type' => 'test',
                     'expires_in' => 3600,
-                    'refresh_token' => \uniqid(),
+                    'refresh_token' => uniqid(),
                 ]), [
                     'response_headers' => [
                         'http_method' => 'GET',
@@ -113,18 +113,18 @@ final class ResourceOwnerCredentialsProviderTest extends TestCase
     {
         $clientMock = new MockHttpClient(
             [
-                new MockResponse(\json_encode([
+                new MockResponse(json_encode([
                     'access_token' => $code,
                     'token_type' => 'test',
                     'expires_in' => 3600,
-                    'refresh_token' => \uniqid(),
+                    'refresh_token' => uniqid(),
                 ]), [
                     'response_headers' => [
                         'http_method' => 'GET',
                         'http_code' => 200,
                     ],
                 ]),
-                new MockResponse(\json_encode([
+                new MockResponse(json_encode([
                     'access_token' => $code,
                     'token_type' => 'test',
                     'expires_in' => 1200,

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Token/AuthorizationCodeGrantAccessTokenTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Token/AuthorizationCodeGrantAccessTokenTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Tests\Token;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\Security\OAuth2Client\Token\AuthorizationCodeGrantAccessToken;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationCodeGrantAccessTokenTest extends TestCase
+{
+    /**
+     * @dataProvider provideWrongKeys
+     */
+    public function testExtraKey(array $keys)
+    {
+        static::expectException(UndefinedOptionsException::class);
+
+        new AuthorizationCodeGrantAccessToken($keys);
+    }
+
+    /**
+     * @dataProvider provideInvalidKeys
+     */
+    public function testInvalidKeyType(array $keys)
+    {
+        static::expectException(InvalidOptionsException::class);
+
+        new AuthorizationCodeGrantAccessToken($keys);
+    }
+
+    /**
+     * @dataProvider provideValidKeys
+     */
+    public function testValidKeys(array $keys)
+    {
+        $token = new AuthorizationCodeGrantAccessToken($keys);
+
+        static::assertNotNull($token->getTokenValue('access_token'));
+    }
+
+    public function provideWrongKeys(): \Generator
+    {
+        yield 'Extra test key' => [
+            [
+                'access_token' => 'foo',
+                'token_type' => 'bar',
+                'test' => 'foo',
+            ],
+        ];
+    }
+
+    public function provideInvalidKeys(): \Generator
+    {
+        yield 'Invalid access_token type' => [
+            [
+                'access_token' => 123,
+                'token_type' => 'bar',
+                'expires_in' => 100,
+                'scope' => 'public',
+            ],
+        ];
+    }
+
+    public function provideValidKeys(): \Generator
+    {
+        yield 'Valid keys | All' => [
+            [
+                'access_token' => 'foo',
+                'token_type' => 'bar',
+                'refresh_token' => 'bar',
+                'expires_in' => 100,
+                'scope' => 'public',
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Tests/Token/ImplicitGrantTokenTest.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Tests/Token/ImplicitGrantTokenTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Tests\Token;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\Security\OAuth2Client\Token\ImplicitGrantToken;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ImplicitGrantTokenTest extends TestCase
+{
+    /**
+     * @dataProvider provideWrongKeys
+     */
+    public function testExtraKey(array $keys)
+    {
+        static::expectException(UndefinedOptionsException::class);
+
+        new ImplicitGrantToken($keys);
+    }
+
+    /**
+     * @dataProvider provideInvalidKeys
+     */
+    public function testInvalidKeyType(array $keys)
+    {
+        static::expectException(InvalidOptionsException::class);
+
+        new ImplicitGrantToken($keys);
+    }
+
+    /**
+     * @dataProvider provideValidKeys
+     */
+    public function testValidKeys(array $keys)
+    {
+        $token = new ImplicitGrantToken($keys);
+
+        static::assertNotNull($token->getTokenValue('access_token'));
+    }
+
+    public function provideWrongKeys(): \Generator
+    {
+        yield 'Extra test key' => [
+            [
+                'access_token' => 'foo',
+                'token_type' => 'bar',
+                'test' => 'foo',
+            ],
+        ];
+    }
+
+    public function provideInvalidKeys(): \Generator
+    {
+        yield 'Invalid access_token type' => [
+            [
+                'access_token' => 123,
+                'token_type' => 'bar',
+                'expires_in' => 100,
+                'scope' => 'public',
+                'state' => 'foo',
+            ],
+        ];
+    }
+
+    public function provideValidKeys(): \Generator
+    {
+        yield 'Valid keys | All' => [
+            [
+                'access_token' => 'foo',
+                'token_type' => 'bar',
+                'expires_in' => 100,
+                'scope' => 'public',
+                'state' => 'foo',
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Token/AbstractToken.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Token;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+abstract class AbstractToken
+{
+    private const DEFAULT_KEYS = [
+        'access_token' => 'string',
+        'token_type' => 'string',
+    ];
+
+    private $options = [];
+    private $additionalOptions = [];
+
+    public function __construct(array $keys, array $additionalOptions = [])
+    {
+        $this->additionalOptions = $additionalOptions;
+
+        $resolver = new OptionsResolver();
+        $this->validateAccessToken($resolver);
+
+        $this->options = $resolver->resolve($keys);
+    }
+
+    /**
+     * Define the required/optionals access_token keys:.
+     *
+     *  - access_token
+     *  - token_type
+     */
+    protected function validateAccessToken(OptionsResolver $resolver)
+    {
+        foreach (self::DEFAULT_KEYS as $key => $keyType) {
+            $resolver->setDefined($key);
+            $resolver->setAllowedTypes($key, $keyType);
+        }
+
+        if (0 < \count($this->additionalOptions)) {
+            foreach ($this->additionalOptions as $option => $value) {
+                $resolver->setDefined($option);
+                $resolver->setAllowedTypes($option, $value);
+            }
+        }
+    }
+
+    /**
+     * Return a single value (null if not defined).
+     */
+    public function getTokenValue($key, $default = null)
+    {
+        return \array_key_exists($key, $this->options) ? $this->options[$key] : $default;
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Token/AuthorizationCodeGrantAccessToken.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Token/AuthorizationCodeGrantAccessToken.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Token;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationCodeGrantAccessToken extends AbstractToken
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $keys)
+    {
+        parent::__construct($keys, [
+            'expires_in' => ['int', 'null'],
+            'refresh_token' => ['string', 'null'],
+            'scope' => ['string', 'null'],
+        ]);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Token/ClientGrantToken.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Token/ClientGrantToken.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Token;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ClientGrantToken extends AbstractToken
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $keys)
+    {
+        parent::__construct($keys, [
+            'expires_in' => ['int', 'null'],
+        ]);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Token/ImplicitGrantToken.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Token/ImplicitGrantToken.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Token;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ImplicitGrantToken extends AbstractToken
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $keys)
+    {
+        parent::__construct($keys, [
+            'expires_in' => ['int', 'null'],
+            'scope' => ['string', 'null'],
+            'state' => ['string', 'null'],
+        ]);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Token/IntrospectedToken.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Token/IntrospectedToken.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Token;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class IntrospectedToken extends AbstractToken
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $keys)
+    {
+        parent::__construct($keys, [
+            'active' => ['bool'],
+            'scope' => ['string', 'null'],
+            'client_id' => ['string', 'null'],
+            'username' => ['string', 'null'],
+            'token_type' => ['string', 'null'],
+            'exp' => ['int', 'null'],
+            'iat' => ['int', 'null'],
+            'nbf' => ['int', 'null'],
+            'sub' => ['string', 'null'],
+            'aud' => ['string', 'null'],
+            'iss' => ['string', 'null'],
+            'jti' => ['string', 'null'],
+        ]);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Token/RefreshToken.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Token/RefreshToken.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Token;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class RefreshToken extends AbstractToken
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $keys)
+    {
+        parent::__construct($keys, [
+            'refresh_token' => ['string', 'null'],
+            'expires_in' => ['int', 'null'],
+            'scope' => ['string', 'null'],
+        ]);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/Token/ResourceOwnerCredentialsGrantToken.php
+++ b/src/Symfony/Component/Security/OAuth2Client/Token/ResourceOwnerCredentialsGrantToken.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth2Client\Token;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ResourceOwnerCredentialsGrantToken extends AbstractToken
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $keys)
+    {
+        parent::__construct($keys, [
+            'expires_in' => ['int', 'null'],
+            'refresh_token' => ['string', 'null'],
+        ]);
+    }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/composer.json
+++ b/src/Symfony/Component/Security/OAuth2Client/composer.json
@@ -1,0 +1,38 @@
+{
+  "name": "symfony/security-oauth2-client",
+  "type": "library",
+  "description": "Symfony Security Component - OAuth2Client",
+  "keywords": [],
+  "homepage": "https://symfony.com",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Guillaume Loulier",
+      "email": "contact@guillaumeloulier.fr"
+    },
+    {
+      "name": "Symfony Community",
+      "homepage": "https://symfony.com/contributors"
+    }
+  ],
+  "require": {
+    "php": "^7.1.3",
+    "ext-json": "*",
+    "psr/log": "^1.0",
+    "symfony/contracts": "~1.1.2",
+    "symfony/http-client": "~4.3",
+    "symfony/options-resolver": "~4.3"
+  },
+  "autoload": {
+    "psr-4": { "Symfony\\Component\\Security\\OAuth2Client\\": "" },
+    "exclude-from-classmap": [
+      "/Tests/"
+    ]
+  },
+  "minimum-stability": "dev",
+  "extra": {
+    "branch-alias": {
+      "dev-master": "4.4-dev"
+    }
+  }
+}

--- a/src/Symfony/Component/Security/OAuth2Client/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/OAuth2Client/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Security Component - OAuth2Client Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Security/OAuthServer/.gitignore
+++ b/src/Symfony/Component/Security/OAuthServer/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Security/OAuthServer/AuthorizationServer.php
+++ b/src/Symfony/Component/Security/OAuthServer/AuthorizationServer.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\OAuthServer\Event\EndAuthorizationRequestHandlingEvent;
+use Symfony\Component\Security\OAuthServer\Event\StartAuthorizationRequestHandlingEvent;
+use Symfony\Component\Security\OAuth\Exception\InvalidRequestException;
+use Symfony\Component\Security\OAuthServer\Exception\MissingGrantTypeException;
+use Symfony\Component\Security\OAuthServer\Exception\UnhandledRequestException;
+use Symfony\Component\Security\OAuthServer\GrantTypes\GrantTypeInterface;
+use Symfony\Component\Security\OAuthServer\Request\AuthorizationRequest;
+use Symfony\Component\Security\OAuthServer\Response\AbstractResponse;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationServer implements AuthorizationServerInterface
+{
+    /**
+     * @var GrantTypeInterface[]
+     */
+    private $grantTypes = [];
+    private $logger;
+    private $eventDispatcher;
+
+    public function __construct(array $grantTypes = [], EventDispatcherInterface $eventDispatcher = null, LoggerInterface $logger = null)
+    {
+        $this->grantTypes = $grantTypes;
+        $this->logger = $logger;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Handle a request.
+     *
+     * @param object|null $request
+     *
+     * @return AbstractResponse
+     */
+    public function handle($request = null)
+    {
+        if (0 === \count($this->grantTypes)) {
+            throw new MissingGrantTypeException('At least one grant type should be passed!');
+        }
+
+        $authorizationRequest = AuthorizationRequest::create($request);
+
+        if ($this->eventDispatcher) {
+            $this->eventDispatcher->dispatch(new StartAuthorizationRequestHandlingEvent($authorizationRequest));
+        }
+
+        $response = null;
+
+        if (null !== $request->getValue('response_type')) {
+            $response = $this->handleAuthorizationRequest($request);
+        }
+
+        if (null !== $request->getValue('grant_type')) {
+            $response = $this->handleAccessTokenRequest($request);
+        }
+
+        if (null === $response) {
+            throw new UnhandledRequestException('');
+        }
+
+        if ($this->eventDispatcher) {
+            $this->eventDispatcher->dispatch(new EndAuthorizationRequestHandlingEvent($request, $response));
+        }
+
+        return $response;
+    }
+
+    private function handleAuthorizationRequest($request = null)
+    {
+        foreach ($this->grantTypes as $grantType) {
+            if (!$grantType->canHandleAuthorizationRequest($request)) {
+                continue;
+            }
+
+            $grantType->handleAuthorizationRequest($request);
+        }
+
+        throw new InvalidRequestException('');
+    }
+
+    private function handleAccessTokenRequest($request = null)
+    {
+        foreach ($this->grantTypes as $grantType) {
+            if (!$grantType->canHandleAccessTokenRequest($request)) {
+                continue;
+            }
+
+            $grantType->handleAccessTokenRequest($request);
+        }
+
+        throw new InvalidRequestException('');
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/AuthorizationServerInterface.php
+++ b/src/Symfony/Component/Security/OAuthServer/AuthorizationServerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+interface AuthorizationServerInterface
+{
+}

--- a/src/Symfony/Component/Security/OAuthServer/Bridge/Psr7Trait.php
+++ b/src/Symfony/Component/Security/OAuthServer/Bridge/Psr7Trait.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Bridge;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+trait Psr7Trait
+{
+    /**
+     * Create an internal request using Psr7 ServerRequestInterface.
+     *
+     * @param ServerRequestInterface $request
+     */
+    protected function createFromPsr7Request(ServerRequestInterface $request): void
+    {
+        $this->options['type'] = 'psr-7';
+        $this->options['GET'] = $request->getQueryParams();
+        $this->options['POST'] = $request->getParsedBody();
+        $this->options['SERVER'] = $request->getServerParams();
+    }
+
+    protected function createPsr7Response(): ResponseInterface
+    {
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/Event/EndAuthorizationRequestHandlingEvent.php
+++ b/src/Symfony/Component/Security/OAuthServer/Event/EndAuthorizationRequestHandlingEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Event;
+
+use Symfony\Component\Security\OAuthServer\Request\AuthorizationRequest;
+use Symfony\Component\Security\OAuthServer\Response\AuthorizationResponse;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * This event allows the user to modify the AuthorizationResponse before returning it,
+ * by default, the AuthorizationRequest is returned as "read-only" as it should not be modified.
+ *
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class EndAuthorizationRequestHandlingEvent extends Event
+{
+    private $authorizationRequest;
+    private $authorizationResponse;
+
+    public function __construct(AuthorizationRequest $request, AuthorizationResponse $authorizationResponse)
+    {
+        $this->authorizationRequest = $request;
+        $this->authorizationResponse = $authorizationResponse;
+    }
+
+    public function getAuthorizationRequest(): array
+    {
+        return $this->authorizationRequest->returnAsReadOnly();
+    }
+
+    public function getAuthorizationResponse(): AuthorizationResponse
+    {
+        return $this->authorizationResponse;
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/Event/StartAuthorizationRequestHandlingEvent.php
+++ b/src/Symfony/Component/Security/OAuthServer/Event/StartAuthorizationRequestHandlingEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Event;
+
+use Symfony\Component\Security\OAuthServer\Request\AuthorizationRequest;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class StartAuthorizationRequestHandlingEvent extends Event
+{
+    private $authorizationRequest;
+
+    public function __construct(AuthorizationRequest $authorizationRequest)
+    {
+        $this->authorizationRequest = $authorizationRequest;
+    }
+
+    public function getAuthorizationRequest(): AuthorizationRequest
+    {
+        return $this->authorizationRequest;
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/Exception/InvalidRequestTypeException.php
+++ b/src/Symfony/Component/Security/OAuthServer/Exception/InvalidRequestTypeException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Exception;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class InvalidRequestTypeException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/Security/OAuthServer/Exception/MissingGrantTypeException.php
+++ b/src/Symfony/Component/Security/OAuthServer/Exception/MissingGrantTypeException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Exception;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class MissingGrantTypeException extends \LogicException
+{
+}

--- a/src/Symfony/Component/Security/OAuthServer/Exception/UnhandledRequestException.php
+++ b/src/Symfony/Component/Security/OAuthServer/Exception/UnhandledRequestException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Exception;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class UnhandledRequestException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/Security/OAuthServer/GrantTypes/AbstractGrantType.php
+++ b/src/Symfony/Component/Security/OAuthServer/GrantTypes/AbstractGrantType.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\GrantTypes;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+abstract class AbstractGrantType implements GrantTypeInterface
+{
+}

--- a/src/Symfony/Component/Security/OAuthServer/GrantTypes/AuthorizationCodeGrantType.php
+++ b/src/Symfony/Component/Security/OAuthServer/GrantTypes/AuthorizationCodeGrantType.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\GrantTypes;
+
+use Symfony\Component\Security\OAuthServer\Request\AbstractRequest;
+use Symfony\Component\Security\OAuthServer\Request\AuthorizationRequest;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationCodeGrantType extends AbstractGrantType
+{
+    protected const RESPONSE_TYPE = 'code';
+    private const ACCESS_TOKEN_REQUEST_TYPE = 'authorization_code';
+
+    private $responsePayload = [];
+
+    public function canHandleRequest(AuthorizationRequest $authorizationRequest): bool
+    {
+        return self::RESPONSE_TYPE === $authorizationRequest->getType($authorizationRequest);
+    }
+
+    public function canHandleAccessTokenRequest(AbstractRequest $request): bool
+    {
+        return self::ACCESS_TOKEN_REQUEST_TYPE === $request->getValue('grant_type');
+    }
+
+    public function handle(AuthorizationRequest $request)
+    {
+        return $this->returnResponsePayload();
+    }
+
+    public function handleAuthorizationRequest(AuthorizationRequest $request)
+    {
+        // TODO: Implement handleAuthorizationRequest() method.
+    }
+
+    public function handleAccessTokenRequest(AuthorizationRequest $request)
+    {
+        // TODO: Implement handleAccessTokenRequest() method.
+    }
+
+    public function handleRefreshTokenRequest(AuthorizationRequest $request)
+    {
+        // TODO: Implement handleRefreshTokenRequest() method.
+    }
+
+    public function returnResponsePayload(): array
+    {
+        return $this->responsePayload;
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/GrantTypes/GrantTypeInterface.php
+++ b/src/Symfony/Component/Security/OAuthServer/GrantTypes/GrantTypeInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\GrantTypes;
+
+use Symfony\Component\Security\OAuthServer\Request\AbstractRequest;
+use Symfony\Component\Security\OAuthServer\Request\AuthorizationRequest;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+interface GrantTypeInterface
+{
+    /**
+     * Allow to define if a request can be handled by the GrantType.
+     *
+     * The way that the handling is determined is up to the user.
+     *
+     * @param AuthorizationRequest $authorizationRequest the internal authorization request
+     *
+     * @return bool if the request can be handled
+     */
+    public function canHandleRequest(AuthorizationRequest $authorizationRequest): bool;
+
+    public function canHandleAccessTokenRequest(AbstractRequest $request): bool;
+
+    public function handleAuthorizationRequest(AuthorizationRequest $request);
+
+    public function handleAccessTokenRequest(AuthorizationRequest $request);
+
+    public function handleRefreshTokenRequest(AuthorizationRequest $request);
+
+    public function returnResponsePayload(): array;
+}

--- a/src/Symfony/Component/Security/OAuthServer/LICENCE
+++ b/src/Symfony/Component/Security/OAuthServer/LICENCE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2019 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Security/OAuthServer/README.md
+++ b/src/Symfony/Component/Security/OAuthServer/README.md
@@ -1,0 +1,13 @@
+Security Component - OAuthServer
+================================
+
+With the OAuthServer component ...
+
+Resources
+---------
+
+  * [Documentation](https://symfony.com/doc/current/components/security.html)
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Security/OAuthServer/Request/AbstractRequest.php
+++ b/src/Symfony/Component/Security/OAuthServer/Request/AbstractRequest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Request;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\OAuthServer\Bridge\Psr7Trait;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+abstract class AbstractRequest
+{
+    use Psr7Trait;
+
+    protected $options = [];
+
+    /**
+     * @param object|null $request
+     */
+    private function __construct($request = null)
+    {
+        if (null === $request) {
+            self::createFromGlobals();
+        }
+
+        if ($request instanceof Request) {
+            self::createFromRequest($request);
+        }
+
+        if ($request instanceof ServerRequestInterface) {
+            self::createFromPsr7Request($request);
+        }
+    }
+
+    public static function create($request = null): self
+    {
+        return new static($request);
+    }
+
+    private function createFromRequest(Request $request)
+    {
+        $this->options['type'] = 'http_foundation';
+        $this->options['GET'] = $request->query->all();
+        $this->options['POST'] = $request->request->all();
+        $this->options['SERVER'] = $request->server->all();
+    }
+
+    private function createFromGlobals()
+    {
+        $this->options['type'] = 'globals';
+        $this->options['GET'] = $_GET;
+        $this->options['POST'] = $_POST;
+        $this->options['SERVER'] = $_SERVER;
+    }
+
+    public function getValue($key, $default = null)
+    {
+        if (\array_key_exists($key, $this->options)) {
+            return $this->options[$key];
+        }
+
+        if (\array_key_exists($key, $this->options['GET'])) {
+            return $this->options['GET'][$key];
+        }
+
+        if (\array_key_exists($key, $this->options['POST'])) {
+            return $this->options['POST'][$key];
+        }
+
+        if (\array_key_exists($key, $this->options['SERVER'])) {
+            return $this->options['SERVER'][$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * Return an array which contains the request main informations,
+     * this method is mainly used during the last request event in order to compare
+     * both request & response.
+     *
+     * @return array
+     */
+    abstract public function returnAsReadOnly(): array;
+}

--- a/src/Symfony/Component/Security/OAuthServer/Request/AccessTokenRequest.php
+++ b/src/Symfony/Component/Security/OAuthServer/Request/AccessTokenRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Request;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AccessTokenRequest extends AbstractRequest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function returnAsReadOnly(): array
+    {
+        $request = [];
+
+        if ('authorization_code' === $this->getValue('grant_type')) {
+            $request = [
+                'grant_type' => $this->getValue('grant_type'),
+                'code' => $this->getValue('code'),
+                'redirect_uri' => $this->getValue('redirect_uri'),
+                'client_id' => $this->getValue('client_id'),
+            ];
+        }
+
+        if ('password' === $this->getValue('grant_type')) {
+            $request = [
+                'grant_type' => $this->getValue('grant_type'),
+                'username' => $this->getValue('username'),
+                'password' => $this->getValue('password'),
+                'scope' => $this->getValue('scope'),
+            ];
+        }
+
+        if ('client_credentials' === $this->getValue('grant_type')) {
+            $request = [
+                'grant_type' => $this->getValue('grant_type'),
+                'scope' => $this->getValue('scope'),
+            ];
+        }
+
+        return $request;
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/Request/AuthorizationRequest.php
+++ b/src/Symfony/Component/Security/OAuthServer/Request/AuthorizationRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Request;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationRequest extends AbstractRequest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function returnAsReadOnly(): array
+    {
+        return [
+            'client_id' => $this->getValue('client_id'),
+            'response_type' => $this->getValue('response_type'),
+            'redirect_uri' => $this->getValue('redirect_uri'),
+            'scope' => $this->getValue('scope'),
+            'state' => $this->getValue('state'),
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/Response/AbstractResponse.php
+++ b/src/Symfony/Component/Security/OAuthServer/Response/AbstractResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Response;
+
+use Symfony\Component\Security\OAuthServer\Bridge\Psr7Trait;
+use Symfony\Component\Security\OAuthServer\Request\AbstractRequest;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+abstract class AbstractResponse
+{
+    use Psr7Trait;
+
+    protected $options = [];
+
+    public static function createFromRequest(AbstractRequest $request)
+    {
+    }
+
+    public function getValue($key, $default = null)
+    {
+        return \array_key_exists($key, $this->options) ? $this->options[$key] : $default;
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/Response/AccessTokenResponse.php
+++ b/src/Symfony/Component/Security/OAuthServer/Response/AccessTokenResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Response;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AccessTokenResponse extends AbstractResponse
+{
+}

--- a/src/Symfony/Component/Security/OAuthServer/Response/AuthorizationResponse.php
+++ b/src/Symfony/Component/Security/OAuthServer/Response/AuthorizationResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Response;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationResponse extends AbstractResponse
+{
+}

--- a/src/Symfony/Component/Security/OAuthServer/Response/ErrorResponse.php
+++ b/src/Symfony/Component/Security/OAuthServer/Response/ErrorResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Response;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ErrorResponse extends AbstractResponse
+{
+}

--- a/src/Symfony/Component/Security/OAuthServer/Tests/AuthorizationServerTest.php
+++ b/src/Symfony/Component/Security/OAuthServer/Tests/AuthorizationServerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuth\Tests\Server;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\OAuthServer\Exception\MissingGrantTypeException;
+use Symfony\Component\Security\OAuthServer\AuthorizationServer;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationServerTest extends TestCase
+{
+    /**
+     * @dataProvider provideWrongGrantTypes
+     */
+    public function testWrongGrantType(array $grantTypes)
+    {
+        static::expectException(MissingGrantTypeException::class);
+
+        $requestMock = Request::create('/oauth', 'GET');
+
+        (new AuthorizationServer($grantTypes))->handle($requestMock);
+    }
+
+    public function provideWrongGrantTypes(): \Generator
+    {
+        yield 'Empty grant types' => [
+            []
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/Tests/Request/AccessTokenRequestTest.php
+++ b/src/Symfony/Component/Security/OAuthServer/Tests/Request/AccessTokenRequestTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Tests\Request;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\OAuthServer\Request\AccessTokenRequest;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AccessTokenRequestTest extends TestCase
+{
+    public function testAuthorizationCodeAccessTokenRequestFromGlobals()
+    {
+        $_GET['grant_type'] = 'authorization_code';
+        $_GET['code'] = \uniqid();
+        $_GET['redirect_uri'] = 'https://foo.com/oauth';
+        $_GET['client_id'] = \uniqid();
+
+        $request = AccessTokenRequest::create();
+
+        static::assertSame('globals', $request->getValue('type'));
+        static::assertNull($request->getValue('username'));
+        static::assertNull($request->getValue('password'));
+        static::assertNull($request->getValue('scope'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('code'));
+        static::assertNotNull($request->getValue('redirect_uri'));
+        static::assertNotNull($request->getValue('client_id'));
+        static::assertArrayNotHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('scope', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayHasKey('client_id', $request->returnAsReadOnly());
+
+        unset($_GET['grant_type']);
+        unset($_GET['code']);
+        unset($_GET['redirect_uri']);
+        unset($_GET['client_id']);
+    }
+
+    public function testAuthorizationCodeAccessTokenRequestFromHttpFoundation()
+    {
+        $requestMock = Request::create('/oauth', 'GET', [
+            'grant_type' => 'authorization_code',
+            'code' => \uniqid(),
+            'redirect_uri' => 'https://foo.com/oauth',
+            'client_id' => \uniqid(),
+        ]);
+
+        $request = AccessTokenRequest::create($requestMock);
+
+        static::assertSame('http_foundation', $request->getValue('type'));
+        static::assertNull($request->getValue('username'));
+        static::assertNull($request->getValue('password'));
+        static::assertNull($request->getValue('scope'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('code'));
+        static::assertNotNull($request->getValue('redirect_uri'));
+        static::assertNotNull($request->getValue('client_id'));
+        static::assertArrayNotHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('scope', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayHasKey('client_id', $request->returnAsReadOnly());
+    }
+
+    public function testAuthorizationCodeAccessTokenRequestFromPsr7Request()
+    {
+        $requestMock = $this->createMock(ServerRequestInterface::class);
+        $requestMock->method('getQueryParams')->willReturn([
+            'grant_type' => 'authorization_code',
+            'code' => \uniqid(),
+            'redirect_uri' => 'https://foo.com/oauth',
+            'client_id' => \uniqid(),
+        ]);
+        $requestMock->method('getParsedBody')->willReturn([]);
+        $requestMock->method('getServerParams')->willReturn([]);
+
+        $request = AccessTokenRequest::create($requestMock);
+
+        static::assertSame('psr-7', $request->getValue('type'));
+        static::assertNull($request->getValue('username'));
+        static::assertNull($request->getValue('password'));
+        static::assertNull($request->getValue('scope'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('code'));
+        static::assertNotNull($request->getValue('redirect_uri'));
+        static::assertNotNull($request->getValue('client_id'));
+        static::assertArrayNotHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('scope', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayHasKey('client_id', $request->returnAsReadOnly());
+    }
+
+    public function testResourceOwnerCredentialsAccessTokenRequestFromGlobals()
+    {
+        $_GET['grant_type'] = 'password';
+        $_GET['username'] = 'foo';
+        $_GET['password'] = 'bar';
+        $_GET['scope'] = 'public';
+
+        $request = AccessTokenRequest::create();
+
+        static::assertSame('globals', $request->getValue('type'));
+        static::assertNull($request->getValue('code'));
+        static::assertNull($request->getValue('redirect_uri'));
+        static::assertNull($request->getValue('client_id'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('username'));
+        static::assertNotNull($request->getValue('password'));
+        static::assertNotNull($request->getValue('scope'));
+        static::assertArrayNotHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayHasKey('scope', $request->returnAsReadOnly());
+
+        unset($_GET['grant_type']);
+        unset($_GET['username']);
+        unset($_GET['password']);
+        unset($_GET['scope']);
+    }
+
+    public function testResourceOwnerCredentialsAccessTokenRequestFromHttpFoundation()
+    {
+        $requestMock = Request::create('/oauth', 'GET', [
+            'grant_type' => 'password',
+            'username' => 'foo',
+            'password' => 'bar',
+            'scope' => 'public',
+        ]);
+
+        $request = AccessTokenRequest::create($requestMock);
+
+        static::assertSame('http_foundation', $request->getValue('type'));
+        static::assertNull($request->getValue('code'));
+        static::assertNull($request->getValue('redirect_uri'));
+        static::assertNull($request->getValue('client_id'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('username'));
+        static::assertNotNull($request->getValue('password'));
+        static::assertNotNull($request->getValue('scope'));
+        static::assertArrayNotHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayHasKey('scope', $request->returnAsReadOnly());
+    }
+
+    public function testResourceOwnerCredentialsAccessTokenRequestFromPsr7Request()
+    {
+        $requestMock = $this->createMock(ServerRequestInterface::class);
+        $requestMock->method('getQueryParams')->willReturn([
+            'grant_type' => 'password',
+            'username' => 'foo',
+            'password' => 'bar',
+            'scope' => 'public',
+        ]);
+        $requestMock->method('getParsedBody')->willReturn([]);
+        $requestMock->method('getServerParams')->willReturn([]);
+
+        $request = AccessTokenRequest::create($requestMock);
+
+        static::assertSame('psr-7', $request->getValue('type'));
+        static::assertNull($request->getValue('code'));
+        static::assertNull($request->getValue('redirect_uri'));
+        static::assertNull($request->getValue('client_id'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('username'));
+        static::assertNotNull($request->getValue('password'));
+        static::assertNotNull($request->getValue('scope'));
+        static::assertArrayNotHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayHasKey('scope', $request->returnAsReadOnly());
+    }
+
+    public function testClientCredentialsAccessTokenRequestFromGlobals()
+    {
+        $_GET['grant_type'] = 'client_credentials';
+        $_GET['scope'] = 'public';
+
+        $request = AccessTokenRequest::create();
+
+        static::assertSame('globals', $request->getValue('type'));
+        static::assertNull($request->getValue('code'));
+        static::assertNull($request->getValue('redirect_uri'));
+        static::assertNull($request->getValue('client_id'));
+        static::assertNull($request->getValue('username'));
+        static::assertNull($request->getValue('password'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('scope'));
+        static::assertArrayNotHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('scope', $request->returnAsReadOnly());
+
+        unset($_GET['grant_type']);
+        unset($_GET['scope']);
+    }
+
+    public function testClientCredentialsAccessTokenRequestFromHttpFoundation()
+    {
+        $requestMock = Request::create('/oauth', 'GET', [
+            'grant_type' => 'client_credentials',
+            'scope' => 'public',
+        ]);
+
+        $request = AccessTokenRequest::create($requestMock);
+
+        static::assertSame('http_foundation', $request->getValue('type'));
+        static::assertNull($request->getValue('code'));
+        static::assertNull($request->getValue('redirect_uri'));
+        static::assertNull($request->getValue('client_id'));
+        static::assertNull($request->getValue('username'));
+        static::assertNull($request->getValue('password'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('scope'));
+        static::assertArrayNotHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('scope', $request->returnAsReadOnly());
+    }
+
+    public function testClientCredentialsAccessTokenRequestFromPsr7Request()
+    {
+        $requestMock = $this->createMock(ServerRequestInterface::class);
+        $requestMock->method('getQueryParams')->willReturn([
+            'grant_type' => 'client_credentials',
+            'scope' => 'public',
+        ]);
+        $requestMock->method('getParsedBody')->willReturn([]);
+        $requestMock->method('getServerParams')->willReturn([]);
+
+        $request = AccessTokenRequest::create($requestMock);
+
+        static::assertSame('psr-7', $request->getValue('type'));
+        static::assertNull($request->getValue('code'));
+        static::assertNull($request->getValue('redirect_uri'));
+        static::assertNull($request->getValue('client_id'));
+        static::assertNull($request->getValue('username'));
+        static::assertNull($request->getValue('password'));
+        static::assertNotNull($request->getValue('grant_type'));
+        static::assertNotNull($request->getValue('scope'));
+        static::assertArrayNotHasKey('code', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('redirect_uri', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('username', $request->returnAsReadOnly());
+        static::assertArrayNotHasKey('password', $request->returnAsReadOnly());
+        static::assertArrayHasKey('grant_type', $request->returnAsReadOnly());
+        static::assertArrayHasKey('scope', $request->returnAsReadOnly());
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/Tests/Request/AuthorizationRequestTest.php
+++ b/src/Symfony/Component/Security/OAuthServer/Tests/Request/AuthorizationRequestTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\OAuthServer\Tests\Request;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\OAuthServer\Request\AuthorizationRequest;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class AuthorizationRequestTest extends TestCase
+{
+    public function testCreationFromGlobals()
+    {
+        $_GET['client_id'] = \uniqid();
+        $_GET['response_type'] = 'code';
+
+        $request = AuthorizationRequest::create();
+
+        static::assertNull($request->getValue('code'));
+        static::assertNotNull($request->getValue('client_id'));
+        static::assertNotNull($request->getValue('response_type'));
+        static::assertArrayHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayHasKey('response_type', $request->returnAsReadOnly());
+
+        unset($_GET['client_id']);
+        unset($_GET['response_type']);
+    }
+
+    public function testCreationFromHttpFoundationRequest()
+    {
+        $requestMock = Request::create('/oauth', 'GET', [
+            'response_type' => 'code',
+            'client_id' => \uniqid()
+        ]);
+
+        $request = AuthorizationRequest::create($requestMock);
+
+        static::assertNull($request->getValue('code'));
+        static::assertNotNull($request->getValue('client_id'));
+        static::assertNotNull($request->getValue('response_type'));
+        static::assertArrayHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayHasKey('response_type', $request->returnAsReadOnly());
+    }
+
+    public function testCreationFromPsr7Request()
+    {
+        $requestMock = $this->createMock(ServerRequestInterface::class);
+        $requestMock->method('getQueryParams')->willReturn([
+            'response_type' => 'code',
+            'client_id' => \uniqid()
+        ]);
+        $requestMock->method('getParsedBody')->willReturn([]);
+        $requestMock->method('getServerParams')->willReturn([]);
+
+        $request = AuthorizationRequest::create($requestMock);
+
+        static::assertNull($request->getValue('code'));
+        static::assertNotNull($request->getValue('client_id'));
+        static::assertNotNull($request->getValue('response_type'));
+        static::assertArrayHasKey('client_id', $request->returnAsReadOnly());
+        static::assertArrayHasKey('response_type', $request->returnAsReadOnly());
+    }
+}

--- a/src/Symfony/Component/Security/OAuthServer/composer.json
+++ b/src/Symfony/Component/Security/OAuthServer/composer.json
@@ -1,0 +1,42 @@
+{
+  "name": "symfony/security-oauth-server",
+  "type": "library",
+  "description": "Symfony Security Component - OAuthServer",
+  "keywords": [],
+  "homepage": "https://symfony.com",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Guillaume Loulier",
+      "email": "contact@guillaumeloulier.fr"
+    },
+    {
+      "name": "Symfony Community",
+      "homepage": "https://symfony.com/contributors"
+    }
+  ],
+  "require": {
+    "php": "^7.1.3",
+    "defuse/php-encryption": "~2.2.1",
+    "ext-json": "*",
+    "psr/log": "^1.0",
+    "symfony/contracts": "~1.1.2",
+    "symfony/options-resolver": "~4.3",
+    "symfony/http-foundation": "~4.3"
+  },
+  "require-dev": {
+    "psr/http-message": "~1.0"
+  },
+  "autoload": {
+    "psr-4": { "Symfony\\Component\\Security\\OAuthServer\\": "" },
+    "exclude-from-classmap": [
+      "/Tests/"
+    ]
+  },
+  "minimum-stability": "dev",
+  "extra": {
+    "branch-alias": {
+      "dev-master": "4.4-dev"
+    }
+  }
+}

--- a/src/Symfony/Component/Security/OAuthServer/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/OAuthServer/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Security Component - OAuthServer Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes    
| Fixed tickets | #...   
| License       | MIT
| Doc PR        | To add

Hi everyone 👋 

Here's my first "big" PR on Symfony, recently, I've decided to implement OAuth authentication in a side-project application, in order to do it, I've used `HttpClient` (thanks to Nicolas Grekas) and I've been amazed by the simplicity of the implementation but something was weird ... Why Symfony doesn't have a "native" OAuth support/Client/Server/Component? 
Then I saw that the hackaton highlighted the idea of having a native support: https://github.com/symfony/symfony/issues/30914

So, I've decided to take time to work on a strict implementation (well, as strict as I could do) thanks to the RFC and `HttpClient` and here's the first result, a new "OAuth component" (actually, that's an experimentation 😄), for now, this experimentation only support the "client" aspect (the server has been started) and that I'm aware that a lot of feature can be lacking or to update. 

So, why opening this PR now ? 

First, I'm aware that this is a WIP and that a lot of feedback can be linked to some choices that I've made, please, do not hesitate to explain me if there's a better option/way to do it.

Second, I think that it's a good idea to discuss about this idea and explain why it's not a good idea/option to do it as a component (or even as a feature?) before going further on the development 🙂 

So here's the PR with the first parts of the components, feel free to comments and have a great day 🙂 

**_This PR replace the following: https://github.com/symfony/symfony/pull/31937_**

**EDIT 13/06/2019:**

Here's the actual documentation of this "component": 

A set of class which allows to use OAuth thanks to `HttpClient` and `OptionsResolver`.

## Usage

Using `symfony/security-oauth-client` outside of the framework is pretty straight forward.

Let's assume that we need to use the Github OAuth API.

First, let's instantiate the provider:

```php
<?php

require __DIR__ . 'vendor/autoload.php';

use Symfony\Components\HttpClient\HttpClient;
use Symfony\Components\OAuth\Provider\AuthorizationCodeProvider;

$client = HttpClient::create();

// The provider requires the main configuration keys
$provider = new AuthorizationCodeProvider($client, [
    'client_id' => 'foo',
    'client_secret' => 'bar',
    'redirect_uri' => 'http://foo.com/',
    'authorization_url' => 'https://github.com/login/oauth/authorize',
    'accessToken_url' => 'https://github.com/login/oauth/access_token',
    'userDetails_url' => 'https://api.github.com/user',
]);

// In the case that a provider cannot fetch an authorization code, a \RuntimeException is thrown
$authenticationCode = $provider->fetchAuthorizationCode([
    'scope' => 'public', 
    'state' => 'randomstring',
]);

// if you need it, you can use the `AuthorizationCodeResponse::get*` methods to access both code and state
// Once the authentication code is fetched, time to receive the access_token

$accessToken = $provider->fetchAccessToken(['code' => $authenticationCode->getCode()]); 

// Now, we can use use the received `AuthorizationCodeGrantAccessToken` object value to fetch the user details
// The $clientProfileLoader is prepared by the GenericProvider
$clientProfileLoader = $provider->prepareClientProfileLoader();

// The $userDate is a `ClientProfile` object
$userData = $clientProfileLoader->fetchClientProfile($accessToken->getTokenValue('access_token'));

echo $userData->get('login'); // Display Bob Foo
```

## Informations

- The constructor arguments order of `GenericProvider` can probably be improved.
- The `AuthorizationCodeGrantAccessToken::getOptionValue()` is similar to `ParameterBag::get()`.
- The `AuthorizationCodeResponse` isn't critical as it's a simple "DTO", we can
  easily return an array.
- For now, the `Symfony\Components\OAuth\Provider\GenericProvider` doesn't allow
  to fetch the user details directly (as it's not part of the RFC), 
  the final request is up to the user.
- If an error occurs, no message are returned for now, it could be a good idea
  to return the `error` key returned by the API.
- No implementation is available on the full-stack framework for now.
- The `Symfony\Component\OAuth\Provider\ProviderInterface` can benefit of 
  having the `fetchAuthorizationCode` and `fetchAccessToken` methods if a 
  contract is created.
- The `\RuntimeException` which is thrown during the `$provider->fetchAuthenticationCode` call (if the provider can't use it)
  can be moved to a `trigger_error`. 

## Supported providers

For now, the component deliver the main providers described in the RFC: https://tools.ietf.org/html/rfc6749

## Tests

The component isn't fully tested as it's considered as a POC, 
the main providers are tested and validated.
The tokens should be fully tested. 

## Framework integration (WIP)

**This part isn't ready to use, it's just an idea**

As an application can use multiples providers, it could be a good idea to 
allows to use a factory (like `HttpClient`?):

```yaml
framework:
    oauth:
        redirect_uri: '%env(REDIRECT_URI)%' # Can be useful in order to share the configuration?
        providers:
            github:
                type: 'authorization_code'
                    client_id: '%env(CLIENT_ID)%'
                    client_secret: '%env(CLIENT_SECRET)%'
                    authorization_url: '%env(API_AUTHORIZATION_URL)%'
                    access_token_url: '%env(API_ACCESS_TOKEN_URL)%'
            google: 
                type: 'authorization_code' # Can be authorization_code, implicit, client_credentials or resource_owner
```

This way, a newly created service can be accessed via `@oauth.github`, 
time to configure the `security.yaml`:

```yaml
security:
    providers:
        github_oauth:
            oauth:
                provider: '@oauth.github' # Or maybe '@oauth.google'? 
    
    firewalls:
        main:
            provider: github_oauth
            
```

Let's imagine that we need to inject the provider in a service:

```php
<?php

namespace App\Services;

use Symfony\Component\OAuth\Provider\ProviderInterface; // Maybe a contract?

class Foo 
{
    private $oauthGithub;
    
    public function __construct(ProviderInterface $oauthGithub) 
    {
        $this->oauthGithub = $oauthGithub;
    }
    
    // ...
}
```

### Creating a custom provider

As the component allows to use a `ProviderInterface`, creating a custom provider
is as easy as it sounds: 

```php
<?php

use Symfony\Component\OAuth\Provider\ProviderInterface;

class FooProvider implements ProviderInterface 
{
    public function fetchAccessToken(array $options,array $headers = [],string $method = 'GET')
    {
        // ...
    }
    
    // ...
}
```

Or if needed, we can directly extends the `GenericProvider` class. 
