### PR TITLE
[Security] [Guard] Removed useless param annotations

### DIFF
--- a/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
@@ -36,8 +36,7 @@ abstract class AbstractGuardAuthenticator implements AuthenticatorInterface
      * Shortcut to create a PostAuthenticationGuardToken for you, if you don't really
      * care about which authenticated token you're using.
      *
-     * @param UserInterface $user
-     * @param string        $providerKey
+     * @param string $providerKey
      *
      * @return PostAuthenticationGuardToken
      */

--- a/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
@@ -55,9 +55,7 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
     /**
      * Override to change what happens after successful authentication.
      *
-     * @param Request        $request
-     * @param TokenInterface $token
-     * @param string         $providerKey
+     * @param string $providerKey
      *
      * @return RedirectResponse
      */

--- a/src/Symfony/Component/Security/Guard/AuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/AuthenticatorInterface.php
@@ -30,8 +30,6 @@ interface AuthenticatorInterface extends GuardAuthenticatorInterface
      *
      * If this returns false, the authenticator will be skipped.
      *
-     * @param Request $request
-     *
      * @return bool
      */
     public function supports(Request $request);
@@ -52,8 +50,6 @@ interface AuthenticatorInterface extends GuardAuthenticatorInterface
      * Or for an API token that's on a header, you might use:
      *
      *      return ['api_key' => $request->headers->get('X-API-TOKEN')];
-     *
-     * @param Request $request
      *
      * @return mixed Any non-null value
      *

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
@@ -70,10 +70,7 @@ class GuardAuthenticatorHandler
     /**
      * Returns the "on success" response for the given GuardAuthenticator.
      *
-     * @param TokenInterface         $token
-     * @param Request                $request
-     * @param AuthenticatorInterface $guardAuthenticator
-     * @param string                 $providerKey        The provider (i.e. firewall) key
+     * @param string $providerKey The provider (i.e. firewall) key
      *
      * @return Response|null
      */
@@ -93,10 +90,7 @@ class GuardAuthenticatorHandler
      * Convenience method for authenticating the user and returning the
      * Response *if any* for success.
      *
-     * @param UserInterface          $user
-     * @param Request                $request
-     * @param AuthenticatorInterface $authenticator
-     * @param string                 $providerKey   The provider (i.e. firewall) key
+     * @param string $providerKey The provider (i.e. firewall) key
      *
      * @return Response|null
      */
@@ -115,10 +109,7 @@ class GuardAuthenticatorHandler
      * Handles an authentication failure and returns the Response for the
      * GuardAuthenticator.
      *
-     * @param AuthenticationException $authenticationException
-     * @param Request                 $request
-     * @param AuthenticatorInterface  $guardAuthenticator
-     * @param string                  $providerKey             The key of the firewall
+     * @param string $providerKey The provider (i.e. firewall) key
      *
      * @return Response|null
      */

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
@@ -55,8 +55,6 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      *
      *     return ['api_key' => $request->headers->get('X-API-TOKEN')];
      *
-     * @param Request $request
-     *
      * @return mixed|null
      */
     public function getCredentials(Request $request);
@@ -68,9 +66,6 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      *
      * You may throw an AuthenticationException if you wish. If you return
      * null, then a UsernameNotFoundException is thrown for you.
-     *
-     * @param mixed                 $credentials
-     * @param UserProviderInterface $userProvider
      *
      * @throws AuthenticationException
      *
@@ -87,9 +82,6 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      *
      * The *credentials* are the return value from getCredentials()
      *
-     * @param mixed         $credentials
-     * @param UserInterface $user
-     *
      * @return bool
      *
      * @throws AuthenticationException
@@ -105,8 +97,7 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      *
      * @see AbstractGuardAuthenticator
      *
-     * @param UserInterface $user
-     * @param string        $providerKey The provider (i.e. firewall) key
+     * @param string $providerKey The provider (i.e. firewall) key
      *
      * @return GuardTokenInterface
      */
@@ -121,9 +112,6 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      * If you return null, the request will continue, but the user will
      * not be authenticated. This is probably not what you want to do.
      *
-     * @param Request                 $request
-     * @param AuthenticationException $exception
-     *
      * @return Response|null
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception);
@@ -137,9 +125,7 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      * If you return null, the current request will continue, and the user
      * will be authenticated. This makes sense, for example, with an API.
      *
-     * @param Request        $request
-     * @param TokenInterface $token
-     * @param string         $providerKey The provider (i.e. firewall) key
+     * @param string $providerKey The provider (i.e. firewall) key
      *
      * @return Response|null
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/32254#issuecomment-506719957
| License       | MIT
| Doc PR        | 

The PR removes useless `@param` annotation, it is linked with the https://github.com/symfony/symfony/pull/32254#issuecomment-506719957