### PR TITLE
[Mailer] throw the right exception when the content type is not json

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Http\AbstractHttpTransport;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -59,7 +60,12 @@ class MailgunTransport extends AbstractHttpTransport
         ]);
 
         if (200 !== $response->getStatusCode()) {
-            $error = $response->toArray(false);
+
+            try {
+                $error = $response->toArray(false);
+            } catch (DecodingExceptionInterface $e) {
+                throw new TransportException(sprintf('Unable to send an email (code %s).', $response->getStatusCode()));
+            }
 
             throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $error['message'], $response->getStatusCode()));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32043   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |none <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

There is something that is wrong with getting text/html instead of json but maybe this is only in the Http Transport, this throws the right exception with the right code, I could need a reproducer to render a message because I tried to reproduce it, but didn't find the way :/.