### PR TITLE
[ErrorCatcher] Use DOMDocument class to generate XML errors

### DIFF
--- a/src/Symfony/Component/ErrorCatcher/ErrorRenderer/XmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorCatcher/ErrorRenderer/XmlErrorRenderer.php
@@ -71,7 +71,7 @@ class XmlErrorRenderer implements ErrorRendererInterface
                         $traceContent .= ' '.$this->formatPath($trace['file'], $trace['line']);
                     }
 
-                    $traceElement =  $xmlDocument->createElement('trace', $this->escapeXml($traceContent));
+                    $traceElement = $xmlDocument->createElement('trace', $this->escapeXml($traceContent));
                     $tracesElement->appendChild($traceElement);
                 }
 

--- a/src/Symfony/Component/ErrorCatcher/Tests/ErrorRenderer/XmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorCatcher/Tests/ErrorRenderer/XmlErrorRendererTest.php
@@ -20,7 +20,17 @@ class XmlErrorRendererTest extends TestCase
     public function testRender()
     {
         $exception = FlattenException::createFromThrowable(new \RuntimeException('Foo'));
-        $expected = '<?xml version="1.0" encoding="UTF-8" ?>%A<problem xmlns="urn:ietf:rfc:7807">%A<title>Internal Server Error</title>%A<status>500</status>%A<detail>Foo</detail>%A';
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<problem xmlns="urn:ietf:rfc:7807">
+  <title>Internal Server Error</title>
+  <status>500</status>
+  <detail>Foo</detail>
+  <exceptions>
+    <exception class="RuntimeException" message="Foo">
+      <traces>
+        <trace>%A
+XML;
 
         $this->assertStringMatchesFormat($expected, (new XmlErrorRenderer())->render($exception));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -
| License       | MIT
| Doc PR        | not needed

I don't like much that we're generating XML contents concatenating strings, so I propose to use the DOMDocument class.