### PR TITLE
[HttpClient] make Psr18Client implement relevant PSR-17 factories

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * made `Psr18Client` implement relevant PSR-17 factories
  * added `$response->cancel()`
 
 4.3.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11820

This should help use the component with libs that consume only PSR-18.