### PR TITLE
[DependencyInjection] Annotated correct return type for getInEdges()/getOutEdges()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
@@ -81,7 +81,7 @@ class ServiceReferenceGraphNode
     /**
      * Returns the in edges.
      *
-     * @return array The in ServiceReferenceGraphEdge array
+     * @return ServiceReferenceGraphEdge[]
      */
     public function getInEdges()
     {
@@ -91,7 +91,7 @@ class ServiceReferenceGraphNode
     /**
      * Returns the out edges.
      *
-     * @return array The out ServiceReferenceGraphEdge array
+     * @return ServiceReferenceGraphEdge[]
      */
     public function getOutEdges()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This changed annotation was quite helpful when analyzing `PhpDumper` for #32266.