### PR TITLE
[FrameworkBundle] tag the FileType service as a form type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -93,6 +93,7 @@
             <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.file" class="Symfony\Component\Form\Extension\Core\Type\FileType" public="true">
+            <tag name="form.type" />
             <argument type="service" id="translator" on-invalid="ignore" />
         </service>
         <service id="form.type.hidden" class="Symfony\Component\Form\Extension\Core\Type\HiddenType" public="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | part of #32045
| License       | MIT
| Doc PR        | 

In #30961 we undeprecated the `form.type.file` service as we need to pass the translator to the form type. But we forgot to add back the `form.type` tag which means that the form registry actually never used our service but instantiated the `FileType` itself and thus the type was never able to use a translator.