### PR TITLE
[Intl] Init compile tmp volume

### DIFF
--- a/src/Symfony/Component/Intl/Resources/bin/compile
+++ b/src/Symfony/Component/Intl/Resources/bin/compile
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-if [[ $1 == force ]]; then
-    docker pull jakzal/php-intl
-fi;
+[[ $1 == force ]] && docker pull jakzal/php-intl
+[[ ! -d /tmp/symfony/icu ]] && mkdir -p /tmp/symfony/icu
 
 docker run \
     -it --rm --name symfony-intl \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixes

```
Symfony\Component\Filesystem\Exception\IOException: Failed to create "/tmp/icu-data": mkdir(): Permission denied.
```

if the initial volume does not exists docker creates it as root, but the container runs for the current user.