### PR TITLE
[Validator] Change Length::$allowEmptyString default to false & make it optional

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -490,6 +490,7 @@ Validator
  * The `symfony/intl` component is now required for using the `Bic`, `Country`, `Currency`, `Language` and `Locale` constraints
  * The `egulias/email-validator` component is now required for using the `Email` constraint in strict mode
  * The `symfony/expression-language` component is now required for using the `Expression` constraint
+ * Changed the default value of `Length::$allowEmptyString` to `false` and made it optional
 
 Workflow
 --------

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/BaseUser.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/BaseUser.php
@@ -2,9 +2,6 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
 
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
-
 /**
  * Class BaseUser.
  */
@@ -48,16 +45,5 @@ class BaseUser
     public function getUsername()
     {
         return $this->username;
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $allowEmptyString = property_exists(Assert\Length::class, 'allowEmptyString') ? ['allowEmptyString' => true] : [];
-
-        $metadata->addPropertyConstraint('username', new Assert\Length([
-            'min' => 2,
-            'max' => 120,
-            'groups' => ['Registration'],
-        ] + $allowEmptyString));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderEntity.php
@@ -14,7 +14,6 @@ namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
  * @ORM\Entity
@@ -37,11 +36,13 @@ class DoctrineLoaderEntity extends DoctrineLoaderParentEntity
 
     /**
      * @ORM\Column(length=20)
+     * @Assert\Length(min=5, allowEmptyString=true)
      */
     public $mergedMaxLength;
 
     /**
      * @ORM\Column(length=20)
+     * @Assert\Length(min=1, max=10, allowEmptyString=true)
      */
     public $alreadyMappedMaxLength;
 
@@ -68,12 +69,4 @@ class DoctrineLoaderEntity extends DoctrineLoaderParentEntity
 
     /** @ORM\Column(type="simple_array", length=100) */
     public $simpleArrayField = [];
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $allowEmptyString = property_exists(Assert\Length::class, 'allowEmptyString') ? ['allowEmptyString' => true] : [];
-
-        $metadata->addPropertyConstraint('mergedMaxLength', new Assert\Length(['min' => 5] + $allowEmptyString));
-        $metadata->addPropertyConstraint('alreadyMappedMaxLength', new Assert\Length(['min' => 1, 'max' => 10] + $allowEmptyString));
-    }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Resources/validator/BaseUser.xml
+++ b/src/Symfony/Bridge/Doctrine/Tests/Resources/validator/BaseUser.xml
@@ -9,6 +9,12 @@
             <constraint name="NotBlank">
                 <option name="groups">Registration</option>
             </constraint>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="max">120</option>
+                <option name="groups">Registration</option>
+                <option name="allowEmptyString">true</option>
+            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -40,7 +40,6 @@ class DoctrineLoaderTest extends TestCase
         }
 
         $validator = Validation::createValidatorBuilder()
-            ->addMethodMapping('loadValidatorMetadata')
             ->enableAnnotationMapping()
             ->addLoader(new DoctrineLoader(DoctrineTestHelper::createTestEntityManager(), '{^Symfony\\\\Bridge\\\\Doctrine\\\\Tests\\\\Fixtures\\\\DoctrineLoader}'))
             ->getValidator()
@@ -143,7 +142,6 @@ class DoctrineLoaderTest extends TestCase
         }
 
         $validator = Validation::createValidatorBuilder()
