### PR TITLE
[Validator] remove invalid test case

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -50,17 +50,6 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function testValidComparisonToPropertyPathOnArray()
-    {
-        $constraint = new Bic(['ibanPropertyPath' => '[root][value]']);
-
-        $this->setObject(['root' => ['value' => 'FR14 2004 1010 0505 0001 3M02 606']]);
-
-        $this->validator->validate('SOGEFRPP', $constraint);
-
-        $this->assertNoViolation();
-    }
-
     public function testInvalidComparisonToPropertyPath()
     {
         $constraint = new Bic(['ibanPropertyPath' => 'value']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Spotted while working on #32179 for the Validator component. Using property paths for comparison when validating arrays simply does not work.