### PR TITLE
[Mime] add check for openssl when using SMime

### DIFF
--- a/src/Symfony/Component/ErrorCatcher/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorCatcher/Exception/FlattenException.php
@@ -36,7 +36,7 @@ class FlattenException
     private $file;
     private $line;
 
-    public static function createFromThrowable(\Throwable $exception, ?int $statusCode = null, array $headers = []): self
+    public static function createFromThrowable(\Throwable $exception, int $statusCode = null, array $headers = []): self
     {
         $e = new static();
         $e->setMessage($exception->getMessage());

--- a/src/Symfony/Component/Mime/Crypto/SMimeEncrypter.php
+++ b/src/Symfony/Component/Mime/Crypto/SMimeEncrypter.php
@@ -24,17 +24,21 @@ final class SMimeEncrypter extends SMime
 
     /**
      * @param string|string[] $certificate The path (or array of paths) of the file(s) containing the X.509 certificate(s)
-     * @param int             $cipher      A set of algorithms used to encrypt the message. Must be one of these PHP constants: https://www.php.net/manual/en/openssl.ciphers.php
+     * @param int|null        $cipher      A set of algorithms used to encrypt the message. Must be one of these PHP constants: https://www.php.net/manual/en/openssl.ciphers.php
      */
-    public function __construct($certificate, int $cipher = OPENSSL_CIPHER_AES_256_CBC)
+    public function __construct($certificate, int $cipher = null)
     {
+        if (!\extension_loaded('openssl')) {
+            throw new \LogicException('PHP extension "openssl" is required to use SMime.');
+        }
+
         if (\is_array($certificate)) {
             $this->certs = array_map([$this, 'normalizeFilePath'], $certificate);
         } else {
             $this->certs = $this->normalizeFilePath($certificate);
         }
 
-        $this->cipher = $cipher;
+        $this->cipher = $cipher ?? OPENSSL_CIPHER_AES_256_CBC;
     }
 
     public function encrypt(Message $message): Message

--- a/src/Symfony/Component/Mime/Crypto/SMimeSigner.php
+++ b/src/Symfony/Component/Mime/Crypto/SMimeSigner.php
@@ -34,10 +34,14 @@ final class SMimeSigner extends SMime
      * @param string      $privateKey           The path of the file containing the private key (in PEM format)
      * @param string|null $privateKeyPassphrase A passphrase of the private key (if any)
      * @param string|null $extraCerts           The path of the file containing intermediate certificates (in PEM format) needed by the signing certificate
-     * @param int         $signOptions          Bitwise operator options for openssl_pkcs7_sign() (@see https://secure.php.net/manual/en/openssl.pkcs7.flags.php)
+     * @param int|null    $signOptions          Bitwise operator options for openssl_pkcs7_sign() (@see https://secure.php.net/manual/en/openssl.pkcs7.flags.php)
      */
-    public function __construct(string $certificate, string $privateKey, ?string $privateKeyPassphrase = null, ?string $extraCerts = null, int $signOptions = PKCS7_DETACHED)
+    public function __construct(string $certificate, string $privateKey, string $privateKeyPassphrase = null, string $extraCerts = null, int $signOptions = null)
     {
+        if (!\extension_loaded('openssl')) {
+            throw new \LogicException('PHP extension "openssl" is required to use SMime.');
+        }
+
         $this->signCertificate = $this->normalizeFilePath($certificate);
 
         if (null !== $privateKeyPassphrase) {
@@ -46,7 +50,7 @@ final class SMimeSigner extends SMime
             $this->signPrivateKey = $this->normalizeFilePath($privateKey);
         }
 
-        $this->signOptions = $signOptions;
+        $this->signOptions = $signOptions ?? PKCS7_DETACHED;
         $this->extraCerts = $extraCerts ? realpath($extraCerts) : null;
         $this->privateKeyPassphrase = $privateKeyPassphrase;
     }

--- a/src/Symfony/Component/Mime/Tests/Crypto/SMimeEncryptorTest.php
+++ b/src/Symfony/Component/Mime/Tests/Crypto/SMimeEncryptorTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Mime\Crypto\SMimeSigner;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Message;
 
+/**
+ * @requires extension openssl
+ */
 class SMimeEncryptorTest extends SMimeTestCase
 {
     public function testEncryptMessage()

--- a/src/Symfony/Component/Mime/Tests/Crypto/SMimeSignerTest.php
+++ b/src/Symfony/Component/Mime/Tests/Crypto/SMimeSignerTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\Part\TextPart;
 
+/**
+ * @requires extension openssl
+ */
 class SMimeSignerTest extends SMimeTestCase
 {
     public function testSignedMessage()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Should also make tests green for the component on Windows.