### PR TITLE
[Messenger] Remove DispatchAfterCurrentBusStamp when message is put on internal queue

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -112,7 +112,7 @@ final class QueuedEnvelope
 
     public function __construct(Envelope $envelope, StackInterface $stack)
     {
-        $this->envelope = $envelope;
+        $this->envelope = $envelope->withoutAll(DispatchAfterCurrentBusStamp::class);
         $this->stack = $stack;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32009
| License       | MIT
| Doc PR        | 

This will fix #32009. 

Thank you @brpauwels for the report. 

I consider it safe to remove the `DispatchAfterCurrentBusStamp` because its meaning disappear after we handled the "current bus". 

T0: We add the stamp
T1: We put the envelope on an internal queue in `DispatchAfterCurrentBusMiddleware`
T2: We handle the current bus. 
T3: We start processing our internal queue. 

At T3 there we are "after current bus", that is why we dont need the stamp any more. 