### PR TITLE
[Routing] Deprecate RouteCollection::addPrefix(null)

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -140,6 +140,10 @@ class RouteCollection implements \IteratorAggregate, \Countable
      */
     public function addPrefix($prefix, array $defaults = [], array $requirements = [])
     {
+        if (null === $prefix) {
+            @trigger_error(sprintf('Passing null as $prefix to %s is deprecated in Symfony 4.4 and will trigger a TypeError in 5.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $prefix = trim(trim($prefix), '/');
 
         if ('' === $prefix) {

--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -309,7 +309,9 @@ class RouteCollectionBuilder
             } else {
                 /* @var self $route */
                 $subCollection = $route->build();
-                $subCollection->addPrefix($this->prefix);
+                if (null !== $this->prefix) {
+                    $subCollection->addPrefix($this->prefix);
+                }
 
                 $routeCollection->addCollection($subCollection);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #32179 
| License       | MIT
| Doc PR        | N/A

This PR deprecates the undocumented possibility to pass `null` as prefix to `RouteCollection::addPrefix()`. This allows us to add a `string` type-hint on the parameter in 5.0, see https://github.com/symfony/symfony/pull/32181#discussion_r298419954

/cc @Tobion 