### PR TITLE
[Form] Names for buttons should start with lowercase

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -61,7 +61,7 @@ Form
 ----
 
  * Using the `format` option of `DateType` and `DateTimeType` when the `html5` option is enabled is deprecated.
- * Using names for buttons that do not start with a letter, a digit, or an underscore is deprecated and will lead to an
+ * Using names for buttons that do not start with a lowercase letter, a digit, or an underscore is deprecated and will lead to an
    exception in 5.0.
  * Using names for buttons that do not contain only letters, digits, underscores, hyphens, and colons is deprecated and
    will lead to an exception in 5.0.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -110,7 +110,7 @@ Form
 ----
 
  * Removed support for using the `format` option of `DateType` and `DateTimeType` when the `html5` option is enabled.
- * Using names for buttons that do not start with a letter, a digit, or an underscore leads to an exception.
+ * Using names for buttons that do not start with a lowercase letter, a digit, or an underscore leads to an exception.
  * Using names for buttons that do not contain only letters, digits, underscores, hyphens, and colons leads to an
    exception.
  * Using the `date_format`, `date_widget`, and `time_widget` options of the `DateTimeType` when the `widget` option is

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -63,7 +63,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
         if (preg_match('/^([^a-z0-9_].*)?(.*[^a-zA-Z0-9_\-:].*)?$/D', $name, $matches)) {
             if (isset($matches[1])) {
-                @trigger_error(sprintf('Using names for buttons that do not start with a letter, a digit, or an underscore is deprecated since Symfony 4.3 and will throw an exception in 5.0 ("%s" given).', $name), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Using names for buttons that do not start with a lowercase letter, a digit, or an underscore is deprecated since Symfony 4.3 and will throw an exception in 5.0 ("%s" given).', $name), E_USER_DEPRECATED);
             }
             if (isset($matches[2])) {
                 @trigger_error(sprintf('Using names for buttons that do not contain only letters, digits, underscores ("_"), hyphens ("-") and colons (":") ("%s" given) is deprecated since Symfony 4.3 and will throw an exception in 5.0.', $name), E_USER_DEPRECATED);

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * added a `symbol` option to the `PercentType` that allows to disable or customize the output of the percent character
  * Using the `format` option of `DateType` and `DateTimeType` when the `html5` option is enabled is deprecated.
- * Using names for buttons that do not start with a letter, a digit, or an underscore is deprecated and will lead to an
+ * Using names for buttons that do not start with a lowercase letter, a digit, or an underscore is deprecated and will lead to an
    exception in 5.0.
  * Using names for buttons that do not contain only letters, digits, underscores, hyphens, and colons is deprecated and
    will lead to an exception in 5.0.

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -47,6 +47,14 @@ class ButtonBuilderTest extends TestCase
         $this->assertInstanceOf('\Symfony\Component\Form\ButtonBuilder', new ButtonBuilder('button[]'));
     }
 
+    /**
+     * @group legacy
+     */
+    public function testNameStartingWithIllegalCharacters()
+    {
+        $this->assertInstanceOf('\Symfony\Component\Form\ButtonBuilder', new ButtonBuilder('Button'));
+    }
+
     public function getInvalidNames()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This fix changes the messages related to the changes in https://github.com/symfony/symfony/pull/28969 - the message used to state that names should start with a letter, a digit ... - so I got a confusing message:

```
Using names for buttons that do not start with a letter, a digit, or an underscore is deprecated since Symfony 4.3 and will throw an exception in 5.0 ("Search" given).'
```

Which made me find the message, look at the regex that was used, and work out that actually it should start with a lowercase letter, and hence this PR - where I assume there is a reason that the name must start with lowercase letters.