### PR TITLE
Don't assume port 0 for X-Forwarded-Port

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1037,7 +1037,7 @@ class Request
             $pos = strrpos($host, ':');
         }
 
-        if (false !== $pos) {
+        if (false !== $pos && !empty(substr($host, $pos + 1))) {
             return (int) substr($host, $pos + 1);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1037,8 +1037,8 @@ class Request
             $pos = strrpos($host, ':');
         }
 
-        if (false !== $pos && !empty(substr($host, $pos + 1))) {
-            return (int) substr($host, $pos + 1);
+        if (false !== $pos && '' !== $port = substr($host, $pos + 1)) {
+            return (int) $port;
         }
 
         return 'https' === $this->getScheme() ? 443 : 80;

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1037,7 +1037,7 @@ class Request
             $pos = strrpos($host, ':');
         }
 
-        if (false !== $pos && '' !== $port = substr($host, $pos + 1)) {
+        if (false !== $pos && $port = substr($host, $pos + 1)) {
             return (int) $port;
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2427,6 +2427,18 @@ class RequestTest extends TestCase
 
         $this->assertSame(443, $request->getPort());
     }
+
+    public function testTrustedPortDoesNotDefaultToZero()
+    {
+        Request::setTrustedProxies(['1.1.1.1'], Request::HEADER_X_FORWARDED_ALL);
+
+        $request = Request::create('/');
+        $request->server->set('REMOTE_ADDR', '1.1.1.1');
+        $request->headers->set('X-Forwarded-Host', 'test.example.com');
+        $request->headers->set('X-Forwarded-Port', null);
+
+        $this->assertSame(80, $request->getPort());
+    }
 }
 
 class RequestContentProxy extends Request


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | none added
| Fixed tickets | 
| License       | MIT
| Doc PR        | -


If you use X-Forwarded-Host but don't provide X-Forwarded-Port, it will default to `0.0.0.0:` which then assumes port `0` instead of following its default assumption based on the scheme.
