### PR TITLE
[HttpFoundation] Throw exception when the "session" extension is not loaded

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -233,6 +233,10 @@ class FrameworkExtension extends Extension
         }
 
         if ($this->isConfigEnabled($container, $config['session'])) {
+            if (!\extension_loaded('session')) {
+                throw new \LogicException('PHP extension "session" is required.');
+            }
+
             $this->sessionConfigEnabled = true;
             $this->registerSessionConfiguration($config['session'], $container, $loader);
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -100,6 +100,10 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function __construct(array $options = [], $handler = null, MetadataBag $metaBag = null)
     {
+        if (!\extension_loaded('session')) {
+            throw new \LogicException('PHP extension "session" is required.');
+        }
+
         $options += [
             'cache_limiter' => '',
             'cache_expire' => 0,

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
@@ -24,6 +24,10 @@ class PhpBridgeSessionStorage extends NativeSessionStorage
      */
     public function __construct($handler = null, MetadataBag $metaBag = null)
     {
+        if (!\extension_loaded('session')) {
+            throw new \LogicException('PHP extension "session" is required.');
+        }
+
         $this->setMetadataBag($metaBag);
         $this->setSaveHandler($handler);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31305 
| License       | MIT

Should I target `3.4` or `master` instead? This change does not alter behavior, but makes the failure more clear.