### PR TITLE
[Mailer] Changed EventDispatcherInterface dependency from Component to Contracts

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Http/Api/SesTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Http/Api/SesTransport.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\Mailer\Bridge\Amazon\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Http\Api\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Http/SesTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Http/SesTransport.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Mailer\Bridge\Amazon\Http;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Http\AbstractHttpTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Smtp/SesTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Smtp/SesTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Amazon\Smtp;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Kevin Verschaeve

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3|^5.0"
+        "symfony/mailer": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"

--- a/src/Symfony/Component/Mailer/Bridge/Google/Smtp/GmailTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Smtp/GmailTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Google\Smtp;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Kevin Verschaeve

--- a/src/Symfony/Component/Mailer/Bridge/Google/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Google/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3|^5.0"
+        "symfony/mailer": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/Api/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/Api/MandrillTransport.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\Mailer\Bridge\Mailchimp\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Http\Api\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/MandrillTransport.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Mailer\Bridge\Mailchimp\Http;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Http\AbstractHttpTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Smtp/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Smtp/MandrillTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Mailchimp\Smtp;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Kevin Verschaeve

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3|^5.0"
+        "symfony/mailer": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/Api/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/Api/MailgunTransport.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\Mailer\Bridge\Mailgun\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Http\Api\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\Mailer\Bridge\Mailgun\Http;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Http\AbstractHttpTransport;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Smtp/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Smtp/MailgunTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Mailgun\Smtp;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Kevin Verschaeve

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3|^5.0"
+        "symfony/mailer": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Http/Api/PostmarkTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Http/Api/PostmarkTransport.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\Mailer\Bridge\Postmark\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Http\Api\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Smtp/PostmarkTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Smtp/PostmarkTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Postmark\Smtp;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Kevin Verschaeve

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3|^5.0"
+        "symfony/mailer": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\Mailer\Bridge\Sendgrid\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Http\Api\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Smtp/SendgridTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Smtp/SendgridTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Sendgrid\Smtp;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Kevin Verschaeve

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3|^5.0"
+        "symfony/mailer": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * [BC BREAK] Transports depend on `Symfony\Contracts\EventDispatcher\EventDispatcherInterface`
+   instead of `Symfony\Component\EventDispatcher\EventDispatcherInterface`.
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Mailer\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Bridge\Amazon;
 use Symfony\Component\Mailer\Bridge\Google;
 use Symfony\Component\Mailer\Bridge\Mailchimp;
@@ -23,6 +22,7 @@ use Symfony\Component\Mailer\Bridge\Sendgrid;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Transport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class TransportTest extends TestCase

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Mailer;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Bridge\Amazon;
 use Symfony\Component\Mailer\Bridge\Google;
 use Symfony\Component\Mailer\Bridge\Mailchimp;
@@ -22,6 +21,7 @@ use Symfony\Component\Mailer\Bridge\Sendgrid;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Mailer\Transport;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\DelayedSmtpEnvelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Exception\TransportException;
@@ -22,6 +21,7 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/Mailer/Transport/Http/AbstractHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Http/AbstractHttpTransport.php
@@ -12,9 +12,9 @@
 namespace Symfony\Component\Mailer\Transport\Http;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Transport/Http/Api/AbstractApiTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Http/Api/AbstractApiTransport.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Mailer\Transport\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Exception\RuntimeException;
 use Symfony\Component\Mailer\SentMessage;
@@ -21,6 +20,7 @@ use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\MessageConverter;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -12,13 +12,13 @@
 namespace Symfony\Component\Mailer\Transport;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\AbstractStream;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\ProcessStream;
 use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * SendmailTransport for sending mail through a Sendmail/Postfix (etc..) binary.

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\Mailer\Transport\Smtp;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Transport\Smtp\Auth\AuthenticatorInterface;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Sends Emails over SMTP with ESMTP support.

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Mailer\Transport\Smtp;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
@@ -22,6 +21,7 @@ use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\AbstractStream;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
 use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Sends emails over SMTP.

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -23,13 +23,13 @@
         "symfony/mime": "^4.3|^5.0"
     },
     "require-dev": {
-        "symfony/amazon-mailer": "^4.3|^5.0",
-        "symfony/google-mailer": "^4.3|^5.0",
+        "symfony/amazon-mailer": "^4.4|^5.0",
+        "symfony/google-mailer": "^4.4|^5.0",
         "symfony/http-client-contracts": "^1.1",
-        "symfony/mailgun-mailer": "^4.3|^5.0",
-        "symfony/mailchimp-mailer": "^4.3|^5.0",
-        "symfony/postmark-mailer": "^4.3|^5.0",
-        "symfony/sendgrid-mailer": "^4.3|^5.0"
+        "symfony/mailgun-mailer": "^4.4|^5.0",
+        "symfony/mailchimp-mailer": "^4.4|^5.0",
+        "symfony/postmark-mailer": "^4.4|^5.0",
+        "symfony/sendgrid-mailer": "^4.4|^5.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | almost yes, see https://github.com/symfony/symfony/pull/31956#issuecomment-500194573
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Follow up of https://github.com/symfony/symfony/pull/31946#discussion_r291795454 . I hope this kind of changes are allowed for experimental components.

BTW, @nicolas-grekas , why Psr14 interface is optional for Contract's `EventDispatcherInterface https://github.com/symfony/symfony/blob/4.4/src/Symfony/Contracts/EventDispatcher/EventDispatcherInterface.php#L16 ?