### PR TITLE
[HTTP Foundation] Fixed get path info issue

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1810,6 +1810,11 @@ class Request
             $baseUrl = substr($requestUri, 0, $pos + \strlen($baseUrl));
         }
 
+        // if requestUri not start from baseUrl
+        if (0 !== strpos(rawurldecode($truncatedRequestUri), $baseUrl)) {
+            return '';
+        }
+
         return rtrim($baseUrl, '/'.\DIRECTORY_SEPARATOR);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1798,7 +1798,8 @@ class Request
         }
 
         $basename = basename($baseUrl);
-        if (empty($basename) || !strpos(rawurldecode($truncatedRequestUri), $basename)) {
+        $truncatedRequestUri = rawurldecode($truncatedRequestUri);
+        if (empty($basename) || !strpos($truncatedRequestUri, $basename) || 0 !== strpos($truncatedRequestUri, $baseUrl)) {
             // no match whatsoever; set it blank
             return '';
         }
@@ -1808,11 +1809,6 @@ class Request
         // from PATH_INFO or QUERY_STRING
         if (\strlen($requestUri) >= \strlen($baseUrl) && (false !== $pos = strpos($requestUri, $baseUrl)) && 0 !== $pos) {
             $baseUrl = substr($requestUri, 0, $pos + \strlen($baseUrl));
-        }
-
-        // if requestUri not start from baseUrl
-        if (0 !== strpos(rawurldecode($truncatedRequestUri), $baseUrl)) {
-            return '';
         }
 
         return rtrim($baseUrl, '/'.\DIRECTORY_SEPARATOR);

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -236,6 +236,20 @@ class RequestTest extends TestCase
         // Fragment should not be included in the URI
         $request = Request::create('http://test.com/foo#bar');
         $this->assertEquals('http://test.com/foo', $request->getUri());
+
+        $request = Request::create('http://test.com/test/app.php', 'GET', [], [], [],
+            [
+                'DOCUMENT_ROOT' => '/var/www/www.test.com',
+                'SCRIPT_FILENAME' => '/var/www/www.test.com/app/app.php',
+                'SCRIPT_NAME' => '/app/app.php',
+                'PHP_SELF' => '/app/app.php/test/app.php',
+            ]);
+        $this->assertEquals('http://test.com/test/app.php', $request->getUri());
+        $this->assertEquals('/test/app.php', $request->getPathInfo());
+        $this->assertEquals('', $request->getQueryString());
+        $this->assertEquals(80, $request->getPort());
+        $this->assertEquals('test.com', $request->getHttpHost());
+        $this->assertFalse($request->isSecure());
     }
 
     public function testCreateWithRequestUri()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Hello,
I fixed some issue on perpareBaseUrl() function.

In the case:

URL: '/xxxxx/index.php'
filePath: '/aaa/index.php/xxxxx/index.php' (apache hide '/aaa/index.php' )

prepareBaseUrl() return '/aaa/index.php' not ''
preparePathInfo() return 'hp' not '/xxxxx/index.php'.

fixed:
ADD check request URI begin with base URL.