### PR TITLE
[Security] Added type-hints to auth providers, tokens and voters

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -48,7 +48,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadTokenBySeries($series)
+    public function loadTokenBySeries(string $series)
     {
         // the alias for lastUsed works around case insensitivity in PostgreSQL
         $sql = 'SELECT class, username, value, lastUsed AS last_used'
@@ -68,7 +68,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteTokenBySeries($series)
+    public function deleteTokenBySeries(string $series)
     {
         $sql = 'DELETE FROM rememberme_token WHERE series=:series';
         $paramValues = ['series' => $series];
@@ -79,7 +79,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function updateToken($series, $tokenValue, \DateTime $lastUsed)
+    public function updateToken(string $series, string $tokenValue, \DateTime $lastUsed)
     {
         $sql = 'UPDATE rememberme_token SET value=:value, lastUsed=:lastUsed'
             .' WHERE series=:series';

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -33,7 +33,7 @@
         "symfony/property-access": "^4.4|^5.0",
         "symfony/property-info": "^4.4|^5.0",
         "symfony/proxy-manager-bridge": "^4.4|^5.0",
-        "symfony/security-core": "^4.4|^5.0",
+        "symfony/security-core": "^5.0",
         "symfony/expression-language": "^4.4|^5.0",
         "symfony/validator": "^4.4|^5.0",
         "symfony/translation": "^4.4|^5.0",
@@ -49,7 +49,8 @@
         "phpunit/phpunit": "<5.4.3",
         "symfony/dependency-injection": "<4.4",
         "symfony/form": "<4.4",
-        "symfony/messenger": "<4.4"
+        "symfony/messenger": "<4.4",
+        "symfony/security-core": "<5"
     },
     "suggest": {
         "symfony/form": "",

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -63,7 +63,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
     /**
      * {@inheritdoc}
      */
-    protected function retrieveUser($username, UsernamePasswordToken $token)
+    protected function retrieveUser(string $username, UsernamePasswordToken $token)
     {
         $user = $token->getUser();
         if ($user instanceof UserInterface) {

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
@@ -46,10 +46,8 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
 
     /**
      * Set a query string to use in order to find a DN for the username.
-     *
-     * @param string $queryString
      */
-    public function setQueryString($queryString)
+    public function setQueryString(string $queryString)
     {
         $this->queryString = $queryString;
     }
@@ -57,7 +55,7 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
     /**
      * {@inheritdoc}
      */
-    protected function retrieveUser($username, UsernamePasswordToken $token)
+    protected function retrieveUser(string $username, UsernamePasswordToken $token)
     {
         if (AuthenticationProviderInterface::USERNAME_NONE_PROVIDED === $username) {
             throw new UsernameNotFoundException('Username can not be null');

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -109,14 +109,11 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
     /**
      * Retrieves the user from an implementation-specific location.
      *
-     * @param string                $username The username to retrieve
-     * @param UsernamePasswordToken $token    The Token
-     *
      * @return UserInterface The user
      *
      * @throws AuthenticationException if the credentials could not be validated
      */
-    abstract protected function retrieveUser($username, UsernamePasswordToken $token);
+    abstract protected function retrieveUser(string $username, UsernamePasswordToken $token);
 
     /**
      * Does additional checks on the user and token (like validating the

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
@@ -25,7 +25,7 @@ class InMemoryTokenProvider implements TokenProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadTokenBySeries($series)
+    public function loadTokenBySeries(string $series)
     {
         if (!isset($this->tokens[$series])) {
             throw new TokenNotFoundException('No token found.');
@@ -37,7 +37,7 @@ class InMemoryTokenProvider implements TokenProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function updateToken($series, $tokenValue, \DateTime $lastUsed)
+    public function updateToken(string $series, string $tokenValue, \DateTime $lastUsed)
     {
         if (!isset($this->tokens[$series])) {
             throw new TokenNotFoundException('No token found.');
@@ -56,7 +56,7 @@ class InMemoryTokenProvider implements TokenProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteTokenBySeries($series)
+    public function deleteTokenBySeries(string $series)
     {
         unset($this->tokens[$series]);
     }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
@@ -23,31 +23,23 @@ interface TokenProviderInterface
     /**
      * Loads the active token for the given series.
      *
-     * @param string $series
-     *
      * @return PersistentTokenInterface
      *
      * @throws TokenNotFoundException if the token is not found
      */
-    public function loadTokenBySeries($series);
+    public function loadTokenBySeries(string $series);
 
     /**
      * Deletes all tokens belonging to series.
-     *
-     * @param string $series
      */
-    public function deleteTokenBySeries($series);
+    public function deleteTokenBySeries(string $series);
 
     /**
      * Updates the token according to this data.
      *
-     * @param string    $series
-     * @param string    $tokenValue
-     * @param \DateTime $lastUsed
-     *
      * @throws TokenNotFoundException if the token is not found
      */
-    public function updateToken($series, $tokenValue, \DateTime $lastUsed);
+    public function updateToken(string $series, string $tokenValue, \DateTime $lastUsed);
 
     /**
      * Creates a new token.

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -108,9 +108,9 @@ abstract class AbstractToken implements TokenInterface
     /**
      * {@inheritdoc}
      */
-    public function setAuthenticated($authenticated)
+    public function setAuthenticated(bool $authenticated)
     {
-        $this->authenticated = (bool) $authenticated;
+        $this->authenticated = $authenticated;
     }
 
     /**
@@ -187,11 +187,9 @@ abstract class AbstractToken implements TokenInterface
     /**
      * Returns true if the attribute exists.
      *
-     * @param string $name The attribute name
-     *
      * @return bool true if the attribute exists, false otherwise
      */
-    public function hasAttribute($name)
+    public function hasAttribute(string $name)
     {
         return \array_key_exists($name, $this->attributes);
     }
@@ -199,13 +197,11 @@ abstract class AbstractToken implements TokenInterface
     /**
      * Returns an attribute value.
      *
-     * @param string $name The attribute name
-     *
      * @return mixed The attribute value
      *
      * @throws \InvalidArgumentException When attribute doesn't exist for this token
      */
-    public function getAttribute($name)
+    public function getAttribute(string $name)
     {
         if (!\array_key_exists($name, $this->attributes)) {
             throw new \InvalidArgumentException(sprintf('This token has no "%s" attribute.', $name));
@@ -217,10 +213,9 @@ abstract class AbstractToken implements TokenInterface
     /**
      * Sets an attribute.
      *
-     * @param string $name  The attribute name
-     * @param mixed  $value The attribute value
+     * @param mixed $value The attribute value
      */
-    public function setAttribute($name, $value)
+    public function setAttribute(string $name, $value)
     {
         $this->attributes[$name] = $value;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -52,7 +52,7 @@ class RememberMeToken extends AbstractToken
     /**
      * {@inheritdoc}
      */
-    public function setAuthenticated($authenticated)
+    public function setAuthenticated(bool $authenticated)
     {
         if ($authenticated) {
             throw new \LogicException('You cannot set this token to authenticated after creation.');

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -80,10 +80,8 @@ interface TokenInterface extends \Serializable
 
     /**
      * Sets the authenticated flag.
-     *
-     * @param bool $isAuthenticated The authenticated flag
      */
-    public function setAuthenticated($isAuthenticated);
+    public function setAuthenticated(bool $isAuthenticated);
 
     /**
      * Removes sensitive information from the token.
@@ -107,30 +105,25 @@ interface TokenInterface extends \Serializable
     /**
      * Returns true if the attribute exists.
      *
-     * @param string $name The attribute name
-     *
      * @return bool true if the attribute exists, false otherwise
      */
-    public function hasAttribute($name);
+    public function hasAttribute(string $name);
 
     /**
      * Returns an attribute value.
-     *
-     * @param string $name The attribute name
      *
      * @return mixed The attribute value
      *
      * @throws \InvalidArgumentException When attribute doesn't exist for this token
      */
-    public function getAttribute($name);
+    public function getAttribute(string $name);
 
     /**
      * Sets an attribute.
      *
-     * @param string $name  The attribute name
-     * @param mixed  $value The attribute value
+     * @param mixed $value The attribute value
      */
-    public function setAttribute($name, $value);
+    public function setAttribute(string $name, $value);
 
     /**
      * Returns all the necessary state of the object for serialization purposes.

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -47,7 +47,7 @@ class UsernamePasswordToken extends AbstractToken
     /**
      * {@inheritdoc}
      */
-    public function setAuthenticated($isAuthenticated)
+    public function setAuthenticated(bool $isAuthenticated)
     {
         if ($isAuthenticated) {
             throw new \LogicException('Cannot set this token to trusted after instantiation.');

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
@@ -54,7 +54,7 @@ abstract class Voter implements VoterInterface
      *
      * @return bool True if the attribute and subject are supported, false otherwise
      */
-    abstract protected function supports($attribute, $subject);
+    abstract protected function supports(string $attribute, $subject);
 
     /**
      * Perform a single access check operation on a given attribute, subject and token.
@@ -66,5 +66,5 @@ abstract class Voter implements VoterInterface
      *
      * @return bool
      */
-    abstract protected function voteOnAttribute($attribute, $subject, TokenInterface $token);
+    abstract protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token);
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -159,7 +159,7 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
-    public function setAuthenticated($isAuthenticated)
+    public function setAuthenticated(bool $isAuthenticated)
     {
     }
 
@@ -175,15 +175,15 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
-    public function hasAttribute($name)
+    public function hasAttribute(string $name)
     {
     }
 
-    public function getAttribute($name)
+    public function getAttribute(string $name)
     {
     }
 
-    public function setAttribute($name, $value)
+    public function setAttribute(string $name, $value)
     {
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -83,7 +83,7 @@ class DaoAuthenticationProviderTest extends TestCase
         $provider = new DaoAuthenticationProvider($userProvider, $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface')->getMock(), 'key', $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface')->getMock());
         $reflection = new \ReflectionMethod($provider, 'retrieveUser');
         $reflection->setAccessible(true);
-        $result = $reflection->invoke($provider, null, $token);
+        $result = $reflection->invoke($provider, 'someUser', $token);
 
         $this->assertSame($user, $result);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -59,12 +59,12 @@ class VoterTest extends TestCase
 
 class VoterTest_Voter extends Voter
 {
-    protected function voteOnAttribute($attribute, $object, TokenInterface $token)
+    protected function voteOnAttribute(string $attribute, $object, TokenInterface $token)
     {
         return 'EDIT' === $attribute;
     }
 
-    protected function supports($attribute, $object)
+    protected function supports(string $attribute, $object)
     {
         return $object instanceof \stdClass && \in_array($attribute, ['EDIT', 'CREATE']);
     }

--- a/src/Symfony/Component/Security/Guard/Token/PreAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PreAuthenticationGuardToken.php
@@ -58,7 +58,7 @@ class PreAuthenticationGuardToken extends AbstractToken implements GuardTokenInt
         return $this->credentials;
     }
 
-    public function setAuthenticated($authenticated)
+    public function setAuthenticated(bool $authenticated)
     {
         throw new \LogicException('The PreAuthenticationGuardToken is *never* authenticated.');
     }

--- a/src/Symfony/Component/Security/Guard/composer.json
+++ b/src/Symfony/Component/Security/Guard/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2.9",
-        "symfony/security-core": "^4.4|^5.0",
+        "symfony/security-core": "^5.0",
         "symfony/security-http": "^4.4|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32179 
| License       | MIT
| Doc PR        | N/A

This PR adds type declarations to authentication providers, tokens and voters.