### PR TITLE
[FrameworkBundle] Fix BC break on WebTestCase::createClient

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
+use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
@@ -35,7 +36,7 @@ abstract class WebTestCase extends KernelTestCase
      * @param array $options An array of options to pass to the createKernel method
      * @param array $server  An array of server parameters
      *
-     * @return KernelBrowser A KernelBrowser instance
+     * @return Client A Client instance
      */
     protected static function createClient(array $options = [], array $server = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32212
| License       | MIT
| Doc PR        | N/A

Changing the return type of `WebTestCase::createClient` method was a BC break. Introduced in #30541.