### PR TITLE
Fixes email adresses format in header

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -148,9 +148,9 @@ class SmtpTransport extends AbstractTransport
     protected function doSend(SentMessage $message): void
     {
         $envelope = $message->getEnvelope();
-        $this->doMailFromCommand($envelope->getSender()->toString());
+        $this->doMailFromCommand($envelope->getSender()->getEncodedAddress());
         foreach ($envelope->getRecipients() as $recipient) {
-            $this->doRcptToCommand($recipient->toString());
+            $this->doRcptToCommand($recipient->getEncodedAddress());
         }
 
         $this->executeCommand("DATA\r\n", [354]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

In the mailer component, when using `Symfony\Component\Mime\NamedAddress` instances for `FROM`/`TO` with SMTP transport, the headers will be misconfigured ie `MAIL FROM:Sender Name<test@test.com>` when the header must be `MAIL FROM:<test@test.com>`.
The corresponding names will be used properly in the `DATA` section (see https://github.com/symfony/symfony/blob/4.3/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php#L157)
