### PR TITLE
[Lock] rename and deprecate Factory into LockFactory

### DIFF
--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Exception\LogicException;
-use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Lock;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 
@@ -48,7 +48,7 @@ trait LockableTrait
             $store = new FlockStore();
         }
 
-        $this->lock = (new Factory($store))->createLock($name ?: $this->getName());
+        $this->lock = (new LockFactory($store))->createLock($name ?: $this->getName());
         if (!$this->lock->acquire($blocking)) {
             $this->lock = null;
 

--- a/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Lock\Factory;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 
@@ -47,7 +47,7 @@ class LockableTraitTest extends TestCase
             $store = new FlockStore();
         }
 
-        $lock = (new Factory($store))->createLock($command->getName());
+        $lock = (new LockFactory($store))->createLock($command->getName());
         $lock->acquire();
 
         $tester = new CommandTester($command);

--- a/src/Symfony/Component/Lock/Factory.php
+++ b/src/Symfony/Component/Lock/Factory.php
@@ -19,6 +19,8 @@ use Psr\Log\NullLogger;
  * Factory provides method to create locks.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @deprecated "Symfony\Component\Lock\Factory" is deprecated since Symfony 4.4 and will be removed in 5.0 use "Symfony\Component\Lock\LockFactory" instead
  */
 class Factory implements LoggerAwareInterface
 {

--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+/**
+ * Factory provides method to create locks.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+class LockFactory extends Factory
+{
+}

--- a/src/Symfony/Component/Lock/Tests/LockFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Lock\StoreInterface;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class LockFactoryTest extends TestCase
+{
+    public function testCreateLock()
+    {
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $factory = new LockFactory($store);
+        $factory->setLogger($logger);
+
+        $lock = $factory->createLock('foo');
+
+        $this->assertInstanceOf(LockInterface::class, $lock);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes<!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR         <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
As highlighted in https://github.com/symfony/symfony/pull/32198#pullrequestreview-255808664 we need to rename the factory to LockFactory for consistency and readability.