### PR TITLE
[Lock] Fix PDO prune not called

### DIFF
--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -124,9 +124,6 @@ class PdoStore implements StoreInterface
 
         try {
             $stmt->execute();
-            $this->checkNotExpired($key);
-
-            return;
         } catch (DBALException $e) {
             // the lock is already acquired. It could be us. Let's try to put off.
             $this->putOffExpiration($key, $this->initialTtl);
@@ -135,11 +132,11 @@ class PdoStore implements StoreInterface
             $this->putOffExpiration($key, $this->initialTtl);
         }
 
-        $this->checkNotExpired($key);
-
         if ($this->gcProbability > 0 && (1.0 === $this->gcProbability || (random_int(0, PHP_INT_MAX) / PHP_INT_MAX) <= $this->gcProbability)) {
             $this->prune();
         }
+
+        $this->checkNotExpired($key);
     }
 
     /**
@@ -289,7 +286,7 @@ class PdoStore implements StoreInterface
     }
 
     /**
-     * Cleanups the table by removing all expired locks.
+     * Cleans up the table by removing all expired locks.
      */
     private function prune(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
| License       | MIT
| Doc PR        | NA

Saving a key in the PDO store have 2 paths: 
- the key is didn't exists in the store, the process exit as soon as the key has been savec
- the key already exists in the store, the process put off the expiration then run GC to prunbe old keys

Calling GC only in the 2nd path was a mistake, if the component is well used, the second could never be used.
This PR call the GC in the first path too.