### PR TITLE
[Lock] Split "StoreInterface" into multiple interfaces with less responsability

### DIFF
--- a/src/Symfony/Component/Lock/BlockingStoreInterface.php
+++ b/src/Symfony/Component/Lock/BlockingStoreInterface.php
@@ -15,13 +15,9 @@ use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\NotSupportedException;
 
 /**
- * StoreInterface defines an interface to manipulate a lock store.
- *
- * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @deprecated "Symfony\Component\Lock\StoreInterface" is deprecated since Symfony 4.4 and has been split into "Symfony\Component\Lock\PersistStoreInterface", "Symfony\Component\Lock\BlockingStoreInterface".'
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
  */
-interface StoreInterface extends PersistStoreInterface
+interface BlockingStoreInterface
 {
     /**
      * Waits until a key becomes free, then stores the resource.
@@ -32,4 +28,9 @@ interface StoreInterface extends PersistStoreInterface
      * @throws NotSupportedException
      */
     public function waitAndSave(Key $key);
+
+    /**
+     * Checks if the store can wait until a key becomes free before storing the resource.
+     */
+    public function supportsWaitAndSave(): bool;
 }

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -4,8 +4,9 @@ CHANGELOG
 4.4.0
 -----
 
- * added InvalidTtlException
- 
+ * added InvalidTtlException  
+ * deprecated `Symfony\Component\Lock\StoreInterface` in favor of `Symfony\Component\Lock\BlockingStoreInterface` and `Symfony\Component\Lock\PersistStoreInterface`
+   
 4.2.0
 -----
 

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -19,6 +19,7 @@ use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Exception\LockReleasingException;
+use Symfony\Component\Lock\Exception\NotSupportedException;
 
 /**
  * Lock is the default implementation of the LockInterface.
@@ -36,12 +37,12 @@ final class Lock implements LockInterface, LoggerAwareInterface
     private $dirty = false;
 
     /**
-     * @param Key            $key         Resource to lock
-     * @param StoreInterface $store       Store used to handle lock persistence
-     * @param float|null     $ttl         Maximum expected lock duration in seconds
-     * @param bool           $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
+     * @param Key                   $key         Resource to lock
+     * @param PersistStoreInterface $store       Store used to handle lock persistence
+     * @param float|null            $ttl         Maximum expected lock duration in seconds
+     * @param bool                  $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
      */
