### PR TITLE
[DebugBundle] fix register ReflectionCaster::unsetClosureFileInfo caster in var cloner service

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
@@ -43,9 +44,9 @@ class DebugExtension extends Extension
             ->addMethodCall('setMinDepth', [$config['min_depth']])
             ->addMethodCall('setMaxString', [$config['max_string_length']]);
 
-        if (method_exists(ReflectionClass::class, 'unsetClosureFileInfo')) {
+        if (method_exists(ReflectionCaster::class, 'unsetClosureFileInfo')) {
             $container->getDefinition('var_dumper.cloner')
-                ->addMethodCall('addCasters', ReflectionClass::UNSET_CLOSURE_FILE_INFO);
+                ->addMethodCall('addCasters', [ReflectionCaster::UNSET_CLOSURE_FILE_INFO]);
         }
 
         if (method_exists(HtmlDumper::class, 'setTheme') && 'dark' !== $config['theme']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Non-existent class was checked by `method_exists` in Debug bundle.
This should fix (and correctly register) the caster while loading `DebugExtension` from `DebugBundle`