### PR TITLE
[Messenger] improve logs

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -64,7 +64,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                 $handler = $handlerDescriptor->getHandler();
                 $handledStamp = HandledStamp::fromDescriptor($handlerDescriptor, $handler($message));
                 $envelope = $envelope->with($handledStamp);
-                $this->logger->info('Message "{class}" handled by "{handler}"', $context + ['handler' => $handledStamp->getHandlerName()]);
+                $this->logger->info('Message {class} handled by {handler}', $context + ['handler' => $handledStamp->getHandlerName()]);
             } catch (\Throwable $e) {
                 $exceptions[] = $e;
             }
@@ -75,7 +75,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                 throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', $context['class']));
             }
 
-            $this->logger->info('No handler for message "{class}"', $context);
+            $this->logger->info('No handler for message {class}', $context);
         }
 
         if (\count($exceptions)) {

--- a/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
@@ -70,14 +70,14 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
             return true;
         }
 
-        $retries = $this->getCurrentRetryCount($message);
+        $retries = RedeliveryStamp::getRetryCountFromEnvelope($message);
 
         return $retries < $this->maxRetries;
     }
 
     public function getWaitingTime(Envelope $message): int
     {
-        $retries = $this->getCurrentRetryCount($message);
+        $retries = RedeliveryStamp::getRetryCountFromEnvelope($message);
 
         $delay = $this->delayMilliseconds * pow($this->multiplier, $retries);
 
@@ -86,13 +86,5 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
         }
 
         return $delay;
-    }
-
-    private function getCurrentRetryCount(Envelope $message): int
-    {
-        /** @var RedeliveryStamp|null $retryMessageStamp */
-        $retryMessageStamp = $message->last(RedeliveryStamp::class);
-
-        return $retryMessageStamp ? $retryMessageStamp->getRetryCount() : 0;
     }
 }

--- a/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Stamp;
 
 use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Messenger\Envelope;
 
 /**
  * Stamp applied when a messages needs to be redelivered.
@@ -36,6 +37,14 @@ class RedeliveryStamp implements StampInterface
         $this->exceptionMessage = $exceptionMessage;
         $this->flattenException = $flattenException;
         $this->redeliveredAt = new \DateTimeImmutable();
+    }
+
+    public static function getRetryCountFromEnvelope(Envelope $envelope): int
+    {
+        /** @var self|null $retryMessageStamp */
+        $retryMessageStamp = $envelope->last(self::class);
+
+        return $retryMessageStamp ? $retryMessageStamp->getRetryCount() : 0;
     }
 
     public function getRetryCount(): int


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The logs are currently very confusing and duplicated:

- When handled sync the uncaught error it logged and displayed by the console / http error handler anyway. Currently it the warning is duplicated and useless:

```
14:26:11 WARNING   [messenger] An exception occurred while handling message "{class}": OUCH, THAT HURTS! GO TO MOM! 
14:26:11 ERROR     [console] Error thrown while running command "{class}". Message: "OUCH, THAT HURTS! GO TO MOM!"

In HandleMessageMiddleware.php line 82:

  [Symfony\Component\Messenger\Exception\HandlerFailedException]
  OUCH, THAT HURTS! GO TO MOM!
```

- When handling async is was even confusing because the actual error was logged as warning and the retry (which is a good thing) was the error.

```
13:48:15 WARNING   [messenger] An exception occurred while handling message "{class}": OUCH, THAT HURTS! GO TO MOM! 
13:48:15 ERROR     [messenger] Retrying {class} - retry #1.
```

Now it's must clearer and adds even context like the delay:

```
16:20:11 ERROR     [messenger] Error thrown while handling message {class}. Dispatching for retry #3 using 4000 ms delay. Error: "OUCH, THAT HURTS! GO TO MOM!"
...
16:20:15 CRITICAL  [messenger] Error thrown while handling message {class}. Removing from transport after 3 retries. Error: "OUCH, THAT HURTS! GO TO MOM!"
```