### PR TITLE
[DI] deprecate booting the kernel twices

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecated the `$parser` argument of `ControllerResolver::__construct()` and `DelegatingLoader::__construct()`
  * Deprecated the `controller_name_converter` and `resolve_controller_name_subscriber` services
  * The `ControllerResolver` and `DelegatingLoader` classes have been marked as `final`
+ * Deprecated booting the kernel before running `WebTestCase::createClient()`
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -37,6 +37,8 @@ abstract class KernelTestCase extends TestCase
      */
     protected static $container;
 
+    protected static $booted;
+
     protected function doTearDown(): void
     {
         static::ensureKernelShutdown();
@@ -72,6 +74,7 @@ abstract class KernelTestCase extends TestCase
 
         static::$kernel = static::createKernel($options);
         static::$kernel->boot();
+        static::$booted = true;
 
         $container = static::$kernel->getContainer();
         static::$container = $container->has('test.service_container') ? $container->get('test.service_container') : $container;
@@ -126,6 +129,7 @@ abstract class KernelTestCase extends TestCase
         if (null !== static::$kernel) {
             $container = static::$kernel->getContainer();
             static::$kernel->shutdown();
+            static::$booted = false;
             if ($container instanceof ResetInterface) {
                 $container->reset();
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -39,6 +39,10 @@ abstract class WebTestCase extends KernelTestCase
      */
     protected static function createClient(array $options = [], array $server = [])
     {
+        if (true === static::$booted) {
+            @trigger_error(sprintf('Booting the kernel before calling %s::%s is deprecated and will throw in Symfony 5.0, the kernel should only be booted once.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
+        }
+
         $kernel = static::bootKernel($options);
 
         try {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -83,6 +83,8 @@ class SessionTest extends WebTestCase
             $client1->insulate();
         }
 
+        $this->ensureKernelShutdown();
+
         // start second client
         $client2 = $this->createClient(['test_case' => 'Session', 'root_config' => $config]);
         if ($insulate) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
@@ -58,6 +58,9 @@ class SecurityRoutingIntegrationTest extends WebTestCase
     public function testSecurityConfigurationForSingleIPAddress($config)
     {
         $allowedClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '10.10.10.10']);
+
+        $this->ensureKernelShutdown();
+
         $barredClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '10.10.20.10']);
 
         $this->assertAllowed($allowedClient, '/secured-by-one-ip');
@@ -70,8 +73,17 @@ class SecurityRoutingIntegrationTest extends WebTestCase
     public function testSecurityConfigurationForMultipleIPAddresses($config)
     {
         $allowedClientA = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '1.1.1.1']);
+
+        $this->ensureKernelShutdown();
+
         $allowedClientB = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '2.2.2.2']);
+
+        $this->ensureKernelShutdown();
+
         $allowedClientC = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '203.0.113.0']);
+
+        $this->ensureKernelShutdown();
+
         $barredClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '192.168.1.1']);
 
         $this->assertAllowed($allowedClientA, '/secured-by-two-ips');
@@ -91,9 +103,11 @@ class SecurityRoutingIntegrationTest extends WebTestCase
     {
         $allowedClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['HTTP_USER_AGENT' => 'Firefox 1.0']);
         $this->assertAllowed($allowedClient, '/protected-via-expression');
+        $this->ensureKernelShutdown();
 
         $barredClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], []);
         $this->assertRestricted($barredClient, '/protected-via-expression');
+        $this->ensureKernelShutdown();
 
         $allowedClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], []);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31233   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | ? <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This adds a check to see if the kernel has been booted twices in a single test, and throw a deprecation
