### PR TITLE
[DependencyInjection] Deprecated passing Parameter instances as class name to Definition

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -41,6 +41,18 @@ DependencyInjection
        arguments: [!tagged_iterator app.handler]
    ```
 
+ * Passing an instance of `Symfony\Component\DependencyInjection\Parameter` as class name to `Symfony\Component\DependencyInjection\Definition` is deprecated.
+
+   Before:
+   ```php
+   new Definition(new Parameter('my_class'));
+   ```
+
+   After:
+   ```php
+   new Definition('%my_class%');
+   ```
+
 Filesystem
 ----------
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * deprecated support for short factories and short configurators in Yaml
  * deprecated `tagged` in favor of `tagged_iterator`
+ * deprecated passing an instance of `Symfony\Component\DependencyInjection\Parameter` as class name to `Symfony\Component\DependencyInjection\Definition`
 
 4.3.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -171,6 +171,13 @@ class Definition
      */
     public function setClass($class)
     {
+        if ($class instanceof Parameter) {
+            @trigger_error(sprintf('Passing an instance of %s as class name to %s in deprecated in Symfony 4.4 and will result in a TypeError in 5.0. Please pass the string "%%%s%%" instead.', Parameter::class, __CLASS__, (string) $class), E_USER_DEPRECATED);
+        }
+        if (null !== $class && !\is_string($class)) {
+            @trigger_error(sprintf('The class name passed to %s is expected to be a string. Passing a %s is deprecated in Symfony 4.4 and will result in a TypeError in 5.0.', __CLASS__, \is_object($class) ? \get_class($class) : \gettype($class)), E_USER_DEPRECATED);
+        }
+
         $this->changes['class'] = true;
 
         $this->class = $class;

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 
 class DefinitionTest extends TestCase
@@ -25,6 +26,18 @@ class DefinitionTest extends TestCase
 
         $def = new Definition('stdClass', ['foo']);
         $this->assertEquals(['foo'], $def->getArguments(), '__construct() takes an optional array of arguments as its second argument');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing an instance of Symfony\Component\DependencyInjection\Parameter as class name to Symfony\Component\DependencyInjection\Definition in deprecated in Symfony 4.4 and will result in a TypeError in 5.0. Please pass the string "%parameter%" instead.
+     */
+    public function testConstructorWithParameter()
+    {
+        $parameter = new Parameter('parameter');
+
+        $def = new Definition($parameter);
+        $this->assertSame($parameter, $def->getClass(), '__construct() accepts Parameter instances');
     }
 
     public function testSetGetFactory()
@@ -47,6 +60,28 @@ class DefinitionTest extends TestCase
         $def = new Definition('stdClass');
         $this->assertSame($def, $def->setClass('foo'), '->setClass() implements a fluent interface');
         $this->assertEquals('foo', $def->getClass(), '->getClass() returns the class name');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing an instance of Symfony\Component\DependencyInjection\Parameter as class name to Symfony\Component\DependencyInjection\Definition in deprecated in Symfony 4.4 and will result in a TypeError in 5.0. Please pass the string "%parameter%" instead.
+     */
+    public function testSetGetClassWithParameter()
+    {
+        $def = new Definition();
+        $parameter = new Parameter('parameter');
+        $this->assertSame($parameter, $def->setClass($parameter)->getClass(), '->getClass() returns the parameterized class name');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The class name passed to Symfony\Component\DependencyInjection\Definition is expected to be a string. Passing a stdClass is deprecated in Symfony 4.4 and will result in a TypeError in 5.0.
+     */
+    public function testSetGetClassWithObject()
+    {
+        $def = new Definition();
+        $classObject = new \stdClass();
+        $this->assertSame($classObject, $def->setClass($classObject)->getClass(), '->getClass() returns the parameterized class name');
     }
 
     public function testSetGetDecoratedService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1082,7 +1082,7 @@ class PhpDumperTest extends TestCase
             'class' => 'stdClass',
         ]));
 
-        $container->setDefinition('foo', new Definition(new Parameter('class')));
+        $container->setDefinition('foo', new Definition('%class%'));
         $container->setDefinition('bar', new Definition('stdClass', [
             new Reference('foo'),
         ]))->setPublic(true);

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -494,10 +494,8 @@ class MessengerPassTest extends TestCase
 
     public function testRegistersTraceableBusesToCollector()
     {
-        $dataCollector = $this->getMockBuilder(MessengerDataCollector::class)->getMock();
-
         $container = $this->getContainerBuilder($fooBusId = 'messenger.bus.foo');
-        $container->register('data_collector.messenger', $dataCollector);
+        $container->register('data_collector.messenger', MessengerDataCollector::class);
         $container->setParameter('kernel.debug', true);
 
         (new MessengerPass())->process($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #32279
| License       | MIT
| Doc PR        | N/A

This PR deprecates the undocumented possibility to use a `Parameter` instance instead of a string as class name for a `Definition`. This was discovered while working on #32266.