### PR TITLE
Adding missing event_dispatcher wiring for messenger.middleware.send_message

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -15,6 +15,7 @@
         <service id="messenger.middleware.send_message" class="Symfony\Component\Messenger\Middleware\SendMessageMiddleware">
             <tag name="monolog.logger" channel="messenger" />
             <argument type="service" id="messenger.senders_locator" />
+            <argument type="service" id="event_dispatcher" />
             <call method="setLogger">
                 <argument type="service" id="logger" on-invalid="ignore" />
             </call>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32375
| License       | MIT
| Doc PR        | not needed

This was probably my bad when I added this hook point (it's not used anywhere in the core). Also reported on Slack :).

Cheers!
