### PR TITLE
[VarDumper] fix dumping objects that implement __debugInfo()

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -53,13 +53,9 @@ class Caster
             $hasDebugInfo = $class->hasMethod('__debugInfo');
             $class = $class->name;
         }
-        if ($hasDebugInfo) {
-            $a = $obj->__debugInfo();
-        } elseif ($obj instanceof \Closure) {
-            $a = [];
-        } else {
-            $a = (array) $obj;
-        }
+
+        $a = $obj instanceof \Closure ? [] : (array) $obj;
+
         if ($obj instanceof \__PHP_Incomplete_Class) {
             return $a;
         }
@@ -90,6 +86,17 @@ class Caster
                     $keys[$i] = $k;
                 }
                 $a = array_combine($keys, $a);
+            }
+        }
+
+        if ($hasDebugInfo && \is_array($debugInfo = $obj->__debugInfo())) {
+            foreach ($debugInfo as $k => $v) {
+                if (!isset($k[0]) || "\0" !== $k[0]) {
+                    $k = self::PREFIX_VIRTUAL.$k;
+                }
+
+                unset($a[$k]);
+                $a[$k] = $v;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Right now it fails if the return value is not an array + it doesn't dump the original details from the object's internals.