### PR TITLE
[Routing] Add type-hints RequestContext and Route classes.

### DIFF
--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -77,11 +77,9 @@ class RequestContext
     /**
      * Sets the base URL.
      *
-     * @param string $baseUrl The base URL
-     *
      * @return $this
      */
-    public function setBaseUrl($baseUrl)
+    public function setBaseUrl(string $baseUrl)
     {
         $this->baseUrl = $baseUrl;
 
@@ -101,11 +99,9 @@ class RequestContext
     /**
      * Sets the path info.
      *
-     * @param string $pathInfo The path info
-     *
      * @return $this
      */
-    public function setPathInfo($pathInfo)
+    public function setPathInfo(string $pathInfo)
     {
         $this->pathInfo = $pathInfo;
 
@@ -127,11 +123,9 @@ class RequestContext
     /**
      * Sets the HTTP method.
      *
-     * @param string $method The HTTP method
-     *
      * @return $this
      */
-    public function setMethod($method)
+    public function setMethod(string $method)
     {
         $this->method = strtoupper($method);
 
@@ -153,11 +147,9 @@ class RequestContext
     /**
      * Sets the HTTP host.
      *
-     * @param string $host The HTTP host
-     *
      * @return $this
      */
-    public function setHost($host)
+    public function setHost(string $host)
     {
         $this->host = strtolower($host);
 
@@ -177,11 +169,9 @@ class RequestContext
     /**
      * Sets the HTTP scheme.
      *
-     * @param string $scheme The HTTP scheme
-     *
      * @return $this
      */
-    public function setScheme($scheme)
+    public function setScheme(string $scheme)
     {
         $this->scheme = strtolower($scheme);
 
@@ -201,13 +191,11 @@ class RequestContext
     /**
      * Sets the HTTP port.
      *
-     * @param int $httpPort The HTTP port
-     *
      * @return $this
      */
-    public function setHttpPort($httpPort)
+    public function setHttpPort(int $httpPort)
     {
-        $this->httpPort = (int) $httpPort;
+        $this->httpPort = $httpPort;
 
         return $this;
     }
@@ -225,13 +213,11 @@ class RequestContext
     /**
      * Sets the HTTPS port.
      *
-     * @param int $httpsPort The HTTPS port
-     *
      * @return $this
      */
-    public function setHttpsPort($httpsPort)
+    public function setHttpsPort(int $httpsPort)
     {
-        $this->httpsPort = (int) $httpsPort;
+        $this->httpsPort = $httpsPort;
 
         return $this;
     }
@@ -249,11 +235,9 @@ class RequestContext
     /**
      * Sets the query string.
      *
-     * @param string $queryString The query string (after "?")
-     *
      * @return $this
      */
-    public function setQueryString($queryString)
+    public function setQueryString(?string $queryString)
     {
         // string cast to be fault-tolerant, accepting null
         $this->queryString = (string) $queryString;
@@ -288,11 +272,9 @@ class RequestContext
     /**
      * Gets a parameter value.
      *
-     * @param string $name A parameter name
-     *
      * @return mixed The parameter value or null if nonexistent
      */
-    public function getParameter($name)
+    public function getParameter(string $name)
     {
         return isset($this->parameters[$name]) ? $this->parameters[$name] : null;
     }
@@ -300,11 +282,9 @@ class RequestContext
     /**
      * Checks if a parameter value is set for the given parameter.
      *
-     * @param string $name A parameter name
-     *
      * @return bool True if the parameter value is set, false otherwise
      */
-    public function hasParameter($name)
+    public function hasParameter(string $name)
     {
         return \array_key_exists($name, $this->parameters);
     }
@@ -312,12 +292,11 @@ class RequestContext
     /**
      * Sets a parameter value.
      *
-     * @param string $name      A parameter name
-     * @param mixed  $parameter The parameter value
+     * @param mixed $parameter The parameter value
      *
      * @return $this
      */
-    public function setParameter($name, $parameter)
+    public function setParameter(string $name, $parameter)
     {
         $this->parameters[$name] = $parameter;
 

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -126,11 +126,9 @@ class Route implements \Serializable
      *
      * This method implements a fluent interface.
      *
-     * @param string $pattern The path pattern
-     *
      * @return $this
      */
-    public function setPath($pattern)
+    public function setPath(string $pattern)
     {
         if (false !== strpbrk($pattern, '?<')) {
             $pattern = preg_replace_callback('#\{(\w++)(<.*?>)?(\?[^\}]*+)?\}#', function ($m) {
@@ -168,11 +166,9 @@ class Route implements \Serializable
      *
      * This method implements a fluent interface.
      *
-     * @param string $pattern The host pattern
-     *
      * @return $this
      */
-    public function setHost($pattern)
+    public function setHost(?string $pattern)
     {
         $this->host = (string) $pattern;
         $this->compiled = null;
@@ -212,11 +208,9 @@ class Route implements \Serializable
     /**
      * Checks if a scheme requirement has been set.
      *
-     * @param string $scheme
-     *
      * @return bool true if the scheme requirement exists, otherwise false
      */
-    public function hasScheme($scheme)
+    public function hasScheme(string $scheme)
     {
         return \in_array(strtolower($scheme), $this->schemes, true);
     }
@@ -302,12 +296,11 @@ class Route implements \Serializable
      *
      * This method implements a fluent interface.
      *
-     * @param string $name  An option name
-     * @param mixed  $value The option value
+     * @param mixed $value The option value
      *
      * @return $this
      */
-    public function setOption($name, $value)
+    public function setOption(string $name, $value)
     {
         $this->options[$name] = $value;
         $this->compiled = null;
@@ -318,11 +311,9 @@ class Route implements \Serializable
     /**
      * Get an option value.
      *
-     * @param string $name An option name
-     *
      * @return mixed The option value or null when not given
      */
-    public function getOption($name)
+    public function getOption(string $name)
     {
         return isset($this->options[$name]) ? $this->options[$name] : null;
     }
@@ -330,11 +321,9 @@ class Route implements \Serializable
     /**
      * Checks if an option has been set.
      *
-     * @param string $name An option name
-     *
      * @return bool true if the option is set, false otherwise
      */
-    public function hasOption($name)
+    public function hasOption(string $name)
     {
         return \array_key_exists($name, $this->options);
     }
@@ -387,11 +376,9 @@ class Route implements \Serializable
     /**
      * Gets a default value.
      *
-     * @param string $name A variable name
-     *
      * @return mixed The default value or null when not given
      */
-    public function getDefault($name)
+    public function getDefault(string $name)
     {
         return isset($this->defaults[$name]) ? $this->defaults[$name] : null;
     }
@@ -399,11 +386,9 @@ class Route implements \Serializable
     /**
      * Checks if a default value is set for the given variable.
      *
-     * @param string $name A variable name
-     *
      * @return bool true if the default value is set, false otherwise
      */
-    public function hasDefault($name)
+    public function hasDefault(string $name)
     {
         return \array_key_exists($name, $this->defaults);
     }
@@ -411,12 +396,11 @@ class Route implements \Serializable
     /**
      * Sets a default value.
      *
-     * @param string $name    A variable name
-     * @param mixed  $default The default value
+     * @param mixed $default The default value
      *
      * @return $this
      */
-    public function setDefault($name, $default)
+    public function setDefault(string $name, $default)
     {
         $this->defaults[$name] = $default;
         $this->compiled = null;
@@ -472,11 +456,9 @@ class Route implements \Serializable
     /**
      * Returns the requirement for the given key.
      *
-     * @param string $key The key
-     *
      * @return string|null The regex or null when not given
      */
-    public function getRequirement($key)
+    public function getRequirement(string $key)
     {
         return isset($this->requirements[$key]) ? $this->requirements[$key] : null;
     }
@@ -484,11 +466,9 @@ class Route implements \Serializable
     /**
      * Checks if a requirement is set for the given key.
      *
-     * @param string $key A variable name
-     *
      * @return bool true if a requirement is specified, false otherwise
      */
-    public function hasRequirement($key)
+    public function hasRequirement(string $key)
     {
         return \array_key_exists($key, $this->requirements);
     }
@@ -496,12 +476,9 @@ class Route implements \Serializable
     /**
      * Sets a requirement for the given key.
      *
-     * @param string $key   The key
-     * @param string $regex The regex
-     *
      * @return $this
      */
-    public function setRequirement($key, $regex)
+    public function setRequirement(string $key, string $regex)
     {
         $this->requirements[$key] = $this->sanitizeRequirement($key, $regex);
         $this->compiled = null;
@@ -524,11 +501,9 @@ class Route implements \Serializable
      *
      * This method implements a fluent interface.
      *
-     * @param string $condition The condition
-     *
      * @return $this
      */
-    public function setCondition($condition)
+    public function setCondition(?string $condition)
     {
         $this->condition = (string) $condition;
         $this->compiled = null;
@@ -557,12 +532,8 @@ class Route implements \Serializable
         return $this->compiled = $class::compile($this);
     }
 
-    private function sanitizeRequirement($key, $regex)
+    private function sanitizeRequirement(string $key, string $regex)
     {
-        if (!\is_string($regex)) {
-            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" must be a string.', $key));
-        }
-
         if ('' !== $regex && '^' === $regex[0]) {
             $regex = (string) substr($regex, 1); // returns false for a single character
         }

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -68,11 +68,8 @@ class RouteCollection implements \IteratorAggregate, \Countable
 
     /**
      * Adds a route.
-     *
-     * @param string $name  The route name
-     * @param Route  $route A Route instance
      */
-    public function add($name, Route $route)
+    public function add(string $name, Route $route)
     {
         unset($this->routes[$name]);
 
@@ -92,11 +89,9 @@ class RouteCollection implements \IteratorAggregate, \Countable
     /**
      * Gets a route by name.
      *
-     * @param string $name The route name
-     *
      * @return Route|null A Route instance or null when not found
      */
-    public function get($name)
+    public function get(string $name)
     {
         return isset($this->routes[$name]) ? $this->routes[$name] : null;
     }
@@ -133,17 +128,9 @@ class RouteCollection implements \IteratorAggregate, \Countable
 
     /**
      * Adds a prefix to the path of all child routes.
-     *
-     * @param string $prefix       An optional prefix to add before each pattern of the route collection
-     * @param array  $defaults     An array of default values
-     * @param array  $requirements An array of requirements
      */
-    public function addPrefix($prefix, array $defaults = [], array $requirements = [])
+    public function addPrefix(string $prefix, array $defaults = [], array $requirements = [])
     {
-        if (null === $prefix) {
-            @trigger_error(sprintf('Passing null as $prefix to %s is deprecated in Symfony 4.4 and will trigger a TypeError in 5.0.', __METHOD__), E_USER_DEPRECATED);
-        }
-
         $prefix = trim(trim($prefix), '/');
 
         if ('' === $prefix) {
@@ -176,12 +163,8 @@ class RouteCollection implements \IteratorAggregate, \Countable
 
     /**
      * Sets the host pattern on all routes.
-     *
-     * @param string $pattern      The pattern
-     * @param array  $defaults     An array of default values
-     * @param array  $requirements An array of requirements
      */
-    public function setHost($pattern, array $defaults = [], array $requirements = [])
+    public function setHost(?string $pattern, array $defaults = [], array $requirements = [])
     {
         foreach ($this->routes as $route) {
             $route->setHost($pattern);
@@ -194,10 +177,8 @@ class RouteCollection implements \IteratorAggregate, \Countable
      * Sets a condition on all routes.
      *
      * Existing conditions will be overridden.
-     *
-     * @param string $condition The condition
      */
-    public function setCondition($condition)
+    public function setCondition(?string $condition)
     {
         foreach ($this->routes as $route) {
             $route->setCondition($condition);
@@ -208,8 +189,6 @@ class RouteCollection implements \IteratorAggregate, \Countable
      * Adds defaults to all routes.
      *
      * An existing default value under the same name in a route will be overridden.
-     *
-     * @param array $defaults An array of default values
      */
     public function addDefaults(array $defaults)
     {
@@ -224,8 +203,6 @@ class RouteCollection implements \IteratorAggregate, \Countable
      * Adds requirements to all routes.
      *
      * An existing requirement under the same name in a route will be overridden.
-     *
-     * @param array $requirements An array of requirements
      */
     public function addRequirements(array $requirements)
     {
@@ -240,8 +217,6 @@ class RouteCollection implements \IteratorAggregate, \Countable
      * Adds options to all routes.
      *
      * An existing option value under the same name in a route will be overridden.
-     *
-     * @param array $options An array of options
      */
     public function addOptions(array $options)
     {

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -92,7 +92,7 @@ class RouteCompiler implements RouteCompilerInterface
         );
     }
 
-    private static function compilePattern(Route $route, $pattern, $isHost)
+    private static function compilePattern(Route $route, string $pattern, bool $isHost): array
     {
         $tokens = [];
         $variables = [];

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -136,7 +136,6 @@ class RouteTest extends TestCase
     {
         return [
            [''],
-           [[]],
            ['^$'],
            ['^'],
            ['$'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32179
| License       | MIT
| Doc PR        | N/A

This PR adds type-hints to `RequestContext` and the Route classes to give them a more php7-like feeling. Adding these type-hints on master should not be a breaking change because we require php 7.2 there, which allows downstream classes/interfaces to remove a type-hint from a method signature.