### PR TITLE
[FrameworkBundle] Modified forward method of AbstractController

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -82,13 +82,16 @@ trait ControllerTrait
     /**
      * Forwards the request to another controller.
      *
-     * @param string $controller The controller name (a string like Bundle\BlogBundle\Controller\PostController::indexAction)
+     * @param string $controller The controller name (a string like Bundle\BlogBundle\Controller\PostController::indexAction) or only method name when forwarding to another method within the same controller
      *
      * @final
      */
     protected function forward(string $controller, array $path = [], array $query = []): Response
     {
         $request = $this->container->get('request_stack')->getCurrentRequest();
+        if (false === strpos($controller, '::')) {
+            $controller = \get_class($this).'::'.$controller;
+        }
         $path['_controller'] = $controller;
         $subRequest = $request->duplicate($query, null, $path);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This simplifies forwards within a controller. For example, if you want to forward from `DefaultController::firstAction` to `DefaultController::secondAction`, instead of writing:
```php
$this->forward('DefaultController::secondAction');
```
you will be able to just write:
```php
$this->forward('secondAction');
```

