### PR TITLE
[WebProfilerBundle] Deprecating templateExists method

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -137,3 +137,9 @@ Validator
    when the `min` option is used.
    Set it to `true` to keep the current behavior and `false` to reject empty strings.
    In 5.0, it'll become optional and will default to `false`.
+
+WebProfilerBundle
+-----------------
+
+ * Deprecated the `ExceptionController::templateExists()` method
+ * Deprecated the `TemplateManager::templateExists()` method

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -477,6 +477,12 @@ Validator
  * The `egulias/email-validator` component is now required for using the `Email` constraint in strict mode
  * The `symfony/expression-language` component is now required for using the `Expression` constraint
 
+WebProfilerBundle
+-----------------
+
+ * Removed the `ExceptionController::templateExists()` method
+ * Removed the `TemplateManager::templateExists()` method
+
 Workflow
 --------
 

--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -4,7 +4,9 @@ CHANGELOG
 4.4.0
 -----
 
-* Added button to clear the ajax request tab
+ * Added button to clear the ajax request tab
+ * Deprecated the `ExceptionController::templateExists()` method
+ * Deprecated the `TemplateManager::templateExists()` method
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
@@ -101,7 +101,7 @@ class ExceptionController
 
         $template = $this->getTemplate();
 
-        if (!$this->templateExists($template)) {
+        if (!$this->templateExists($template, false)) {
             return new Response($this->errorRenderer->getStylesheet(), 200, ['Content-Type' => 'text/css']);
         }
 
@@ -113,9 +113,15 @@ class ExceptionController
         return '@Twig/Exception/'.($this->debug ? 'exception' : 'error').'.html.twig';
     }
 
-    // to be removed when the minimum required version of Twig is >= 2.0
-    protected function templateExists($template)
+    /**
+     * @deprecated since Symfony 4.4
+     */
+    protected function templateExists($template/*, bool $triggerDeprecation = true */)
     {
+        if (1 === \func_num_args()) {
+            @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.4, use the "exists()" method of the Twig loader instead.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $loader = $this->twig->getLoader();
         if ($loader instanceof ExistsLoaderInterface) {
             return $loader->exists($template);

--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
@@ -18,7 +18,6 @@ use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Loader\ExistsLoaderInterface;
 use Twig\Loader\SourceContextLoaderInterface;
-use Twig\Template;
 
 /**
  * Profiler Templates Manager.
@@ -86,7 +85,7 @@ class TemplateManager
                 $template = substr($template, 0, -10);
             }
 
-            if (!$this->templateExists($template.'.html.twig')) {
+            if (!$this->templateExists($template.'.html.twig', false)) {
                 throw new \UnexpectedValueException(sprintf('The profiler template "%s.html.twig" for data collector "%s" does not exist.', $template, $name));
             }
 
@@ -96,9 +95,15 @@ class TemplateManager
         return $templates;
     }
 
-    // to be removed when the minimum required version of Twig is >= 2.0
-    protected function templateExists($template)
+    /**
+     * @deprecated since Symfony 4.4
+     */
+    protected function templateExists($template/*, bool $triggerDeprecation = true */)
     {
+        if (1 === \func_num_args()) {
+            @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.4, use the "exists()" method of the Twig loader instead.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $loader = $this->twig->getLoader();
         if ($loader instanceof ExistsLoaderInterface) {
             return $loader->exists($template);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | not needed

Follow up https://github.com/symfony/symfony/pull/32458, so in 5.0 we can remove these methods safely.

I'm not deprecating the `Symfony\Bundle\TwigBundle\Controller\ExceptionController::templateExists()` method because the whole class is being deprecated in https://github.com/symfony/symfony/pull/31398

See also https://github.com/symfony/symfony/pull/32461