### PR TITLE
[Validator] The PropertyInfoLoader should return early when disabled

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
@@ -47,7 +47,7 @@ final class PropertyInfoLoader implements LoaderInterface
     public function loadClassMetadata(ClassMetadata $metadata)
     {
         $className = $metadata->getClassName();
-        if (null !== $this->classValidatorRegexp && !preg_match($this->classValidatorRegexp, $className)) {
+        if (null === $this->classValidatorRegexp || !preg_match($this->classValidatorRegexp, $className)) {
             return false;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -80,7 +80,7 @@ class PropertyInfoLoaderTest extends TestCase
             ))
         ;
 
-        $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub);
+        $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{^Symfony\\\\Component\\\\Validator\\\\Tests\\\\Fixtures\\\\PropertyInfoLoaderEntity}');
 
         $validator = Validation::createValidatorBuilder()
             ->enableAnnotationMapping()
@@ -184,7 +184,7 @@ class PropertyInfoLoaderTest extends TestCase
     public function regexpProvider()
     {
         return [
-            [true, null],
+            [false, null],
             [true, '{^'.preg_quote(PropertyInfoLoaderEntity::class).'$|^'.preg_quote(Entity::class).'$}'],
             [false, '{^'.preg_quote(Entity::class).'$}'],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Related to: https://github.com/symfony/symfony/pull/31749 and https://github.com/doctrine/DoctrineBundle/pull/988.

If the auto-mapping was partially enabled for one resource (the Doctrine one), then the property info loader was applied for all the resources.

For instance, considering this configuration:
```yml
    validation:
        auto_mapping:
            App\Entity\Foo: ['doctrine.orm.default_entity_manager.validator_loader']
```
If there is a `Bar` entity, then the loader is applied too.