### PR TITLE
[WebProfilerBundle] Removed templateExists method

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.0.0
+-----
+
+ * removed the `ExceptionController::templateExists()` method
+ * removed the `TemplateManager::templateExists()` method
+
 4.3.0
 -----
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Twig\Environment;
-use Twig\Error\LoaderError;
-use Twig\Loader\ExistsLoaderInterface;
 
 /**
  * ExceptionController.
@@ -97,7 +95,7 @@ class ExceptionController
 
         $template = $this->getTemplate();
 
-        if (!$this->templateExists($template)) {
+        if (!$this->twig->getLoader()->exists($template)) {
             return new Response($this->errorRenderer->getStylesheet(), 200, ['Content-Type' => 'text/css']);
         }
 
@@ -107,23 +105,5 @@ class ExceptionController
     protected function getTemplate()
     {
         return '@Twig/Exception/'.($this->debug ? 'exception' : 'error').'.html.twig';
-    }
-
-    // to be removed when the minimum required version of Twig is >= 2.0
-    protected function templateExists(string $template)
-    {
-        $loader = $this->twig->getLoader();
-        if ($loader instanceof ExistsLoaderInterface) {
-            return $loader->exists($template);
-        }
-
-        try {
-            $loader->getSource($template);
-
-            return true;
-        } catch (LoaderError $e) {
-        }
-
-        return false;
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
@@ -15,10 +15,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Twig\Environment;
-use Twig\Error\LoaderError;
-use Twig\Loader\ExistsLoaderInterface;
-use Twig\Loader\SourceContextLoaderInterface;
-use Twig\Template;
 
 /**
  * Profiler Templates Manager.
@@ -66,6 +62,7 @@ class TemplateManager
      */
     public function getNames(Profile $profile)
     {
+        $loader = $this->twig->getLoader();
         $templates = [];
 
         foreach ($this->templates as $arguments) {
@@ -83,7 +80,7 @@ class TemplateManager
                 $template = substr($template, 0, -10);
             }
 
-            if (!$this->templateExists($template.'.html.twig')) {
+            if (!$loader->exists($template.'.html.twig')) {
                 throw new \UnexpectedValueException(sprintf('The profiler template "%s.html.twig" for data collector "%s" does not exist.', $template, $name));
             }
 
@@ -91,27 +88,5 @@ class TemplateManager
         }
 
         return $templates;
-    }
-
-    // to be removed when the minimum required version of Twig is >= 2.0
-    protected function templateExists(string $template)
-    {
-        $loader = $this->twig->getLoader();
-        if ($loader instanceof ExistsLoaderInterface) {
-            return $loader->exists($template);
-        }
-
-        try {
-            if ($loader instanceof SourceContextLoaderInterface || method_exists($loader, 'getSourceContext')) {
-                $loader->getSourceContext($template);
-            } else {
-                $loader->getSource($template);
-            }
-
-            return true;
-        } catch (LoaderError $e) {
-        }
-
-        return false;
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -45,9 +45,9 @@ class TemplateManagerTest extends TestCase
         $profiler = $this->mockProfiler();
         $twigEnvironment = $this->mockTwigEnvironment();
         $templates = [
-            'data_collector.foo' => ['foo', 'FooBundle:Collector:foo'],
-            'data_collector.bar' => ['bar', 'FooBundle:Collector:bar'],
-            'data_collector.baz' => ['baz', 'FooBundle:Collector:baz'],
+            'data_collector.foo' => ['foo', '@Foo/Collector/foo.html.twig'],
+            'data_collector.bar' => ['bar', '@Foo/Collector/bar.html.twig'],
+            'data_collector.baz' => ['baz', '@Foo/Collector/baz.html.twig'],
         ];
 
         $this->templateManager = new TemplateManager($profiler, $twigEnvironment, $templates);
@@ -71,7 +71,7 @@ class TemplateManagerTest extends TestCase
             ->withAnyParameters()
             ->willReturnCallback([$this, 'profilerHasCallback']);
 
-        $this->assertEquals('FooBundle:Collector:foo.html.twig', $this->templateManager->getName(new ProfileDummy(), 'foo'));
+        $this->assertEquals('@Foo/Collector/foo.html.twig', $this->templateManager->getName(new ProfileDummy(), 'foo'));
     }
 
     public function profilerHasCallback($panel)
@@ -103,17 +103,10 @@ class TemplateManagerTest extends TestCase
 
     protected function mockTwigEnvironment()
     {
+        $loader = $this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock();
+        $loader->method('exists')->willReturn(true);
+
         $this->twigEnvironment = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
-
-        $this->twigEnvironment->expects($this->any())
-            ->method('loadTemplate')
-            ->willReturn('loadedTemplate');
-
-        if (interface_exists('Twig\Loader\SourceContextLoaderInterface')) {
-            $loader = $this->getMockBuilder('Twig\Loader\SourceContextLoaderInterface')->getMock();
-        } else {
-            $loader = $this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock();
-        }
         $this->twigEnvironment->expects($this->any())->method('getLoader')->willReturn($loader);
 
         return $this->twigEnvironment;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | not needed

Follow up https://github.com/symfony/symfony/pull/32458, since Twig 2.0 the `exists()` method is part of the `LoaderInterface`.

I'm not removing the `Symfony\Bundle\TwigBundle\Controller\ExceptionController::templateExists()` method because the whole class will be removed after https://github.com/symfony/symfony/pull/31398

See also https://github.com/symfony/symfony/pull/32462