### PR TITLE
Browserkit client https fix

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -302,7 +302,7 @@ abstract class Client
             $server['HTTP_HOST'] = $this->extractHost($uri);
         }
 
-        if ('https' == parse_url($uri, PHP_URL_SCHEME)) {
+        if ('https' === parse_url($uri, PHP_URL_SCHEME)) {
             $server['HTTPS'] = 'on';
         } else {
             unset($server['HTTPS']);
@@ -610,8 +610,11 @@ abstract class Client
     private function updateServerFromUri($server, $uri)
     {
         $server['HTTP_HOST'] = $this->extractHost($uri);
-        $scheme = parse_url($uri, PHP_URL_SCHEME);
-        $server['HTTPS'] = null === $scheme ? $server['HTTPS'] : 'https' == $scheme;
+
+        if ('https' === parse_url($uri, PHP_URL_SCHEME)) {
+            $server['HTTPS'] = 'on';
+        }
+
         unset($server['HTTP_IF_NONE_MATCH'], $server['HTTP_IF_MODIFIED_SINCE']);
 
         return $server;

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -302,7 +302,11 @@ abstract class Client
             $server['HTTP_HOST'] = $this->extractHost($uri);
         }
 
-        $server['HTTPS'] = (int) 'https' == parse_url($uri, PHP_URL_SCHEME);
+        if ('https' == parse_url($uri, PHP_URL_SCHEME)) {
+            $server['HTTPS'] = 'on';
+        } else {
+            unset($server['HTTPS']);
+        }
 
         $this->internalRequest = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
 

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -302,7 +302,7 @@ abstract class Client
             $server['HTTP_HOST'] = $this->extractHost($uri);
         }
 
-        $server['HTTPS'] = 'https' == parse_url($uri, PHP_URL_SCHEME);
+        $server['HTTPS'] = (int) 'https' == parse_url($uri, PHP_URL_SCHEME);
 
         $this->internalRequest = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
 

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -157,7 +157,7 @@ class ClientTest extends TestCase
 
         $client->request('GET', 'https://www.example.com');
         $headers = $client->getRequest()->getServer();
-        $this->assertTrue($headers['HTTPS'], '->request() sets the HTTPS header');
+        $this->assertEquals('on', $headers['HTTPS'], '->request() sets the HTTPS header');
 
         $client = new TestClient();
         $client->request('GET', 'http://www.example.com:8080');
@@ -435,7 +435,6 @@ class ClientTest extends TestCase
             'HTTP_HOST' => 'www.example.com',
             'HTTP_USER_AGENT' => 'Symfony BrowserKit',
             'CONTENT_TYPE' => 'application/vnd.custom+xml',
-            'HTTPS' => false,
         ];
 
         $client = new TestClient();
@@ -461,7 +460,6 @@ class ClientTest extends TestCase
         $headers = [
             'HTTP_HOST' => 'www.example.com:8080',
             'HTTP_USER_AGENT' => 'Symfony BrowserKit',
-            'HTTPS' => false,
             'HTTP_REFERER' => 'http://www.example.com:8080/',
         ];
 
@@ -675,7 +673,6 @@ class ClientTest extends TestCase
         $client->request('GET', 'https://www.example.com/https/www.example.com', [], [], [
             'HTTP_HOST' => 'testhost',
             'HTTP_USER_AGENT' => 'testua',
-            'HTTPS' => false,
             'NEW_SERVER_KEY' => 'new-server-key-value',
         ]);
 
@@ -696,7 +693,7 @@ class ClientTest extends TestCase
         $this->assertEquals('new-server-key-value', $server['NEW_SERVER_KEY']);
 
         $this->assertArrayHasKey('HTTPS', $server);
-        $this->assertTrue($server['HTTPS']);
+        $this->assertEquals('on', $server['HTTPS']);
     }
 
     public function testRequestWithRelativeUri()
@@ -705,13 +702,12 @@ class ClientTest extends TestCase
 
         $client->request('GET', '/', [], [], [
             'HTTP_HOST' => 'testhost',
-            'HTTPS' => true,
+            'HTTPS' => 'on',
         ]);
         $this->assertEquals('https://testhost/', $client->getRequest()->getUri());
 
         $client->request('GET', 'https://www.example.com/', [], [], [
             'HTTP_HOST' => 'testhost',
-            'HTTPS' => false,
         ]);
         $this->assertEquals('https://www.example.com/', $client->getRequest()->getUri());
     }
@@ -723,7 +719,6 @@ class ClientTest extends TestCase
         $client->request('GET', 'https://www.example.com/https/www.example.com', [], [], [
             'HTTP_HOST' => 'testhost',
             'HTTP_USER_AGENT' => 'testua',
-            'HTTPS' => false,
             'NEW_SERVER_KEY' => 'new-server-key-value',
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | (in progress)
| Fixed tickets | #32292
| License       | MIT
| Doc PR        | --

This PR fixes the wrong server header type `HTTPS` (currently boolean) which should be not available if not true or `on` if request is in https mode. 