### PR TITLE
Fix toolbar load when GET params are present in "_wdt" route

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -15,7 +15,7 @@
 
         Sfjs.load(
             'sfwdt{{ token }}',
-            '{{ path("_wdt", { "token": token }) }}',
+            '{{ path("_wdt", { "token": token })|escape('js') }}',
             function(xhr, el) {
 
                 /* Evaluate embedded scripts inside the toolbar */


### PR DESCRIPTION
When using a custom router that inject GET parameters, eg:

```
# services.yaml
parameters:
    # Replace default url generator service
    router.options.generator_base_class: Combodo\iTop\Portal\Routing\UrlGenerator
```

The path generated by the toolbar JS is HTML entity encoded which breaks the JS call (`&` becomes `&amp;`).

| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4, 4.2 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
