### PR TITLE
[FrameworkBundle] Fix calling Client::getProfile() before sending a request

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -66,7 +66,7 @@ class Client extends BaseClient
      */
     public function getProfile()
     {
-        if (!$this->kernel->getContainer()->has('profiler')) {
+        if (null === $this->response || !$this->kernel->getContainer()->has('profiler')) {
             return false;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
@@ -28,9 +28,9 @@ class ProfilerTest extends WebTestCase
 
         // enable the profiler for the next request
         $client->enableProfiler();
-        $crawler = $client->request('GET', '/profiler');
-        $profile = $client->getProfile();
-        $this->assertInternalType('object', $profile);
+        $this->assertFalse($client->getProfile());
+        $client->request('GET', '/profiler');
+        $this->assertInternalType('object', $client->getProfile());
 
         $client->request('GET', '/profiler');
         $this->assertFalse($client->getProfile());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Prevent throwing an error when calling getProfile before a request has been sent.