### PR TITLE
Psr16Adapter fails to cache any item if a namespace is used

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -34,7 +34,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).':';
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).'_';
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s")', $this->maxIdLength - 24, \strlen($namespace), $namespace));
         }

--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -29,12 +29,14 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
     use AbstractAdapterTrait;
     use ContractsTrait;
 
+    protected const NS_SEPARATOR = ':';
+
     private static $apcuSupported;
     private static $phpFilesSupported;
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).'_';
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).static::NS_SEPARATOR;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s")', $this->maxIdLength - 24, \strlen($namespace), $namespace));
         }

--- a/src/Symfony/Component/Cache/Adapter/Psr16Adapter.php
+++ b/src/Symfony/Component/Cache/Adapter/Psr16Adapter.php
@@ -25,6 +25,8 @@ class Psr16Adapter extends AbstractAdapter implements PruneableInterface, Resett
 {
     use ProxyTrait;
 
+    protected const NS_SEPARATOR = '_';
+
     private $miss;
 
     public function __construct(CacheInterface $pool, string $namespace = '', int $defaultLifetime = 0)

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -26,8 +26,8 @@ class MaxIdLengthAdapterTest extends TestCase
         $cache->expects($this->exactly(2))
             ->method('doHave')
             ->withConsecutive(
-                [$this->equalTo('----------_nWfzGiCgLczv3SSUzXL3kg:')],
-                [$this->equalTo('----------_---------------------------------------')]
+                [$this->equalTo('----------:nWfzGiCgLczv3SSUzXL3kg:')],
+                [$this->equalTo('----------:---------------------------------------')]
             );
 
         $cache->hasItem(str_repeat('-', 40));
@@ -46,7 +46,7 @@ class MaxIdLengthAdapterTest extends TestCase
         $reflectionMethod->setAccessible(true);
 
         // No versioning enabled
-        $this->assertEquals('--------------------------_------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
+        $this->assertEquals('--------------------------:------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 23)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 40)])));
@@ -56,7 +56,7 @@ class MaxIdLengthAdapterTest extends TestCase
         $reflectionProperty->setValue($cache, true);
 
         // Versioning enabled
-        $this->assertEquals('--------------------------_1/------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
+        $this->assertEquals('--------------------------:1/------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 23)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 40)])));

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -26,8 +26,8 @@ class MaxIdLengthAdapterTest extends TestCase
         $cache->expects($this->exactly(2))
             ->method('doHave')
             ->withConsecutive(
-                [$this->equalTo('----------:nWfzGiCgLczv3SSUzXL3kg:')],
-                [$this->equalTo('----------:---------------------------------------')]
+                [$this->equalTo('----------_nWfzGiCgLczv3SSUzXL3kg:')],
+                [$this->equalTo('----------_---------------------------------------')]
             );
 
         $cache->hasItem(str_repeat('-', 40));
@@ -46,7 +46,7 @@ class MaxIdLengthAdapterTest extends TestCase
         $reflectionMethod->setAccessible(true);
 
         // No versioning enabled
-        $this->assertEquals('--------------------------:------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
+        $this->assertEquals('--------------------------_------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 23)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 40)])));
@@ -56,7 +56,7 @@ class MaxIdLengthAdapterTest extends TestCase
         $reflectionProperty->setValue($cache, true);
 
         // Versioning enabled
-        $this->assertEquals('--------------------------:1/------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
+        $this->assertEquals('--------------------------_1/------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 23)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 40)])));

--- a/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\Debug\BufferingLogger;
 
 /**
  * @group time-sensitive
@@ -27,5 +28,21 @@ class Psr16AdapterTest extends AdapterTestCase
     public function createCachePool($defaultLifetime = 0)
     {
         return new Psr16Adapter(new Psr16Cache(new FilesystemAdapter()), '', $defaultLifetime);
+    }
+
+    public function testValidCacheKeyWithNamespace()
+    {
+        $logger = new BufferingLogger();
+        $cache = new Psr16Adapter(new Psr16Cache(new FilesystemAdapter()), 'some_namespace', 0);
+        $cache->setLogger($logger);
+        $this->assertSame('foo', $cache->get('my_key', function () {
+            return 'foo';
+        }));
+        $logs = $logger->cleanLogs();
+        foreach ($logs as $log) {
+            if ('warning' === $log[0] || 'error' === $log[0]) {
+                $this->fail('An error was triggered while caching key with a namespace: '.$log[1]);
+            }
+        }
     }
 }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -35,6 +35,7 @@
         "predis/predis": "~1.1",
         "psr/simple-cache": "^1.0",
         "symfony/config": "~4.2",
+        "symfony/debug": "^4",
         "symfony/dependency-injection": "~3.4|~4.1",
         "symfony/var-dumper": "^4.1.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

The Psr16Adapter extends AdapterTestCase.
When adding a namespace, the AdapterTestCase adds ":" after the namespace:

https://github.com/symfony/symfony/blob/v4.3.1/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php#L37

The namespace is prepended to the cache key.
But in PSR-16, the ":" is a forbidden character.

As a result, the cache key is invalid and cache is not persisted. If you use Psr16Adapter + a namespace, the cache simply does not work.

The first commit of this PR starts with an additional test and no fix (to showcase the problem).