### PR TITLE
[Form] deprecate int/float for string input in NumberType

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -41,6 +41,11 @@ DependencyInjection
        arguments: [!tagged_iterator app.handler]
    ```
 
+Form
+----
+
+ * Using `int` or `float` as data for the `NumberType` when the `input` option is set to `string` is deprecated.
+
 FrameworkBundle
 ---------------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -146,6 +146,7 @@ Finder
 Form
 ----
 
+ * Removed support for using `int` or `float` as data for the `NumberType` when the `input` option is set to `string`.
  * Removed support for using the `format` option of `DateType` and `DateTimeType` when the `html5` option is enabled.
  * Using names for buttons that do not start with a letter, a digit, or an underscore leads to an exception.
  * Using names for buttons that do not contain only letters, digits, underscores, hyphens, and colons leads to an

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * deprecated using `int` or `float` as data for the `NumberType` when the `input` option is set to `string`
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/NumberType.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\StringToFloatTransformer;
@@ -37,6 +38,19 @@ class NumberType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new StringToFloatTransformer($options['scale']));
+            $builder->addModelTransformer(new CallbackTransformer(
+                function ($value) {
+                    if (\is_float($value) || \is_int($value)) {
+                        @trigger_error(sprintf('Using the %s with float or int data when the "input" option is set to "string" is deprecated since Symfony 4.4 and will throw an exception in 5.0.', self::class), E_USER_DEPRECATED);
+                        $value = (string) $value;
+                    }
+
+                    return $value;
+                },
+                function ($value) {
+                    return $value;
+                }
+            ));
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -77,6 +77,34 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12345,68', $form->createView()->vars['value']);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the Symfony\Component\Form\Extension\Core\Type\NumberType with float or int data when the "input" option is set to "string" is deprecated since Symfony 4.4 and will throw an exception in 5.0.
+     */
+    public function testStringInputWithFloatData(): void
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, 12345.6789, [
+            'input' => 'string',
+            'scale' => 2,
+        ]);
+
+        $this->assertSame('12345,68', $form->createView()->vars['value']);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the Symfony\Component\Form\Extension\Core\Type\NumberType with float or int data when the "input" option is set to "string" is deprecated since Symfony 4.4 and will throw an exception in 5.0.
+     */
+    public function testStringInputWithIntData(): void
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, 12345, [
+            'input' => 'string',
+            'scale' => 2,
+        ]);
+
+        $this->assertSame('12345,00', $form->createView()->vars['value']);
+    }
+
     public function testDefaultFormattingWithRounding(): void
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/32125#issuecomment-504317999
| License       | MIT
| Doc PR        | 