### PR TITLE
[PropertyInfo] Add type-hints to public interfaces and classes

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -68,7 +68,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     /**
      * {@inheritdoc}
      */
-    public function getShortDescription($class, $property, array $context = [])
+    public function getShortDescription(string $class, string $property, array $context = [])
     {
         /** @var $docBlock DocBlock */
         list($docBlock) = $this->getDocBlock($class, $property);
@@ -94,7 +94,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     /**
      * {@inheritdoc}
      */
-    public function getLongDescription($class, $property, array $context = [])
+    public function getLongDescription(string $class, string $property, array $context = [])
     {
         /** @var $docBlock DocBlock */
         list($docBlock) = $this->getDocBlock($class, $property);
@@ -110,7 +110,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes(string $class, string $property, array $context = [])
     {
         /** @var $docBlock DocBlock */
         list($docBlock, $source, $prefix) = $this->getDocBlock($class, $property);

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -75,7 +75,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * {@inheritdoc}
      */
-    public function getProperties($class, array $context = [])
+    public function getProperties(string $class, array $context = [])
     {
         try {
             $reflectionClass = new \ReflectionClass($class);
@@ -131,7 +131,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes(string $class, $property, array $context = [])
     {
         if ($fromMutator = $this->extractFromMutator($class, $property)) {
             return $fromMutator;
@@ -156,7 +156,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * {@inheritdoc}
      */
-    public function isReadable($class, $property, array $context = []): bool
+    public function isReadable(string $class, $property, array $context = []): bool
     {
         if ($this->isAllowedProperty($class, $property)) {
             return true;
@@ -170,7 +170,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * {@inheritdoc}
      */
-    public function isWritable($class, $property, array $context = []): bool
+    public function isWritable(string $class, $property, array $context = []): bool
     {
         if ($this->isAllowedProperty($class, $property)) {
             return true;

--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -33,7 +33,7 @@ class SerializerExtractor implements PropertyListExtractorInterface
     /**
      * {@inheritdoc}
      */
-    public function getProperties($class, array $context = [])
+    public function getProperties(string $class, array $context = [])
     {
         if (!isset($context['serializer_groups']) || !\is_array($context['serializer_groups'])) {
             return;

--- a/src/Symfony/Component/PropertyInfo/PropertyAccessExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyAccessExtractorInterface.php
@@ -21,22 +21,14 @@ interface PropertyAccessExtractorInterface
     /**
      * Is the property readable?
      *
-     * @param string $class
-     * @param string $property
-     * @param array  $context
-     *
      * @return bool|null
      */
-    public function isReadable($class, $property, array $context = []);
+    public function isReadable(string $class, string $property, array $context = []);
 
     /**
      * Is the property writable?
      *
-     * @param string $class
-     * @param string $property
-     * @param array  $context
-     *
      * @return bool|null
      */
-    public function isWritable($class, $property, array $context = []);
+    public function isWritable(string $class, string $property, array $context = []);
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyDescriptionExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyDescriptionExtractorInterface.php
@@ -21,22 +21,14 @@ interface PropertyDescriptionExtractorInterface
     /**
      * Gets the short description of the property.
      *
-     * @param string $class
-     * @param string $property
-     * @param array  $context
-     *
      * @return string|null
      */
-    public function getShortDescription($class, $property, array $context = []);
+    public function getShortDescription(string $class, string $property, array $context = []);
 
     /**
      * Gets the long description of the property.
      *
-     * @param string $class
-     * @param string $property
-     * @param array  $context
-     *
      * @return string|null
      */
-    public function getLongDescription($class, $property, array $context = []);
+    public function getLongDescription(string $class, string $property, array $context = []);
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -35,7 +35,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function isReadable($class, $property, array $context = [])
+    public function isReadable(string $class, string $property, array $context = [])
     {
         return $this->extract('isReadable', [$class, $property, $context]);
     }
@@ -43,7 +43,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function isWritable($class, $property, array $context = [])
+    public function isWritable(string $class, string $property, array $context = [])
     {
         return $this->extract('isWritable', [$class, $property, $context]);
     }
@@ -51,7 +51,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function getShortDescription($class, $property, array $context = [])
+    public function getShortDescription(string $class, string $property, array $context = [])
     {
         return $this->extract('getShortDescription', [$class, $property, $context]);
     }
@@ -59,7 +59,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function getLongDescription($class, $property, array $context = [])
+    public function getLongDescription(string $class, string $property, array $context = [])
     {
         return $this->extract('getLongDescription', [$class, $property, $context]);
     }
@@ -67,7 +67,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function getProperties($class, array $context = [])
+    public function getProperties(string $class, array $context = [])
     {
         return $this->extract('getProperties', [$class, $context]);
     }
@@ -75,7 +75,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes(string $class, string $property, array $context = [])
     {
         return $this->extract('getTypes', [$class, $property, $context]);
     }

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -45,7 +45,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function getProperties($class, array $context = [])
+    public function getProperties(string $class, array $context = [])
     {
         return $this->extract($this->listExtractors, 'getProperties', [$class, $context]);
     }
@@ -53,7 +53,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function getShortDescription($class, $property, array $context = [])
+    public function getShortDescription(string $class, string $property, array $context = [])
     {
         return $this->extract($this->descriptionExtractors, 'getShortDescription', [$class, $property, $context]);
     }
@@ -61,7 +61,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function getLongDescription($class, $property, array $context = [])
+    public function getLongDescription(string $class, string $property, array $context = [])
     {
         return $this->extract($this->descriptionExtractors, 'getLongDescription', [$class, $property, $context]);
     }
@@ -69,7 +69,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes(string $class, string $property, array $context = [])
     {
         return $this->extract($this->typeExtractors, 'getTypes', [$class, $property, $context]);
     }
@@ -77,7 +77,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function isReadable($class, $property, array $context = [])
+    public function isReadable(string $class, string $property, array $context = [])
     {
         return $this->extract($this->accessExtractors, 'isReadable', [$class, $property, $context]);
     }
@@ -85,7 +85,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function isWritable($class, $property, array $context = [])
+    public function isWritable(string $class, string $property, array $context = [])
     {
         return $this->extract($this->accessExtractors, 'isWritable', [$class, $property, $context]);
     }

--- a/src/Symfony/Component/PropertyInfo/PropertyListExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyListExtractorInterface.php
@@ -21,10 +21,7 @@ interface PropertyListExtractorInterface
     /**
      * Gets the list of properties available for the given class.
      *
-     * @param string $class
-     * @param array  $context
-     *
      * @return string[]|null
      */
-    public function getProperties($class, array $context = []);
+    public function getProperties(string $class, array $context = []);
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
@@ -21,11 +21,7 @@ interface PropertyTypeExtractorInterface
     /**
      * Gets types of a property.
      *
-     * @param string $class
-     * @param string $property
-     * @param array  $context
-     *
      * @return Type[]|null
      */
-    public function getTypes($class, $property, array $context = []);
+    public function getTypes(string $class, string $property, array $context = []);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32179  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

This PR adds type hints to public interfaces and classes of the PropertyInfo component. Some docblocks without valuable information got also removed.
