### PR TITLE
[HttpClient] throw DecodingExceptionInterface when toArray() fails because of content-type error

### DIFF
--- a/src/Symfony/Component/HttpClient/Exception/JsonException.php
+++ b/src/Symfony/Component/HttpClient/Exception/JsonException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpClient\Exception;
 
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 
 /**
  * Thrown by responses' toArray() method when their content cannot be JSON-decoded.
@@ -20,6 +20,6 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
  *
  * @experimental in 4.3
  */
-final class JsonException extends \JsonException implements TransportExceptionInterface
+final class JsonException extends \JsonException implements DecodingExceptionInterface
 {
 }

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.1.3",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^1.1.3",
+        "symfony/http-client-contracts": "^1.1.4",
         "symfony/polyfill-php73": "^1.11"
     },
     "require-dev": {

--- a/src/Symfony/Contracts/HttpClient/Exception/DecodingExceptionInterface.php
+++ b/src/Symfony/Contracts/HttpClient/Exception/DecodingExceptionInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\HttpClient\Exception;
+
+/**
+ * When a content-type cannot be decoded to the expected representation.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @experimental in 1.1
+ */
+interface DecodingExceptionInterface extends ExceptionInterface
+{
+}

--- a/src/Symfony/Contracts/HttpClient/ResponseInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ResponseInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Contracts\HttpClient;
 
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
@@ -64,7 +65,8 @@ interface ResponseInterface
      *
      * @param bool $throw Whether an exception should be thrown on 3/4/5xx status codes
      *
-     * @throws TransportExceptionInterface   When the body cannot be decoded or when a network error occurs
+     * @throws DecodingExceptionInterface    When the body cannot be decoded to an array
+     * @throws TransportExceptionInterface   When a network error occurs
      * @throws RedirectionExceptionInterface On a 3xx when $throw is true and the "max_redirects" option has been reached
      * @throws ClientExceptionInterface      On a 4xx when $throw is true
      * @throws ServerExceptionInterface      On a 5xx when $throw is true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31913
| License       | MIT
| Doc PR        | -

As spotted in the linked issue, we are missing this type of exception. It's a bug at the contracts level.