### PR TITLE
[ErrorCatcher] Pretty print JSON formatted errors

### DIFF
--- a/src/Symfony/Component/ErrorCatcher/ErrorRenderer/JsonErrorRenderer.php
+++ b/src/Symfony/Component/ErrorCatcher/ErrorRenderer/JsonErrorRenderer.php
@@ -47,6 +47,6 @@ class JsonErrorRenderer implements ErrorRendererInterface
             $content['exceptions'] = $exception->toArray();
         }
 
-        return (string) json_encode($content);
+        return (string) json_encode($content, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_LINE_TERMINATORS | JSON_PRESERVE_ZERO_FRACTION);
     }
 }

--- a/src/Symfony/Component/ErrorCatcher/Tests/ErrorRenderer/JsonErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorCatcher/Tests/ErrorRenderer/JsonErrorRendererTest.php
@@ -20,7 +20,17 @@ class JsonErrorRendererTest extends TestCase
     public function testRender()
     {
         $exception = FlattenException::createFromThrowable(new \RuntimeException('Foo'));
-        $expected = '{"title":"Internal Server Error","status":500,"detail":"Foo","exceptions":[{"message":"Foo","class":"RuntimeException","trace":';
+        $expected = <<<JSON
+{
+    "title": "Internal Server Error",
+    "status": 500,
+    "detail": "Foo",
+    "exceptions": [
+        {
+            "message": "Foo",
+            "class": "RuntimeException",
+            "trace":
+JSON;
 
         $this->assertStringStartsWith($expected, (new JsonErrorRenderer())->render($exception));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | not needed

A long string with JSON contents is not very useful to quickly parse the error contents, so I propose to "pretty print" the JSON errors.