### PR TITLE
[DependencyInjection] The class of a service definition might be passed as parameter

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -51,8 +51,8 @@ class Definition
     private static $defaultDeprecationTemplate = 'The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.';
 
     /**
-     * @param string|null $class     The service class
-     * @param array       $arguments An array of arguments to pass to the service constructor
+     * @param string|Parameter|null $class     The service class
+     * @param array                 $arguments An array of arguments to pass to the service constructor
      */
     public function __construct($class = null, array $arguments = [])
     {
@@ -157,7 +157,7 @@ class Definition
     /**
      * Sets the service class.
      *
-     * @param string $class The service class
+     * @param string|Parameter|null $class The service class
      *
      * @return $this
      */
@@ -173,7 +173,7 @@ class Definition
     /**
      * Gets the service class.
      *
-     * @return string|null The service class
+     * @return string|Parameter|null The service class
      */
     public function getClass()
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Parameter;
 
 class DefinitionTest extends TestCase
 {
@@ -43,6 +44,14 @@ class DefinitionTest extends TestCase
         $def = new Definition('stdClass');
         $this->assertSame($def, $def->setClass('foo'), '->setClass() implements a fluent interface');
         $this->assertEquals('foo', $def->getClass(), '->getClass() returns the class name');
+    }
+
+    public function testSetGetClassWithParameter()
+    {
+        $def = new Definition('stdClass');
+        $parameter = new Parameter('foo');
+        $this->assertSame($def, $def->setClass($parameter), '->setClass() implements a fluent interface');
+        $this->assertSame($parameter, $def->getClass(), '->getClass() returns the parameterized class name');
     }
 
     public function testSetGetDecoratedService()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

While working on #32266, I discovered that we can pass an instance of `Parameter` as `$class` to a `Definition`, although the docblock says `string|null`.

https://github.com/symfony/symfony/blob/6eeec6506ca007a15fedd4cd73fc385d5b25ba41/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php#L931

I'd like to adjust the docblock, so nobody will ever be tempted to add a type-hint to `setClass()` again. 😉 

I've also added a test because the test failure that I got wasn't really obviously pointing at the problem.