### PR TITLE
[Messenger] use database platform to convert correctly the DateTime

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -44,8 +44,11 @@ class ConnectionTest extends TestCase
         $queryBuilder
             ->method('getParameters')
             ->willReturn([]);
+        $queryBuilder
+            ->method('getParameterTypes')
+            ->willReturn([]);
         $driverConnection
-            ->method('prepare')
+            ->method('executeQuery')
             ->willReturn($stmt);
 
         $connection = new Connection([], $driverConnection, $schemaSynchronizer);
@@ -65,13 +68,17 @@ class ConnectionTest extends TestCase
         $queryBuilder
             ->method('getParameters')
             ->willReturn([]);
+        $queryBuilder
+            ->method('getParameterTypes')
+            ->willReturn([]);
         $driverConnection->expects($this->once())
             ->method('createQueryBuilder')
             ->willReturn($queryBuilder);
-        $driverConnection->method('prepare')
-            ->willReturn($stmt);
         $driverConnection->expects($this->never())
             ->method('update');
+        $driverConnection
+            ->method('executeQuery')
+            ->willReturn($stmt);
 
         $connection = new Connection([], $driverConnection, $schemaSynchronizer);
         $doctrineEnvelope = $connection->get();
@@ -273,7 +280,7 @@ class ConnectionTest extends TestCase
             ->method('getParameters')
             ->willReturn([]);
         $driverConnection
-            ->method('prepare')
+            ->method('executeQuery')
             ->willReturn($stmt);
 
         $connection = new Connection([], $driverConnection, $schemaSynchronizer);
@@ -316,8 +323,11 @@ class ConnectionTest extends TestCase
         $queryBuilder
             ->method('getParameters')
             ->willReturn([]);
+        $queryBuilder
+            ->method('getParameterTypes')
+            ->willReturn([]);
         $driverConnection
-            ->method('prepare')
+            ->method('executeQuery')
             ->willReturn($stmt);
 
         $connection = new Connection([], $driverConnection, $schemaSynchronizer);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
@@ -80,25 +80,25 @@ class DoctrineIntegrationTest extends TestCase
             'body' => '{"message": "Hi handled"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'delivered_at' => Connection::formatDateTime(new \DateTime()),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'delivered_at' => $this->formatDateTime(new \DateTime()),
         ]);
         // one available later
         $this->driverConnection->insert('messenger_messages', [
             'body' => '{"message": "Hi delayed"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime(new \DateTime('2019-03-15 13:00:00')),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime(new \DateTime('2019-03-15 13:00:00')),
         ]);
         // one available
         $this->driverConnection->insert('messenger_messages', [
             'body' => '{"message": "Hi available"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:30:00')),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:30:00')),
         ]);
 
         $encoded = $this->connection->get();
@@ -114,33 +114,33 @@ class DoctrineIntegrationTest extends TestCase
             'body' => '{"message": "Hi handled"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'delivered_at' => Connection::formatDateTime(new \DateTime()),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'delivered_at' => $this->formatDateTime(new \DateTime()),
         ]);
         // one available later
         $this->driverConnection->insert('messenger_messages', [
             'body' => '{"message": "Hi delayed"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime((new \DateTime())->modify('+1 minute')),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime((new \DateTime())->modify('+1 minute')),
         ]);
         // one available
         $this->driverConnection->insert('messenger_messages', [
             'body' => '{"message": "Hi available"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:30:00')),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:30:00')),
         ]);
         // another available
         $this->driverConnection->insert('messenger_messages', [
             'body' => '{"message": "Hi available"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:30:00')),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:30:00')),
         ]);
 
         $this->assertSame(2, $this->connection->getMessageCount());
@@ -155,16 +155,16 @@ class DoctrineIntegrationTest extends TestCase
             'body' => '{"message": "Hi requeued"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'delivered_at' => Connection::formatDateTime($twoHoursAgo),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'delivered_at' => $this->formatDateTime($twoHoursAgo),
         ]);
         $this->driverConnection->insert('messenger_messages', [
             'body' => '{"message": "Hi available"}',
             'headers' => json_encode(['type' => DummyMessage::class]),
             'queue_name' => 'default',
-            'created_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:00:00')),
-            'available_at' => Connection::formatDateTime(new \DateTime('2019-03-15 12:30:00')),
+            'created_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:00:00')),
+            'available_at' => $this->formatDateTime(new \DateTime('2019-03-15 12:30:00')),
         ]);
 
         $next = $this->connection->get();
@@ -180,5 +180,10 @@ class DoctrineIntegrationTest extends TestCase
         $this->connection->send('the body', ['my' => 'header']);
         $envelope = $this->connection->get();
         $this->assertEquals('the body', $envelope['body']);
+    }
+
+    private function formatDateTime(\DateTime $dateTime)
+    {
+        return $dateTime->format($this->driverConnection->getDatabasePlatform()->getDateTimeFormatString());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/32427
| License       | MIT

In Doctrine Messenger the method `\Symfony\Component\Messenger\Transport\Doctrine\Connection::formatDateTime()` is used to format dateTime into this: `Y-m-d\TH:i:s`.
But this is not supported in all databases platform.

Here we use the database platform to convert correctly the dateTime.
