### PR TITLE
[Messager] Simplified MessageBus::__construct()

### DIFF
--- a/src/Symfony/Component/Messenger/MessageBus.php
+++ b/src/Symfony/Component/Messenger/MessageBus.php
@@ -33,17 +33,26 @@ class MessageBus implements MessageBusInterface
         } elseif (\is_array($middlewareHandlers)) {
             $this->middlewareAggregate = new \ArrayObject($middlewareHandlers);
         } else {
-            $this->middlewareAggregate = new class() {
-                public $aggregate;
-                public $iterator;
+            // $this->middlewareAggregate should be an instance of IteratorAggregate.
+            // When $middlewareHandlers is an Iterator, we wrap it to ensure it is lazy-loaded and can be rewound.
+            $this->middlewareAggregate = new class($middlewareHandlers) implements \IteratorAggregate {
+                private $middlewareHandlers;
+                private $cachedIterator;
+
+                public function __construct($middlewareHandlers)
+                {
+                    $this->middlewareHandlers = $middlewareHandlers;
+                }
 
                 public function getIterator()
                 {
-                    return $this->aggregate = new \ArrayObject(iterator_to_array($this->iterator, false));
+                    if (null === $this->cachedIterator) {
+                        $this->cachedIterator = new \ArrayObject(iterator_to_array($this->middlewareHandlers, false));
+                    }
+
+                    return $this->cachedIterator;
                 }
             };
-            $this->middlewareAggregate->aggregate = &$this->middlewareAggregate;
-            $this->middlewareAggregate->iterator = $middlewareHandlers;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

The third path deals with generator (or other king of iterator that are

not an IteratorAggregate). It means, very few cases in practice

The previous code saved one object on the first call of `self::dispatch()`
by replacing it at runtime. More over, this object (anon. class) is very
light in memory.

The performance optimization (even if fun) is not useful here. Let's
make the code readable to everyone.