### PR TITLE
[Lock] add an InvalidTTLException to be more accurate

### DIFF
--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * added InvalidTtlException
+ 
 4.2.0
 -----
 

--- a/src/Symfony/Component/Lock/Exception/InvalidTtlException.php
+++ b/src/Symfony/Component/Lock/Exception/InvalidTtlException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Exception;
+
+/**
+ * @author Amrouche Hamza <hamza.simperfit@gmail.com>
+ */
+class InvalidTtlException extends InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Store;
 
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
@@ -79,7 +80,7 @@ class MemcachedStore implements StoreInterface
     public function putOffExpiration(Key $key, $ttl)
     {
         if ($ttl < 1) {
-            throw new InvalidArgumentException(sprintf('%s() expects a TTL greater or equals to 1 second. Got %s.', __METHOD__, $ttl));
+            throw new InvalidTtlException(sprintf('%s() expects a TTL greater or equals to 1 second. Got %s.', __METHOD__, $ttl));
         }
 
         // Interface defines a float value but Store required an integer.

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Schema\Schema;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
@@ -80,7 +81,7 @@ class PdoStore implements StoreInterface
             throw new InvalidArgumentException(sprintf('"%s" requires gcProbability between 0 and 1, "%f" given.', __METHOD__, $gcProbability));
         }
         if ($initialTtl < 1) {
-            throw new InvalidArgumentException(sprintf('%s() expects a strictly positive TTL, "%d" given.', __METHOD__, $initialTtl));
+            throw new InvalidTtlException(sprintf('%s() expects a strictly positive TTL, "%d" given.', __METHOD__, $initialTtl));
         }
 
         if ($connOrDsn instanceof \PDO) {
@@ -153,7 +154,7 @@ class PdoStore implements StoreInterface
     public function putOffExpiration(Key $key, $ttl)
     {
         if ($ttl < 1) {
-            throw new InvalidArgumentException(sprintf('%s() expects a TTL greater or equals to 1 second. Got %s.', __METHOD__, $ttl));
+            throw new InvalidTtlException(sprintf('%s() expects a TTL greater or equals to 1 second. Got %s.', __METHOD__, $ttl));
         }
 
         $key->reduceLifetime($ttl);

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Store;
 use Symfony\Component\Cache\Traits\RedisClusterProxy;
 use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
@@ -41,7 +42,7 @@ class RedisStore implements StoreInterface
         }
 
         if ($initialTtl <= 0) {
-            throw new InvalidArgumentException(sprintf('%s() expects a strictly positive TTL. Got %d.', __METHOD__, $initialTtl));
+            throw new InvalidTtlException(sprintf('%s() expects a strictly positive TTL. Got %d.', __METHOD__, $initialTtl));
         }
 
         $this->redis = $redisClient;

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\Store\MemcachedStore;
 
 /**
@@ -56,5 +57,14 @@ class MemcachedStoreTest extends AbstractStoreTest
     public function testAbortAfterExpiration()
     {
         $this->markTestSkipped('Memcached expects a TTL greater than 1 sec. Simulating a slow network is too hard');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Lock\Exception\InvalidTtlException
+     */
+    public function testInvalidTtl()
+    {
+        $store = $this->getStore();
+        $store->putOffExpiration(new Key('toto'), 0.1);
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\Store\PdoStore;
 
 /**
@@ -56,5 +57,22 @@ class PdoStoreTest extends AbstractStoreTest
     public function testAbortAfterExpiration()
     {
         $this->markTestSkipped('Pdo expects a TTL greater than 1 sec. Simulating a slow network is too hard');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Lock\Exception\InvalidTtlException
+     */
+    public function testInvalidTtl()
+    {
+        $store = $this->getStore();
+        $store->putOffExpiration(new Key('toto'), 0.1);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Lock\Exception\InvalidTtlException
+     */
+    public function testInvalidTtlConstruct()
+    {
+        return new PdoStore('sqlite:'.self::$dbFile, [], 0.1, 0.1);
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Component\Lock\Store\RedisStore;
+
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -32,5 +34,13 @@ class RedisStoreTest extends AbstractRedisStoreTest
         $redis->connect(getenv('REDIS_HOST'));
 
         return $redis;
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Lock\Exception\InvalidTtlException
+     */
+    public function testInvalidTtl()
+    {
+        new RedisStore($this->getRedisConnection(), -1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | not needed<!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This adds a new exception to be more precise when using wrong ttl.
