### PR TITLE
SimpleCacheAdapter fails to cache any item if a namespace is used

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -39,7 +39,7 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
      */
     protected function __construct($namespace = '', $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).':';
+        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).static::getNsSeparator();
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(sprintf('Namespace must be %d chars max, %d given ("%s")', $this->maxIdLength - 24, \strlen($namespace), $namespace));
         }

--- a/src/Symfony/Component/Cache/Adapter/SimpleCacheAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/SimpleCacheAdapter.php
@@ -75,4 +75,12 @@ class SimpleCacheAdapter extends AbstractAdapter implements PruneableInterface
     {
         return $this->pool->setMultiple($values, 0 === $lifetime ? null : $lifetime);
     }
+
+    /**
+     * @return string the namespace separator for cache keys
+     */
+    protected static function getNsSeparator()
+    {
+        return '_';
+    }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/SimpleCacheAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/SimpleCacheAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Symfony\Component\Cache\Adapter\SimpleCacheAdapter;
+use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 
 /**
@@ -26,5 +27,15 @@ class SimpleCacheAdapterTest extends AdapterTestCase
     public function createCachePool($defaultLifetime = 0)
     {
         return new SimpleCacheAdapter(new FilesystemCache(), '', $defaultLifetime);
+    }
+
+    public function testValidCacheKeyWithNamespace()
+    {
+        $cache = new SimpleCacheAdapter(new ArrayCache(), 'some_namespace', 0);
+        $item = $cache->getItem('my_key');
+        $item->set('someValue');
+        $cache->save($item);
+
+        $this->assertTrue($cache->getItem('my_key')->isHit(), 'Stored item is successfully retrieved.');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This is a backport of #32019

The SimpleCacheAdapter extends AdapterTestCase.
When adding a namespace, the AdapterTestCase adds ":" after the namespace:

https://github.com/symfony/symfony/blob/v4.3.1/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php#L37

The namespace is prepended to the cache key.
But in PSR-16, the ":" is a forbidden character.

As a result, the cache key is invalid and cache is not persisted. If you use Psr16Adapter + a namespace, the cache simply does not work.

As per @nicolas-grekas advices, a NS_SEPARATOR const is added to change the namespace separator for the `SimpleCacheAdapter` to "_" (that is compatible with PSR-16).

The first commit of this PR starts with an additional test and no fix (to showcase the problem).