### PR TITLE
[Serializer] Handle true and false appropriately in CSV encoder

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -189,7 +189,8 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
             if (\is_array($value)) {
                 $this->flatten($value, $result, $keySeparator, $parentKey.$key.$keySeparator);
             } else {
-                $result[$parentKey.$key] = $value;
+                // Ensures an actual value is used when dealing with true and false
+                $result[$parentKey.$key] = false === $value ? 0 : (true === $value ? 1 : $value);
             }
         }
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -29,6 +29,24 @@ class CsvEncoderTest extends TestCase
         $this->encoder = new CsvEncoder();
     }
 
+    public function testTrueFalseValues()
+    {
+        $data = [
+            'string' => 'foo',
+            'int' => 2,
+            'false' => false,
+            'true' => true,
+        ];
+
+        // Check that true and false are appropriately handled
+        $this->assertEquals(<<<'CSV'
+string,int,false,true
+foo,2,0,1
+
+CSV
+    , $this->encoder->encode($data, 'csv'));
+    }
+
     public function testSupportEncoding()
     {
         $this->assertTrue($this->encoder->supportsEncoding('csv'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27642
| License       | MIT
| Doc PR        | -

Previously, if `true` was passed in as a value to the CSV encoder then `fputcsv()` would correctly treat it as 1. However, if `false` was passed in, it would be treated as a blank value. `null` would also be treated as a blank value.

This fix makes it consistent so that true and false will map to 1 and 0, while null maps to an empty string.