### PR TITLE
[Messenger] make all stamps final and mark stamp not meant to be sent

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/BusNameStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/BusNameStamp.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-class BusNameStamp implements StampInterface
+final class BusNameStamp implements StampInterface
 {
     private $busName;
 

--- a/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @experimental in 4.3
  */
-class DelayStamp implements StampInterface
+final class DelayStamp implements StampInterface
 {
     private $delay;
 

--- a/src/Symfony/Component/Messenger/Stamp/DispatchAfterCurrentBusStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DispatchAfterCurrentBusStamp.php
@@ -20,6 +20,6 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class DispatchAfterCurrentBusStamp implements StampInterface
+final class DispatchAfterCurrentBusStamp implements NonSendableStampInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Stamp/HandledStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/HandledStamp.php
@@ -17,7 +17,11 @@ use Symfony\Component\Messenger\Handler\HandlerDescriptor;
  * Stamp identifying a message handled by the `HandleMessageMiddleware` middleware
  * and storing the handler returned value.
  *
+ * This is used by synchronous command buses expecting a return value and the retry logic
+ * to only execute handlers that didn't succeed.
+ *
  * @see \Symfony\Component\Messenger\Middleware\HandleMessageMiddleware
+ * @see \Symfony\Component\Messenger\HandleTrait
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  *

--- a/src/Symfony/Component/Messenger/Stamp/ReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ReceivedStamp.php
@@ -25,7 +25,7 @@ use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
  *
  * @experimental in 4.3
  */
-final class ReceivedStamp implements StampInterface
+final class ReceivedStamp implements NonSendableStampInterface
 {
     private $transportName;
 

--- a/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
@@ -19,7 +19,7 @@ use Symfony\Component\Messenger\Envelope;
  *
  * @experimental in 4.3
  */
-class RedeliveryStamp implements StampInterface
+final class RedeliveryStamp implements StampInterface
 {
     private $retryCount;
     private $senderClassOrAlias;

--- a/src/Symfony/Component/Messenger/Stamp/SentStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SentStamp.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @experimental in 4.3
  */
-final class SentStamp implements StampInterface
+final class SentStamp implements NonSendableStampInterface
 {
     private $senderClass;
     private $senderAlias;

--- a/src/Symfony/Component/Messenger/Stamp/SentToFailureTransportStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SentToFailureTransportStamp.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @experimental in 4.3
  */
-class SentToFailureTransportStamp implements StampInterface
+final class SentToFailureTransportStamp implements StampInterface
 {
     private $originalReceiverName;
 

--- a/src/Symfony/Component/Messenger/Stamp/TransportMessageIdStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/TransportMessageIdStamp.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Messenger\Stamp;
  *
  * @experimental in 4.3
  */
-class TransportMessageIdStamp implements StampInterface
+final class TransportMessageIdStamp implements StampInterface
 {
     private $id;
 

--- a/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
@@ -55,9 +55,8 @@ class EnvelopeTest extends TestCase
     {
         $envelope = new Envelope(new DummyMessage('dummy'), [
             new ReceivedStamp('transport1'),
-            new DelayStamp(5000),
-            new DummyExtendsDelayStamp(5000),
-            new DummyImplementsFooBarStampInterface(),
+            new DummyExtendsFooBarStamp(),
+            new DummyImplementsFooBarStamp(),
         ]);
 
         $envelope2 = $envelope->withoutStampsOfType(DummyNothingImplementsMeStampInterface::class);
@@ -66,12 +65,11 @@ class EnvelopeTest extends TestCase
         $envelope3 = $envelope2->withoutStampsOfType(ReceivedStamp::class);
         $this->assertEmpty($envelope3->all(ReceivedStamp::class));
 
-        $envelope4 = $envelope3->withoutStampsOfType(DelayStamp::class);
-        $this->assertEmpty($envelope4->all(DelayStamp::class));
-        $this->assertEmpty($envelope4->all(DummyExtendsDelayStamp::class));
+        $envelope4 = $envelope3->withoutStampsOfType(DummyImplementsFooBarStamp::class);
+        $this->assertEmpty($envelope4->all(DummyImplementsFooBarStamp::class));
+        $this->assertEmpty($envelope4->all(DummyExtendsFooBarStamp::class));
 
-        $envelope5 = $envelope4->withoutStampsOfType(DummyFooBarStampInterface::class);
-        $this->assertEmpty($envelope5->all(DummyImplementsFooBarStampInterface::class));
+        $envelope5 = $envelope3->withoutStampsOfType(DummyFooBarStampInterface::class);
         $this->assertEmpty($envelope5->all());
     }
 
@@ -118,15 +116,15 @@ class EnvelopeTest extends TestCase
     }
 }
 
-class DummyExtendsDelayStamp extends DelayStamp
-{
-}
 interface DummyFooBarStampInterface extends StampInterface
 {
 }
 interface DummyNothingImplementsMeStampInterface extends StampInterface
 {
 }
-class DummyImplementsFooBarStampInterface implements DummyFooBarStampInterface
+class DummyImplementsFooBarStamp implements DummyFooBarStampInterface
+{
+}
+class DummyExtendsFooBarStamp extends DummyImplementsFooBarStamp
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Some newer stamps were already final. This makes all of them final. Also marks all stamps that are not meant to be sent using the new `NonSendableStampInterface`. This makes it easier to see which stamps are actually important and required to persist in a queue for certain functionality, like the `BusNameStamp` for the `RoutableMessageBus`