### PR TITLE
[Validator] deprecate non-string constraint violation codes

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -90,5 +90,8 @@ TwigBridge
 Validator
 ---------
 
+ * Deprecated using anything else than a `string` as the code of a `ConstraintViolation`, a `string` type-hint will
+   be added to the constructor of the `ConstraintViolation` class and to the `ConstraintViolationBuilder::setCode()`
+   method in 5.0.
  * Deprecated passing an `ExpressionLanguage` instance as the second argument of `ExpressionValidator::__construct()`. 
    Pass it as the first argument instead.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -454,6 +454,8 @@ TwigBridge
 Validator
 --------
 
+ * Removed support for non-string codes of a `ConstraintViolation`. A `string` type-hint was added to the constructor of
+   the `ConstraintViolation` class and to the `ConstraintViolationBuilder::setCode()` method.
  * An `ExpressionLanguage` instance or null must be passed as the first argument of `ExpressionValidator::__construct()`
  * The `checkMX` and `checkHost` options of the `Email` constraint were removed
  * The `Email::__construct()` 'strict' property has been removed. Use 'mode'=>"strict" instead.

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 4.4.0
 -----
 
+ * using anything else than a `string` as the code of a `ConstraintViolation` is deprecated, a `string` type-hint will
+   be added to the constructor of the `ConstraintViolation` class and to the `ConstraintViolationBuilder::setCode()`
+   method in 5.0
  * deprecated passing an `ExpressionLanguage` instance as the second argument of `ExpressionValidator::__construct()`. Pass it as the first argument instead.
  * added the `compared_value_path` parameter in violations when using any 
    comparison constraint with the `propertyPath` option.

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -56,6 +56,10 @@ class ConstraintViolation implements ConstraintViolationInterface
             $message = '';
         }
 
