### PR TITLE
[DomCrawler] add a normalizeWhitespace argument to text() method

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 * Added `Crawler::matches()` method.
 * Added `Crawler::closest()` method.
 * Added `Crawler::outerHtml()` method.
+* Added an argument to the `Crawler::text()` method to opt-in normalizing whitespaces.
 
 4.3.0
 -----

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -591,7 +591,9 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * Returns the node value of the first node of the list.
+     * Returns the text of the first node of the list.
+     *
+     * Pass true as the 2nd argument to normalize whitespaces.
      *
      * @param mixed $default When provided and the current node is empty, this value is returned and no exception is thrown
      *
@@ -599,7 +601,7 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function text(/* $default = null */)
+    public function text(/* $default = null, $normalizeWhitespace = true */)
     {
         if (!$this->nodes) {
             if (0 < \func_num_args()) {
@@ -609,7 +611,13 @@ class Crawler implements \Countable, \IteratorAggregate
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        return $this->getNode(0)->nodeValue;
+        $text = $this->getNode(0)->nodeValue;
+
+        if (\func_num_args() > 1 && func_get_arg(1)) {
+            return trim(preg_replace('/(?:\s{2,}+|[^\S ])/', ' ', $text));
+        }
+
+        return $text;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -253,6 +253,14 @@ abstract class AbstractCrawlerTest extends TestCase
         $this->assertCount(0, $crawler->eq(100), '->eq() returns an empty crawler if the nth node does not exist');
     }
 
+    public function testNormalizeWhiteSpace()
+    {
+        $crawler = $this->createTestCrawler()->filterXPath('//p');
+        $this->assertSame('Elsa <3', $crawler->text(null, true), '->text(null, true) returns the text with normalized whitespace');
+        $this->assertNotSame('Elsa <3', $crawler->text(null, false));
+        $this->assertNotSame('Elsa <3', $crawler->text());
+    }
+
     public function testEach()
     {
         $data = $this->createTestCrawler()->filterXPath('//ul[1]/li')->each(function ($node, $i) {
@@ -1291,6 +1299,10 @@ HTML;
                         <li>Two Bis</li>
                         <li>Three Bis</li>
                     </ul>
+                    <p class="whitespace">
+                        Elsa
+                        &lt;3
+                    </p>
                     <div id="parent">
                         <div id="child"></div>
                         <div id="child2" xmlns:foo="http://example.com"></div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #21302, #23626  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

I've taken #24412, rebased with 4.4, fixed the comments in the PR.

cc @xabbuh @stof @nicolas-grekas
