### PR TITLE
[Security/Core] Don't use ParagonIE_Sodium_Compat

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/Argon2iPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/Argon2iPasswordEncoder.php
@@ -26,10 +26,6 @@ class Argon2iPasswordEncoder extends BasePasswordEncoder implements SelfSaltingE
             return true;
         }
 
-        if (class_exists('ParagonIE_Sodium_Compat') && method_exists('ParagonIE_Sodium_Compat', 'crypto_pwhash_is_available')) {
-            return \ParagonIE_Sodium_Compat::crypto_pwhash_is_available();
-        }
-
         return \function_exists('sodium_crypto_pwhash_str') || \extension_loaded('libsodium');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is dead code:
https://github.com/paragonie/sodium_compat#features-excluded-from-this-polyfill