### PR TITLE
[PHPUnit Bridge] Spell "triggering" properly

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -76,7 +76,7 @@ class Deprecation
             // No-op
         }
         $line = $trace[$i];
-        $this->trigerringFilePathType = $this->getPathType($file);
+        $this->triggeringFilePathType = $this->getPathType($file);
         if (isset($line['object']) || isset($line['class'])) {
             if (isset($line['class']) && 0 === strpos($line['class'], SymfonyTestsListenerFor::class)) {
                 $parsedMsg = unserialize($this->message);
@@ -88,7 +88,7 @@ class Deprecation
                 // then we need to use the serialized information to determine
                 // if the error has been triggered from vendor code.
                 if (isset($parsedMsg['triggering_file'])) {
-                    $this->trigerringFilePathType = $this->getPathType($parsedMsg['triggering_file']);
+                    $this->triggeringFilePathType = $this->getPathType($parsedMsg['triggering_file']);
                 }
 
                 return;
@@ -177,10 +177,10 @@ class Deprecation
      */
     public function getType()
     {
-        if (self::PATH_TYPE_SELF === $this->trigerringFilePathType) {
+        if (self::PATH_TYPE_SELF === $this->triggeringFilePathType) {
             return self::TYPE_SELF;
         }
-        if (self::PATH_TYPE_UNDETERMINED === $this->trigerringFilePathType) {
+        if (self::PATH_TYPE_UNDETERMINED === $this->triggeringFilePathType) {
             return self::TYPE_UNDETERMINED;
         }
         $erroringFile = $erroringPackage = null;


### PR DESCRIPTION
As a side effect, the property name matches the one in the declaration,
which was correct.

| Q             | A
| ------------- | ---
| Branch?       | 4.3 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a