### PR TITLE
[DomCrawler][Feature][DX] Add Form::getName() method

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+* Added `Form::getName()` method.
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -251,6 +251,16 @@ class Form extends Link implements \ArrayAccess
     }
 
     /**
+     * Gets the form name.
+     *
+     * If no name is defined on the form, an empty string is returned.
+     */
+    public function getName(): string
+    {
+        return $this->node->getAttribute('name');
+    }
+
+    /**
      * Returns true if the named field exists.
      *
      * @param string $name The field name

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -327,6 +327,18 @@ class FormTest extends TestCase
         $this->assertEquals('POST', $form->getMethod(), '->getMethod() returns the method attribute value of the form');
     }
 
+    public function testGetName()
+    {
+        $form = $this->createForm('<form name="foo"><input type="submit" /></form>');
+        $this->assertSame('foo', $form->getName());
+    }
+
+    public function testGetNameOnFormWithoutName()
+    {
+        $form = $this->createForm('<form><input type="submit" /></form>');
+        $this->assertSame('', $form->getName());
+    }
+
     public function testGetSetValue()
     {
         $form = $this->createForm('<form><input type="text" name="foo" value="foo" /><input type="submit" /></form>');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | None
| License       | MIT
| Doc PR        | symfony/symfony-docs#11705

The PR adds `Symfony\Component\DomCrawler\Form::getName` method.

The method is actually a syntax sugar but can improve DX when dealing with tests. For example, in the snippet

```php
$client = static::createClient();
$crawler = $client->request('GET', '/post/hello-world');
$form = $crawler->selectButton('submit')->form();

$form['my_form[name]'] = 'Fabien';
$form['my_form[subject]'] = 'Symfony rocks!';
```
the prefix in field name (`my_form`) is form name, which is generated by Symfony automatically. The method, added in the PR helps to get that name in a most obvious way.