### PR TITLE
[Mailer] Catch missing scheme in DSN

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -69,11 +69,18 @@ class TransportTest extends TestCase
         Transport::fromDsn('some://');
     }
 
+    public function testNoScheme()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "//sendmail" mailer DSN must contain a transport scheme.');
+        Transport::fromDsn('//sendmail');
+    }
+
     public function testFromInvalidDsnNoHost()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "?!" mailer DSN must contain a mailer name.');
-        Transport::fromDsn('?!');
+        $this->expectExceptionMessage('The "file:///some/path" mailer DSN must contain a mailer name.');
+        Transport::fromDsn('file:///some/path');
     }
 
     public function testFromInvalidTransportName()

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -64,6 +64,10 @@ class Transport
             throw new InvalidArgumentException(sprintf('The "%s" mailer DSN is invalid.', $dsn));
         }
 
+        if (!isset($parsedDsn['scheme'])) {
+            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a transport scheme.', $dsn));
+        }
+
         if (!isset($parsedDsn['host'])) {
             throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a mailer name.', $dsn));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The `Symfony\Component\Mailer\Transport::createTransport()` method parses and validates a passed DSN. I noticed that we never check if the DSN contains a valid scheme, but we always assume that the scheme is present in then parse result. If someone passes a DSN without a scheme to that method, they would almost certainly run into a PHP notice.

This PR makes sure that a scheme is present in the URL and throws a proper exception otherwise.