### PR TITLE
[Validator] Fix tests

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -84,7 +84,7 @@ class ConstraintViolation implements ConstraintViolationInterface
             $class .= '.';
         }
 
-        if ('' !== $code = $this->code) {
+        if ('' !== $code = (string) $this->code) {
             $code = ' (code '.$code.')';
         }
 

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -109,10 +109,6 @@ EOF;
         $this->assertSame($expected, (string) $violation);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Not using a string as the error code in Symfony\Component\Validator\ConstraintViolation::__construct() is deprecated since Symfony 4.4. A type-hint will be added in 5.0.
-     */
     public function testNonStringCode()
     {
         $violation = new ConstraintViolation(
@@ -126,6 +122,6 @@ EOF;
             42
         );
 
-        self::assertSame(42, $violation->getCode());
+        self::assertSame('42', $violation->getCode());
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
@@ -19,11 +19,6 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
 
 class ConstraintViolationBuilderTest extends TestCase
 {
-    /**
-     * @group legacy
-     * @expectedDeprecation Not using a string as the error code in Symfony\Component\Validator\Violation\ConstraintViolationBuilder::setCode() is deprecated since Symfony 4.4. A type-hint will be added in 5.0.
-     * @expectedDeprecation Not using a string as the error code in Symfony\Component\Validator\ConstraintViolation::__construct() is deprecated since Symfony 4.4. A type-hint will be added in 5.0.
-     */
     public function testNonStringCode()
     {
         $constraintViolationList = new ConstraintViolationList();
@@ -31,6 +26,6 @@ class ConstraintViolationBuilderTest extends TestCase
             ->setCode(42)
             ->addViolation();
 
-        self::assertSame(42, $constraintViolationList->get(0)->getCode());
+        self::assertSame('42', $constraintViolationList->get(0)->getCode());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | relates to #32265   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Fixes the following tests currently failing on master, as well as a bug where a null code was printed:

```diff
1) Symfony\Component\Validator\Tests\ConstraintViolationListTest::testToString
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 'Root:\n
-    Error 1\n
+    Error 1 (code )\n
 Root.foo.bar:\n
-    Error 2\n
+    Error 2 (code )\n
 Root[baz]:\n
-    Error 3\n
+    Error 3 (code )\n
 foo.bar:\n
-    Error 4\n
+    Error 4 (code )\n
 [baz]:\n
-    Error 5\n
+    Error 5 (code )\n

2) Symfony\Component\Validator\Tests\ConstraintViolationTest::testToStringHandlesArrays
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 'Root.property.path:
-    Array'
+    Array (code )'

3) Symfony\Component\Validator\Tests\ConstraintViolationTest::testToStringHandlesArrayRoots
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 'Array.some_value:
-    42 cannot be used here'
+    42 cannot be used here (code )'

4) Symfony\Component\Validator\Tests\ConstraintViolationTest::testToStringOmitsEmptyCodes
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 'Array.some_value:
-    42 cannot be used here'
+    42 cannot be used here (code )'

5) Symfony\Component\Validator\Tests\ConstraintViolationTest::testNonStringCode
Failed asserting that '42' is identical to 42.

6) Symfony\Component\Validator\Tests\Violation\ConstraintViolationBuilderTest::testNonStringCode
Failed asserting that '42' is identical to 42.
```
