### PR TITLE
[Messenger] Doctrine Connection find and findAll now correctly decode headers

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -230,4 +230,90 @@ class ConnectionTest extends TestCase
     {
         Connection::buildConfiguration('doctrine://default?new_option=woops');
     }
+
+    public function testFind()
+    {
+        $queryBuilder = $this->getQueryBuilderMock();
+        $driverConnection = $this->getDBALConnectionMock();
+        $schemaSynchronizer = $this->getSchemaSynchronizerMock();
+        $id = 1;
+        $stmt = $this->getStatementMock([
+            'id' => $id,
+            'body' => '{"message":"Hi"}',
+            'headers' => \json_encode(['type' => DummyMessage::class]),
+        ]);
+
+        $driverConnection
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+        $queryBuilder
+            ->method('where')
+            ->willReturn($queryBuilder);
+        $queryBuilder
+            ->method('getSQL')
+            ->willReturn('');
+        $queryBuilder
+            ->method('getParameters')
+            ->willReturn([]);
+        $driverConnection
+            ->method('prepare')
+            ->willReturn($stmt);
+
+        $connection = new Connection([], $driverConnection, $schemaSynchronizer);
+        $doctrineEnvelope = $connection->find($id);
+        $this->assertEquals(1, $doctrineEnvelope['id']);
+        $this->assertEquals('{"message":"Hi"}', $doctrineEnvelope['body']);
+        $this->assertEquals(['type' => DummyMessage::class], $doctrineEnvelope['headers']);
+    }
+
+    public function testFindAll()
+    {
+        $queryBuilder = $this->getQueryBuilderMock();
+        $driverConnection = $this->getDBALConnectionMock();
+        $schemaSynchronizer = $this->getSchemaSynchronizerMock();
+        $message1 = [
+            'id' => 1,
+            'body' => '{"message":"Hi"}',
+            'headers' => \json_encode(['type' => DummyMessage::class]),
+        ];
+        $message2 = [
+            'id' => 2,
+            'body' => '{"message":"Hi again"}',
+            'headers' => \json_encode(['type' => DummyMessage::class]),
+        ];
+
+        $stmt = $this->getMockBuilder(Statement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $stmt->expects($this->once())
+            ->method('fetchAll')
+            ->willReturn([$message1, $message2]);
+
+        $driverConnection
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+        $queryBuilder
+            ->method('where')
+            ->willReturn($queryBuilder);
+        $queryBuilder
+            ->method('getSQL')
+            ->willReturn('');
+        $queryBuilder
+            ->method('getParameters')
+            ->willReturn([]);
+        $driverConnection
+            ->method('prepare')
+            ->willReturn($stmt);
+
+        $connection = new Connection([], $driverConnection, $schemaSynchronizer);
+        $doctrineEnvelopes = $connection->findAll();
+
+        $this->assertEquals(1, $doctrineEnvelopes[0]['id']);
+        $this->assertEquals('{"message":"Hi"}', $doctrineEnvelopes[0]['body']);
+        $this->assertEquals(['type' => DummyMessage::class], $doctrineEnvelopes[0]['headers']);
+
+        $this->assertEquals(2, $doctrineEnvelopes[1]['id']);
+        $this->assertEquals('{"message":"Hi again"}', $doctrineEnvelopes[1]['body']);
+        $this->assertEquals(['type' => DummyMessage::class], $doctrineEnvelopes[1]['headers']);
+    }
 }

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -155,7 +155,7 @@ class Connection
                 return null;
             }
 
-            $doctrineEnvelope['headers'] = \json_decode($doctrineEnvelope['headers'], true);
+            $doctrineEnvelope = $this->decodeEnvelopeHeaders($doctrineEnvelope);
 
             $queryBuilder = $this->driverConnection->createQueryBuilder()
                 ->update($this->configuration['table_name'])
@@ -238,7 +238,11 @@ class Connection
             $queryBuilder->setMaxResults($limit);
         }
 
-        return $this->executeQuery($queryBuilder->getSQL(), $queryBuilder->getParameters())->fetchAll();
+        $data = $this->executeQuery($queryBuilder->getSQL(), $queryBuilder->getParameters())->fetchAll();
+
+        return \array_map(function ($doctrineEnvelope) {
+            return $this->decodeEnvelopeHeaders($doctrineEnvelope);
+        }, $data);
     }
 
     public function find($id): ?array
@@ -254,7 +258,7 @@ class Connection
             'id' => $id,
         ])->fetch();
 
-        return false === $data ? null : $data;
+        return false === $data ? null : $this->decodeEnvelopeHeaders($data);
     }
 
     private function createAvailableMessagesQueryBuilder(): QueryBuilder
@@ -331,5 +335,12 @@ class Connection
     public static function formatDateTime(\DateTimeInterface $dateTime)
     {
         return $dateTime->format('Y-m-d\TH:i:s');
+    }
+
+    private function decodeEnvelopeHeaders(array $doctrineEnvelope): array
+    {
+        $doctrineEnvelope['headers'] = \json_decode($doctrineEnvelope['headers'], true);
+
+        return $doctrineEnvelope;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31916
| License       | MIT
| Doc PR        | N/A

The Doctrine transport `Connection` class methods `find` and `findAll` did not JSON-decode the headers of the envelope after retrieving it from Doctrine. The `get` method, however, did this correctly.

I added two tests to verify the results of `find` and `findAll` and then added the JSON-decoding to the `Connection` class. I moved the JSON-decoding to a separate method to avoid duplicate code.
