### PR TITLE
[Contracts] add missing required dependencies

### DIFF
--- a/src/Symfony/Contracts/Cache/composer.json
+++ b/src/Symfony/Contracts/Cache/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "psr/cache": "^1.0"
     },
     "suggest": {
-        "psr/cache": "",
         "symfony/cache-implementation": ""
     },
     "autoload": {

--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "psr/container": "^1.0"
     },
     "suggest": {
-        "psr/container": "",
         "symfony/service-implementation": ""
     },
     "autoload": {

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "psr/cache": "^1.0",
+        "psr/container": "^1.0"
     },
     "require-dev": {
-        "psr/cache": "^1.0",
-        "psr/container": "^1.0",
         "symfony/polyfill-intl-idn": "^1.10"
     },
     "replace": {
@@ -31,8 +31,6 @@
         "symfony/translation-contracts": "self.version"
     },
     "suggest": {
-        "psr/cache": "When using the Cache contracts",
-        "psr/container": "When using the Service contracts",
         "psr/event-dispatcher": "When using the EventDispatcher contracts",
         "symfony/cache-implementation": "",
         "symfony/event-dispatcher-implementation": "",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32016    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->

As discussed in #32016, added missing required deps so that symfony/cache-contracts and symfony/service-contracts can be installed and used on their own. 

cc @nicolas-grekas 