### PR TITLE
[Messenger] fix delay exchange recreation after disconnect

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -430,6 +430,7 @@ class Connection
         $this->amqpChannel = null;
         $this->amqpQueues = [];
         $this->amqpExchange = null;
+        $this->amqpDelayExchange = null;
     }
 
     private function shouldSetup(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
