### PR TITLE
[DependencyInjection][ProxyManagerBridge] Added type-hints to LazyProxy classes and interfaces

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
@@ -38,7 +38,7 @@ class RuntimeInstantiator implements InstantiatorInterface
     /**
      * {@inheritdoc}
      */
-    public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
+    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator)
     {
         return $this->factory->createProxy(
             $this->factory->getGenerator()->getProxifiedClass($definition),

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -48,16 +48,12 @@ class ProxyDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode = null): string
+    public function getProxyFactoryCode(Definition $definition, string $id, string $factoryCode): string
     {
         $instantiation = 'return';
 
         if ($definition->isShared()) {
             $instantiation .= sprintf(' $this->%s[%s] =', $definition->isPublic() && !$definition->isPrivate() ? 'services' : 'privates', var_export($id, true));
-        }
-
-        if (null === $factoryCode) {
-            throw new \InvalidArgumentException(sprintf('Missing factory code to construct the service "%s".', $id));
         }
 
         $proxyClass = $this->getProxyClassName($definition);

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -109,17 +109,6 @@ class ProxyDumperTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Missing factory code to construct the service "foo".
-     */
-    public function testGetProxyFactoryCodeWithoutCustomMethod()
-    {
-        $definition = new Definition(__CLASS__);
-        $definition->setLazy(true);
-        $this->dumper->getProxyFactoryCode($definition, 'foo');
-    }
-
     public function testGetProxyFactoryCodeForInterface()
     {
         $class = DummyClass::class;

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2.9",
-        "symfony/dependency-injection": "^4.4|^5.0",
+        "symfony/dependency-injection": "^5.0",
         "ocramius/proxy-manager": "~2.1"
     },
     "require-dev": {

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/InstantiatorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/InstantiatorInterface.php
@@ -32,5 +32,5 @@ interface InstantiatorInterface
      *
      * @return object
      */
-    public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator);
+    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator);
 }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
@@ -26,7 +26,7 @@ class RealServiceInstantiator implements InstantiatorInterface
     /**
      * {@inheritdoc}
      */
-    public function instantiateProxy(ContainerInterface $container, Definition $definition, $id, $realInstantiator)
+    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator)
     {
         return $realInstantiator();
     }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
@@ -30,13 +30,9 @@ interface DumperInterface
     /**
      * Generates the code to be used to instantiate a proxy in the dumped factory code.
      *
-     * @param Definition $definition
-     * @param string     $id          Service identifier
-     * @param string     $factoryCode The code to execute to create the service
-     *
      * @return string
      */
-    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode);
+    public function getProxyFactoryCode(Definition $definition, string $id, string $factoryCode);
 
     /**
      * Generates the code for the lazy proxy.

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
@@ -33,7 +33,7 @@ class NullDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode = null): string
+    public function getProxyFactoryCode(Definition $definition, string $id, string $factoryCode): string
     {
         return '';
     }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
@@ -21,7 +21,7 @@ class ProxyHelper
     /**
      * @return string|null The FQCN or builtin name of the type hint, or null when the type hint references an invalid self|parent context
      */
-    public static function getTypeHint(\ReflectionFunctionAbstract $r, \ReflectionParameter $p = null, $noBuiltin = false)
+    public static function getTypeHint(\ReflectionFunctionAbstract $r, \ReflectionParameter $p = null, bool $noBuiltin = false)
     {
         if ($p instanceof \ReflectionParameter) {
             $type = $p->getType();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
@@ -88,7 +88,7 @@ class DummyProxyDumper implements ProxyDumper
         return $definition->isLazy();
     }
 
-    public function getProxyFactoryCode(Definition $definition, $id, $factoryCall = null)
+    public function getProxyFactoryCode(Definition $definition, string $id, string $factoryCode)
     {
         return "        // lazy factory for {$definition->getClass()}\n\n";
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32179 
| License       | MIT
| Doc PR        | N/A

This PR adds type-hints to the LazyProxy namespace of the DepenencyInjection component.

It also updates implementations of the LazyProxy interfaces inside the ProxyManager bridge. The consequence is that ProxyManagerBridge 5.0 won't work with DependencyInjection 4.4 anymore. If that is a problem, please tell me and I revert the ProxyManager part.