### PR TITLE
[HttpFoundation] Drop support for ApacheRequest

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -26,7 +26,7 @@ DependencyInjection
    services:
        App\Handler:
            tags: ['app.handler']
-   
+
        App\HandlerCollection:
            arguments: [!tagged app.handler]
    ```
@@ -36,7 +36,7 @@ DependencyInjection
    services:
        App\Handler:
        tags: ['app.handler']
-    
+
    App\HandlerCollection:
        arguments: [!tagged_iterator app.handler]
    ```
@@ -59,6 +59,11 @@ HttpClient
 ----------
 
  * Added method `cancel()` to `ResponseInterface`
+
+HttpFoundation
+--------------
+
+ * `ApacheRequest` is deprecated, use `Request` class instead.
 
 HttpKernel
 ----------
@@ -84,11 +89,11 @@ Security
 TwigBridge
 ----------
 
- * Deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
+ * Deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the
    `DebugCommand::__construct()` method, swap the variables position.
 
 Validator
 ---------
 
- * Deprecated passing an `ExpressionLanguage` instance as the second argument of `ExpressionValidator::__construct()`. 
+ * Deprecated passing an `ExpressionLanguage` instance as the second argument of `ExpressionValidator::__construct()`.
    Pass it as the first argument instead.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -101,7 +101,7 @@ DependencyInjection
    services:
        App\Handler:
            tags: ['app.handler']
- 
+
        App\HandlerCollection:
            arguments: [!tagged_iterator app.handler]
    ```
@@ -113,7 +113,6 @@ DoctrineBridge
    injected instead
  * Passing an `IdReader` to the `DoctrineChoiceLoader` when the query cannot be optimized with single id field will throw an exception, pass `null` instead
  * Not passing an `IdReader` to the `DoctrineChoiceLoader` when the query can be optimized with single id field will not apply any optimization
-
 
 DomCrawler
 ----------
@@ -268,6 +267,7 @@ HttpFoundation
    use `Symfony\Component\Mime\FileBinaryMimeTypeGuesser` instead.
  * The `FileinfoMimeTypeGuesser` class has been removed,
    use `Symfony\Component\Mime\FileinfoMimeTypeGuesser` instead.
+ * `ApacheRequest` has been removed, use the `Request` class instead.
 
 HttpKernel
 ----------
@@ -517,7 +517,6 @@ Workflow
                marking_store:
                    property: state
    ```
-
 
  * Support for using a workflow with a single state marking is dropped. Use a state machine instead.
 

--- a/src/Symfony/Component/HttpFoundation/ApacheRequest.php
+++ b/src/Symfony/Component/HttpFoundation/ApacheRequest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\HttpFoundation;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.4, use "%s" instead.', ApacheRequest::class, Request::class), E_USER_DEPRECATED);
+
 /**
  * Request represents an HTTP request from an Apache server.
+ *
+ * @deprecated since Symfony 4.4. Use the Request class instead.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * passing arguments to `Request::isMethodSafe()` is deprecated.
+ * `ApacheRequest` is deprecated, use the `Request` class instead.
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Tests/ApacheRequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ApacheRequestTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpFoundation\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\ApacheRequest;
 
+/** @group legacy */
 class ApacheRequestTest extends TestCase
 {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

`ApacheUrlMatcher` has been [deprecated in 2.7](https://github.com/symfony/symfony/pull/12728) and removed in 3.0
I think we forgot to remove this class too.

This class in never used in symfony, and there are no more reference in
the documentation.