### PR TITLE
[Mailer] Fix error message when connecting to a stream raises an error before connect()

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream/SocketStreamTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream/SocketStreamTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Transport\Smtp\Stream;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+
+class SocketStreamTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\Mailer\Exception\TransportException
+     * @expectedExceptionMessage Connection refused
+     */
+    public function testSocketErrorNoConnection()
+    {
+        $s = new SocketStream();
+        $s->setTimeout(0.1);
+        $s->setPort(9999);
+        $s->initialize();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Mailer\Exception\TransportException
+     * @expectedExceptionMessage no valid certs found cafile stream
+     */
+    public function testSocketErrorBeforeConnectError()
+    {
+        $s = new SocketStream();
+        $s->setStreamOptions([
+            'ssl' => [
+                // not a CA file :)
+                'cafile' => __FILE__,
+            ],
+        ]);
+        $s->setEncryption('ssl');
+        $s->setHost('smtp.gmail.com');
+        $s->setPort(465);
+        $s->initialize();
+    }
+}


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | see https://github.com/swiftmailer/swiftmailer/issues/1201
| License       | MIT
| Doc PR        | n/a

According to the PHP docs, "If the value returned in errno is 0 and the function returned FALSE, it is an indication that the error occurred before the connect() call.".

Using the `@` operator means that we get a generic error message without any clues about why connection cannot be done. Using an error handler allows to get the real issue.

