### PR TITLE
[Ldap] [5.0] add type-hint to interface and implementation

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/AdapterInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/AdapterInterface.php
@@ -26,13 +26,9 @@ interface AdapterInterface
     /**
      * Creates a new Query.
      *
-     * @param string $dn
-     * @param string $query
-     * @param array  $options
-     *
      * @return QueryInterface
      */
-    public function createQuery($dn, $query, array $options = []);
+    public function createQuery(string $dn, string $query, array $options = []);
 
     /**
      * Fetches the entry manager instance.
@@ -44,11 +40,7 @@ interface AdapterInterface
     /**
      * Escape a string for use in an LDAP filter or DN.
      *
-     * @param string $subject
-     * @param string $ignore
-     * @param int    $flags
-     *
      * @return string
      */
-    public function escape($subject, $ignore = '', $flags = 0);
+    public function escape(string $subject, string $ignore = '', int $flags = 0);
 }

--- a/src/Symfony/Component/Ldap/Adapter/ConnectionInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/ConnectionInterface.php
@@ -24,10 +24,7 @@ interface ConnectionInterface
     public function isBound();
 
     /**
-     * Binds the connection against a DN and password.
-     *
-     * @param string $dn       The user's DN
-     * @param string $password The associated password
+     * Binds the connection against a user's DN and password.
      */
-    public function bind($dn = null, $password = null);
+    public function bind(string $dn = null, string $password = null);
 }

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
@@ -59,7 +59,7 @@ class Adapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function createQuery($dn, $query, array $options = [])
+    public function createQuery(string $dn, string $query, array $options = [])
     {
         return new Query($this->getConnection(), $dn, $query, $options);
     }
