### PR TITLE
[Lock] Fix expired lock not cleaned in ZooKeeper

### DIFF
--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -25,6 +25,8 @@ use Symfony\Component\Lock\StoreInterface;
  */
 class ZookeeperStore implements StoreInterface
 {
+    use ExpiringStoreTrait;
+
     private $zookeeper;
 
     public function __construct(\Zookeeper $zookeeper)
@@ -45,6 +47,8 @@ class ZookeeperStore implements StoreInterface
         $token = $this->getUniqueToken($key);
 
         $this->createNewLock($resource, $token);
+
+        $this->checkNotExpired($key);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | ,p
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #31426 
| License       | MIT
| Doc PR        | NA

Following #32071 for 4.3 branch

context:
When a lock is acquired BUT not as fast as expected, a LockExpiredException is thrown.
Issue is, that the lock is not removed which avoid other process to acquire that lock.

This PR clean state of store when a LockExpiredException is triggered in PDO and ZooKeepeer.