### PR TITLE
Fix #32396

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -19,12 +19,12 @@
         "php": "^5.5.9|>=7.0.8",
         "doctrine/common": "~2.4",
         "symfony/polyfill-ctype": "~1.8",
-        "symfony/polyfill-mbstring": "~1.0"
+        "symfony/polyfill-mbstring": "~1.0",
+        "symfony/form": "^3.3.10|~4.0"
     },
     "require-dev": {
         "symfony/stopwatch": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~3.4|~4.0",
-        "symfony/form": "^3.3.10|~4.0",
         "symfony/http-kernel": "~2.8|~3.0|~4.0",
         "symfony/property-access": "~2.8|~3.0|~4.0",
         "symfony/property-info": "~2.8|3.0|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32396
| License       | MIT
| Doc PR        | 

The src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php implements
the FormTypeGuesserInterface and that interface is only defined in the
symfony/form component.
By implementing that interface that code depends on it not only for test but
also in production use.

We discovered it because we have an api which doesn't require symfony form
who blew up with the update to php 7.2.20.
The release of php 7.2.20 fixed a bug that was allowing the implementation
of interface that are not available.
