### PR TITLE
[Form] Allow to translate each language into its language in LanguageType

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class LanguageTypeTest extends BaseTypeTest
@@ -84,6 +85,52 @@ class LanguageTypeTest extends BaseTypeTest
         $this->assertContainsEquals(new ChoiceView('fra', 'fra', 'французька'), $choices);
         // Burmese has no three letter language code
         $this->assertNotContainsEquals(new ChoiceView('my', 'my', 'бірманська'), $choices);
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testChoiceSelfTranslationOption()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_self_translation' => true,
+            ])
+            ->createView()->vars['choices'];
+
+        $this->assertContainsEquals(new ChoiceView('cs', 'cs', 'čeština'), $choices);
+        $this->assertContainsEquals(new ChoiceView('es', 'es', 'español'), $choices);
+        $this->assertContainsEquals(new ChoiceView('fr', 'fr', 'français'), $choices);
+        $this->assertContainsEquals(new ChoiceView('ta', 'ta', 'தமிழ்'), $choices);
+        $this->assertContainsEquals(new ChoiceView('uk', 'uk', 'українська'), $choices);
+        $this->assertContainsEquals(new ChoiceView('yi', 'yi', 'ייִדיש'), $choices);
+        $this->assertContainsEquals(new ChoiceView('zh', 'zh', '中文'), $choices);
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testChoiceSelfTranslationAndAlpha3Options()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'alpha3' => true,
+                'choice_self_translation' => true,
+            ])
+            ->createView()->vars['choices'];
+
+        $this->assertContainsEquals(new ChoiceView('spa', 'spa', 'español'), $choices, '', false, false);
+        $this->assertContainsEquals(new ChoiceView('yid', 'yid', 'ייִדיש'), $choices, '', false, false);
+    }
+
+    public function testSelfTranslationNotAllowedWithChoiceTranslation()
+    {
+        $this->expectException(LogicException::class);
+
+        $this->factory->create(static::TESTED_TYPE, null, [
+            'choice_translation_locale' => 'es',
+            'choice_self_translation' => true,
+        ]);
     }
 
     public function testMultipleLanguagesIsNotIncluded()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31562
| License       | MIT
| Doc PR        | I'll do it if this is approved

This would allow to set this option:

```php
->add('language', LanguageType::class, [
    'choice_self_translation' => true,
])
```

To display each language translated into its own language:

![image](https://user-images.githubusercontent.com/73419/60709908-cdf29b80-9f11-11e9-83c8-8ee939c0de3a.png)

@ro0NL if this proposal is approved, could you please tell me why I must `try ... catch` with `\Exception`?

* First, I need the try..catch because of a special language with the code "root" which triggers exceptions (*The resource bundle "symfony-code/src/Symfony/Component/Intl/Resources/data/languages/root.json" does not exist*)
* Second, I must catch \Exception because when I try to catch the exact exception (`Symfony\Component\Intl\Exception\ResourceBundleNotFoundException`) the exception is not caught. Why?
