### PR TITLE
[Stopwatch] Deprecate passing null in Section::get() method.

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -108,6 +108,11 @@ Security
 
  * Implementations of `PasswordEncoderInterface` and `UserPasswordEncoderInterface` should add a new `needsRehash()` method
 
+Stopwatch
+---------
+
+ * Deprecated passing `null` as 1st (`$id`) argument of `Section::get()` method, pass a valid child section identifier instead.
+
 TwigBridge
 ----------
 

--- a/src/Symfony/Component/Stopwatch/CHANGELOG.md
+++ b/src/Symfony/Component/Stopwatch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * Deprecated passing `null` as 1st (`$id`) argument of `Section::get()` method, pass a valid child section identifier instead.
+
 3.4.0
 -----
 

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -62,6 +62,10 @@ class Section
      */
     public function get($id)
     {
+        if (null === $id) {
+            @trigger_error(sprintf('Passing null as 1st ("$id") argument of the "%s()" method is deprecated since Symfony 4.4, pass a valid child section identifier instead.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         foreach ($this->children as $child) {
             if ($id === $child->getId()) {
                 return $child;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32179<!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This PR is related to https://github.com/symfony/symfony/pull/32242
