### PR TITLE
Support for specific user instances to be resolved

### DIFF
--- a/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
@@ -34,8 +34,9 @@ final class UserValueResolver implements ArgumentValueResolverInterface
 
     public function supports(Request $request, ArgumentMetadata $argument)
     {
+        $type = $argument->getType();
         // only security user implementations are supported
-        if (UserInterface::class !== $argument->getType()) {
+        if (UserInterface::class !== $type && !is_subclass_of($type, UserInterface::class)) {
             return false;
         }
 
@@ -47,7 +48,11 @@ final class UserValueResolver implements ArgumentValueResolverInterface
         $user = $token->getUser();
 
         // in case it's not an object we cannot do anything with it; E.g. "anon."
-        return $user instanceof UserInterface;
+        if (!$user instanceof UserInterface){
+            return false;
+        }
+        
+        return $user instanceof $type;
     }
 
     public function resolve(Request $request, ArgumentMetadata $argument)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes 
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

[ ] - Need to add tests
[ ] - Need to update changelog

At the moment if my application supports multiple users I have to do this:

```
public function __invoke(UserInterface $user): Response {
    ...
    if ($user instance of JwtUser) {

    }
    ....
}
```

With the proposed change I can autowire directly the specific UserInstance

`public function __invoke(JWTUser $user): Response`

if you have any objections let me know in order not to proceed with the tests.