### PR TITLE
[HttpClient] fix Psr18Client handling of non-200 response codes

### DIFF
--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -73,13 +73,13 @@ final class Psr18Client implements ClientInterface
 
             $psrResponse = $this->responseFactory->createResponse($response->getStatusCode());
 
-            foreach ($response->getHeaders() as $name => $values) {
+            foreach ($response->getHeaders(false) as $name => $values) {
                 foreach ($values as $value) {
                     $psrResponse = $psrResponse->withAddedHeader($name, $value);
                 }
             }
 
-            return $psrResponse->withBody($this->streamFactory->createStream($response->getContent()));
+            return $psrResponse->withBody($this->streamFactory->createStream($response->getContent(false)));
         } catch (TransportExceptionInterface $e) {
             if ($e instanceof \InvalidArgumentException) {
                 throw new Psr18RequestException($e, $request);

--- a/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
@@ -74,4 +74,13 @@ class Psr18ClientTest extends TestCase
         $this->expectException(Psr18RequestException::class);
         $client->sendRequest($factory->createRequest('BAD.METHOD', 'http://localhost:8057'));
     }
+
+    public function test404()
+    {
+        $factory = new Psr17Factory();
+        $client = new Psr18Client(new NativeHttpClient());
+
+        $response = $client->sendRequest($factory->createRequest('GET', 'http://localhost:8057/404'));
+        $this->assertSame(404, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31979
| License       | MIT
| Doc PR        | -