### PR TITLE
No longer assume session service has a getFlashBag method

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -165,6 +165,10 @@ class AppVariable
             return [];
         }
 
+        if (!method_exists($session, 'getFlashBag')) {
+            return [];
+        }
+
         if (null === $types || '' === $types || [] === $types) {
             return $session->getFlashBag()->all();
         }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\Twig;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -105,7 +105,7 @@ class AppVariable
     /**
      * Returns the current session.
      *
-     * @return Session|null The session
+     * @return SessionInterface|null The session
      */
     public function getSession()
     {
@@ -158,14 +158,11 @@ class AppVariable
     {
         try {
             $session = $this->getSession();
-            if (null === $session) {
-                return [];
-            }
         } catch (\RuntimeException $e) {
             return [];
         }
 
-        if (!method_exists($session, 'getFlashBag')) {
+        if (null === $session || !method_exists($session, 'getFlashBag')) {
             return [];
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -7,6 +7,7 @@ use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class AppVariableTest extends TestCase
 {
@@ -232,6 +233,18 @@ class AppVariableTest extends TestCase
             ['this-does-not-exist' => []],
             $this->appVariable->getFlashes(['this-does-not-exist'])
         );
+    }
+
+    public function testGetFlashesWithoutGetFlashBag()
+    {
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+
+        $request = $this->getMockBuilder(Request::class)->getMock();
+        $request->method('getSession')->willReturn($session);
+
+        $this->setRequestStack($request);
+
+        $this->assertEquals([], $this->appVariable->getFlashes());
     }
 
     protected function setRequestStack($request)

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -197,6 +197,10 @@ trait ControllerTrait
             throw new \LogicException('You can not use the addFlash method if sessions are disabled. Enable them in "config/packages/framework.yaml".');
         }
 
+        if (!method_exists($this->container->get('session'), 'getFlashBag')) {
+            throw new \LogicException('You can not use the addFlash method because the session is missing the getFlashBag() method.');
+        }
+
         $this->container->get('session')->getFlashBag()->add($type, $message);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -197,11 +197,12 @@ trait ControllerTrait
             throw new \LogicException('You can not use the addFlash method if sessions are disabled. Enable them in "config/packages/framework.yaml".');
         }
 
-        if (!method_exists($this->container->get('session'), 'getFlashBag')) {
+        $session = $this->container->get('session');
+        if (!method_exists($session, 'getFlashBag')) {
             throw new \LogicException('You can not use the addFlash method because the session is missing the getFlashBag() method.');
         }
 
-        $this->container->get('session')->getFlashBag()->add($type, $message);
+        $session->getFlashBag()->add($type, $message);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\User;
@@ -391,6 +392,23 @@ abstract class ControllerTraitTest extends TestCase
         $controller->addFlash('foo', 'bar');
 
         $this->assertSame(['bar'], $flashBag->get('foo'));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You can not use the addFlash method because the session is missing the getFlashBag() method.
+     */
+    public function testAddFlashWithoutGetFlashBag()
+    {
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+
+        $container = new Container();
+        $container->set('session', $session);
+
+        $controller = $this->createController();
+        $container->setContainer($container);
+
+        $controller->addFlash('foo', 'bar');
     }
 
     public function testCreateAccessDeniedException()

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -89,7 +89,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
 
         if ($response->headers->has('X-Debug-Token') && $response->isRedirect() && $this->interceptRedirects && 'html' === $request->getRequestFormat()) {
             $session = $request->getSession();
-            if (null !== $session && $session->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
+            if (null !== $session && $session->isStarted() && method_exists($session, 'getFlashBag') && $session->getFlashBag() instanceof AutoExpireFlashBag) {
                 // keep current flashes for one more request if using AutoExpireFlashBag
                 $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
             }

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -68,7 +68,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 $sessionMetadata['Last used'] = date(DATE_RFC822, $session->getMetadataBag()->getLastUsed());
                 $sessionMetadata['Lifetime'] = $session->getMetadataBag()->getLifetime();
                 $sessionAttributes = $session->all();
-                $flashes = $session->getFlashBag()->peekAll();
+                $flashes = method_exists($session, 'getFlashBag') ? $session->getFlashBag()->peekAll() : [];
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

In runtime the `sessions` service usually has a `getFlashBag` method, because the symfony Session class has that method, but it's not on the SessionInterface, so we must not assume it exists.
Calling it breaks custom implementation of the SessionInterface that do not have the getFlashBag method.