### PR TITLE
[PhpunitBridge] Restore php 5.5 compat

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -90,9 +90,12 @@ class Configuration
      */
     public function tolerates(array $deprecations)
     {
-        $deprecationCounts = array_filter($deprecations, function ($key) {
-            return false !== strpos($key, 'Count') && false === strpos($key, 'legacy');
-        }, ARRAY_FILTER_USE_KEY);
+        $deprecationCounts = [];
+        foreach ($deprecations as $key => $deprecation) {
+            if (false !== strpos($key, 'Count') && false === strpos($key, 'legacy')) {
+                $deprecationCounts[$key] = $deprecation;
+            }
+        }
 
         if (array_sum($deprecationCounts) > $this->thresholds['total']) {
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The `ARRAY_FILTER_USE_KEY` constant was introduced in php 5.6, let us
avoid it for now.
See https://www.php.net/manual/en/function.array-filter.php#refsect1-function.array-filter-changelog

Thanks @alcaeus for spotting this in https://travis-ci.org/doctrine/DoctrineBundle/jobs/543340482#L596
