### PR TITLE
[Translation] deprecate passing a null locale

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -32,6 +32,10 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function __construct(?string $locale, array $messages = [])
     {
+        if (null === $locale) {
+            @trigger_error(sprintf('Passing "null" to the first argument of the "%s" method has been deprecated since Symfony 4.4 and will throw an error in 5.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $this->locale = $locale;
         $this->messages = $messages;
     }

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -23,6 +23,17 @@ class MessageCatalogueTest extends TestCase
         $this->assertEquals('en', $catalogue->getLocale());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing "null" to the first argument of the "Symfony\Component\Translation\MessageCatalogue::__construct" method has been deprecated since Symfony 4.4 and will throw an error in 5.0.
+     */
+    public function testGetNullLocale()
+    {
+        $catalogue = new MessageCatalogue(null);
+
+        $this->assertNull($catalogue->getLocale());
+    }
+
     public function testGetDomains()
     {
         $catalogue = new MessageCatalogue('en', ['domain1' => [], 'domain2' => [], 'domain2+intl-icu' => [], 'domain3+intl-icu' => []]);

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -184,10 +184,23 @@ class TranslatorTest extends TestCase
      */
     public function testAddResourceValidLocales($locale)
     {
+        if (null === $locale) {
+            $this->markTestSkipped('null is not a valid locale');
+        }
         $translator = new Translator('fr');
         $translator->addResource('array', ['foo' => 'foofoo'], $locale);
         // no assertion. this method just asserts that no exception is thrown
         $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing "null" to the third argument of the "Symfony\Component\Translation\Translator::addResource" method has been deprecated since Symfony 4.4 and will throw an error in 5.0.
+     */
+    public function testAddResourceNull()
+    {
+        $translator = new Translator('fr');
+        $translator->addResource('array', ['foo' => 'foofoo'], null);
     }
 
     public function testAddResourceAfterTrans()
@@ -367,16 +380,30 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getValidLocalesTests
+     * @dataProvider getValidLocalesTests
      */
     public function testTransValidLocale($locale)
     {
+        if (null === $locale) {
+            $this->markTestSkipped('null is not a valid locale');
+        }
         $translator = new Translator($locale);
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', ['test' => 'OK'], $locale);
 
         $this->assertEquals('OK', $translator->trans('test'));
         $this->assertEquals('OK', $translator->trans('test', [], null, $locale));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing "null" to the third argument of the "Symfony\Component\Translation\Translator::addResource" method has been deprecated since Symfony 4.4 and will throw an error in 5.0.
+     */
+    public function testTransNullLocale()
+    {
+        $translator = new Translator(null);
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['test' => 'OK'], null);
     }
 
     /**

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -132,6 +132,10 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
             $domain = 'messages';
         }
 
+        if (null === $locale) {
+            @trigger_error(sprintf('Passing "null" to the third argument of the "%s" method has been deprecated since Symfony 4.4 and will throw an error in 5.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $this->assertValidLocale($locale);
 
         $this->resources[$locale][] = [$format, $resource, $domain];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | not needed <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

According to the discussion in https://github.com/symfony/symfony/pull/32386#discussion_r300590343 it seems that allowing null here was not the right thing to do, so we are deprecating this behaviour.
