### PR TITLE
[Cache] Fix missing requirement to PSR-16

### DIFF
--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -24,6 +24,7 @@
         "php": "^7.1.3",
         "psr/cache": "~1.0",
         "psr/log": "~1.0",
+        "psr/simple-cache": "~1.0",
         "symfony/cache-contracts": "^1.1",
         "symfony/service-contracts": "^1.1",
         "symfony/var-exporter": "^4.2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31720
| License       | MIT

Since 4.3, the PSR-6 adapter is deprecated in favor of the simpler PSR-16; the deprecation notice tries to load the PSR-16 class (due to calling `Psr16Cache::class`), which in turn breaks the autoloader, since 
`implements Psr\SimpleCache\CacheInterface`, but that package is nowhere required in the entire component:

https://github.com/symfony/symfony/blob/c45c6e50e18b61ec8bf7a74bc001a59045057a5a/src/Symfony/Component/Cache/Simple/Psr6Cache.php#L16