### PR TITLE
Make Symfony\Component\Debug\ExceptionHandler::setFileLinkFormat accept Null as a return type

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -97,9 +97,9 @@ class ExceptionHandler
      *
      * @param string|FileLinkFormatter $fileLinkFormat The format for links to source files
      *
-     * @return string The previous file link format
+     * @return string|FileLinkFormatter|null The previous file link format
      */
-    public function setFileLinkFormat($fileLinkFormat): string
+    public function setFileLinkFormat($fileLinkFormat)
     {
         $old = $this->fileLinkFormat;
         $this->fileLinkFormat = $fileLinkFormat;


### PR DESCRIPTION
fixes #32150 

| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32150    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
Make `Symfony\Component\Debug\ExceptionHandler::setFileLinkFormat` accept null as a return type. 
Since Symfony requires PHP 7.2+ and that PHP feature was introduced in 7.1, I use that feature instead of changing the default value of the variable.