### PR TITLE
[Messenger] Extract unrecoverable exception to interface

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/DelayedMessageHandlingException.php
+++ b/src/Symfony/Component/Messenger/Exception/DelayedMessageHandlingException.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\Messenger\Exception;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class DelayedMessageHandlingException extends \RuntimeException implements ExceptionInterface
+class DelayedMessageHandlingException extends RuntimeException
 {
     private $exceptions;
 

--- a/src/Symfony/Component/Messenger/Exception/MessageDecodingFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/MessageDecodingFailedException.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Messenger\Exception;
  *
  * @experimental in 4.3
  */
-class MessageDecodingFailedException extends \InvalidArgumentException implements ExceptionInterface
+class MessageDecodingFailedException extends InvalidArgumentException
 {
 }

--- a/src/Symfony/Component/Messenger/Exception/NoHandlerForMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/NoHandlerForMessageException.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Messenger\Exception;
  *
  * @experimental in 4.3
  */
-class NoHandlerForMessageException extends \LogicException implements ExceptionInterface
+class NoHandlerForMessageException extends LogicException
 {
 }

--- a/src/Symfony/Component/Messenger/Exception/UnknownSenderException.php
+++ b/src/Symfony/Component/Messenger/Exception/UnknownSenderException.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Messenger\Exception;
  *
  * @experimental in 4.3
  */
-class UnknownSenderException extends \InvalidArgumentException implements ExceptionInterface
+class UnknownSenderException extends InvalidArgumentException
 {
 }

--- a/src/Symfony/Component/Messenger/Exception/UnrecoverableExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/UnrecoverableExceptionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * Marker interface for exceptions to indicate that handling a message will continue to fail.
+ *
+ * If something goes wrong while handling a message that's received from a transport
+ * and the message should not be retried, a handler can throw such an exception.
+ *
+ * @author Tobias Schultze <http://tobion.de>
+ *
+ * @experimental in 4.3
+ */
+interface UnrecoverableExceptionInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/Messenger/Exception/UnrecoverableMessageHandlingException.php
+++ b/src/Symfony/Component/Messenger/Exception/UnrecoverableMessageHandlingException.php
@@ -12,15 +12,12 @@
 namespace Symfony\Component\Messenger\Exception;
 
 /**
- * Thrown while handling a message to indicate that handling will continue to fail.
- *
- * If something goes wrong while handling a message that's received from a transport
- * and the message should not be retried, a handler can throw this exception.
+ * A concrete implementation of UnrecoverableExceptionInterface that can be used directly.
  *
  * @author Frederic Bouchery <frederic@bouchery.fr>
  *
  * @experimental in 4.3
  */
-class UnrecoverableMessageHandlingException extends RuntimeException
+class UnrecoverableMessageHandlingException extends RuntimeException implements UnrecoverableExceptionInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Exception/ValidationFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/ValidationFailedException.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  *
  * @experimental in 4.3
  */
-class ValidationFailedException extends \RuntimeException implements ExceptionInterface
+class ValidationFailedException extends RuntimeException
 {
     private $violations;
     private $violatingMessage;

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -17,7 +17,7 @@ use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
-use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
 use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
@@ -191,7 +191,7 @@ class Worker implements WorkerInterface
 
     private function shouldRetry(\Throwable $e, Envelope $envelope, RetryStrategyInterface $retryStrategy): bool
     {
-        if ($e instanceof UnrecoverableMessageHandlingException) {
+        if ($e instanceof UnrecoverableExceptionInterface) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Refactoring to extend messenger exceptions and extract unrecoverable exception into an interface. The exception is meant for people consuming messages. By using an interface, developers don't need to catch and rethrow or change their exception hierarchies. They can simply implement the interface in their existing exceptions to avoid unnecessary retries.