### PR TITLE
[Serializer] AbstractObjectNormalizer ignores the property types of discriminated classes

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -281,13 +281,14 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         $reflectionClass = new \ReflectionClass($class);
         $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
+        $resolvedClass = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
 
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {
-                $attribute = $this->nameConverter->denormalize($attribute, $class, $format, $context);
+                $attribute = $this->nameConverter->denormalize($attribute, $resolvedClass, $format, $context);
             }
 
-            if ((false !== $allowedAttributes && !\in_array($attribute, $allowedAttributes)) || !$this->isAllowedAttribute($class, $attribute, $format, $context)) {
+            if ((false !== $allowedAttributes && !\in_array($attribute, $allowedAttributes)) || !$this->isAllowedAttribute($resolvedClass, $attribute, $format, $context)) {
                 if (!($context[self::ALLOW_EXTRA_ATTRIBUTES] ?? $this->defaultContext[self::ALLOW_EXTRA_ATTRIBUTES])) {
                     $extraAttributes[] = $attribute;
                 }
@@ -295,7 +296,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 continue;
             }
 
-            $value = $this->validateAndDenormalize($class, $attribute, $value, $format, $context);
+            $value = $this->validateAndDenormalize($resolvedClass, $attribute, $value, $format, $context);
             try {
                 $this->setAttributeValue($object, $attribute, $value, $format, $context);
             } catch (InvalidArgumentException $e) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractDummyFirstChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractDummyFirstChild.php
@@ -15,10 +15,23 @@ class AbstractDummyFirstChild extends AbstractDummy
 {
     public $bar;
 
+    /** @var DummyFirstChildQuux|null */
+    public $quux;
+
     public function __construct($foo = null, $bar = null)
     {
         parent::__construct($foo);
 
         $this->bar = $bar;
+    }
+
+    public function getQuux(): ?DummyFirstChildQuux
+    {
+        return $this->quux;
+    }
+
+    public function setQuux(DummyFirstChildQuux $quux): void
+    {
+        $this->quux = $quux;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractDummySecondChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractDummySecondChild.php
@@ -15,10 +15,23 @@ class AbstractDummySecondChild extends AbstractDummy
 {
     public $baz;
 
+    /** @var DummySecondChildQuux|null */
+    public $quux;
+
     public function __construct($foo = null, $baz = null)
     {
         parent::__construct($foo);
 
         $this->baz = $baz;
+    }
+
+    public function getQuux(): ?DummySecondChildQuux
+    {
+        return $this->quux;
+    }
+
+    public function setQuux(DummySecondChildQuux $quux): void
+    {
+        $this->quux = $quux;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyFirstChildQuux.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyFirstChildQuux.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class DummyFirstChildQuux
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummySecondChildQuux.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummySecondChildQuux.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class DummySecondChildQuux
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
@@ -34,6 +35,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo;
@@ -382,6 +384,7 @@ class SerializerTest extends TestCase
     public function testDeserializeAndSerializeAbstractObjectsWithTheClassMetadataDiscriminatorResolver()
     {
         $example = new AbstractDummyFirstChild('foo-value', 'bar-value');
+        $example->setQuux(new DummyFirstChildQuux('quux'));
 
         $loaderMock = $this->getMockBuilder(ClassMetadataFactoryInterface::class)->getMock();
         $loaderMock->method('hasMetadataFor')->willReturnMap([
@@ -405,9 +408,9 @@ class SerializerTest extends TestCase
         ]);
 
         $discriminatorResolver = new ClassDiscriminatorFromClassMetadata($loaderMock);
-        $serializer = new Serializer([new ObjectNormalizer(null, null, null, null, $discriminatorResolver)], ['json' => new JsonEncoder()]);
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new PhpDocExtractor(), $discriminatorResolver)], ['json' => new JsonEncoder()]);
 
-        $jsonData = '{"type":"first","bar":"bar-value","foo":"foo-value"}';
+        $jsonData = '{"type":"first","quux":{"value":"quux"},"bar":"bar-value","foo":"foo-value"}';
 
         $deserialized = $serializer->deserialize($jsonData, AbstractDummy::class, 'json');
         $this->assertEquals($example, $deserialized);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27607
| License       | MIT
| Doc PR        | 

As discusses in ticket #27607, when using a discriminator map and the symfony serializer, things go wrong when having two classes in the discriminator map having the same property name. When the function ```validateAndDenormalize``` is called, the function ```getTypes``` would be called with the wrong class name.

If you take a look at the ```getTypes``` function below, I'm not even sure if we still need the part of the discriminator at this place because we already passed the class name of the discriminated class.

```
    /**
     * @return Type[]|null
     */
    private function getTypes(string $currentClass, string $attribute)
    {
        if (null === $this->propertyTypeExtractor) {
            return null;
        }

        if (null !== $types = $this->propertyTypeExtractor->getTypes($currentClass, $attribute)) {
            return $types;
        }

        if (null !== $this->classDiscriminatorResolver && null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForClass($currentClass)) {
            if ($discriminatorMapping->getTypeProperty() === $attribute) {
                return [
                    new Type(Type::BUILTIN_TYPE_STRING),
                ];
            }

            foreach ($discriminatorMapping->getTypesMapping() as $mappedClass) {
                if (null !== $types = $this->propertyTypeExtractor->getTypes($mappedClass, $attribute)) {
                    return $types;
                }
            }
        }

        return null;
    }
```
