### PR TITLE
[FrameworkBundle] Require symfony/debug

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -20,6 +20,7 @@
         "ext-xml": "*",
         "symfony/cache": "^4.3|^5.0",
         "symfony/config": "^4.2|^5.0",
+        "symfony/debug": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/error-catcher": "^4.4|^5.0",
         "symfony/http-foundation": "^4.3|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In https://github.com/symfony/symfony/pull/32227/files#diff-9abb1cf74d470e961cc3fb6b0dc3b781L23 the `symfony/debug` dependency was removed from the `HttpKernel` component because all the features that were used from the `Debug` component are now in the `ErrorCatcher` component.

I just updated the dependencies of an existing project to the `4.4.x-dev` versions and got a problem : the `symfony/debug` package was removed, because the only package that was requiring it was `symfony/http-kernel`.

Since there is a call to `Debug::enable()` in all front controllers of existing applications, (cf https://github.com/symfony/recipes/blob/fa6571b2a261e137a302c86e9d112a12fa414480/symfony/framework-bundle/4.2/public/index.php), we still need to require it somewhere. I guess we can't expect thousands of projects to add this dependency manually.

Adding it in the `FrameworkBundle` seems more logical to me than restoring it in the `HttpKernel` component since the front controller recipe of flex is for this bundle.