### PR TITLE
[Messenger] Fix authentication for redis transport

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -79,6 +79,16 @@ class ConnectionTest extends TestCase
         $this->assertNotNull($connection->get());
     }
 
+    public function testAuth()
+    {
+        $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('password');
+
+        Connection::fromDsn('redis://password@localhost/queue', [], $redis);
+    }
+
     public function testFirstGetPendingMessagesThenNewMessages()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -51,6 +51,11 @@ class Connection
         $this->connection = $redis ?: new \Redis();
         $this->connection->connect($connectionCredentials['host'] ?? '127.0.0.1', $connectionCredentials['port'] ?? 6379);
         $this->connection->setOption(\Redis::OPT_SERIALIZER, $redisOptions['serializer'] ?? \Redis::SERIALIZER_PHP);
+
+        if (isset($connectionCredentials['auth'])) {
+            $this->connection->auth($connectionCredentials['auth']);
+        }
+
         $this->stream = $configuration['stream'] ?? self::DEFAULT_OPTIONS['stream'];
         $this->group = $configuration['group'] ?? self::DEFAULT_OPTIONS['group'];
         $this->consumer = $configuration['consumer'] ?? self::DEFAULT_OPTIONS['consumer'];
@@ -72,6 +77,7 @@ class Connection
         $connectionCredentials = [
             'host' => $parsedUrl['host'] ?? '127.0.0.1',
             'port' => $parsedUrl['port'] ?? 6379,
+            'auth' => $parsedUrl['pass'] ?? $parsedUrl['user'] ?? null,
         ];
 
         if (isset($parsedUrl['query'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #32304
| License       | MIT
| Doc PR        | symfony/symfony-docs#... TODO

This will implement support for password in redis stream transport.