### PR TITLE
[Config] Fix for signatures of typed properties

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -140,7 +140,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface, \Seriali
 
             foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED) as $p) {
                 yield $p->getDocComment().$p;
-                yield print_r($defaults[$p->name], true);
+                yield print_r($defaults[$p->name] ?? null, true);
             }
         }
 

--- a/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
@@ -137,6 +137,14 @@ EOPHP;
         yield [1, 13, 'protected function prot($a = [123]) {}'];
         yield [0, 14, '/** priv docblock */'];
         yield [0, 15, ''];
+
+        if (\PHP_VERSION_ID >= 70400) {
+            // PHP7.4 typed properties without default value are
+            // undefined, make sure this doesn't throw an error
+            yield [1, 5, 'public array $pub;'];
+            yield [0, 7, 'protected int $prot;'];
+            yield [0, 9, 'private string $priv;'];
+        }
     }
 
     public function testEventSubscriber()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32465 
| License       | MIT
| Doc PR        | -

Also see the issue description, when using public typed properties ([new in PHP7.4](https://wiki.php.net/rfc/typed_properties_v2)) like this:

```
namespace App;

class Foo {
    public int $bar;
} 
```

will cause `$defaults['bar']` not to be set in Symfony/Component/Config/Resource/ReflectionClassResource.php::139.

This is because `$bar` doesn't have a default value, but does have a type hint, meaning it's default value is not `null` but undefined. This causes an 'undefined index' error when clearing the cache through `bin/console cache:clear` when running PHP7.4.

The default value is used here for the class signature, having `null` should be appropriate for all cases.