### PR TITLE
[HttpClient] fix closing debug stream prematurely

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -168,8 +168,8 @@ final class CurlResponse implements ResponseInterface
                 rewind($this->debugBuffer);
                 $info['debug'] = stream_get_contents($this->debugBuffer);
                 curl_setopt($this->handle, CURLOPT_VERBOSE, false);
-                fclose($this->debugBuffer);
-                $this->debugBuffer = null;
+                rewind($this->debugBuffer);
+                ftruncate($this->debugBuffer, 0);
                 $this->finalInfo = $info;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31985
| License       | MIT
| Doc PR        | -

@ElGecko76 can you please confirm this fixes the issue for you?
I'm not able to reproduce so I can't myself. Thanks.