### PR TITLE
[Cache] Make sure cache pool namespace does not contain any invalid characters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
@@ -121,7 +121,7 @@ class CachePoolPass implements CompilerPassInterface
 
     private function getNamespace($seed, $id)
     {
-        return substr(str_replace('/', '-', base64_encode(hash('sha256', $id.$seed, true))), 0, 10);
+        return substr(str_replace(['/', '+'], ['_', '_'], base64_encode(hash('sha256', $id.$seed, true))), 0, 10);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
@@ -89,7 +89,7 @@ class CachePoolPassTest extends TestCase
 
         $this->assertInstanceOf(Reference::class, $cachePool->getArgument(0));
         $this->assertSame('foobar', (string) $cachePool->getArgument(0));
-        $this->assertSame('itantF+pIq', $cachePool->getArgument(1));
+        $this->assertSame('itantF_pIq', $cachePool->getArgument(1));
         $this->assertSame(3, $cachePool->getArgument(2));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (cache items my get new keys)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In my production log I found this message: 

> Failed to save key "{key}" of type string.

I think it comes form the Apcu adapter. 

The key I was trying to store was: `da-8C4vr+9foo_bar`

This is not a (guaranteed) valid key according to the [PSR6 specification](https://www.php-fig.org/psr/psr-6/) (nor is it invalid). 

Im not sure why we allow `+` and `-`. It seams arbitrary. (See the possible [Base64 output](https://en.wikipedia.org/wiki/Base64)). 

This PR makes sure that the namespace only contains `A-Z`, `a-z`, `0-9` and `_`.


