### PR TITLE
[FrameworkBundle] Allow creating chained cache pools by providing several adapters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecated the `$parser` argument of `ControllerResolver::__construct()` and `DelegatingLoader::__construct()`
  * Deprecated the `controller_name_converter` and `resolve_controller_name_subscriber` services
  * The `ControllerResolver` and `DelegatingLoader` classes have been marked as `final`
+ * Added support for configuring chained cache pools
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -269,6 +269,10 @@
     </xsd:complexType>
 
     <xsd:complexType name="cache_pool">
+        <xsd:sequence>
+            <xsd:element name="adapter" type="cache_pool_adapter" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+
         <xsd:attribute name="name" type="xsd:string" use="required" />
         <xsd:attribute name="adapter" type="xsd:string" />
         <xsd:attribute name="tags" type="xsd:string" />
@@ -276,6 +280,11 @@
         <xsd:attribute name="default-lifetime" type="xsd:integer" />
         <xsd:attribute name="provider" type="xsd:string" />
         <xsd:attribute name="clearer" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="cache_pool_adapter">
+        <xsd:attribute name="name" type="xsd:string" use="required" />
+        <xsd:attribute name="provider" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="workflow">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -24,6 +24,14 @@ $container->loadFromExtension('framework', [
             'cache.def' => [
                 'default_lifetime' => 11,
             ],
+            'cache.chain' => [
+                'default_lifetime' => 12,
+                'adapter' => [
+                    'cache.adapter.array',
+                    'cache.adapter.filesystem',
+                    'redis://foo' => 'cache.adapter.redis',
+                ],
+            ],
         ],
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -12,6 +12,11 @@
             <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" />
             <framework:pool name="cache.foobar" adapter="cache.adapter.psr6" default-lifetime="10" provider="app.cache_pool" />
             <framework:pool name="cache.def" default-lifetime="11" />
+            <framework:pool name="cache.chain" default-lifetime="12">
+                <framework:adapter name="cache.adapter.array" />
+                <framework:adapter name="cache.adapter.filesystem" />
+                <framework:adapter name="cache.adapter.redis" provider="redis://foo" />
+            </framework:pool>
         </framework:cache>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -17,3 +17,9 @@ framework:
                 provider: app.cache_pool
             cache.def:
                 default_lifetime: 11
+            cache.chain:
+                default_lifetime: 12
+                adapter:
+                    - cache.adapter.array
+                    - cache.adapter.filesystem
+                    - {name: cache.adapter.redis, provider: 'redis://foo'}

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-xml": "*",
-        "symfony/cache": "^4.3|^5.0",
+        "symfony/cache": "^4.4|^5.0",
         "symfony/config": "^4.2|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/error-catcher": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Replaces #30984, follows https://github.com/symfony/symfony-docs/pull/11813

This PR allows defining several adapters for one pool. When doing so, this defines a chain pool.
The benefit is that all chained pools get automatic namespace and lifetime, so things are transparent:

```yaml
pools:
    my_chained_pool:
        default_lifetime: 12
        adapters:
          - cache.adapter.array
          - cache.adapter.filesystem
          - {name: cache.adapter.redis, provider: 'redis://foo'}
```

(see fixtures for example of PHP/XML config)

/cc @Nyholm @pborreli FYI