### PR TITLE
[Lock] Stores must implement `putOffExpiration`

### DIFF
--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -91,7 +91,7 @@ class ZookeeperStore implements StoreInterface
      */
     public function putOffExpiration(Key $key, $ttl)
     {
-        throw new NotSupportedException();
+        // do nothing, zookeeper locks forever.
     }
 
     /**

--- a/src/Symfony/Component/Lock/StoreInterface.php
+++ b/src/Symfony/Component/Lock/StoreInterface.php
@@ -49,7 +49,6 @@ interface StoreInterface
      * @param float $ttl amount of seconds to keep the lock in the store
      *
      * @throws LockConflictedException
-     * @throws NotSupportedException
      */
     public function putOffExpiration(Key $key, $ttl);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

Following https://github.com/symfony/symfony/pull/32198#pullrequestreview-256165051 every stores MUST implement the method `putOffExpiration` either by ignoring the arguments (by design they lock forever) or using a mechanism to define the expiration.

It was a mistake to add the dockblock `@throws NotSupportedException` tell me if it's a BC break, I'll create a dedicated PR for it.