### PR TITLE
[Routing] Fixed type annotation

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -71,9 +71,9 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      *
      * The special parameter _fragment will be used as the document fragment suffixed to the final URL.
      *
-     * @param string $name          The name of the route
-     * @param mixed  $parameters    An array of parameters
-     * @param int    $referenceType The type of reference to be generated (one of the constants)
+     * @param string  $name          The name of the route
+     * @param mixed[] $parameters    An array of parameters
+     * @param int     $referenceType The type of reference to be generated (one of the constants)
      *
      * @return string The generated URL
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The `UrlGeneratorInterface::generate()` method expects an array as argument `$parameters`, but the docblock does not reflect that. This PR fixes the type. Discovered while working on #32176.