### PR TITLE
Document that HTTP Response status text is ignored in HTTP2

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -441,6 +441,7 @@ class Response
      * If the status text is null it will be automatically populated for the known
      * status codes and left empty otherwise.
      *
+     * @param null|string $text Reason Phrase, to be sent with the code. This not sent in HTTP/2.
      * @return $this
      *
      * @throws \InvalidArgumentException When the HTTP status code is not valid


### PR DESCRIPTION
See https://evertpot.com/http-2-finalized/

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

