### PR TITLE
[Messenger] No need for retry to require SentStamp

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/RetryIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/RetryIntegrationTest.php
@@ -34,9 +34,9 @@ class RetryIntegrationTest extends TestCase
         $senderAndReceiver = new DummySenderAndReceiver();
 
         $senderLocator = $this->createMock(ContainerInterface::class);
-        $senderLocator->method('has')->with('sender_alias')->willReturn(true);
-        $senderLocator->method('get')->with('sender_alias')->willReturn($senderAndReceiver);
-        $senderLocator = new SendersLocator([DummyMessage::class => ['sender_alias']], $senderLocator);
+        $senderLocator->method('has')->with('transportName')->willReturn(true);
+        $senderLocator->method('get')->with('transportName')->willReturn($senderAndReceiver);
+        $senderLocator = new SendersLocator([DummyMessage::class => ['transportName']], $senderLocator);
 
         $handler = new DummyMessageHandlerFailingFirstTimes(0);
         $throwingHandler = new DummyMessageHandlerFailingFirstTimes(1);
@@ -52,7 +52,7 @@ class RetryIntegrationTest extends TestCase
         $envelope = new Envelope(new DummyMessage('API'));
         $bus->dispatch($envelope);
 
-        $worker = new Worker(['receiverName' => $senderAndReceiver], $bus, ['receiverName' => new MultiplierRetryStrategy()]);
+        $worker = new Worker(['transportName' => $senderAndReceiver], $bus, ['transportName' => new MultiplierRetryStrategy()]);
         $worker->run([], function (?Envelope $envelope) use ($worker) {
             if (null === $envelope) {
                 $worker->stop();

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -84,7 +84,7 @@ class WorkerTest extends TestCase
     public function testDispatchCausesRetry()
     {
         $receiver = new DummyReceiver([
-            [new Envelope(new DummyMessage('Hello'), [new SentStamp('Some\Sender', 'sender_alias')])],
+            [new Envelope(new DummyMessage('Hello'), [new SentStamp('Some\Sender', 'transport1')])],
         ]);
 
         $bus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
@@ -97,7 +97,7 @@ class WorkerTest extends TestCase
             $this->assertNotNull($redeliveryStamp);
             // retry count now at 1
             $this->assertSame(1, $redeliveryStamp->getRetryCount());
-            $this->assertSame('sender_alias', $redeliveryStamp->getSenderClassOrAlias());
+            $this->assertSame('transport1', $redeliveryStamp->getSenderClassOrAlias());
 
             // received stamp is removed
             $this->assertNull($envelope->last(ReceivedStamp::class));
@@ -108,7 +108,7 @@ class WorkerTest extends TestCase
         $retryStrategy = $this->getMockBuilder(RetryStrategyInterface::class)->getMock();
         $retryStrategy->expects($this->once())->method('isRetryable')->willReturn(true);
 
-        $worker = new Worker(['receiver1' => $receiver], $bus, ['receiver1' => $retryStrategy]);
+        $worker = new Worker(['transport1' => $receiver], $bus, ['transport1' => $retryStrategy]);
         $worker->run([], function (?Envelope $envelope) use ($worker) {
             // stop after the messages finish
             if (null === $envelope) {
@@ -123,7 +123,7 @@ class WorkerTest extends TestCase
     public function testDispatchCausesRejectWhenNoRetry()
     {
         $receiver = new DummyReceiver([
-            [new Envelope(new DummyMessage('Hello'), [new SentStamp('Some\Sender', 'sender_alias')])],
+            [new Envelope(new DummyMessage('Hello'), [new SentStamp('Some\Sender', 'transport1')])],
         ]);
 
         $bus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
@@ -132,7 +132,7 @@ class WorkerTest extends TestCase
         $retryStrategy = $this->getMockBuilder(RetryStrategyInterface::class)->getMock();
         $retryStrategy->expects($this->once())->method('isRetryable')->willReturn(false);
 
-        $worker = new Worker(['receiver1' => $receiver], $bus, ['receiver1' => $retryStrategy]);
+        $worker = new Worker(['transport1' => $receiver], $bus, ['transport1' => $retryStrategy]);
         $worker->run([], function (?Envelope $envelope) use ($worker) {
             // stop after the messages finish
             if (null === $envelope) {
@@ -155,7 +155,7 @@ class WorkerTest extends TestCase
         $retryStrategy = $this->getMockBuilder(RetryStrategyInterface::class)->getMock();
         $retryStrategy->expects($this->never())->method('isRetryable');
 
-        $worker = new Worker(['receiver1' => $receiver], $bus, ['receiver1' => $retryStrategy]);
+        $worker = new Worker(['transport1' => $receiver], $bus, ['transport1' => $retryStrategy]);
         $worker->run([], function (?Envelope $envelope) use ($worker) {
             // stop after the messages finish
             if (null === $envelope) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Fixes 2) in #32049
@weaverryan the SentStamp in the worker seems totally irrelevant. You always want to send messages back to the transport where they came from for retry. The only relevance I can potentially see is for the SyncTransport. Messages received async from worker might be routed to the SyncTransport. Using the SentStamp would redeliver the messages into the SyncTransport instead of the async. But that doesn't seem to have any use-case. I'm running the worker which handles the messages immediately. So basically there is no difference if they go to the Sync or Async transport from within the worker.