### PR TITLE
[Intl] Remove --dev from intl compile autoloader

### DIFF
--- a/src/Symfony/Component/Intl/Resources/bin/autoload.php
+++ b/src/Symfony/Component/Intl/Resources/bin/autoload.php
@@ -12,7 +12,7 @@
 $autoload = __DIR__.'/../../vendor/autoload.php';
 
 if (!file_exists($autoload)) {
-    bailout('You should run "composer install --dev" in the component before running this script.');
+    bailout('You should run "composer install" in the component before running this script.');
 }
 
 require_once $autoload;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Remove implicit composer default (`jakzal/php-intl` uses latest composer during compile)