### PR TITLE
[Mailer] Introduces an InMemoryTransport to save messages in memory.

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * Added InMemoryTransport to save messages in memory. Use `in-memory://` as DSN.
  * [BC BREAK] Transports depend on `Symfony\Contracts\EventDispatcher\EventDispatcherInterface`
    instead of `Symfony\Component\EventDispatcher\EventDispatcherInterface`.
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/InMemoryTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/InMemoryTransportTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Mailer\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\InMemoryTransport;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Message;
+
+class InMemoryTransportTest extends TestCase
+{
+    public function testItShouldSaveMessages()
+    {
+        $email = $this->createEmailMessage();
+
+        $inMemoryTransport = new InMemoryTransport();
+        $inMemoryTransport->send($email);
+
+        /** @var SentMessage[] $inMemoryMessages */
+        $inMemoryMessages = $inMemoryTransport->get();
+
+        $this->assertCount(1, $inMemoryMessages);
+        $this->assertSame(
+            $email->getSender()->toString(),
+            $inMemoryMessages[0]->getEnvelope()->getSender()->toString()
+        );
+    }
+
+    public function testItShouldResetTransport()
+    {
+        $email = $this->createEmailMessage();
+
+        $inMemoryTransport = new InMemoryTransport();
+        $inMemoryTransport->send($email);
+
+        $this->assertCount(1, $inMemoryTransport->get());
+
+        $inMemoryTransport->reset();
+
+        $this->assertCount(0, $inMemoryTransport->get());
+    }
+
+    private function createEmailMessage(): Message
+    {
+        return (new Email())
+            ->sender('schaedlich.jan@gmail.com')
+            ->to('jan.schaedlich@sensiolabs.de')
+            ->subject('Important Notification')
+            ->text('Lorem ipsum...');
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -40,6 +40,20 @@ class TransportTest extends TestCase
         $this->assertSame($dispatcher, $p->getValue($transport));
     }
 
+    public function testFromDsnInMemory()
+    {
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+        $transport = Transport::fromDsn('in-memory://', $dispatcher, null, $logger);
+
+        $this->assertInstanceOf(Transport\InMemoryTransport::class, $transport);
+
+        $property = new \ReflectionProperty(Transport\AbstractTransport::class, 'dispatcher');
+        $property->setAccessible(true);
+
+        $this->assertSame($dispatcher, $property->getValue($transport));
+    }
+
     public function testFromDsnSendmail()
     {
         $dispatcher = $this->createMock(EventDispatcherInterface::class);

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -53,6 +53,11 @@ class Transport
             return new Transport\RoundRobinTransport($transports);
         }
 
+        // in-memory
+        if (0 === strpos($dsn, 'in-memory://')) {
+            return new Transport\InMemoryTransport($dispatcher, $logger);
+        }
+
         return self::createTransport($dsn, $dispatcher, $client, $logger);
     }
 

--- a/src/Symfony/Component/Mailer/Transport/InMemoryTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/InMemoryTransport.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Transport;
+
+use Symfony\Component\Mailer\SentMessage;
+
+/**
+ * Stores messages in memory.
+ *
+ * @author Jan Schädlich <schaedlich.jan@gmail.com>
+ */
+final class InMemoryTransport extends AbstractTransport
+{
+    /**
+     * @var SentMessage[]
+     */
+    private $messages = [];
+
+    protected function doSend(SentMessage $message): void
+    {
+        $this->messages[] = $message;
+    }
+
+    public function get(): iterable
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Resets the transport and removes all messages.
+     */
+    public function reset(): void
+    {
+        $this->messages = [];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #31747   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This PR provides an in-memory transport to save sent messages in memory. 

To use this transport you need to configure your mailer with this DSN: `in-memory://`

```bash
# .env.local .env.test

MAILER_DSN=in-memory://
```

Now you can retrieve the `mailer.default_transport` which is of type `InMemoryTransport` and can get the sent messages via calling the get() method.

```php
class DefaultControllerTest extends WebTestCase
{
    public function testSomething()
    {
        $client = static::createClient();
        // ...

        $this->assertSame(200, $client->getResponse()->getStatusCode());

        /* @var InMemoryTransport $transport */
        $transport = self::$container->get('mailer.default_transport');
        $this->assertCount(1, $transport->get());
    }
}
```