### PR TITLE
[Validator] Add AutoMapping constraint to enable or disable auto-validation

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderEntity.php
@@ -69,6 +69,12 @@ class DoctrineLoaderEntity extends DoctrineLoaderParentEntity
     /** @ORM\Column(type="simple_array", length=100) */
     public $simpleArrayField = [];
 
+    /**
+     * @ORM\Column(length=10)
+     * @Assert\DisableAutoMapping
+     */
+    public $noAutoMapping;
+
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $allowEmptyString = property_exists(Assert\Length::class, 'allowEmptyString') ? ['allowEmptyString' => true] : [];

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderNoAutoMappingEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderNoAutoMappingEntity.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity
+ * @Assert\DisableAutoMapping
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DoctrineLoaderNoAutoMappingEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(length=20, unique=true)
+     */
+    public $maxLength;
+
+    /**
+     * @Assert\EnableAutoMapping
+     * @ORM\Column(length=20)
+     */
+    public $autoMappingExplicitlyEnabled;
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -17,12 +17,15 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\BaseUser;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderEmbed;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderNestedEmbed;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderNoAutoMappingEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineLoaderParentEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bridge\Doctrine\Validator\DoctrineLoader;
+use Symfony\Component\Validator\Constraints\DisableAutoMapping;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Mapping\CascadingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AutoMappingTrait;
 use Symfony\Component\Validator\Mapping\TraversalStrategy;
 use Symfony\Component\Validator\Tests\Fixtures\Entity;
 use Symfony\Component\Validator\Validation;
@@ -33,12 +36,15 @@ use Symfony\Component\Validator\ValidatorBuilder;
  */
 class DoctrineLoaderTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (!trait_exists(AutoMappingTrait::class)) {
+            $this->markTestSkipped('Auto-mapping requires symfony/validation 4.4+');
+        }
+    }
+
     public function testLoadClassMetadata()
     {
-        if (!method_exists(ValidatorBuilder::class, 'addLoader')) {
-            $this->markTestSkipped('Auto-mapping requires symfony/validation 4.2+');
-        }
-
         $validator = Validation::createValidatorBuilder()
             ->addMethodMapping('loadValidatorMetadata')
             ->enableAnnotationMapping()
@@ -134,6 +140,12 @@ class DoctrineLoaderTest extends TestCase
         $this->assertCount(1, $textFieldConstraints);
         $this->assertInstanceOf(Length::class, $textFieldConstraints[0]);
         $this->assertSame(1000, $textFieldConstraints[0]->max);
+
+        $noAutoMappingMetadata = $classMetadata->getPropertyMetadata('noAutoMapping');
+        $this->assertCount(1, $noAutoMappingMetadata);
+        $noAutoMappingConstraints = $noAutoMappingMetadata[0]->getConstraints();
+        $this->assertCount(1, $noAutoMappingConstraints);
+        $this->assertInstanceOf(DisableAutoMapping::class, $noAutoMappingConstraints[0]);
     }
 
     public function testFieldMappingsConfiguration()
@@ -179,5 +191,29 @@ class DoctrineLoaderTest extends TestCase
             [true, '{^'.preg_quote(DoctrineLoaderEntity::class).'$|^'.preg_quote(Entity::class).'$}'],
             [false, '{^'.preg_quote(Entity::class).'$}'],
         ];
+    }
+
+    public function testClassNoAutoMapping()
+    {
+        if (!method_exists(ValidatorBuilder::class, 'addLoader')) {
+            $this->markTestSkipped('Auto-mapping requires symfony/validation 4.2+');
+        }
+
+        $validator = Validation::createValidatorBuilder()
+            ->enableAnnotationMapping()
+            ->addLoader(new DoctrineLoader(DoctrineTestHelper::createTestEntityManager()))
+            ->getValidator();
+
+        $classMetadata = $validator->getMetadataFor(new DoctrineLoaderNoAutoMappingEntity());
+
+        $classConstraints = $classMetadata->getConstraints();
+        $this->assertCount(1, $classConstraints);
+        $this->assertInstanceOf(DisableAutoMapping::class, $classConstraints[0]);
+
+        $maxLengthMetadata = $classMetadata->getPropertyMetadata('maxLength');
+        $this->assertEmpty($maxLengthMetadata);
+
+        $autoMappingExplicitlyEnabledMetadata = $classMetadata->getPropertyMetadata('autoMappingExplicitlyEnabled');
+        $this->assertCount(2, $autoMappingExplicitlyEnabledMetadata[0]->constraints);
     }
 }

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * added `EnableAutoMapping` and `DisableAutoMapping` constraints to enable or disable auto mapping for class or a property 
  * using anything else than a `string` as the code of a `ConstraintViolation` is deprecated, a `string` type-hint will
    be added to the constructor of the `ConstraintViolation` class and to the `ConstraintViolationBuilder::setCode()`
    method in 5.0

