### PR TITLE
Make BuferringLogger classes internal and final

### DIFF
--- a/src/Symfony/Component/Debug/BufferingLogger.php
+++ b/src/Symfony/Component/Debug/BufferingLogger.php
@@ -11,13 +11,31 @@
 
 namespace Symfony\Component\Debug;
 
-use Symfony\Component\ErrorHandler\BufferingLogger as BaseBufferingLogger;
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.4 and will be removed in 5.0.', BufferingLogger::class), E_USER_DEPRECATED);
 
-@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.4, use "%s" instead.', BufferingLogger::class, BaseBufferingLogger::class), E_USER_DEPRECATED);
+use Psr\Log\AbstractLogger;
 
 /**
- * @deprecated since Symfony 4.4, use Symfony\Component\ErrorHandler\BufferingLogger instead.
+ * A buffering logger that stacks logs for later.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated since Symfony 4.4 and will be removed in 5.0.
  */
-class BufferingLogger extends BaseBufferingLogger
+class BufferingLogger extends AbstractLogger
 {
+    private $logs = [];
+
+    public function log($level, $message, array $context = [])
+    {
+        $this->logs[] = [$level, $message, $context];
+    }
+
+    public function cleanLogs()
+    {
+        $logs = $this->logs;
+        $this->logs = [];
+
+        return $logs;
+    }
 }

--- a/src/Symfony/Component/ErrorHandler/BufferingLogger.php
+++ b/src/Symfony/Component/ErrorHandler/BufferingLogger.php
@@ -18,7 +18,7 @@ use Psr\Log\AbstractLogger;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class BufferingLogger extends AbstractLogger
+final class BufferingLogger extends AbstractLogger
 {
     private $logs = [];
 
@@ -27,7 +27,7 @@ class BufferingLogger extends AbstractLogger
         $this->logs[] = [$level, $message, $context];
     }
 
-    public function cleanLogs()
+    public function cleanLogs(): array
     {
         $logs = $this->logs;
         $this->logs = [];

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/LoggerThatSetAnErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/LoggerThatSetAnErrorHandler.php
@@ -2,14 +2,24 @@
 
 namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
 
-use Symfony\Component\ErrorHandler\BufferingLogger;
+use Psr\Log\AbstractLogger;
 
-class LoggerThatSetAnErrorHandler extends BufferingLogger
+class LoggerThatSetAnErrorHandler extends AbstractLogger
 {
+    private $logs = [];
+
     public function log($level, $message, array $context = [])
     {
         set_error_handler('is_string');
-        parent::log($level, $message, $context);
+        $this->logs[] = [$level, $message, $context];
         restore_error_handler();
+    }
+
+    public function cleanLogs(): array
+    {
+        $logs = $this->logs;
+        $this->logs = [];
+
+        return $logs;
     }
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures2/RequiredTwice.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures2/RequiredTwice.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Component\Debug\Tests\Fixtures2;
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures2;
 
 class RequiredTwice
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The `BufferingLogger` classes are internal code that nobody should use directly. Let's make it clear.
