### PR TITLE
[Security/Core] require libsodium >= 1.0.14

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -33,8 +33,8 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
         $opsLimit = $opsLimit ?? max(6, \defined('SODIUM_CRYPTO_PWHASH_OPSLIMIT_MODERATE') ? \SODIUM_CRYPTO_PWHASH_OPSLIMIT_MODERATE : 6);
         $memLimit = $memLimit ?? max(64 * 1024 * 1024, \defined('SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE : 64 * 1024 * 1024);
 
-        if (2 > $opsLimit) {
-            throw new \InvalidArgumentException('$opsLimit must be 2 or greater.');
+        if (3 > $opsLimit) {
+            throw new \InvalidArgumentException('$opsLimit must be 3 or greater.');
         }
 
         if (10 * 1024 > $memLimit) {

--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -37,8 +37,8 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
         $this->opsLimit = $opsLimit ?? max(6, \defined('SODIUM_CRYPTO_PWHASH_OPSLIMIT_MODERATE') ? \SODIUM_CRYPTO_PWHASH_OPSLIMIT_MODERATE : 6);
         $this->memLimit = $memLimit ?? max(64 * 1024 * 1024, \defined('SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE : 64 * 1024 * 2014);
 
-        if (2 > $this->opsLimit) {
-            throw new \InvalidArgumentException('$opsLimit must be 2 or greater.');
+        if (3 > $this->opsLimit) {
+            throw new \InvalidArgumentException('$opsLimit must be 3 or greater.');
         }
 
         if (10 * 1024 > $this->memLimit) {
@@ -48,11 +48,7 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
 
     public static function isSupported(): bool
     {
-        if (class_exists('ParagonIE_Sodium_Compat') && method_exists('ParagonIE_Sodium_Compat', 'crypto_pwhash_is_available')) {
-            return \ParagonIE_Sodium_Compat::crypto_pwhash_is_available();
-        }
-
-        return \function_exists('sodium_crypto_pwhash_str') || \extension_loaded('libsodium');
+        return \function_exists('sodium_crypto_pwhash_str_needs_rehash') || \function_exists('Sodium\crypto_pwhash_str_needs_rehash');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32166
| License       | MIT
| Doc PR        | -

- bump libsodium to >=1.0.14
- Minimum opscost must be 3, as described in https://wiki.php.net/rfc/libsodium and in https://github.com/jedisct1/libsodium/releases/tag/1.0.15
- ParagonIE_Sodium_Compat [explicitly doesn't implement Argon2](https://github.com/paragonie/sodium_compat#features-excluded-from-this-polyfill), so it makes no sense to check for it.