### PR TITLE
[Messenger] Show exceptions after multiple retries

### DIFF
--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -62,8 +62,7 @@ abstract class AbstractFailedMessagesCommand extends Command
 
         /** @var SentToFailureTransportStamp|null $sentToFailureTransportStamp */
         $sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class);
-        /** @var RedeliveryStamp|null $lastRedeliveryStamp */
-        $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
+        $lastRedeliveryStampWithException = $this->getLastRedeliveryStampWithException($envelope);
 
         $rows = [
             ['Class', \get_class($envelope->getMessage())],
@@ -73,13 +72,13 @@ abstract class AbstractFailedMessagesCommand extends Command
             $rows[] = ['Message Id', $id];
         }
 
-        $flattenException = null === $lastRedeliveryStamp ? null : $lastRedeliveryStamp->getFlattenException();
+        $flattenException = null === $lastRedeliveryStampWithException ? null : $lastRedeliveryStampWithException->getFlattenException();
         if (null === $sentToFailureTransportStamp) {
             $io->warning('Message does not appear to have been sent to this transport after failing');
         } else {
             $rows = array_merge($rows, [
-                ['Failed at', null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')],
-                ['Error', null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getExceptionMessage()],
+                ['Failed at', null === $lastRedeliveryStampWithException ? '' : $lastRedeliveryStampWithException->getRedeliveredAt()->format('Y-m-d H:i:s')],
+                ['Error', null === $lastRedeliveryStampWithException ? '' : $lastRedeliveryStampWithException->getExceptionMessage()],
                 ['Error Class', null === $flattenException ? '(unknown)' : $flattenException->getClass()],
                 ['Transport', $sentToFailureTransportStamp->getOriginalReceiverName()],
             ]);
@@ -120,5 +119,17 @@ abstract class AbstractFailedMessagesCommand extends Command
     protected function getReceiver(): ReceiverInterface
     {
         return $this->receiver;
+    }
+
+    protected function getLastRedeliveryStampWithException(Envelope $envelope): ?RedeliveryStamp
+    {
+        /** @var RedeliveryStamp $stamp */
+        foreach (array_reverse($envelope->all(RedeliveryStamp::class)) as $stamp) {
+            if (null !== $stamp->getExceptionMessage()) {
+                return $stamp;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 
 /**
@@ -83,14 +82,13 @@ EOF
 
         $rows = [];
         foreach ($envelopes as $envelope) {
-            /** @var RedeliveryStamp|null $lastRedeliveryStamp */
-            $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
+            $lastRedeliveryStampWithException = $this->getLastRedeliveryStampWithException($envelope);
 
             $rows[] = [
                 $this->getMessageId($envelope),
                 \get_class($envelope->getMessage()),
-                null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s'),
-                null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getExceptionMessage(),
+                null === $lastRedeliveryStampWithException ? '' : $lastRedeliveryStampWithException->getRedeliveredAt()->format('Y-m-d H:i:s'),
+                null === $lastRedeliveryStampWithException ? '' : $lastRedeliveryStampWithException->getExceptionMessage(),
             ];
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -58,4 +58,40 @@ EOF
             $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
             $tester->getDisplay(true));
     }
+
+    public function testMultipleRedeliveryFails()
+    {
+        $sentToFailureStamp = new SentToFailureTransportStamp('async');
+        $redeliveryStamp1 = new RedeliveryStamp(0, 'failure_receiver', 'Things are bad!');
+        $redeliveryStamp2 = new RedeliveryStamp(0, 'failure_receiver');
+        $envelope = new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp(15),
+            $sentToFailureStamp,
+            $redeliveryStamp1,
+            $redeliveryStamp2,
+        ]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->with(15)->willReturn($envelope);
+
+        $command = new FailedMessagesShowCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => 15]);
+
+        $this->assertStringContainsString(sprintf(<<<EOF
+ ------------- --------------------- 
+  Class         stdClass             
+  Message Id    15                   
+  Failed at     %s  
+  Error         Things are bad!      
+  Error Class   (unknown)            
+  Transport     async
+EOF
+            ,
+            $redeliveryStamp2->getRedeliveredAt()->format('Y-m-d H:i:s')),
+            $tester->getDisplay(true));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32311 
| License       | MIT
| Doc PR        | n/a

After retrying a failed message, the `RedeliveryStamp` looses it's exception information. This PR will remedy that.
