### PR TITLE
[Process] Allow writing portable "prepared" command lines

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1500,6 +1500,50 @@ EOTXT;
         yield [1.1];
     }
 
+    public function testPreparedCommand()
+    {
+        $p = Process::fromShellCommandline('echo "$abc"DEF');
+        $p->run(null, ['abc' => 'ABC']);
+
+        $this->assertSame('ABCDEF', rtrim($p->getOutput()));
+    }
+
+    public function testPreparedCommandMulti()
+    {
+        $p = Process::fromShellCommandline('echo "$abc""$def"');
+        $p->run(null, ['abc' => 'ABC', 'def' => 'DEF']);
+
+        $this->assertSame('ABCDEF', rtrim($p->getOutput()));
+    }
+
+    public function testPreparedCommandWithQuoteInIt()
+    {
+        $p = Process::fromShellCommandline('php -r "$code" "$def"');
+        $p->run(null, ['code' => 'echo $argv[1];', 'def' => '"DEF"']);
+
+        $this->assertSame('"DEF"', rtrim($p->getOutput()));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Command line is missing a value for key "$abc": echo "$abc".
+     */
+    public function testPreparedCommandWithMissingValue()
+    {
+        $p = Process::fromShellCommandline('echo "$abc"');
+        $p->run(null, ['bcd' => 'BCD']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Command line is missing a value for key "$abc": echo "$abc".
+     */
+    public function testPreparedCommandWithNoValues()
+    {
+        $p = Process::fromShellCommandline('echo "$abc"');
+        $p->run(null, []);
+    }
+
     public function testEnvArgument()
     {
         $env = ['FOO' => 'Foo', 'BAR' => 'Bar'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #23778  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11802 <!-- required for new features -->

Hey here, it's me, again !

I've talked with @nicolas-grekas and he gave me a new way of writing this feature that will not be a problem for people using things like {{ toto }} since we are using the linux style of using envvar, the replaced arguments is only replaced when using windows.

This should not break anything and work as expected!

see https://github.com/symfony/symfony/pull/24763

This makes `"$FOO"` work seamlessly on Linux and on Windows to reference an env var (that can be provided when calling e.g. the "run" method)