### PR TITLE
[FrameworkBundle] sync `require-dev` and `conflict` constraints

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -48,7 +48,7 @@
         "symfony/security-http": "~3.4|~4.0",
         "symfony/serializer": "^4.3",
         "symfony/stopwatch": "~3.4|~4.0",
-        "symfony/translation": "~4.2",
+        "symfony/translation": "~4.3",
         "symfony/templating": "~3.4|~4.0",
         "symfony/twig-bundle": "~2.8|~3.2|~4.0",
         "symfony/validator": "^4.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The `conflict` section already prevents the Translation component 4.2 to be installed.