### PR TITLE
[Messenger] fix delay delivery for non-fanout exchanges

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
@@ -25,14 +25,14 @@ class ConnectionTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The given AMQP DSN "amqp://" is invalid.
+     * @expectedExceptionMessage The given AMQP DSN "amqp://:" is invalid.
      */
     public function testItCannotBeConstructedWithAWrongDsn()
     {
-        Connection::fromDsn('amqp://');
+        Connection::fromDsn('amqp://:');
     }
 
-    public function testItGetsParametersFromTheDsn()
+    public function testItCanBeConstructedWithDefaults()
     {
         $this->assertEquals(
             new Connection([
@@ -44,7 +44,23 @@ class ConnectionTest extends TestCase
             ], [
                 'messages' => [],
             ]),
-            Connection::fromDsn('amqp://localhost/%2f/messages')
+            Connection::fromDsn('amqp://')
+        );
+    }
+
+    public function testItGetsParametersFromTheDsn()
+    {
+        $this->assertEquals(
+            new Connection([
+                'host' => 'host',
+                'port' => 5672,
+                'vhost' => '/',
+            ], [
+                'name' => 'custom',
+            ], [
+                'custom' => [],
+            ]),
+            Connection::fromDsn('amqp://host/%2f/custom')
         );
     }
 
@@ -52,9 +68,9 @@ class ConnectionTest extends TestCase
     {
         $this->assertEquals(
             new Connection([
-                'host' => 'redis',
+                'host' => 'localhost',
                 'port' => 1234,
-                'vhost' => '/',
+                'vhost' => 'vhost',
                 'login' => 'guest',
                 'password' => 'password',
             ], [
@@ -62,7 +78,7 @@ class ConnectionTest extends TestCase
             ], [
                 'queueName' => [],
             ]),
-            Connection::fromDsn('amqp://guest:password@redis:1234/%2f/queue?exchange[name]=exchangeName&queues[queueName]')
+            Connection::fromDsn('amqp://guest:password@localhost:1234/vhost/queue?exchange[name]=exchangeName&queues[queueName]')
         );
     }
 
@@ -70,18 +86,16 @@ class ConnectionTest extends TestCase
     {
         $this->assertEquals(
             new Connection([
-                'host' => 'redis',
-                'port' => 1234,
+                'host' => 'localhost',
+                'port' => 5672,
                 'vhost' => '/',
-                'login' => 'guest',
-                'password' => 'password',
                 'persistent' => 'true',
             ], [
                 'name' => 'exchangeName',
             ], [
                 'queueName' => [],
             ]),
-            Connection::fromDsn('amqp://guest:password@redis:1234/%2f/queue?exchange[name]=exchangeName&queues[queueName]', [
+            Connection::fromDsn('amqp://localhost/%2f/queue?exchange[name]=exchangeName&queues[queueName]', [
                 'persistent' => 'true',
                 'exchange' => ['name' => 'toBeOverwritten'],
             ])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixes two bugs and outdated phpdoc:
1. When your exchange is not of type fanout, but direct for example, then delivery of delayed (retrying) messages does not work. This is because the delay logics adds a routing key to message. It was fixed if you have a custom routing key in #31355. But if you have no routing key, it still changed the routing key which means the message will not be delivery from your direct exchange to your queue anymore after being in the delay exchange. For fanout, which is the default, it does not matter because the routing key is ignored.
2. also fix dsn parsing of plain `amqp://` which is a valid URI that parse_url cannot handle when you want to pass all parameters as options