### PR TITLE
[ErrorCatcher] Fixed some escaping in error renderers

### DIFF
--- a/src/Symfony/Component/ErrorCatcher/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorCatcher/ErrorRenderer/HtmlErrorRenderer.php
@@ -55,14 +55,16 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     {
         $css = $this->getStylesheet();
         $body = $this->getBody($exception);
+        $charset = $this->escapeHtml($this->charset);
+        $title = $this->escapeHtml($exception->getTitle());
 
         return <<<EOF
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="{$this->charset}" />
+        <meta charset="{$charset}" />
         <meta name="robots" content="noindex,nofollow,noarchive" />
-        <title>{$exception->getTitle()}</title>
+        <title>{$title}</title>
         <style>$css</style>
     </head>
     <body>
@@ -94,11 +96,14 @@ EOF;
      */
     public function getBody(FlattenException $exception)
     {
+        $statusCode = $this->escapeHtml($exception->getStatusCode());
+        $title = $this->escapeHtml($exception->getTitle());
+
         if (!$this->debug) {
             return <<<EOF
                 <div class="container">
                     <h1>Oops! An Error Occurred</h1>
-                    <h2>The server returned a "{$exception->getStatusCode()} {$exception->getTitle()}".</h2>
+                    <h2>The server returned a "{$statusCode} {$title}".</h2>
                     <p>
                         Something is broken. Please let us know what you were doing when this error occurred.
                         We will fix it as soon as possible. Sorry for any inconvenience caused.

--- a/src/Symfony/Component/ErrorCatcher/ErrorRenderer/XmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorCatcher/ErrorRenderer/XmlErrorRenderer.php
@@ -40,7 +40,10 @@ class XmlErrorRenderer implements ErrorRendererInterface
      */
     public function render(FlattenException $exception): string
     {
+        $title = $this->escapeXml($exception->getTitle());
         $message = $this->escapeXml($exception->getMessage());
+        $statusCode = $this->escapeXml($exception->getStatusCode());
+        $charset = $this->escapeXml($this->charset);
 
         $exceptions = '';
         if ($this->debug) {
@@ -63,10 +66,10 @@ class XmlErrorRenderer implements ErrorRendererInterface
         }
 
         return <<<EOF
-<?xml version="1.0" encoding="{$this->charset}" ?>
+<?xml version="1.0" encoding="{$charset}" ?>
 <problem xmlns="urn:ietf:rfc:7807">
-    <title>{$exception->getTitle()}</title>
-    <status>{$exception->getStatusCode()}</status>
+    <title>{$title}</title>
+    <status>{$statusCode}</status>
     <detail>{$message}</detail>
     {$exceptions}
 </problem>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -
| License       | MIT
| Doc PR        | not needed

Fixes this: https://github.com/symfony/symfony/pull/32364/files#r300394620