### PR TITLE
Do not log or call the proxy function when the locale is the same

### DIFF
--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -84,6 +84,10 @@ class LoggingTranslator implements TranslatorInterface, LegacyTranslatorInterfac
     {
         $prev = $this->translator->getLocale();
         $this->translator->setLocale($locale);
+        if ($prev === $locale) {
+            return;
+        }
+
         $this->logger->debug(sprintf('The locale of the translator has changed from "%s" to "%s".', $prev, $locale));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I was the one creating the PR for logging the change of the locale but ATM I am filled with logs of translator about switching the locale from "en" to "en".. Not sure why.