### PR TITLE
[Mailer] Fix timeout type hint

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php
@@ -34,14 +34,14 @@ final class SocketStream extends AbstractStream
     private $sourceIp;
     private $streamContextOptions = [];
 
-    public function setTimeout(int $timeout): self
+    public function setTimeout(float $timeout): self
     {
         $this->timeout = $timeout;
 
         return $this;
     }
 
-    public function getTimeout(): int
+    public function getTimeout(): float
     {
         return $this->timeout;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The timeout on a socket is a float, not an integer.
