### PR TITLE
[EventDispatcher] add ability to subscribe to child events

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * The signature of the `EventDispatcherInterface::dispatch()` method should be updated to `dispatch($event, string $eventName = null)`, not doing so is deprecated
  * deprecated the `Event` class, use `Symfony\Contracts\EventDispatcher\Event` instead
+ * added support for events to be subscribed to using the FQCN of their parent
 
 4.1.0
 -----

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -135,7 +135,19 @@ class EventDispatcher implements EventDispatcherInterface
     public function hasListeners($eventName = null)
     {
         if (null !== $eventName) {
-            return !empty($this->listeners[$eventName]);
+            if(!empty($this->listeners[$eventName])) {
+                return true;
+            }
+
+            if (\class_exists($eventName)) {
+                foreach (\class_parents($eventName) as $parentEvent) {
+                    if (!empty($this->listeners[$parentEvent])) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         foreach ($this->listeners as $eventListeners) {

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -97,7 +97,7 @@ class EventDispatcher implements EventDispatcherInterface
                 return $listeners;
             }
 
-            $classParents = class_parents($eventName);
+            $classParents = array_merge(class_parents($eventName), class_implements($eventName));
             foreach ($classParents as $parentEvent) {
                 $this->sortListeners($parentEvent);
                 $listeners = array_merge($listeners, $this->sorted[$parentEvent] ?? []);
@@ -151,7 +151,8 @@ class EventDispatcher implements EventDispatcherInterface
             }
 
             if (class_exists($eventName)) {
-                foreach (class_parents($eventName) as $parentEvent) {
+                $classParents = array_merge(class_parents($eventName), class_implements($eventName));
+                foreach ($classParents as $parentEvent) {
                     if (!empty($this->listeners[$parentEvent])) {
                         return true;
                     }
@@ -321,7 +322,7 @@ class EventDispatcher implements EventDispatcherInterface
             return $listeners;
         }
 
-        $classParents = class_parents($eventName);
+        $classParents = array_merge(class_parents($eventName), class_implements($eventName));
         foreach ($classParents as $parentEvent) {
             if (isset($this->listeners[$parentEvent]) && !isset($this->optimized[$parentEvent])) {
                 $this->optimizeListeners($parentEvent);

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -93,14 +93,14 @@ class EventDispatcher implements EventDispatcherInterface
             }
 
             $listeners = $this->sorted[$eventName] ?? [];
-            if (!\class_exists($eventName)) {
+            if (!class_exists($eventName)) {
                 return $listeners;
             }
 
-            $classParents = \class_parents($eventName);
+            $classParents = class_parents($eventName);
             foreach ($classParents as $parentEvent) {
                 $this->sortListeners($parentEvent);
-                $listeners = \array_merge($listeners, $this->sorted[$parentEvent] ?? []);
+                $listeners = array_merge($listeners, $this->sorted[$parentEvent] ?? []);
             }
 
             return $listeners;
@@ -146,12 +146,12 @@ class EventDispatcher implements EventDispatcherInterface
     public function hasListeners($eventName = null)
     {
         if (null !== $eventName) {
-            if(!empty($this->listeners[$eventName])) {
+            if (!empty($this->listeners[$eventName])) {
                 return true;
             }
 
-            if (\class_exists($eventName)) {
-                foreach (\class_parents($eventName) as $parentEvent) {
+            if (class_exists($eventName)) {
+                foreach (class_parents($eventName) as $parentEvent) {
                     if (!empty($this->listeners[$parentEvent])) {
                         return true;
                     }
@@ -317,16 +317,16 @@ class EventDispatcher implements EventDispatcherInterface
         }
 
         $listeners = $this->optimized[$eventName] ?? [];
-        if (!\class_exists($eventName)) {
+        if (!class_exists($eventName)) {
             return $listeners;
         }
 
-        $classParents = \class_parents($eventName);
+        $classParents = class_parents($eventName);
         foreach ($classParents as $parentEvent) {
             if (isset($this->listeners[$parentEvent]) && !isset($this->optimized[$parentEvent])) {
                 $this->optimizeListeners($parentEvent);
             }
-            $listeners = \array_merge($listeners, $this->optimized[$parentEvent] ?? []);
+            $listeners = array_merge($listeners, $this->optimized[$parentEvent] ?? []);
         }
 
         return $listeners;

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -420,6 +420,19 @@ class EventDispatcherTest extends TestCase
         $this->assertTrue($this->dispatcher->hasListeners(ParentEvent::class));
         $this->assertTrue($this->dispatcher->hasListeners(ChildEvent::class));
     }
+
+    public function testGetListenersWithEventChild()
+    {
+        $subscriber = new TestEventSubscriberWithEventFqcn();
+        $this->dispatcher->addSubscriber($subscriber);
+
+        $parent = $this->dispatcher->getListeners(ParentEvent::class);
+        $child = $this->dispatcher->getListeners(ChildEvent::class);
+
+        $expected = [[$subscriber, 'handleParentEvent']];
+        $this->assertSame($expected, $this->dispatcher->getListeners(ParentEvent::class));
+        $this->assertSame($expected, $this->dispatcher->getListeners(ChildEvent::class));
+    }
 }
 
 class CallableClass

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -519,12 +519,10 @@ class TestEventSubscriberWithMultipleListeners implements EventSubscriberInterfa
 
 class ParentEvent
 {
-
 }
 
 class ChildEvent extends ParentEvent
 {
-
 }
 
 class TestEventSubscriberWithEventFqcn implements EventSubscriberInterface

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -453,7 +453,7 @@ class EventDispatcherTest extends TestCase
 
     public function testGetListenersWithEventInterface()
     {
-        $subscriber = new TestEventSubscriberWithInterfaceFqcn()    ;
+        $subscriber = new TestEventSubscriberWithInterfaceFqcn();
         $this->dispatcher->addSubscriber($subscriber);
 
         $expected = [[$subscriber, 'handleEventInterface']];

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -412,6 +412,14 @@ class EventDispatcherTest extends TestCase
 
         $this->assertTrue($testLoaded);
     }
+
+    public function testHasListenersWithEventChild()
+    {
+        $this->dispatcher->addSubscriber(new TestEventSubscriberWithEventFqcn());
+        $this->assertTrue($this->dispatcher->hasListeners());
+        $this->assertTrue($this->dispatcher->hasListeners(ParentEvent::class));
+        $this->assertTrue($this->dispatcher->hasListeners(ChildEvent::class));
+    }
 }
 
 class CallableClass
@@ -482,5 +490,23 @@ class TestEventSubscriberWithMultipleListeners implements EventSubscriberInterfa
             ['preFoo1'],
             ['preFoo2', 10],
         ]];
+    }
+}
+
+class ParentEvent extends ContractsEvent
+{
+
+}
+
+class ChildEvent extends ParentEvent
+{
+
+}
+
+class TestEventSubscriberWithEventFqcn implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [ParentEvent::class => 'handleParentEvent'];
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\EventDispatcher\Tests;
 
-use Nelmio\Alice\Throwable\Exception\Generator\Resolver\ChildCircularReferenceException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31969   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none, see below <!-- required for new features -->

As mentioned in the linked ticket, now that we can subscribe to events using the FQCN, it would be great if we can use a parent FQCN to subscribe to all it's children events. An example pulled from the ticket:

```php
class VehicleEvent {
}

class MotorcycleEvent extends VehicleEvent 
{
}

class SedanEvent extends VehicleEvent 
{
}

class BicycleEvent extends VehicleEvent 
{
}

class PlaneEvent extends VehicleEvent 
{
}

class VehicleSubscriber extends EventSubscriberInterface 
{
    public function getSubscribedEvents(): array
    {
        return [
            VehicleEvent::class => 'handleVehicleEvent',
        ];
    }

    public function handleVehicleEvent(VehicleEvent $event): void
    {
        // Do vehicle related things
        // This will get called for all the events above
    }
}
```

I haven't created a docs PR because [the event dispatcher docs] have not yet been updated to reflect the [updates from 4.3](https://symfony.com/doc/current/components/event_dispatcher.html). So I think these changes could be bundled in with the 4.3 changes for a docs update. Which I'm happy to do if required, not sure if anyone else is currently doing it though?

### TODO

- [x] update CHANGELOG