+        if (null !== $code && !\is_string($code)) {
+            @trigger_error(sprintf('Not using a string as the error code in %s() is deprecated since Symfony 4.4. A type-hint will be added in 5.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $this->message = $message;
         $this->messageTemplate = $messageTemplate;
         $this->parameters = $parameters;

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -65,49 +65,49 @@ class FileValidator extends ConstraintValidator
                     $this->context->buildViolation($constraint->uploadIniSizeErrorMessage)
                         ->setParameter('{{ limit }}', $limitAsString)
                         ->setParameter('{{ suffix }}', $suffix)
-                        ->setCode(UPLOAD_ERR_INI_SIZE)
+                        ->setCode((string) UPLOAD_ERR_INI_SIZE)
                         ->addViolation();
 
                     return;
                 case UPLOAD_ERR_FORM_SIZE:
                     $this->context->buildViolation($constraint->uploadFormSizeErrorMessage)
-                        ->setCode(UPLOAD_ERR_FORM_SIZE)
+                        ->setCode((string) UPLOAD_ERR_FORM_SIZE)
                         ->addViolation();
 
                     return;
                 case UPLOAD_ERR_PARTIAL:
                     $this->context->buildViolation($constraint->uploadPartialErrorMessage)
-                        ->setCode(UPLOAD_ERR_PARTIAL)
+                        ->setCode((string) UPLOAD_ERR_PARTIAL)
                         ->addViolation();
 
                     return;
                 case UPLOAD_ERR_NO_FILE:
                     $this->context->buildViolation($constraint->uploadNoFileErrorMessage)
-                        ->setCode(UPLOAD_ERR_NO_FILE)
+                        ->setCode((string) UPLOAD_ERR_NO_FILE)
                         ->addViolation();
 
                     return;
                 case UPLOAD_ERR_NO_TMP_DIR:
                     $this->context->buildViolation($constraint->uploadNoTmpDirErrorMessage)
-                        ->setCode(UPLOAD_ERR_NO_TMP_DIR)
+                        ->setCode((string) UPLOAD_ERR_NO_TMP_DIR)
                         ->addViolation();
 
                     return;
                 case UPLOAD_ERR_CANT_WRITE:
                     $this->context->buildViolation($constraint->uploadCantWriteErrorMessage)
-                        ->setCode(UPLOAD_ERR_CANT_WRITE)
+                        ->setCode((string) UPLOAD_ERR_CANT_WRITE)
                         ->addViolation();
 
                     return;
                 case UPLOAD_ERR_EXTENSION:
                     $this->context->buildViolation($constraint->uploadExtensionErrorMessage)
-                        ->setCode(UPLOAD_ERR_EXTENSION)
+                        ->setCode((string) UPLOAD_ERR_EXTENSION)
                         ->addViolation();
 
                     return;
                 default:
                     $this->context->buildViolation($constraint->uploadErrorMessage)
-                        ->setCode($value->getError())
+                        ->setCode((string) $value->getError())
                         ->addViolation();
 
                     return;

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -64,7 +64,7 @@ EOF;
             'some_value',
             null,
             null,
-            0
+            '0'
         );
 
         $expected = <<<'EOF'
@@ -107,5 +107,25 @@ EOF;
         );
 
         $this->assertSame($expected, (string) $violation);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not using a string as the error code in Symfony\Component\Validator\ConstraintViolation::__construct() is deprecated since Symfony 4.4. A type-hint will be added in 5.0.
+     */
+    public function testNonStringCode()
+    {
+        $violation = new ConstraintViolation(
+            '42 cannot be used here',
+            'this is the message template',
+            [],
+            ['some_value' => 42],
+            'some_value',
+            null,
+            null,
+            42
+        );
+
+        self::assertSame(42, $violation->getCode());
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -435,23 +435,23 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
     public function uploadedFileErrorProvider()
     {
         $tests = [
-            [UPLOAD_ERR_FORM_SIZE, 'uploadFormSizeErrorMessage'],
-            [UPLOAD_ERR_PARTIAL, 'uploadPartialErrorMessage'],
-            [UPLOAD_ERR_NO_FILE, 'uploadNoFileErrorMessage'],
-            [UPLOAD_ERR_NO_TMP_DIR, 'uploadNoTmpDirErrorMessage'],
-            [UPLOAD_ERR_CANT_WRITE, 'uploadCantWriteErrorMessage'],
-            [UPLOAD_ERR_EXTENSION, 'uploadExtensionErrorMessage'],
+            [(string) UPLOAD_ERR_FORM_SIZE, 'uploadFormSizeErrorMessage'],
+            [(string) UPLOAD_ERR_PARTIAL, 'uploadPartialErrorMessage'],
+            [(string) UPLOAD_ERR_NO_FILE, 'uploadNoFileErrorMessage'],
+            [(string) UPLOAD_ERR_NO_TMP_DIR, 'uploadNoTmpDirErrorMessage'],
+            [(string) UPLOAD_ERR_CANT_WRITE, 'uploadCantWriteErrorMessage'],
+            [(string) UPLOAD_ERR_EXTENSION, 'uploadExtensionErrorMessage'],
         ];
 
         if (class_exists('Symfony\Component\HttpFoundation\File\UploadedFile')) {
             // when no maxSize is specified on constraint, it should use the ini value
-            $tests[] = [UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
+            $tests[] = [(string) UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
                 '{{ limit }}' => UploadedFile::getMaxFilesize() / 1048576,
                 '{{ suffix }}' => 'MiB',
             ]];
 
             // it should use the smaller limitation (maxSize option in this case)
-            $tests[] = [UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
+            $tests[] = [(string) UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
                 '{{ limit }}' => 1,
                 '{{ suffix }}' => 'bytes',
             ], '1'];
@@ -464,14 +464,14 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
 
             // it correctly parses the maxSize option and not only uses simple string comparison
             // 1000M should be bigger than the ini value
-            $tests[] = [UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
+            $tests[] = [(string) UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
                 '{{ limit }}' => $limit,
                 '{{ suffix }}' => $suffix,
             ], '1000M'];
 
             // it correctly parses the maxSize option and not only uses simple string comparison
             // 1000M should be bigger than the ini value
-            $tests[] = [UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
+            $tests[] = [(string) UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
                 '{{ limit }}' => '0.1',
                 '{{ suffix }}' => 'MB',
             ], '100K'];

--- a/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Violation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
+
+class ConstraintViolationBuilderTest extends TestCase
+{
+    /**
+     * @group legacy
+     * @expectedDeprecation Not using a string as the error code in Symfony\Component\Validator\Violation\ConstraintViolationBuilder::setCode() is deprecated since Symfony 4.4. A type-hint will be added in 5.0.
+     * @expectedDeprecation Not using a string as the error code in Symfony\Component\Validator\ConstraintViolation::__construct() is deprecated since Symfony 4.4. A type-hint will be added in 5.0.
+     */
+    public function testNonStringCode()
+    {
+        $constraintViolationList = new ConstraintViolationList();
+        (new ConstraintViolationBuilder($constraintViolationList, new ConstraintA(), 'invalid message', [], null, 'foo', 'baz', new IdentityTranslator()))
+            ->setCode(42)
+            ->addViolation();
+
+        self::assertSame(42, $constraintViolationList->get(0)->getCode());
+    }
+}

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -132,6 +132,10 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
      */
     public function setCode($code)
     {
+        if (null !== $code && !\is_string($code)) {
+            @trigger_error(sprintf('Not using a string as the error code in %s() is deprecated since Symfony 4.4. A type-hint will be added in 5.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $this->code = $code;
 
         return $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/32066#discussion_r294106130
| License       | MIT
| Doc PR        | 