@@ -67,7 +67,7 @@ class Adapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function escape($subject, $ignore = '', $flags = 0)
+    public function escape(string $subject, string $ignore = '', int $flags = 0)
     {
         $value = ldap_escape($subject, $ignore, $flags);
 

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -51,7 +51,7 @@ class Connection extends AbstractConnection
     /**
      * {@inheritdoc}
      */
-    public function bind($dn = null, $password = null)
+    public function bind(string $dn = null, string $password = null)
     {
         if (!$this->connection) {
             $this->connect();
@@ -85,14 +85,14 @@ class Connection extends AbstractConnection
         return $this->connection;
     }
 
-    public function setOption($name, $value)
+    public function setOption(string $name, $value)
     {
         if (!@ldap_set_option($this->connection, ConnectionOptions::getOption($name), $value)) {
             throw new LdapException(sprintf('Could not set value "%s" for option "%s".', $value, $name));
         }
     }
 
-    public function getOption($name)
+    public function getOption(string $name)
     {
         if (!@ldap_get_option($this->connection, ConnectionOptions::getOption($name), $ret)) {
             throw new LdapException(sprintf('Could not retrieve value for option "%s".', $name));

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/ConnectionOptions.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/ConnectionOptions.php
@@ -45,7 +45,7 @@ final class ConnectionOptions
     const X_SASL_AUTHCID = 0x6102;
     const X_SASL_AUTHZID = 0x6103;
 
-    public static function getOptionName($name): string
+    public static function getOptionName(string $name): string
     {
         return sprintf('%s::%s', self::class, strtoupper($name));
     }
@@ -58,7 +58,7 @@ final class ConnectionOptions
      *
      * @throws LdapException
      */
-    public static function getOption($name): int
+    public static function getOption(string $name): int
     {
         // Convert
         $constantName = self::getOptionName($name);
@@ -70,7 +70,7 @@ final class ConnectionOptions
         return \constant($constantName);
     }
 
-    public static function isOption($name): bool
+    public static function isOption(string $name): bool
     {
         return \defined(self::getOptionName($name));
     }

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/EntryManager.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/EntryManager.php
@@ -101,7 +101,7 @@ class EntryManager implements EntryManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function rename(Entry $entry, $newRdn, $removeOldRdn = true)
+    public function rename(Entry $entry, string $newRdn, bool $removeOldRdn = true)
     {
         $con = $this->getConnectionResource();
 

--- a/src/Symfony/Component/Ldap/Entry.php
+++ b/src/Symfony/Component/Ldap/Entry.php
@@ -42,7 +42,7 @@ class Entry
      *
      * @return bool
      */
-    public function hasAttribute($name)
+    public function hasAttribute(string $name)
     {
         return isset($this->attributes[$name]);
     }
@@ -57,7 +57,7 @@ class Entry
      *
      * @return array|null
      */
-    public function getAttribute($name)
+    public function getAttribute(string $name)
     {
         return isset($this->attributes[$name]) ? $this->attributes[$name] : null;
     }
@@ -78,7 +78,7 @@ class Entry
      * @param string $name
      * @param array  $value
      */
-    public function setAttribute($name, array $value)
+    public function setAttribute(string $name, array $value)
     {
         $this->attributes[$name] = $value;
     }
@@ -88,7 +88,7 @@ class Entry
      *
      * @param string $name
      */
-    public function removeAttribute($name)
+    public function removeAttribute(string $name)
     {
         unset($this->attributes[$name]);
     }

--- a/src/Symfony/Component/Ldap/Ldap.php
+++ b/src/Symfony/Component/Ldap/Ldap.php
@@ -35,7 +35,7 @@ final class Ldap implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function bind($dn = null, $password = null)
+    public function bind(string $dn = null, string $password = null)
     {
         $this->adapter->getConnection()->bind($dn, $password);
     }
@@ -43,7 +43,7 @@ final class Ldap implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function query($dn, $query, array $options = []): ?QueryInterface
+    public function query(string $dn, string $query, array $options = []): ?QueryInterface
     {
         return $this->adapter->createQuery($dn, $query, $options);
     }
@@ -59,7 +59,7 @@ final class Ldap implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function escape($subject, $ignore = '', $flags = 0): ?string
+    public function escape(string $subject, string $ignore = '', int $flags = 0): ?string
     {
         return $this->adapter->escape($subject, $ignore, $flags);
     }
@@ -72,7 +72,7 @@ final class Ldap implements LdapInterface
      *
      * @return static
      */
-    public static function create($adapter, array $config = []): self
+    public static function create(string $adapter, array $config = []): self
     {
         if (!isset(self::$adapterMap[$adapter])) {
             throw new DriverNotFoundException(sprintf(

--- a/src/Symfony/Component/Ldap/LdapInterface.php
+++ b/src/Symfony/Component/Ldap/LdapInterface.php
@@ -28,23 +28,16 @@ interface LdapInterface
     /**
      * Return a connection bound to the ldap.
      *
-     * @param string $dn       A LDAP dn
-     * @param string $password A password
-     *
      * @throws ConnectionException if dn / password could not be bound
      */
-    public function bind($dn = null, $password = null);
+    public function bind(string $dn = null, string $password = null);
 
     /**
      * Queries a ldap server for entries matching the given criteria.
      *
-     * @param string $dn
-     * @param string $query
-     * @param array  $options
-     *
      * @return QueryInterface
      */
-    public function query($dn, $query, array $options = []);
+    public function query(string $dn, string $query, array $options = []);
 
     /**
      * @return EntryManagerInterface
@@ -54,11 +47,7 @@ interface LdapInterface
     /**
      * Escape a string for use in an LDAP filter or DN.
      *
-     * @param string $subject
-     * @param string $ignore
-     * @param int    $flags
-     *
      * @return string
      */
-    public function escape($subject, $ignore = '', $flags = 0);
+    public function escape(string $subject, string $ignore = '', int $flags = 0);
 }

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -34,7 +34,7 @@ class AdapterTest extends LdapTestCase
     {
         $ldap = new Adapter();
 
-        $this->assertEquals('\20foo\3dbar\0d(baz)*\20', $ldap->escape(" foo=bar\r(baz)* ", null, LdapInterface::ESCAPE_DN));
+        $this->assertEquals('\20foo\3dbar\0d(baz)*\20', $ldap->escape(" foo=bar\r(baz)* ", '', LdapInterface::ESCAPE_DN));
     }
 
     /**

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -52,9 +52,9 @@ class LdapTest extends TestCase
         $this->adapter
             ->expects($this->once())
             ->method('escape')
-            ->with('foo', 'bar', 'baz')
+            ->with('foo', 'bar', 0)
         ;
-        $this->ldap->escape('foo', 'bar', 'baz');
+        $this->ldap->escape('foo', 'bar', 0);
     }
 
     public function testLdapQuery()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Contribute to #32179 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This adds the type-hint to the Ldap interfaces and implementation
