### PR TITLE
[HttpClient] fix dealing with 1xx informational responses

### DIFF
--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -41,6 +41,17 @@ switch ($vars['REQUEST_URI']) {
         ob_start('ob_gzhandler');
         break;
 
+    case '/103':
+        header('HTTP/1.1 103 Early Hints');
+        header('Link: </style.css>; rel=preload; as=style', false);
+        header('Link: </script.js>; rel=preload; as=script', false);
+        echo "HTTP/1.1 200 OK\r\n";
+        echo "Date: Fri, 26 May 2017 10:02:11 GMT\r\n";
+        echo "Content-Length: 13\r\n";
+        echo "\r\n";
+        echo 'Here the body';
+        exit;
+
     case '/404':
         header('Content-Type: application/json', true, 404);
         break;

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -721,6 +721,15 @@ abstract class HttpClientTestCase extends TestCase
         $this->assertSame('/?a=a&b=b', $body['REQUEST_URI']);
     }
 
+    public function testInformationalResponse()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/103');
+
+        $this->assertSame('Here the body', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
     /**
      * @requires extension zlib
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I never had a look at 1xx status codes until today.
This PR fixes reading them when using curl.

If one wonders:
- `NativeHttpClient` uses `fopen()`, which skips informational parts as allowed by the HTTP spec and doesn't give any way to access their response headers.
- `CurlHttpClient` allows reading informational responses using the progress callback or via the getInfo() method. That's the way if you need to implement e.g. HTTP 103 early hints.