### PR TITLE
[DoctrineBridge] Fix type error

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -138,6 +138,9 @@ class DoctrineDataCollector extends DataCollector
         if (!\is_array($query['params'])) {
             $query['params'] = [$query['params']];
         }
+        if (!\is_array($query['types'])) {
+            $query['types'] = [];
+        }
         foreach ($query['params'] as $j => $param) {
             if (isset($query['types'][$j])) {
                 // Transform the param according to the type

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -102,6 +102,18 @@ class DoctrineDataCollectorTest extends TestCase
         $this->assertTrue($collectedQueries['default'][1]['explainable']);
     }
 
+    public function testCollectQueryWithNoTypes()
+    {
+        $queries = [
+            ['sql' => 'SET sql_mode=(SELECT REPLACE(@@sql_mode, \'ONLY_FULL_GROUP_BY\', \'\'))', 'params' => [], 'types' => null, 'executionMS' => 1],
+        ];
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+
+        $collectedQueries = $c->getQueries();
+        $this->assertSame([], $collectedQueries['default'][0]['types']);
+    }
+
     public function testReset()
     {
         $queries = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

See discussion here: https://github.com/doctrine/DoctrineBundle/pull/984

> Having SET sql_mode=(SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', '')) query and when clicking on explain currently it throws:

> Argument 2 passed to Doctrine\DBAL\Connection::resolveParams() must be of the type array, null given, called in /vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php on line 911

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
