### PR TITLE
[Serializer] Add CsvEncoder tests for PHP 7.4

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -39,8 +39,12 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
      * @param string $escapeChar
      * @param string $keySeparator
      */
-    public function __construct($delimiter = ',', $enclosure = '"', $escapeChar = '\\', $keySeparator = '.')
+    public function __construct($delimiter = ',', $enclosure = '"', $escapeChar = '', $keySeparator = '.')
     {
+        if ('' === $escapeChar && \PHP_VERSION_ID < 70400) {
+            $escapeChar = '\\';
+        }
+
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
         $this->escapeChar = $escapeChar;

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -36,15 +36,51 @@ class CsvEncoderTest extends TestCase
             'int' => 2,
             'false' => false,
             'true' => true,
+            'int_one' => 1,
+            'string_one' => '1',
         ];
 
         // Check that true and false are appropriately handled
-        $this->assertEquals(<<<'CSV'
-string,int,false,true
-foo,2,0,1
+        $this->assertSame($csv = <<<'CSV'
+string,int,false,true,int_one,string_one
+foo,2,0,1,1,1
 
 CSV
-    , $this->encoder->encode($data, 'csv'));
+        , $this->encoder->encode($data, 'csv'));
+
+        $this->assertSame([
+            'string' => 'foo',
+            'int' => '2',
+            'false' => '0',
+            'true' => '1',
+            'int_one' => '1',
+            'string_one' => '1',
+        ], $this->encoder->decode($csv, 'csv'));
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testDoubleQuotesAndSlashes()
+    {
+        $this->assertSame($csv = <<<'CSV'
+0,1,2,3,4,5
+,"""","foo""","\""",\,foo\
+
+CSV
+        , $this->encoder->encode($data = ['', '"', 'foo"', '\\"', '\\', 'foo\\'], 'csv'));
+
+        $this->assertSame($data, $this->encoder->decode($csv, 'csv'));
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testSingleSlash()
+    {
+        $this->assertSame($csv = "0\n\\\n", $this->encoder->encode($data = ['\\'], 'csv'));
+        $this->assertSame($data, $this->encoder->decode($csv, 'csv'));
+        $this->assertSame($data, $this->encoder->decode(trim($csv), 'csv'));
     }
 
     public function testSupportEncoding()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Some CSV encoder tests to show the broken behavior of a trailing slash. Spotted in #31867, not sure what to do with it :)