### PR TITLE
Add conflict rule for Monolog 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
         "phpdocumentor/reflection-docblock": "^3.0|^4.0"
     },
     "conflict": {
+        "monolog/monolog": ">=2",
         "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
         "phpdocumentor/type-resolver": "<0.3.0",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27857, symfony/monolog-bundle#300
| License       | MIT
| Doc PR        | N/A

Depending on the monorepo has been best practice in Symfony 3 and is discouraged but still possible in Symfony 4. If the Symfony Standard Edition was used to bootstrap the application, Monolog is installed as dependency of the MonologBundle. Thus, if we released a MonologBundle that indicates compatibility with Monolog 2, those application would be bumped to Version 2 although MonologBridge 3.4 is not ready for it. The goal is to prevent this from happening.

This PR adds a conflict rule for Monolog 2 to the 3.4 branch. Assuming this gets merged before the next Symfony releases (3.4.30, 4.2.11, 4.3.3), my plan would be to bump MonologBundle's dependencies like this:

```diff
"require": {
-     "monolog/monolog": "~1.22",
-     "symfony/monolog-bridge": "~3.4|~4.0"
+     "monolog/monolog": "~1.22|~2.0",
+     "symfony/monolog-bridge": "^3.4.30|~4.2.11|^4.3.3|^5.0"
}
```

If I'm not mistaken, this should remove any possible combination of Symfony 3/4 and Monolog 2.

Projects depending on individual packages instead of the monorepo should be safe already because MonologBridge 3.x/4.x locks Monolog at version 1.