### PR TITLE
[PropertyAccess] Allow to disable magic __get & __set

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -17,6 +17,17 @@ Mime
 
  * Deprecated `Address::fromString()`, use `Address::create()` instead
 
+PropertyAccess
+--------------
+
+ * Deprecated passing a boolean as the first argument of `PropertyAccessor::__construct()`.
+   Pass a combination of bitwise flags instead.
+
+PropertyInfo
+------------
+
+ * Dropped the `enable_magic_call_extraction` context option in `ReflectionExtractor::getWriteInfo()` and `ReflectionExtractor::getReadInfo()` in favor of `enable_magic_methods_extraction`.
+
 TwigBundle
 ----------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -108,6 +108,17 @@ PhpUnitBridge
 
  * Removed support for `@expectedDeprecation` annotations, use the `ExpectDeprecationTrait::expectDeprecation()` method instead.
 
+PropertyAccess
+--------------
+
+ * Dropped support of a boolean as the first argument of `PropertyAccessor::__construct()`.
+   Pass a combination of bitwise flags instead.
+
+PropertyInfo
+------------
+
+ * Dropped the `enable_magic_call_extraction` context option in `ReflectionExtractor::getWriteInfo()` and `ReflectionExtractor::getReadInfo()` in favor of `enable_magic_methods_extraction`.
+
 Routing
 -------
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -949,6 +949,8 @@ class Configuration implements ConfigurationInterface
                     ->info('Property access configuration')
                     ->children()
                         ->booleanNode('magic_call')->defaultFalse()->end()
+                        ->booleanNode('magic_get')->defaultTrue()->end()
+                        ->booleanNode('magic_set')->defaultTrue()->end()
                         ->booleanNode('throw_exception_on_invalid_index')->defaultFalse()->end()
                         ->booleanNode('throw_exception_on_invalid_property_path')->defaultTrue()->end()
                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1429,9 +1429,14 @@ class FrameworkExtension extends Extension
 
         $loader->load('property_access.php');
 
+        $magicMethods = PropertyAccessor::DISALLOW_MAGIC_METHODS;
+        $magicMethods |= $config['magic_call'] ? PropertyAccessor::MAGIC_CALL : 0;
+        $magicMethods |= $config['magic_get'] ? PropertyAccessor::MAGIC_GET : 0;
+        $magicMethods |= $config['magic_set'] ? PropertyAccessor::MAGIC_SET : 0;
+
         $container
             ->getDefinition('property_accessor')