-    public function __construct(Key $key, StoreInterface $store, float $ttl = null, bool $autoRelease = true)
+    public function __construct(Key $key, PersistStoreInterface $store, float $ttl = null, bool $autoRelease = true)
     {
         $this->store = $store;
         $this->key = $key;
@@ -70,6 +71,9 @@ final class Lock implements LockInterface, LoggerAwareInterface
     {
         try {
             if ($blocking) {
+                if (!($this->store instanceof StoreInterface) && !($this->store instanceof BlockingStoreInterface && $this->store->supportsWaitAndSave())) {
+                    throw new NotSupportedException(sprintf('The store "%s" does not support blocking locks.', \get_class($this->store)));
+                }
                 $this->store->waitAndSave($this->key);
             } else {
                 $this->store->save($this->key);

--- a/src/Symfony/Component/Lock/PersistStoreInterface.php
+++ b/src/Symfony/Component/Lock/PersistStoreInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockReleasingException;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface PersistStoreInterface
+{
+    /**
+     * Stores the resource if it's not locked by someone else.
+     *
+     * @throws LockAcquiringException
+     * @throws LockConflictedException
+     */
+    public function save(Key $key);
+
+    /**
+     * Removes a resource from the storage.
+     *
+     * @throws LockReleasingException
+     */
+    public function delete(Key $key);
+
+    /**
+     * Returns whether or not the resource exists in the storage.
+     *
+     * @return bool
+     */
+    public function exists(Key $key);
+
+    /**
+     * Extends the TTL of a resource.
+     *
+     * @param float $ttl amount of seconds to keep the lock in the store
+     *
+     * @throws LockConflictedException
+     */
+    public function putOffExpiration(Key $key, $ttl);
+}

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Lock\Store;
 
+use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockStorageException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistStoreInterface;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
@@ -27,7 +29,7 @@ use Symfony\Component\Lock\StoreInterface;
  * @author Romain Neutron <imprec@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class FlockStore implements StoreInterface
+class FlockStore implements StoreInterface, BlockingStoreInterface, PersistStoreInterface
 {
     private $lockPath;
 
@@ -62,6 +64,14 @@ class FlockStore implements StoreInterface
     public function waitAndSave(Key $key)
     {
         $this->lock($key, true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsWaitAndSave(): bool
+    {
+        return true;
     }
 
     private function lock(Key $key, $blocking)

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -15,6 +15,7 @@ use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistStoreInterface;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
@@ -22,7 +23,7 @@ use Symfony\Component\Lock\StoreInterface;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class MemcachedStore implements StoreInterface
+class MemcachedStore implements StoreInterface, PersistStoreInterface
 {
     use ExpiringStoreTrait;
 
@@ -69,8 +70,12 @@ class MemcachedStore implements StoreInterface
         $this->checkNotExpired($key);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function waitAndSave(Key $key)
     {
+        @trigger_error(sprintf('%s has been deprecated since Symfony 4.4 and will be removed in Symfony 5.0.', __METHOD__));
         throw new InvalidArgumentException(sprintf('The store "%s" does not supports blocking locks.', \get_class($this)));
     }
 

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -19,6 +19,7 @@ use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistStoreInterface;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
@@ -34,7 +35,7 @@ use Symfony\Component\Lock\StoreInterface;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class PdoStore implements StoreInterface
+class PdoStore implements StoreInterface, PersistStoreInterface
 {
     use ExpiringStoreTrait;
 
@@ -145,6 +146,7 @@ class PdoStore implements StoreInterface
      */
     public function waitAndSave(Key $key)
     {
+        @trigger_error(sprintf('%s has been deprecated since Symfony 4.4 and will be removed in Symfony 5.0.', __METHOD__));
         throw new NotSupportedException(sprintf('The store "%s" does not supports blocking locks.', __METHOD__));
     }
 

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -17,6 +17,7 @@ use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistStoreInterface;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
@@ -24,7 +25,7 @@ use Symfony\Component\Lock\StoreInterface;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class RedisStore implements StoreInterface
+class RedisStore implements StoreInterface, PersistStoreInterface
 {
     use ExpiringStoreTrait;
 
@@ -77,6 +78,7 @@ class RedisStore implements StoreInterface
      */
     public function waitAndSave(Key $key)
     {
+        @trigger_error(sprintf('%s::%s has been deprecated since Symfony 4.4 and will be removed in Symfony 5.0.', \get_class($this), __METHOD__), E_USER_DEPRECATED);
         throw new InvalidArgumentException(sprintf('The store "%s" does not supports blocking locks.', \get_class($this)));
     }
 

--- a/src/Symfony/Component/Lock/Store/RetryTillSaveStore.php
+++ b/src/Symfony/Component/Lock/Store/RetryTillSaveStore.php
@@ -14,8 +14,10 @@ namespace Symfony\Component\Lock\Store;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
+use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistStoreInterface;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
@@ -24,7 +26,7 @@ use Symfony\Component\Lock\StoreInterface;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class RetryTillSaveStore implements StoreInterface, LoggerAwareInterface
+class RetryTillSaveStore implements PersistStoreInterface, BlockingStoreInterface, StoreInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
@@ -33,11 +35,11 @@ class RetryTillSaveStore implements StoreInterface, LoggerAwareInterface
     private $retryCount;
 
     /**
-     * @param StoreInterface $decorated  The decorated StoreInterface
-     * @param int            $retrySleep Duration in ms between 2 retry
-     * @param int            $retryCount Maximum amount of retry
+     * @param PersistStoreInterface $decorated  The decorated StoreInterface
+     * @param int                   $retrySleep Duration in ms between 2 retry
+     * @param int                   $retryCount Maximum amount of retry
      */
-    public function __construct(StoreInterface $decorated, int $retrySleep = 100, int $retryCount = PHP_INT_MAX)
+    public function __construct(PersistStoreInterface $decorated, int $retrySleep = 100, int $retryCount = PHP_INT_MAX)
     {
         $this->decorated = $decorated;
         $this->retrySleep = $retrySleep;
@@ -98,5 +100,13 @@ class RetryTillSaveStore implements StoreInterface, LoggerAwareInterface
     public function exists(Key $key)
     {
         return $this->decorated->exists($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsWaitAndSave(): bool
+    {
+        return true;
     }
 }

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Component\Lock\Store;
 
+use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistStoreInterface;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
@@ -21,7 +23,7 @@ use Symfony\Component\Lock\StoreInterface;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class SemaphoreStore implements StoreInterface
+class SemaphoreStore implements StoreInterface, PersistStoreInterface, BlockingStoreInterface
 {
     /**
      * Returns whether or not the store is supported.
@@ -111,5 +113,13 @@ class SemaphoreStore implements StoreInterface
     public function exists(Key $key)
     {
         return $key->hasState(__CLASS__);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsWaitAndSave(): bool
+    {
+        return true;
     }
 }

--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -16,6 +16,7 @@ use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockReleasingException;
 use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistStoreInterface;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
@@ -23,7 +24,7 @@ use Symfony\Component\Lock\StoreInterface;
  *
  * @author Ganesh Chandrasekaran <gchandrasekaran@wayfair.com>
  */
-class ZookeeperStore implements StoreInterface
+class ZookeeperStore implements StoreInterface, PersistStoreInterface
 {
     use ExpiringStoreTrait;
 
@@ -87,6 +88,7 @@ class ZookeeperStore implements StoreInterface
      */
     public function waitAndSave(Key $key)
     {
+        @trigger_error(sprintf('%s::%s has been deprecated since Symfony 4.4 and will be removed in Symfony 5.0.', \get_class($this), __METHOD__), E_USER_DEPRECATED);
         throw new NotSupportedException();
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
 
@@ -56,6 +57,7 @@ trait BlockingStoreTestTrait
                 // This call should failed given the lock should already by acquired by the child
                 $store->save($key);
                 $this->fail('The store saves a locked key.');
+            } catch (NotSupportedException $e) {
             } catch (LockConflictedException $e) {
             }
 
@@ -63,13 +65,17 @@ trait BlockingStoreTestTrait
             posix_kill($childPID, SIGHUP);
 
             // This call should be blocked by the child #1
-            $store->waitAndSave($key);
-            $this->assertTrue($store->exists($key));
-            $store->delete($key);
+            try {
+                $store->waitAndSave($key);
+                $this->assertTrue($store->exists($key));
+                $store->delete($key);
 
-            // Now, assert the child process worked well
-            pcntl_waitpid($childPID, $status1);
-            $this->assertSame(0, pcntl_wexitstatus($status1), 'The child process couldn\'t lock the resource');
+                // Now, assert the child process worked well
+                pcntl_waitpid($childPID, $status1);
+                $this->assertSame(0, pcntl_wexitstatus($status1), 'The child process couldn\'t lock the resource');
+            } catch (NotSupportedException $e) {
+                $this->markTestSkipped(sprintf('The store %s does not support waitAndSave.', \get_class($store)));
+            }
         } else {
             // Block SIGHUP signal
             pcntl_sigprocmask(SIG_BLOCK, [SIGHUP]);

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -11,11 +11,12 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistStoreInterface;
 use Symfony\Component\Lock\Store\CombinedStore;
 use Symfony\Component\Lock\Store\RedisStore;
-use Symfony\Component\Lock\StoreInterface;
 use Symfony\Component\Lock\Strategy\StrategyInterface;
 use Symfony\Component\Lock\Strategy\UnanimousStrategy;
 
@@ -61,8 +62,8 @@ class CombinedStoreTest extends AbstractStoreTest
     protected function setUp()
     {
         $this->strategy = $this->getMockBuilder(StrategyInterface::class)->getMock();
-        $this->store1 = $this->getMockBuilder(StoreInterface::class)->getMock();
-        $this->store2 = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $this->store1 = $this->getMockBuilder([PersistStoreInterface::class, BlockingStoreInterface::class])->getMock();
+        $this->store2 = $this->getMockBuilder([PersistStoreInterface::class, BlockingStoreInterface::class])->getMock();
 
         $this->store = new CombinedStore([$this->store1, $this->store2], $this->strategy);
     }
@@ -266,8 +267,8 @@ class CombinedStoreTest extends AbstractStoreTest
 
     public function testPutOffExpirationIgnoreNonExpiringStorage()
     {
-        $store1 = $this->getMockBuilder(StoreInterface::class)->getMock();
-        $store2 = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store1 = $this->getMockBuilder([PersistStoreInterface::class, BlockingStoreInterface::class])->getMock();
+        $store2 = $this->getMockBuilder([PersistStoreInterface::class, BlockingStoreInterface::class])->getMock();
 
         $store = new CombinedStore([$store1, $store2], $this->strategy);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Contribute to #28694 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | TODO <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

We are removing the StoreInterface in order to split into multiple interface, it will help reduce de responsability of the StoreInterface.

Firstly, since not all stores needs to have all the methods of the StoreInterface, we can split this like this in order to limit the methods that are needed for each store.

Secondly, we add supportsX methods in order to avoid throwing exception when a store does not supports a feature it's easier an instance of the special interface or not, and it can return true/false on the support method.

**Really big thanks to** @jderusse for working with me on this, 1-2 hours of talking together, and another 1-2 hours of pre-review :). now giving it to the whole community !

*some time has been sponsored by* @izisolutions