### PR TITLE
add callback to BinaryFileResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * passing arguments to `Request::isMethodSafe()` is deprecated.
+ * added callback to BinaryFileResponse
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -352,6 +352,17 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertNull($response->headers->get('Content-Length'));
     }
 
+    public function testCallback()
+    {
+        $called = 0;
+
+        $response = new BinaryFileResponse(__FILE__, 200, [], true, null, false, true, function () use (&$called) { ++$called; });
+
+        $response->sendContent();
+        $this->assertEquals(1, $called);
+
+    }
+
     protected function provideResponse()
     {
         return new BinaryFileResponse(__DIR__.'/../README.md', 200, ['Content-Type' => 'application/octet-stream']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Added a callback to BinaryFileResponse, called after send of the content
