### PR TITLE
[Messenger] Use ConnectionRegistry instead of RegistryInterface

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineTransportFactoryTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Messenger\Tests\Transport\Doctrine;
 
+use Doctrine\Common\Persistence\ConnectionRegistry;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Messenger\Transport\Doctrine\Connection;
 use Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransport;
 use Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory;
@@ -23,7 +23,7 @@ class DoctrineTransportFactoryTest extends TestCase
     public function testSupports()
     {
         $factory = new DoctrineTransportFactory(
-            $this->getMockBuilder(RegistryInterface::class)->getMock()
+            $this->getMockBuilder(ConnectionRegistry::class)->getMock()
         );
 
         $this->assertTrue($factory->supports('doctrine://default', []));
@@ -35,7 +35,7 @@ class DoctrineTransportFactoryTest extends TestCase
         $connection = $this->getMockBuilder(\Doctrine\DBAL\Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $registry = $this->getMockBuilder(RegistryInterface::class)->getMock();
+        $registry = $this->getMockBuilder(ConnectionRegistry::class)->getMock();
         $registry->expects($this->once())
             ->method('getConnection')
             ->willReturn($connection);
@@ -55,7 +55,7 @@ class DoctrineTransportFactoryTest extends TestCase
      */
     public function testCreateTransportMustThrowAnExceptionIfManagerIsNotFound()
     {
-        $registry = $this->getMockBuilder(RegistryInterface::class)->getMock();
+        $registry = $this->getMockBuilder(ConnectionRegistry::class)->getMock();
         $registry->expects($this->once())
             ->method('getConnection')
             ->willReturnCallback(function () {

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/DoctrineTransportFactory.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\Doctrine;
 
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Common\Persistence\ConnectionRegistry;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
@@ -24,7 +24,7 @@ class DoctrineTransportFactory implements TransportFactoryInterface
 {
     private $registry;
 
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ConnectionRegistry $registry)
     {
         $this->registry = $registry;
     }

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -25,7 +25,6 @@
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4.19|^4.1.8|^5.0",
         "symfony/error-catcher": "^4.4|^5.0",
-        "symfony/doctrine-bridge": "^3.4|^4.0|^5.0",
         "symfony/event-dispatcher": "^4.3|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/process": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This PR changes the constructor type-hint on `DoctrineTransportFactory` from `Symfony\Bridge\Doctrine\RegistryInterface` to the smaller `Doctrine\Common\Persistence\ConnectionRegistry`. Since we only call the `getConnection()` method, this interface is sufficient.

This change allows to use the factory without the Doctrine bridge and makes it easier to use it stand-alone.