### PR TITLE
[Validator] Deprecate unused arg in ExpressionValidator

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -85,3 +85,9 @@ TwigBridge
 
  * Deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
    `DebugCommand::__construct()` method, swap the variables position.
+
+Validator
+---------
+
+ * Deprecated passing an `ExpressionLanguage` instance as the second argument of `ExpressionValidator::__construct()`. 
+   Pass it as the first argument instead.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -453,6 +453,7 @@ TwigBridge
 Validator
 --------
 
+ * An `ExpressionLanguage` instance or null must be passed as the first argument of `ExpressionValidator::__construct()`
  * The `checkMX` and `checkHost` options of the `Email` constraint were removed
  * The `Email::__construct()` 'strict' property has been removed. Use 'mode'=>"strict" instead.
  * Calling `EmailValidator::__construct()` method with a boolean parameter has been removed, use `EmailValidator("strict")` instead.

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * deprecated passing an `ExpressionLanguage` instance as the second argument of `ExpressionValidator::__construct()`. Pass it as the first argument instead.
  * added the `compared_value_path` parameter in violations when using any 
    comparison constraint with the `propertyPath` option.
  * added support for checking an array of types in `TypeValidator`

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -25,8 +25,19 @@ class ExpressionValidator extends ConstraintValidator
 {
     private $expressionLanguage;
 
-    public function __construct($propertyAccessor = null, ExpressionLanguage $expressionLanguage = null)
+    public function __construct(/*ExpressionLanguage */$expressionLanguage = null)
     {
+        if (!$expressionLanguage instanceof ExpressionLanguage) {
+            if (null !== $expressionLanguage) {
+                @trigger_error(sprintf('The "%s" first argument must be an instance of "%s" or null since 4.4. "%s" given', __METHOD__, ExpressionLanguage::class, \is_object($expressionLanguage) ? \get_class($expressionLanguage) : \gettype($expressionLanguage)), E_USER_DEPRECATED);
+            }
+
+            if (\func_num_args() > 1 && func_get_arg(1) instanceof ExpressionLanguage) {
+                @trigger_error(sprintf('The "%s" instance should be passed as "%s" first argument instead of second argument since 4.4.', ExpressionLanguage::class, __METHOD__), E_USER_DEPRECATED);
+                $expressionLanguage = func_get_arg(1);
+            }
+        }
+
         $this->expressionLanguage = $expressionLanguage;
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -253,6 +254,34 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             'expression' => 'false',
         ]);
 
+        $expressionLanguage = $this->getMockBuilder(ExpressionLanguage::class)->getMock();
+
+        $used = false;
+
+        $expressionLanguage->method('evaluate')
+            ->willReturnCallback(function () use (&$used) {
+                $used = true;
+
+                return true;
+            });
+
+        $validator = new ExpressionValidator($expressionLanguage);
+        $validator->initialize($this->createContext());
+        $validator->validate(null, $constraint);
+
+        $this->assertTrue($used, 'Failed asserting that custom ExpressionLanguage instance is used.');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The "Symfony\Component\ExpressionLanguage\ExpressionLanguage" instance should be passed as "Symfony\Component\Validator\Constraints\ExpressionValidator::__construct" first argument instead of second argument since 4.4.
+     */
+    public function testLegacyExpressionLanguageUsage()
+    {
+        $constraint = new Expression([
+            'expression' => 'false',
+        ]);
+
         $expressionLanguage = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ExpressionLanguage')->getMock();
 
         $used = false;
@@ -269,6 +298,15 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
         $validator->validate(null, $constraint);
 
         $this->assertTrue($used, 'Failed asserting that custom ExpressionLanguage instance is used.');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The "Symfony\Component\Validator\Constraints\ExpressionValidator::__construct" first argument must be an instance of "Symfony\Component\ExpressionLanguage\ExpressionLanguage" or null since 4.4. "string" given
+     */
+    public function testConstructorInvalidType()
+    {
+        new ExpressionValidator('foo');
     }
 
     public function testPassingCustomValues()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

Time to deprecate this unused first argument?