-            ->replaceArgument(0, $config['magic_call'])
+            ->replaceArgument(0, $magicMethods)
             ->replaceArgument(1, $config['throw_exception_on_invalid_index'])
             ->replaceArgument(3, $config['throw_exception_on_invalid_property_path'])
             ->replaceArgument(4, new Reference(PropertyReadInfoExtractorInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE))

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.php
@@ -18,7 +18,7 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('property_accessor', PropertyAccessor::class)
             ->args([
-                abstract_arg('magicCall, set by the extension'),
+                abstract_arg('magic methods allowed, set by the extension'),
                 abstract_arg('throwExceptionOnInvalidIndex, set by the extension'),
                 service('cache.property_access')->ignoreOnInvalid(),
                 abstract_arg('throwExceptionOnInvalidPropertyPath, set by the extension'),

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -236,6 +236,8 @@
 
     <xsd:complexType name="property_access">
         <xsd:attribute name="magic-call" type="xsd:boolean" />
+        <xsd:attribute name="magic-get" type="xsd:boolean" />
+        <xsd:attribute name="magic-set" type="xsd:boolean" />
         <xsd:attribute name="throw-exception-on-invalid-index" type="xsd:boolean" />
         <xsd:attribute name="throw-exception-on-invalid-property-path" type="xsd:boolean" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -415,6 +415,8 @@ class ConfigurationTest extends TestCase
             ],
             'property_access' => [
                 'magic_call' => false,
+                'magic_get' => true,
+                'magic_set' => true,
                 'throw_exception_on_invalid_index' => false,
                 'throw_exception_on_invalid_property_path' => true,
             ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
@@ -3,6 +3,8 @@
 $container->loadFromExtension('framework', [
     'property_access' => [
         'magic_call' => true,
+        'magic_get' => true,
+        'magic_set' => false,
         'throw_exception_on_invalid_index' => true,
         'throw_exception_on_invalid_property_path' => false,
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_accessor.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_accessor.xml
@@ -7,6 +7,6 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:property-access magic-call="true" throw-exception-on-invalid-index="true" throw-exception-on-invalid-property-path="false"/>
+        <framework:property-access magic-call="true" magic-get="true" magic-set="false" throw-exception-on-invalid-index="true" throw-exception-on-invalid-property-path="false"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
@@ -1,5 +1,7 @@
 framework:
     property_access:
         magic_call: true
+        magic_get: true
+        magic_set: false
         throw_exception_on_invalid_index: true
         throw_exception_on_invalid_property_path: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -86,7 +86,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('full');
 
         $def = $container->getDefinition('property_accessor');
-        $this->assertFalse($def->getArgument(0));
+        $this->assertSame(PropertyAccessor::MAGIC_SET | PropertyAccessor::MAGIC_GET, $def->getArgument(0));
         $this->assertFalse($def->getArgument(1));
         $this->assertTrue($def->getArgument(3));
     }
@@ -95,7 +95,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('property_accessor');
         $def = $container->getDefinition('property_accessor');
-        $this->assertTrue($def->getArgument(0));
+        $this->assertSame(PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_CALL, $def->getArgument(0));
         $this->assertTrue($def->getArgument(1));
         $this->assertFalse($def->getArgument(3));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -83,6 +83,7 @@
         "symfony/messenger": "<4.4",
         "symfony/mime": "<4.4",
         "symfony/property-info": "<4.4",
+        "symfony/property-access": "<5.2",
         "symfony/serializer": "<5.2",
         "symfony/stopwatch": "<4.4",
         "symfony/translation": "<5.0",

--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * deprecated passing a boolean as the first argument of `PropertyAccessor::__construct()`, expecting a combination of bitwise flags instead
+ * added the ability to disable usage of the magic `__get` & `__set` methods
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -38,6 +38,15 @@ use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
  */
 class PropertyAccessor implements PropertyAccessorInterface
 {
+    /** @var int Allow none of the magic methods */
+    public const DISALLOW_MAGIC_METHODS = ReflectionExtractor::DISALLOW_MAGIC_METHODS;
+    /** @var int Allow magic __get methods */
+    public const MAGIC_GET = ReflectionExtractor::ALLOW_MAGIC_GET;
+    /** @var int Allow magic __set methods */
+    public const MAGIC_SET = ReflectionExtractor::ALLOW_MAGIC_SET;
+    /** @var int Allow magic __call methods */
+    public const MAGIC_CALL = ReflectionExtractor::ALLOW_MAGIC_CALL;
+
     private const VALUE = 0;
     private const REF = 1;
     private const IS_REF_CHAINED = 2;
@@ -45,10 +54,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     private const CACHE_PREFIX_WRITE = 'w';
     private const CACHE_PREFIX_PROPERTY_PATH = 'p';
 
-    /**
-     * @var bool
-     */
-    private $magicCall;
+    private $magicMethodsFlags;
     private $ignoreInvalidIndices;
     private $ignoreInvalidProperty;
 
@@ -68,7 +74,6 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @var PropertyWriteInfoExtractorInterface
      */
     private $writeInfoExtractor;
-
     private $readPropertyCache = [];
     private $writePropertyCache = [];
     private static $resultProto = [self::VALUE => null];
@@ -76,10 +81,20 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * Should not be used by application code. Use
      * {@link PropertyAccess::createPropertyAccessor()} instead.
+     *
+     * @param int $magicMethods A bitwise combination of the MAGIC_* constants
+     *                          to specify the allowed magic methods (__get, __set, __call)
+     *                          or self::DISALLOW_MAGIC_METHODS for none
      */
-    public function __construct(bool $magicCall = false, bool $throwExceptionOnInvalidIndex = false, CacheItemPoolInterface $cacheItemPool = null, bool $throwExceptionOnInvalidPropertyPath = true, PropertyReadInfoExtractorInterface $readInfoExtractor = null, PropertyWriteInfoExtractorInterface $writeInfoExtractor = null)
+    public function __construct(/*int */$magicMethods = self::MAGIC_GET | self::MAGIC_SET, bool $throwExceptionOnInvalidIndex = false, CacheItemPoolInterface $cacheItemPool = null, bool $throwExceptionOnInvalidPropertyPath = true, PropertyReadInfoExtractorInterface $readInfoExtractor = null, PropertyWriteInfoExtractorInterface $writeInfoExtractor = null)
     {
-        $this->magicCall = $magicCall;
+        if (\is_bool($magicMethods)) {
+            trigger_deprecation('symfony/property-info', '5.2', 'Passing a boolean to "%s()" first argument is deprecated since 5.1 and expect a combination of bitwise flags instead (i.e an integer).', __METHOD__);
+
+            $magicMethods = ($magicMethods ? self::MAGIC_CALL : 0) | self::MAGIC_GET | self::MAGIC_SET;
+        }
+
+        $this->magicMethodsFlags = $magicMethods;
         $this->ignoreInvalidIndices = !$throwExceptionOnInvalidIndex;
         $this->cacheItemPool = $cacheItemPool instanceof NullAdapter ? null : $cacheItemPool; // Replace the NullAdapter by the null value
         $this->ignoreInvalidProperty = !$throwExceptionOnInvalidPropertyPath;
@@ -472,7 +487,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         $accessor = $this->readInfoExtractor->getReadInfo($class, $property, [
             'enable_getter_setter_extraction' => true,
-            'enable_magic_call_extraction' => $this->magicCall,
+            'enable_magic_methods_extraction' => $this->magicMethodsFlags,
             'enable_constructor_extraction' => false,
         ]);
 
@@ -592,7 +607,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         $mutator = $this->writeInfoExtractor->getWriteInfo($class, $property, [
             'enable_getter_setter_extraction' => true,
-            'enable_magic_call_extraction' => $this->magicCall,
+            'enable_magic_methods_extraction' => $this->magicMethodsFlags,
             'enable_constructor_extraction' => false,
             'enable_adder_remover_extraction' => $useAdderAndRemover,
         ]);

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
@@ -22,7 +22,8 @@ use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
  */
 class PropertyAccessorBuilder
 {
-    private $magicCall = false;
+    /** @var int */
+    private $magicMethods = PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_SET;
     private $throwExceptionOnInvalidIndex = false;
     private $throwExceptionOnInvalidPropertyPath = true;
 
@@ -42,13 +43,53 @@ class PropertyAccessorBuilder
     private $writeInfoExtractor;
 
     /**
+     * Enables the use of all magic methods by the PropertyAccessor.
+     */
+    public function enableMagicMethods(): self
+    {
+        $this->magicMethods = PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_SET | PropertyAccessor::MAGIC_CALL;
+
+        return $this;
+    }
+
+    /**
+     * Disable the use of all magic methods by the PropertyAccessor.
+     */
+    public function disableMagicMethods(): self
+    {
+        $this->magicMethods = PropertyAccessor::DISALLOW_MAGIC_METHODS;
+
+        return $this;
+    }
+
+    /**
      * Enables the use of "__call" by the PropertyAccessor.
      *
      * @return $this
      */
     public function enableMagicCall()
     {
-        $this->magicCall = true;
+        $this->magicMethods |= PropertyAccessor::MAGIC_CALL;
+
+        return $this;
+    }
+
+    /**
+     * Enables the use of "__get" by the PropertyAccessor.
+     */
+    public function enableMagicGet(): self
+    {
+        $this->magicMethods |= PropertyAccessor::MAGIC_GET;
+
+        return $this;
+    }
+
+    /**
+     * Enables the use of "__set" by the PropertyAccessor.
+     */
+    public function enableMagicSet(): self
+    {
+        $this->magicMethods |= PropertyAccessor::MAGIC_SET;
 
         return $this;
     }
@@ -60,7 +101,27 @@ class PropertyAccessorBuilder
      */
     public function disableMagicCall()
     {
-        $this->magicCall = false;
+        $this->magicMethods ^= PropertyAccessor::MAGIC_CALL;
+
+        return $this;
+    }
+
+    /**
+     * Disables the use of "__get" by the PropertyAccessor.
+     */
+    public function disableMagicGet(): self
+    {
+        $this->magicMethods ^= PropertyAccessor::MAGIC_GET;
+
+        return $this;
+    }
+
+    /**
+     * Disables the use of "__set" by the PropertyAccessor.
+     */
+    public function disableMagicSet(): self
+    {
+        $this->magicMethods ^= PropertyAccessor::MAGIC_SET;
 
         return $this;
     }
@@ -70,7 +131,23 @@ class PropertyAccessorBuilder
      */
     public function isMagicCallEnabled()
     {
-        return $this->magicCall;
+        return (bool) ($this->magicMethods & PropertyAccessor::MAGIC_CALL);
+    }
+
+    /**
+     * @return bool whether the use of "__get" by the PropertyAccessor is enabled
+     */
+    public function isMagicGetEnabled(): bool
+    {
+        return $this->magicMethods & PropertyAccessor::MAGIC_GET;
+    }
+
+    /**
+     * @return bool whether the use of "__set" by the PropertyAccessor is enabled
+     */
+    public function isMagicSetEnabled(): bool
+    {
+        return $this->magicMethods & PropertyAccessor::MAGIC_SET;
     }
 
     /**
@@ -206,6 +283,6 @@ class PropertyAccessorBuilder
      */
     public function getPropertyAccessor()
     {
-        return new PropertyAccessor($this->magicCall, $this->throwExceptionOnInvalidIndex, $this->cacheItemPool, $this->throwExceptionOnInvalidPropertyPath, $this->readInfoExtractor, $this->writeInfoExtractor);
+        return new PropertyAccessor($this->magicMethods, $this->throwExceptionOnInvalidIndex, $this->cacheItemPool, $this->throwExceptionOnInvalidPropertyPath, $this->readInfoExtractor, $this->writeInfoExtractor);
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
@@ -45,7 +45,21 @@ class PropertyAccessorBuilderTest extends TestCase
         $this->assertSame($this->builder, $this->builder->disableMagicCall());
     }
 
-    public function testIsMagicCallEnable()
+    public function testTogglingMagicGet()
+    {
+        $this->assertTrue($this->builder->isMagicGetEnabled());
+        $this->assertFalse($this->builder->disableMagicGet()->isMagicCallEnabled());
+        $this->assertTrue($this->builder->enableMagicGet()->isMagicGetEnabled());
+    }
+
+    public function testTogglingMagicSet()
+    {
+        $this->assertTrue($this->builder->isMagicSetEnabled());
+        $this->assertFalse($this->builder->disableMagicSet()->isMagicSetEnabled());
+        $this->assertTrue($this->builder->enableMagicSet()->isMagicSetEnabled());
+    }
+
+    public function testTogglingMagicCall()
     {
         $this->assertFalse($this->builder->isMagicCallEnabled());
         $this->assertTrue($this->builder->enableMagicCall()->isMagicCallEnabled());

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -17,8 +17,9 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-php80": "^1.15",
-        "symfony/property-info": "^5.1.1"
+        "symfony/property-info": "^5.2"
     },
     "require-dev": {
         "symfony/cache": "^4.4|^5.0"

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+* deprecated the `enable_magic_call_extraction` context option in `ReflectionExtractor::getWriteInfo()` and `ReflectionExtractor::getReadInfo()`. in favor of `enable_magic_methods_extraction`
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
@@ -30,6 +31,8 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class ReflectionExtractorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var ReflectionExtractor
      */
@@ -517,5 +520,31 @@ class ReflectionExtractorTest extends TestCase
             [Php71DummyExtended2::class, 'string', true, false,  '', '', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71DummyExtended2::class, 'baz', false, true, PropertyWriteInfo::TYPE_ADDER_AND_REMOVER, null, 'addBaz', 'removeBaz', PropertyWriteInfo::VISIBILITY_PUBLIC, false],
         ];
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetReadInfoDeprecatedEnableMagicCallExtractionInContext()
+    {
+        $this->expectDeprecation('Since symfony/property-info 5.2: Using the "enable_magic_call_extraction" context option in "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getReadInfo()" is deprecated. Use "enable_magic_methods_extraction" instead.');
+
+        $extractor = new ReflectionExtractor();
+        $extractor->getReadInfo(\stdClass::class, 'foo', [
+            'enable_magic_call_extraction' => true,
+        ]);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetWriteInfoDeprecatedEnableMagicCallExtractionInContext()
+    {
+        $this->expectDeprecation('Since symfony/property-info 5.2: Using the "enable_magic_call_extraction" context option in "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getWriteInfo()" is deprecated. Use "enable_magic_methods_extraction" instead.');
+
+        $extractor = new ReflectionExtractor();
+        $extractor->getWriteInfo(\stdClass::class, 'foo', [
+            'enable_magic_call_extraction' => true,
+        ]);
     }
 }

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -24,6 +24,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-php80": "^1.15",
         "symfony/string": "^5.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes   <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | TODO

Working with some legacy code having annoying `__get` & `__set` methods, this would have been useful the same way `__call` can be enabled/disabled.