### PR TITLE
Add statement to fileLink to ignore href code when no fileLink.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -557,8 +557,11 @@ class TextDescriptor extends Descriptor
         }
 
         $fileLink = $this->fileLinkFormatter->format($r->getFileName(), $r->getStartLine());
+        if ($fileLink) {
+            return sprintf('<href=%s>%s</>', $fileLink, $anchorText);
+        }
 
-        return sprintf('<href=%s>%s</>', $fileLink, $anchorText);
+        return $anchorText;
     }
 
     private function formatCallable($callable): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
This fix add statement to `\Symfony\Bundle\FrameworkBundle\Console\Descriptor\TextDescriptor::formatControllerLink` to fix display bug.

**Before**

![image](https://user-images.githubusercontent.com/23213308/59355771-ed8a1000-8d27-11e9-998f-fa2fc34edd62.png)

**After**

![image](https://user-images.githubusercontent.com/23213308/59355785-f2e75a80-8d27-11e9-953b-7523e0c9ad35.png)