-            ->addMethodMapping('loadValidatorMetadata')
             ->enableAnnotationMapping()
             ->addXmlMappings([__DIR__.'/../Resources/validator/BaseUser.xml'])
             ->addLoader(

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -57,15 +57,13 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     public function testGroupSequenceWithConstraintsOption()
     {
-        $allowEmptyString = property_exists(Length::class, 'allowEmptyString') ? ['allowEmptyString' => true] : [];
-
         $form = Forms::createFormFactoryBuilder()
             ->addExtension(new ValidatorExtension(Validation::createValidator()))
             ->getFormFactory()
             ->create(FormTypeTest::TESTED_TYPE, null, (['validation_groups' => new GroupSequence(['First', 'Second'])]))
             ->add('field', TextTypeTest::TESTED_TYPE, [
                 'constraints' => [
-                    new Length(['min' => 10, 'groups' => ['First']] + $allowEmptyString),
+                    new Length(['min' => 10, 'allowEmptyString' => true, 'groups' => ['First']]),
                     new Email(['groups' => ['Second']]),
                 ],
             ])

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -61,13 +61,11 @@ class ValidatorTypeGuesserTest extends TestCase
 
     public function guessRequiredProvider()
     {
-        $allowEmptyString = property_exists(Length::class, 'allowEmptyString') ? ['allowEmptyString' => true] : [];
-
         return [
             [new NotNull(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)],
             [new NotBlank(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)],
             [new IsTrue(), new ValueGuess(true, Guess::HIGH_CONFIDENCE)],
-            [new Length(['min' => 10, 'max' => 10] + $allowEmptyString), new ValueGuess(false, Guess::LOW_CONFIDENCE)],
+            [new Length(['min' => 10, 'max' => 10, 'allowEmptyString' => true]), new ValueGuess(false, Guess::LOW_CONFIDENCE)],
             [new Range(['min' => 1, 'max' => 20]), new ValueGuess(false, Guess::LOW_CONFIDENCE)],
         ];
     }
@@ -103,9 +101,7 @@ class ValidatorTypeGuesserTest extends TestCase
 
     public function testGuessMaxLengthForConstraintWithMinValue()
     {
-        $allowEmptyString = property_exists(Length::class, 'allowEmptyString') ? ['allowEmptyString' => true] : [];
-
-        $constraint = new Length(['min' => '2'] + $allowEmptyString);
+        $constraint = new Length(['min' => '2', 'allowEmptyString' => true]);
 
         $result = $this->guesser->guessMaxLengthForConstraint($constraint);
         $this->assertNull($result);

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * changed default value of `canonicalize` option of `Locale` constraint to `true`
  * removed `ValidatorBuilderInterface`
  * passing a null message when instantiating a `ConstraintViolation` is not allowed
+ * changed the default value of `Length::$allowEmptyString` to `false` and made it optional
 
 4.4.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -41,7 +41,7 @@ class Length extends Constraint
     public $min;
     public $charset = 'UTF-8';
     public $normalizer;
-    public $allowEmptyString;
+    public $allowEmptyString = false;
 
     public function __construct($options = null)
     {
@@ -56,13 +56,6 @@ class Length extends Constraint
         }
 
         parent::__construct($options);
-
-        if (null === $this->allowEmptyString) {
-            $this->allowEmptyString = true;
-            if (null !== $this->min) {
-                @trigger_error(sprintf('Using the "%s" constraint with the "min" option without setting the "allowEmptyString" one is deprecated and defaults to true. In 5.0, it will become optional and default to false.', self::class), E_USER_DEPRECATED);
-            }
-        }
 
         if (null === $this->min && null === $this->max) {
             throw new MissingOptionsException(sprintf('Either option "min" or "max" must be given for constraint %s', __CLASS__), ['min', 'max']);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
@@ -21,7 +21,7 @@ class LengthTest extends TestCase
 {
     public function testNormalizerCanBeSet()
     {
-        $length = new Length(['min' => 0, 'max' => 10, 'normalizer' => 'trim', 'allowEmptyString' => false]);
+        $length = new Length(['min' => 0, 'max' => 10, 'normalizer' => 'trim']);
 
         $this->assertEquals('trim', $length->normalizer);
     }
@@ -32,7 +32,7 @@ class LengthTest extends TestCase
      */
     public function testInvalidNormalizerThrowsException()
     {
-        new Length(['min' => 0, 'max' => 10, 'normalizer' => 'Unknown Callable', 'allowEmptyString' => false]);
+        new Length(['min' => 0, 'max' => 10, 'normalizer' => 'Unknown Callable']);
     }
 
     /**
@@ -41,6 +41,6 @@ class LengthTest extends TestCase
      */
     public function testInvalidNormalizerObjectThrowsException()
     {
-        new Length(['min' => 0, 'max' => 10, 'normalizer' => new \stdClass(), 'allowEmptyString' => false]);
+        new Length(['min' => 0, 'max' => 10, 'normalizer' => new \stdClass()]);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -22,20 +22,16 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
         return new LengthValidator();
     }
 
-    public function testLegacyNullIsValid()
+    public function testNullIsValid()
     {
-        $this->validator->validate(null, new Length(['value' => 6, 'allowEmptyString' => false]));
+        $this->validator->validate(null, new Length(['value' => 6]));
 
         $this->assertNoViolation();
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Using the "Symfony\Component\Validator\Constraints\Length" constraint with the "min" option without setting the "allowEmptyString" one is deprecated and defaults to true. In 5.0, it will become optional and default to false.
-     */
-    public function testLegacyEmptyStringIsValid()
+    public function testAllowEmptyString()
     {
-        $this->validator->validate('', new Length(6));
+        $this->validator->validate('', new Length(['value' => 6, 'allowEmptyString' => true]));
 
         $this->assertNoViolation();
     }
@@ -44,7 +40,6 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     {
         $this->validator->validate('', new Length([
             'value' => $limit = 6,
-            'allowEmptyString' => false,
             'exactMessage' => 'myMessage',
         ]));
 
@@ -62,7 +57,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->validate(new \stdClass(), new Length(['value' => 5, 'allowEmptyString' => false]));
+        $this->validator->validate(new \stdClass(), new Length(['value' => 5]));
     }
 
     public function getThreeOrLessCharacters()
@@ -130,7 +125,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValuesMin($value)
     {
-        $constraint = new Length(['min' => 5, 'allowEmptyString' => false]);
+        $constraint = new Length(['min' => 5]);
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -152,7 +147,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidValuesExact($value)
     {
-        $constraint = new Length(['value' => 4, 'allowEmptyString' => false]);
+        $constraint = new Length(4);
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -163,7 +158,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidNormalizedValues($value)
     {
-        $constraint = new Length(['min' => 3, 'max' => 3, 'normalizer' => 'trim', 'allowEmptyString' => false]);
+        $constraint = new Length(['min' => 3, 'max' => 3, 'normalizer' => 'trim']);
         $this->validator->validate($value, $constraint);
 
         $this->assertNoViolation();
@@ -177,7 +172,6 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Length([
             'min' => 4,
             'minMessage' => 'myMessage',
-            'allowEmptyString' => false,
         ]);
 
         $this->validator->validate($value, $constraint);
@@ -221,7 +215,6 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             'min' => 4,
             'max' => 4,
             'exactMessage' => 'myMessage',
-            'allowEmptyString' => false,
         ]);
 
         $this->validator->validate($value, $constraint);
@@ -244,7 +237,6 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             'min' => 4,
             'max' => 4,
             'exactMessage' => 'myMessage',
-            'allowEmptyString' => false,
         ]);
 
         $this->validator->validate($value, $constraint);
@@ -268,7 +260,6 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             'max' => 1,
             'charset' => $charset,
             'charsetMessage' => 'myMessage',
-            'allowEmptyString' => false,
         ]);
 
         $this->validator->validate($value, $constraint);
@@ -287,7 +278,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
 
     public function testConstraintDefaultOption()
     {
-        $constraint = new Length(['value' => 5, 'allowEmptyString' => false]);
+        $constraint = new Length(5);
 
         $this->assertEquals(5, $constraint->min);
         $this->assertEquals(5, $constraint->max);
@@ -295,7 +286,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
 
     public function testConstraintAnnotationDefaultOption()
     {
-        $constraint = new Length(['value' => 5, 'exactMessage' => 'message', 'allowEmptyString' => false]);
+        $constraint = new Length(['value' => 5, 'exactMessage' => 'message']);
 
         $this->assertEquals(5, $constraint->min);
         $this->assertEquals(5, $constraint->max);

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -103,7 +103,7 @@ class RecursiveValidatorTest extends AbstractTest
     public function testCollectionConstraintValidateAllGroupsForNestedConstraints()
     {
         $this->metadata->addPropertyConstraint('data', new Collection(['fields' => [
-            'one' => [new NotBlank(['groups' => 'one']), new Length(['min' => 2, 'groups' => 'two', 'allowEmptyString' => false])],
+            'one' => [new NotBlank(['groups' => 'one']), new Length(['min' => 2, 'groups' => 'two'])],
             'two' => [new NotBlank(['groups' => 'two'])],
         ]]));
 
@@ -121,7 +121,7 @@ class RecursiveValidatorTest extends AbstractTest
     {
         $this->metadata->addPropertyConstraint('data', new All(['constraints' => [
             new NotBlank(['groups' => 'one']),
-            new Length(['min' => 2, 'groups' => 'two', 'allowEmptyString' => false]),
+            new Length(['min' => 2, 'groups' => 'two']),
         ]]));
 
         $entity = new Entity();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | should pass after #32372    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31528   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | ~TODO: change default value and mention it's optional~ Done. Thx @javiereguiluz 
