### PR TITLE
[Bundles] Rename getPublicPath() as getPublicDir()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -137,13 +137,13 @@ EOT
         $validAssetDirs = [];
         /** @var BundleInterface $bundle */
         foreach ($kernel->getBundles() as $bundle) {
-            if (!method_exists($bundle, 'getPublicPath')) {
-                @trigger_error('Not defining "getPublicPath()" method is deprecated since Symfony 4.4 and will not be supported in 5.0.', E_USER_DEPRECATED);
-                $publicPath = 'Resources/public';
+            if (!method_exists($bundle, 'getPublicDir')) {
+                @trigger_error(sprintf('Not defining "getPublicDir()" method in the "%s" class is deprecated since Symfony 4.4 and will not be supported in 5.0.', get_class($bundle)), E_USER_DEPRECATED);
+                $publicDir = 'Resources/public';
             } else {
-                $publicPath = $bundle->getPublicPath();
+                $publicDir = ltrim($bundle->getPublicDir(), '\\/');
             }
-            if (!is_dir($originDir = $bundle->getPath().\DIRECTORY_SEPARATOR.$publicPath)) {
+            if (!is_dir($originDir = $bundle->getPath().\DIRECTORY_SEPARATOR.$publicDir)) {
                 continue;
             }
 

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -135,7 +135,7 @@ abstract class Bundle implements BundleInterface
     {
     }
 
-    public function getPublicPath(): string
+    public function getPublicDir(): string
     {
         return 'Resources/public';
     }

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @method string getPublicPath() Returns relative path for public assets
+ * @method string getPublicDir() Returns relative path for the public assets directory
  */
 interface BundleInterface extends ContainerAwareInterface
 {

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -627,7 +627,7 @@ EOF;
     {
         $bundle = $this
             ->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')
-            ->setMethods(['getPath', 'getPublicPath', 'getParent', 'getName'])
+            ->setMethods(['getPath', 'getPublicDir', 'getParent', 'getName'])
             ->disableOriginalConstructor()
         ;
 
@@ -651,7 +651,7 @@ EOF;
 
         $bundle
             ->expects($this->any())
-            ->method('getPublicPath')
+            ->method('getPublicDir')
             ->willReturn('Resources/public')
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -
| License       | MIT
| Doc PR        | I'll add this if approved

While documenting #31975 (see https://github.com/symfony/symfony-docs/pull/11930) I realized that the `getPublicPath()` method name is not consistent with the rest of Symfony.

In Symfony, "path" is usually associated to routes and we use "dir" for things similar to this:

* `getCacheDir()` and `getLogdir()` to override Symfony structure (https://symfony.com/doc/current/configuration/override_dir_structure.html)
* `binDir`, `configDir`, `srcDir`, `varDir`, `publicDir` in Symfony Flex recipes (https://github.com/symfony/recipes) to override the dir structure

So, this PR proposes to rename `getPublicPath()` as `getPublicDir()`