### PR TITLE
[Filesystem] Add a dangling param to Filesystem::exists() to check if there are dangling links

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -375,9 +375,22 @@ class FilesystemTest extends FilesystemTestCase
         mkdir($basePath);
         touch($basePath.'file1');
         mkdir($basePath.'folder');
-
         $this->assertTrue($this->filesystem->exists($basePath.'file1'));
         $this->assertTrue($this->filesystem->exists($basePath.'folder'));
+    }
+
+    public function testDanglingExists()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Symbolink files does not work the same on windows');
+        }
+        $basePath = $this->workspace.\DIRECTORY_SEPARATOR.'directory'.\DIRECTORY_SEPARATOR;
+
+        mkdir($basePath);
+        touch($basePath.'testLink');
+        exec(sprintf('ln -s %stestLink %stestDanglingLink && rm %stestLink', $basePath, $basePath, $basePath));
+        $this->assertTrue($this->filesystem->exists($basePath.'testDanglingLink', true));
+        $this->assertFalse($this->filesystem->exists($basePath.'testDanglingLink', false));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #24984  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This adds a new parameter to be able to check if the links are dangling or not, just like described in the issue.