--- a/src/Symfony/Component/Validator/Constraints/DisableAutoMapping.php
+++ b/src/Symfony/Component/Validator/Constraints/DisableAutoMapping.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * Disables auto mapping.
+ *
+ * Using the annotations on a property has higher precedence than using it on a class,
+ * which has higher precedence than any configuration that might be defined outside the class.
+ *
+ * @Annotation
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DisableAutoMapping extends Constraint
+{
+    public function __construct($options = null)
+    {
+        if (\is_array($options) && \array_key_exists('groups', $options)) {
+            throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/EnableAutoMapping.php
+++ b/src/Symfony/Component/Validator/Constraints/EnableAutoMapping.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * Enables auto mapping.
+ *
+ * Using the annotations on a property has higher precedence than using it on a class,
+ * which has higher precedence than any configuration that might be defined outside the class.
+ *
+ * @Annotation
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class EnableAutoMapping extends Constraint
+{
+    public function __construct($options = null)
+    {
+        if (\is_array($options) && \array_key_exists('groups', $options)) {
+            throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
+    }
+}

--- a/src/Symfony/Component/Validator/Mapping/Loader/AutoMappingTrait.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AutoMappingTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Mapping\Loader;
+
+use Symfony\Component\Validator\Constraints\DisableAutoMapping;
+use Symfony\Component\Validator\Constraints\EnableAutoMapping;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+/**
+ * Utility methods to create auto mapping loaders.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+trait AutoMappingTrait
+{
+    private function isAutoMappingEnabledForClass(ClassMetadata $metadata, string $classValidatorRegexp = null): bool
+    {
+        // Check if AutoMapping constraint is set first
+        foreach ($metadata->getConstraints() as $constraint) {
+            if ($constraint instanceof DisableAutoMapping) {
+                return false;
+            }
+
+            if ($constraint instanceof EnableAutoMapping) {
+                return true;
+            }
+        }
+
+        // Fallback on the config
+        return null === $classValidatorRegexp || preg_match($classValidatorRegexp, $metadata->getClassName());
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/DisableAutoMappingTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DisableAutoMappingTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\DisableAutoMapping;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DisableAutoMappingTest extends TestCase
+{
+    public function testGroups()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage(sprintf('The option "groups" is not supported by the constraint "%s".', DisableAutoMapping::class));
+
+        new DisableAutoMapping(['groups' => 'foo']);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/EnableAutoMappingTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EnableAutoMappingTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\EnableAutoMapping;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class EnableAutoMappingTest extends TestCase
+{
+    public function testGroups()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage(sprintf('The option "groups" is not supported by the constraint "%s".', EnableAutoMapping::class));
+
+        new EnableAutoMapping(['groups' => 'foo']);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderEntity.php
@@ -49,6 +49,11 @@ class PropertyInfoLoaderEntity
 
     public $readOnly;
 
+    /**
+     * @Assert\DisableAutoMapping
+     */
+    public $noAutoMapping;
+
     public function setNonExistentField()
     {
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderNoAutoMappingEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderNoAutoMappingEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @Assert\DisableAutoMapping
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class PropertyInfoLoaderNoAutoMappingEntity
+{
+    public $string;
+
+    /**
+     * @Assert\EnableAutoMapping
+     */
+    public $autoMappingExplicitlyEnabled;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32070, #32015   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo

As discussed in #32070 and #32015, it's sometimes mandatory to prevent some classes or properties to be auto mapped (auto-validated). This PR introduces a new constraint, `@AutoMapping` allowing to do exactly that. Examples:

Class:

```php
use Doctrine\ORM\Mapping as ORM;
use Symfony\Component\Validator\Constraints as Assert;

/**
 * @ORM\Entity
 * @Assert\AutoMapping(false)
 */
class DoctrineLoaderNoAutoMappingEntity
{
    /**
     * @ORM\Id
     * @ORM\Column
     */
    public $id;

    /**
     * @ORM\Column(length=20, unique=true)
     */
    public $maxLength;
}
```

Property:

```php
namespace Symfony\Bridge\Doctrine\Tests\Fixtures;

use Doctrine\ORM\Mapping as ORM;
use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
use Symfony\Component\Validator\Constraints as Assert;

/**
 * @ORM\Entity
 */
class DoctrineLoaderEntity extends DoctrineLoaderParentEntity
{
    /**
     * @ORM\Id
     * @ORM\Column
     */
    public $id;

    /**
     * @ORM\Column(length=10)
     * @Assert\AutoMapping(false)
     */
    public $noAutoMapping;
}
```

The rules are the following:

* If the constraint is present on a property, and set to true, auto-mapping is always on, regardless of the config, and of any class level annotation
* If the constraint is present on a property, and set to false, auto-mapping is always off, regardless of the config, and of any class level annotation
* If the constraint is present on a class, and set to true, auto-mapping is always on except if a the annotation has been added to a specific property, and regardless of the config
* If the constraint is present on a class, and set to false, auto-mapping is always off except if a the annotation has been added to a specific property, and regardless of the config