### PR TITLE
[Debug] workaround BC break in PHP 7.3

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -382,6 +382,11 @@ class ErrorHandler
      */
     public function handleError($type, $message, $file, $line)
     {
+        // @deprecated to be removed in Symfony 5.0
+        if (\PHP_VERSION_ID >= 70300 && $message && '"' === $message[0] && 0 === strpos($message, '"continue') && preg_match('/^"continue(?: \d++)?" targeting switch is equivalent to "break(?: \d++)?"\. Did you mean to use "continue(?: \d++)?"\?$/', $message)) {
+            $type = E_DEPRECATED;
+        }
+
         // Level is the current error reporting level to manage silent error.
         $level = error_reporting();
         $silenced = 0 === ($level & $type);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony-standard/issues/1138 https://github.com/symfony/website-skeleton/issues/231
| License       | MIT
| Doc PR        | -

A new warning has been added in PHP 7.3 that is breaking BC with Symfony, since we turn warnings into exceptions.
This PR turns the new warning into a deprecation, so that we will be able to remove the added "if" in 5.0.

I noticed a few other similar BC breaks in 7.1 and 7.2, but *unless someone reports that they block them*, I don't think we need to care.
- 7.1 A non well formed numeric value encountered E_NOTICE
- 7.1 A non-numeric value encountered E_WARNING
- 7.2 count() now raises a warning when an invalid parameter is passed.

See https://github.com/php/php-src/blob/PHP-7.1/UPGRADING + same in upper branches.