### PR TITLE
[HttpClient] Don't use CurlHttpClient on Windows when curl.cainfo is not set

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClient.php
+++ b/src/Symfony/Component/HttpClient/HttpClient.php
@@ -32,7 +32,11 @@ final class HttpClient
     public static function create(array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 50): HttpClientInterface
     {
         if (\extension_loaded('curl')) {
-            return new CurlHttpClient($defaultOptions, $maxHostConnections, $maxPendingPushes);
+            if ('\\' !== \DIRECTORY_SEPARATOR || ini_get('curl.cainfo') || ini_get('openssl.cafile') || ini_get('openssl.capath')) {
+                return new CurlHttpClient($defaultOptions, $maxHostConnections, $maxPendingPushes);
+            }
+
+            @trigger_error('Configure the "curl.cainfo", "openssl.cafile" or "openssl.capath" php.ini setting to enable the CurlHttpClient', E_USER_WARNING);
         }
 
         return new NativeHttpClient($defaultOptions, $maxHostConnections);

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -336,7 +336,7 @@ final class CurlResponse implements ResponseInterface
                 return 0;
             }
 
-            if ($certinfo = curl_getinfo($ch, CURLINFO_CERTINFO)) {
+            if (\function_exists('openssl_x509_read') && $certinfo = curl_getinfo($ch, CURLINFO_CERTINFO)) {
                 $info['peer_certificate_chain'] = array_map('openssl_x509_read', array_column($certinfo, 'Cert'));
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

On Windows, curl has no cabundle configured by default.