### PR TITLE
[PhpunitBridge] Read environment variable from superglobals

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -216,7 +216,13 @@ class DeprecationErrorHandler
             return $this->configuration;
         }
         if (false === $mode = $this->mode) {
-            $mode = getenv('SYMFONY_DEPRECATIONS_HELPER');
+            if (isset($_SERVER['SYMFONY_DEPRECATIONS_HELPER'])) {
+                $mode = $_SERVER['SYMFONY_DEPRECATIONS_HELPER'];
+            } elseif (isset($_ENV['SYMFONY_DEPRECATIONS_HELPER'])) {
+                $mode = $_ENV['SYMFONY_DEPRECATIONS_HELPER'];
+            } else {
+                $mode = getenv('SYMFONY_DEPRECATIONS_HELPER');
+            }
         }
         if ('strict' === $mode) {
             return $this->configuration = Configuration::inStrictMode();

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/disabled_from_env_superglobal.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/disabled_from_env_superglobal.phpt
@@ -1,9 +1,9 @@
 --TEST--
-Test DeprecationErrorHandler in disabled mode
+Test DeprecationErrorHandler in disabled mode (via putenv)
 --FILE--
 <?php
 
-$_SERVER['SYMFONY_DEPRECATIONS_HELPER'] = 'disabled';
+$_ENV['SYMFONY_DEPRECATIONS_HELPER'] = 'disabled';
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/disabled_from_putenv.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/disabled_from_putenv.phpt
@@ -1,9 +1,9 @@
 --TEST--
-Test DeprecationErrorHandler in disabled mode
+Test DeprecationErrorHandler in disabled mode (via putenv)
 --FILE--
 <?php
 
-$_SERVER['SYMFONY_DEPRECATIONS_HELPER'] = 'disabled';
+putenv('SYMFONY_DEPRECATIONS_HELPER=disabled');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31857
| License       | MIT
| Doc PR        | n/a

The Dotenv component has recently been switched to using superglobals
instead of putenv(). Let us support both and give priority to
superglobals.
