### PR TITLE
[HttpKernel] Add @method PHPDoc for getRequest and getResponse back to Client

### DIFF
--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -23,6 +23,9 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Client simulates a browser and makes requests to an HttpKernel instance.
  *
+ * @method Request  getRequest()  A Request instance
+ * @method Response getResponse() A Response instance
+ *
  * @deprecated since Symfony 4.3, use HttpKernelBrowser instead.
  */
 class Client extends AbstractBrowser


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

As the deprecated `Symfony\Component\HttpKernel\Client` does not extend `Symfony\Component\HttpKernel\HttpKernelBrowser`, it has not retained the correct PHPDoc from before.

The order of inheritance was changed in https://github.com/symfony/symfony/pull/31881, but the PHPDoc was never restored.