### PR TITLE
[Filesystem] deprecate calling isAbsolutePath with a null

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -41,6 +41,11 @@ DependencyInjection
        arguments: [!tagged_iterator app.handler]
    ```
 
+Filesystem
+----------
+
+ * Support for passing a `null` value to `Filesystem::isAbsolutePath()` is deprecated.
+
 Form
 ----
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -135,6 +135,7 @@ EventDispatcher
 Filesystem
 ----------
 
+ * The `Filesystem::isAbsolutePath()` method no longer supports `null` in the `$file` argument.
  * The `Filesystem::dumpFile()` method no longer supports arrays in the `$content` argument.
  * The `Filesystem::appendToFile()` method no longer supports arrays in the `$content` argument.
 

--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * support for passing a `null` value to `Filesystem::isAbsolutePath()` is deprecated and will be removed in 5.0
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -600,6 +600,10 @@ class Filesystem
      */
     public function isAbsolutePath($file)
     {
+        if (null === $file) {
+            @trigger_error(sprintf('Calling "%s()" with a null in the $file argument is deprecated since Symfony 4.4.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         return strspn($file, '/\\', 0, 1)
             || (\strlen($file) > 3 && ctype_alpha($file[0])
                 && ':' === $file[1]

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1397,8 +1397,16 @@ class FilesystemTest extends FilesystemTestCase
             ['var/lib', false],
             ['../var/lib', false],
             ['', false],
-            [null, false],
         ];
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Calling "Symfony\Component\Filesystem\Filesystem::isAbsolutePath()" with a null in the $file argument is deprecated since Symfony 4.4.
+     */
+    public function testIsAbsolutePathWithNull()
+    {
+        $this->assertFalse($this->filesystem->isAbsolutePath(null));
     }
 
     public function testTempnam()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This PR is a result of #32247 and deprecates calling `Filesystem::isAbsolutePath()` with a `null` value.
