### PR TITLE
[Translation] Introduce a way to configure the enabled locales

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -677,6 +677,16 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('paths')
                             ->prototype('scalar')->end()
                         ->end()
+                        ->arrayNode('enabled_locales')
+                            ->prototype('scalar')
+                            ->defaultValue([])
+                            ->beforeNormalization()
+                                ->always()
+                                ->then(function ($config) {
+                                    return array_unique((array) $config);
+                                })
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1039,6 +1039,8 @@ class FrameworkExtension extends Extension
         $defaultOptions['cache_dir'] = $config['cache_dir'];
         $translator->setArgument(4, $defaultOptions);
 
+        $translator->setArgument(6, $config['enabled_locales']);
+
         $container->setParameter('translator.logging', $config['logging']);
         $container->setParameter('translator.default_path', $config['default_path']);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -16,6 +16,7 @@
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>
                 <argument key="debug">%kernel.debug%</argument>
             </argument>
+            <argument type="collection" /> <!-- enabled locales -->
             <call method="setConfigCacheFactory">
                 <argument type="service" id="config_cache_factory" />
             </call>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -373,6 +373,7 @@ class ConfigurationTest extends TestCase
                 'formatter' => 'translator.formatter.default',
                 'paths' => [],
                 'default_path' => '%kernel.project_dir%/translations',
+                'enabled_locales' => [],
             ],
             'validation' => [
                 'enabled' => !class_exists(FullStack::class),

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -58,6 +58,11 @@ class Translator extends BaseTranslator implements WarmableInterface
     private $scannedDirectories;
 
     /**
+     * @var string[]
+     */
+    private $enabledLocales;
+
+    /**
      * Constructor.
      *
      * Available options:
@@ -69,10 +74,11 @@ class Translator extends BaseTranslator implements WarmableInterface
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(ContainerInterface $container, MessageFormatterInterface $formatter, string $defaultLocale, array $loaderIds = [], array $options = [])
+    public function __construct(ContainerInterface $container, MessageFormatterInterface $formatter, string $defaultLocale, array $loaderIds = [], array $options = [], array $enabledLocales = [])
     {
         $this->container = $container;
         $this->loaderIds = $loaderIds;
+        $this->enabledLocales = $enabledLocales;
 
         // check option names
         if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
@@ -97,8 +103,9 @@ class Translator extends BaseTranslator implements WarmableInterface
             return;
         }
 
-        $locales = array_merge($this->getFallbackLocales(), [$this->getLocale()], $this->resourceLocales);
-        foreach (array_unique($locales) as $locale) {
+        $localesToWarmUp = $this->enabledLocales ?: array_merge($this->getFallbackLocales(), [$this->getLocale()], $this->resourceLocales);
+
+        foreach (array_unique($localesToWarmUp) as $locale) {
             // reset catalogue in case it's already loaded during the dump of the other locales.
             if (isset($this->catalogues[$locale])) {
                 unset($this->catalogues[$locale]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31563
| License       | MIT
| Doc PR        | -

This implements the idea #31563 so we can decide if we want to add this or not. I tested it in the "Symfony Demo" app. Before: 107 catalogs created in cache/dev/translations/. After: 43 catalogs. But that's because the app is translated into lots of languages. In most cases, only 2 catalog files will be generated (vs 107 before).

If this idea is approved, I'll add tests and docs. Thanks.