### PR TITLE
Typing for Symfony\Component\Form\FormView::$vars

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -20,6 +20,8 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
 {
     /**
      * The variables assigned to this view.
+     *
+     * @var array
      */
     public $vars = [
         'value' => null,


### PR DESCRIPTION
Not having it triggers the psalm `MissingPropertyType` check:

```
INFO: MissingPropertyType - src/Path/To/My/Class.php:95:22 - Property Symfony\Component\Form\FormView::$vars does not have a declared type
```

I agree, having a 3rd party complaining is not a well enough justification, but:

1. A large part of the community agrees that static analysis (including psalm or other tools) is a good thing
1. The fields should be typed regardless

| Q             | A
| ------------- | ---
| Branch?       | N/A
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
