### PR TITLE
[Messenger] Removes deprecated call to ReflectionType::__toString() on MessengerPass

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -214,7 +214,7 @@ class MessengerPass implements CompilerPassInterface
             throw new RuntimeException(sprintf('Invalid handler service "%s": type-hint of argument "$%s" in method "%s::__invoke()" must be a class , "%s" given.', $serviceId, $parameters[0]->getName(), $handlerClass->getName(), $type));
         }
 
-        return [(string) $parameters[0]->getType()];
+        return [$parameters[0]->getType()->getName()];
     }
 
     private function registerReceivers(ContainerBuilder $container, array $busIds)


### PR DESCRIPTION
Closes #32397 

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32397
| License       | MIT
| Doc PR        | -

Removes deprecated call to ReflectionType::__toString() for 7.4 support
