### PR TITLE
[EventDispatcher] Add tag kernel.rest on 'debug.event_dispatcher' service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -9,6 +9,7 @@
 
         <service id="debug.event_dispatcher" class="Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher" decorates="event_dispatcher">
             <tag name="monolog.logger" channel="event" />
+            <tag name="kernel.reset" method="reset" />
             <argument type="service" id="debug.event_dispatcher.inner" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" on-invalid="null" />

--- a/src/Symfony/Component/Console/CommandLoader/CommandLoaderInterface.php
+++ b/src/Symfony/Component/Console/CommandLoader/CommandLoaderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Console\CommandLoader;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Symfony/Component/Console/CommandLoader/ContainerCommandLoader.php
+++ b/src/Symfony/Component/Console/CommandLoader/ContainerCommandLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Console\CommandLoader;
 
 use Psr\Container\ContainerInterface;

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -75,11 +75,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
-     * Sets style foreground color.
-     *
-     * @param string|null $color The color name
-     *
-     * @throws InvalidArgumentException When the color name isn't defined
+     * {@inheritdoc}
      */
     public function setForeground($color = null)
     {
@@ -97,11 +93,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
-     * Sets style background color.
-     *
-     * @param string|null $color The color name
-     *
-     * @throws InvalidArgumentException When the color name isn't defined
+     * {@inheritdoc}
      */
     public function setBackground($color = null)
     {
@@ -119,11 +111,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
-     * Sets some specific style option.
-     *
-     * @param string $option The option name
-     *
-     * @throws InvalidArgumentException When the option name isn't defined
+     * {@inheritdoc}
      */
     public function setOption($option)
     {
@@ -137,11 +125,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
-     * Unsets some specific style option.
-     *
-     * @param string $option The option name
-     *
-     * @throws InvalidArgumentException When the option name isn't defined
+     * {@inheritdoc}
      */
     public function unsetOption($option)
     {
@@ -168,11 +152,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
-     * Applies the style to a given text.
-     *
-     * @param string $text The text to style
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function apply($text)
     {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
@@ -21,7 +21,7 @@ interface OutputFormatterStyleInterface
     /**
      * Sets style foreground color.
      *
-     * @param string $color The color name
+     * @param string|null $color The color name
      */
     public function setForeground($color = null);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |


In CLI, Symfony leaks because it uses the TraceableEventDispatcher.
Let's make this service resetable.

This PR is related to #32418

---

Side note: Forcing user to use the `ServicesResetter` is IMHO bad for
the DX. I prefer to have something that does not leak by default.
More over, the TraceableEventDispatcher stores some informations for the
profiler. But in CLI it does not make sens, since the tooling does not
exist. I have already fixed such issue for monolog in #30339. I think we
should do the same for the TraceableEventDispatcher.

---

Note: When using #32418 + this PR and with the following code, it does not leak **at all**

<details>
<summary>code</summary>

```php
<?php

namespace App\Command;

use Psr\Log\LoggerInterface;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputOption;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Console\Style\SymfonyStyle;
use Symfony\Component\EventDispatcher\Event;
use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;

class LeakCommand extends Command
{
    protected static $defaultName = 'leak';

    private $dispatcher;
    private $resetter;
    private $logger;

    public function __construct(EventDispatcherInterface $dispatcher, ServicesResetter $resetter, LoggerInterface $logger)
    {
        $this->dispatcher = $dispatcher;
        $this->resetter = $resetter;
        $this->logger = $logger;

        parent::__construct();
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $this->dispatcher->addListener(MyEvent::class, function ($e) {

        });
        for ($i=0; $i < INF; $i++) {
            $output->writeln(memory_get_usage());

            $this->dispatcher->dispatch(new MyEvent());
            $this->logger->debug('some log');

            // if ($i > 2000) {
            //     meminfo_dump(fopen('/tmp/my_dump_file.json', 'w'));
            //     die;
            // }

            usleep(100);
            $this->resetter->reset();
        }
    }
}

class MyEvent {}

```
</detail>


