### PR TITLE
Add missing rendering of form help block.

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -114,6 +114,7 @@
     <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
         {{- form_label(form) }} {# -#}
         {{ form_widget(form, widget_attr) }} {# -#}
+        {{- form_help(form) -}}
         {{ form_errors(form) }} {# -#}
     </div> {# -#}
 {%- endblock form_row %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

When using `bootstrap_3_layout.html.twig` form theme, the help blocks are not rendered. 

```twig
{% form_theme form 'bootstrap_3_layout.html.twig' %}

{{ form_start(form) }}
  {{ form_row(form.some_field) }} {# <-- no help text is rendered #}
{{ form_end(form) }}
```