### PR TITLE
[Mailgun Mailer] fixed issue when using html body

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/Api/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/Api/MailgunTransport.php
@@ -68,7 +68,7 @@ class MailgunTransport extends AbstractApiTransport
     {
         $headers = $email->getHeaders();
         $html = $email->getHtmlBody();
-        if (null !== $html) {
+        if (null !== $html && \is_resource($html)) {
             if (stream_get_meta_data($html)['seekable'] ?? false) {
                 rewind($html);
             }

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -168,6 +168,19 @@ class TransportTest extends TestCase
         $transport = Transport::fromDsn('api://'.urlencode('u$er').':'.urlencode('pa$s').'@mailgun?region=us', $dispatcher, $client, $logger);
         $transport->send($message);
 
+        $message = (new Email())->from('me@me.com')->to('you@you.com')->subject('hello')->html('test');
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->expects($this->once())->method('request')->with('POST', 'https://api.mailgun.net/v3/pa%24s/messages')->willReturn($response);
+        $transport = Transport::fromDsn('api://'.urlencode('u$er').':'.urlencode('pa$s').'@mailgun?region=us', $dispatcher, $client, $logger);
+        $transport->send($message);
+
+        $stream = fopen('data://text/plain,'.$message->getTextBody(), 'r');
+        $message = (new Email())->from('me@me.com')->to('you@you.com')->subject('hello')->html($stream);
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->expects($this->once())->method('request')->with('POST', 'https://api.mailgun.net/v3/pa%24s/messages')->willReturn($response);
+        $transport = Transport::fromDsn('api://'.urlencode('u$er').':'.urlencode('pa$s').'@mailgun?region=us', $dispatcher, $client, $logger);
+        $transport->send($message);
+
         $this->expectException(LogicException::class);
         Transport::fromDsn('foo://mailgun');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

I tested the `symfony/mailgun-mailer` and get an issue when using the `api` scheme with a templated email cause we try to manipulate a stream whereas the `Symfony\Component\Mime\Email::getHtmlBody()` could return also a string (in my case it is one).

The issue : 

```
stream_get_meta_data() expects parameter 1 to be resource, string given
```
