### PR TITLE
[CssSelector] [5.0] Add type-hint whenever possible

### DIFF
--- a/src/Symfony/Component/CssSelector/CssSelectorConverter.php
+++ b/src/Symfony/Component/CssSelector/CssSelectorConverter.php
@@ -53,12 +53,9 @@ class CssSelectorConverter
      * Optionally, a prefix can be added to the resulting XPath
      * expression with the $prefix parameter.
      *
-     * @param string $cssExpr The CSS expression
-     * @param string $prefix  An optional prefix for the XPath expression
-     *
      * @return string
      */
-    public function toXPath($cssExpr, $prefix = 'descendant-or-self::')
+    public function toXPath(string $cssExpr, string $prefix = 'descendant-or-self::')
     {
         return $this->translator->cssToXPath($cssExpr, $prefix);
     }

--- a/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
+++ b/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
@@ -29,7 +29,7 @@ class SyntaxErrorException extends ParseException
      *
      * @return self
      */
-    public static function unexpectedToken($expectedValue, Token $foundToken)
+    public static function unexpectedToken(string $expectedValue, Token $foundToken)
     {
         return new self(sprintf('Expected %s, but %s found.', $expectedValue, $foundToken));
     }
@@ -40,7 +40,7 @@ class SyntaxErrorException extends ParseException
      *
      * @return self
      */
-    public static function pseudoElementFound($pseudoElement, $unexpectedLocation)
+    public static function pseudoElementFound(string $pseudoElement, string $unexpectedLocation)
     {
         return new self(sprintf('Unexpected pseudo-element "::%s" found %s.', $pseudoElement, $unexpectedLocation));
     }
@@ -50,7 +50,7 @@ class SyntaxErrorException extends ParseException
      *
      * @return self
      */
-    public static function unclosedString($position)
+    public static function unclosedString(int $position)
     {
         return new self(sprintf('Unclosed/invalid string at %s.', $position));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | contribute to #32179   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

Add type hint to css selector ;).
