### PR TITLE
[PropertyAccess] Add type-hints to public interfaces and classes

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -335,6 +335,11 @@ Process
    $process = Process::fromShellCommandline('ls -l');
    ```
 
+PropertyAccess
+--------------
+
+ * Removed support of passing `null` as 2nd argument of `PropertyAccessor::createCache()` method (`$defaultLifetime`), pass `0` instead.
+
 Routing
 -------
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1704,7 +1704,7 @@ class FrameworkExtension extends Extension
 
             if (!$container->getParameter('kernel.debug')) {
                 $propertyAccessDefinition->setFactory([PropertyAccessor::class, 'createCache']);
-                $propertyAccessDefinition->setArguments([null, null, $version, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)]);
+                $propertyAccessDefinition->setArguments([null, 0, $version, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)]);
                 $propertyAccessDefinition->addTag('cache.pool', ['clearer' => 'cache.system_clearer']);
                 $propertyAccessDefinition->addTag('monolog.logger', ['channel' => 'cache']);
             } else {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -181,7 +181,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
     }
 
-    private static function throwInvalidArgumentException($message, $trace, $i, $propertyPath)
+    private static function throwInvalidArgumentException(string $message, array $trace, $i, $propertyPath)
     {
         // the type mismatch is not caused by invalid arguments (but e.g. by an incompatible return type hint of the writer method)
         if (0 !== strpos($message, 'Argument ')) {
@@ -274,7 +274,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @throws UnexpectedTypeException if a value within the path is neither object nor array
      * @throws NoSuchIndexException    If a non-existing index is accessed
      */
-    private function readPropertiesUntil($zval, PropertyPathInterface $propertyPath, $lastIndex, $ignoreInvalidIndices = true)
+    private function readPropertiesUntil(array $zval, PropertyPathInterface $propertyPath, int $lastIndex, bool $ignoreInvalidIndices = true)
     {
         if (!\is_object($zval[self::VALUE]) && !\is_array($zval[self::VALUE])) {
             throw new UnexpectedTypeException($zval[self::VALUE], $propertyPath, 0);
@@ -383,7 +383,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @throws NoSuchPropertyException If $ignoreInvalidProperty is false and the property does not exist or is not public
      */
-    private function readProperty($zval, $property, bool $ignoreInvalidProperty = false)
+    private function readProperty(array $zval, string $property, bool $ignoreInvalidProperty = false)
     {
         if (!\is_object($zval[self::VALUE])) {
             throw new NoSuchPropertyException(sprintf('Cannot read property "%s" from an array. Maybe you intended to write the property path as "[%1$s]" instead.', $property));
@@ -430,12 +430,9 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * Guesses how to read the property value.
      *
-     * @param string $class
-     * @param string $property
-     *
      * @return array
      */
-    private function getReadAccessInfo($class, $property)
+    private function getReadAccessInfo(string $class, string $property)
     {
         $key = str_replace('\\', '.', $class).'..'.$property;
 
@@ -520,7 +517,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @throws NoSuchIndexException If the array does not implement \ArrayAccess or it is not an array
      */
-    private function writeIndex($zval, $index, $value)
+    private function writeIndex(array $zval, $index, $value)
     {
         if (!$zval[self::VALUE] instanceof \ArrayAccess && !\is_array($zval[self::VALUE])) {
             throw new NoSuchIndexException(sprintf('Cannot modify index "%s" in object of type "%s" because it doesn\'t implement \ArrayAccess.', $index, \get_class($zval[self::VALUE])));
@@ -538,7 +535,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @throws NoSuchPropertyException if the property does not exist or is not public
      */
-    private function writeProperty($zval, $property, $value)
+    private function writeProperty(array $zval, string $property, $value)
     {
         if (!\is_object($zval[self::VALUE])) {
             throw new NoSuchPropertyException(sprintf('Cannot write property "%s" to an array. Maybe you should write the property path as "[%1$s]" instead?', $property));
@@ -579,7 +576,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @param string   $addMethod    The add*() method
      * @param string   $removeMethod The remove*() method
      */
-    private function writeCollection($zval, $property, $collection, $addMethod, $removeMethod)
+    private function writeCollection(array $zval, string $property, $collection, string $addMethod, string $removeMethod)
     {
         // At this point the add and remove methods have been found
         $previousValue = $this->readProperty($zval, $property);
@@ -817,16 +814,11 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * Creates the APCu adapter if applicable.
      *
-     * @param string               $namespace
-     * @param int                  $defaultLifetime
-     * @param string               $version
-     * @param LoggerInterface|null $logger
-     *
      * @return AdapterInterface
      *
      * @throws \LogicException When the Cache Component isn't available
      */
-    public static function createCache($namespace, $defaultLifetime, $version, LoggerInterface $logger = null)
+    public static function createCache(string $namespace, int $defaultLifetime, string $version, LoggerInterface $logger = null)
     {
         if (!class_exists('Symfony\Component\Cache\Adapter\ApcuAdapter')) {
             throw new \LogicException(sprintf('The Symfony Cache component must be installed to use %s().', __METHOD__));

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -170,7 +170,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     /**
      * {@inheritdoc}
      */
-    public function getElement($index)
+    public function getElement(int $index)
     {
         if (!isset($this->elements[$index])) {
             throw new OutOfBoundsException(sprintf('The index %s is not within the property path', $index));
@@ -182,7 +182,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     /**
      * {@inheritdoc}
      */
-    public function isProperty($index)
+    public function isProperty(int $index)
     {
         if (!isset($this->isIndex[$index])) {
             throw new OutOfBoundsException(sprintf('The index %s is not within the property path', $index));
@@ -194,7 +194,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     /**
      * {@inheritdoc}
      */
-    public function isIndex($index)
+    public function isIndex(int $index)
     {
         if (!isset($this->isIndex[$index])) {
             throw new OutOfBoundsException(sprintf('The index %s is not within the property path', $index));

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -43,7 +43,7 @@ class PropertyPathBuilder
      * @param int                          $length The length of the appended piece
      *                                             If 0, the full path is appended
      */
-    public function append($path, $offset = 0, $length = 0)
+    public function append($path, int $offset = 0, int $length = 0)
     {
         if (\is_string($path)) {
             $path = new PropertyPath($path);
@@ -66,7 +66,7 @@ class PropertyPathBuilder
      *
      * @param string $name The name of the appended index
      */
-    public function appendIndex($name)
+    public function appendIndex(string $name)
     {
         $this->elements[] = $name;
         $this->isIndex[] = true;
@@ -77,7 +77,7 @@ class PropertyPathBuilder
      *
      * @param string $name The name of the appended property
      */
-    public function appendProperty($name)
+    public function appendProperty(string $name)
     {
         $this->elements[] = $name;
         $this->isIndex[] = false;
@@ -91,7 +91,7 @@ class PropertyPathBuilder
      *
      * @throws OutOfBoundsException if offset is invalid
      */
-    public function remove($offset, $length = 1)
+    public function remove(int $offset, int $length = 1)
     {
         if (!isset($this->elements[$offset])) {
             throw new OutOfBoundsException(sprintf('The offset %s is not within the property path', $offset));
@@ -113,7 +113,7 @@ class PropertyPathBuilder
      *
      * @throws OutOfBoundsException If the offset is invalid
      */
-    public function replace($offset, $length, $path, $pathOffset = 0, $pathLength = 0)
+    public function replace(int $offset, int $length, $path, int $pathOffset = 0, int $pathLength = 0)
     {
         if (\is_string($path)) {
             $path = new PropertyPath($path);
@@ -146,7 +146,7 @@ class PropertyPathBuilder
      *
      * @throws OutOfBoundsException If the offset is invalid
      */
-    public function replaceByIndex($offset, $name = null)
+    public function replaceByIndex(int $offset, string $name = null)
     {
         if (!isset($this->elements[$offset])) {
             throw new OutOfBoundsException(sprintf('The offset %s is not within the property path', $offset));
@@ -167,7 +167,7 @@ class PropertyPathBuilder
      *
      * @throws OutOfBoundsException If the offset is invalid
      */
-    public function replaceByProperty($offset, $name = null)
+    public function replaceByProperty(int $offset, string $name = null)
     {
         if (!isset($this->elements[$offset])) {
             throw new OutOfBoundsException(sprintf('The offset %s is not within the property path', $offset));
@@ -233,7 +233,7 @@ class PropertyPathBuilder
      * @param int $cutLength       The length of the removed chunk
      * @param int $insertionLength The length of the inserted chunk
      */
-    private function resize($offset, $cutLength, $insertionLength)
+    private function resize(int $offset, int $cutLength, int $insertionLength)
     {
         // Nothing else to do in this case
         if ($insertionLength === $cutLength) {

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -60,7 +60,7 @@ interface PropertyPathInterface extends \Traversable
      *
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */
-    public function getElement($index);
+    public function getElement(int $index);
 
     /**
      * Returns whether the element at the given index is a property.
@@ -71,7 +71,7 @@ interface PropertyPathInterface extends \Traversable
      *
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */
-    public function isProperty($index);
+    public function isProperty(int $index);
 
     /**
      * Returns whether the element at the given index is an array index.
@@ -82,5 +82,5 @@ interface PropertyPathInterface extends \Traversable
      *
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */
-    public function isIndex($index);
+    public function isIndex(int $index);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32179  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

This PR adds type hints to public interfaces and classes of the PropertyAccess component. Some docblocks without valuable information got also removed.
