### PR TITLE
[Process] Deprecate Process::inheritEnvironmentVariables()

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -102,6 +102,11 @@ MonologBridge
 --------------
 
  * The `RouteProcessor` has been marked final.
+ 
+Process
+-------
+
+ * Deprecated the `Process::inheritEnvironmentVariables()` method: env variables are always inherited.
 
 PropertyAccess
 --------------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -319,6 +319,7 @@ MonologBridge
 Process
 -------
 
+ * Removed the `Process::inheritEnvironmentVariables()` method: env variables are always inherited.
  * Removed the `Process::setCommandline()` and the `PhpProcess::setPhpBinary()` methods.
  * Commands must be defined as arrays when creating a `Process` instance.
 

--- a/src/Symfony/Bundle/WebServerBundle/WebServer.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServer.php
@@ -167,7 +167,11 @@ class WebServer
 
         if (\in_array('APP_ENV', explode(',', getenv('SYMFONY_DOTENV_VARS')))) {
             $process->setEnv(['APP_ENV' => false]);
-            $process->inheritEnvironmentVariables();
+
+            if (!method_exists(Process::class, 'fromShellCommandline')) {
+                // Symfony 3.4 does not inherit env vars by default:
+                $process->inheritEnvironmentVariables();
+            }
         }
 
         return $process;

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -402,7 +402,12 @@ final class Dotenv
             }
 
             $process = method_exists(Process::class, 'fromShellCommandline') ? Process::fromShellCommandline('echo '.$matches[0]) : new Process('echo '.$matches[0]);
-            $process->inheritEnvironmentVariables(true);
+
+            if (!method_exists(Process::class, 'fromShellCommandline')) {
+                // Symfony 3.4 does not inherit env vars by default:
+                $process->inheritEnvironmentVariables();
+            }
+
             $process->setEnv($this->values);
             try {
                 $process->mustRun();

--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+* deprecated `Process::inheritEnvironmentVariables()`: env variables are always inherited.
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1210,9 +1210,13 @@ class Process implements \IteratorAggregate
      * @param bool $inheritEnv
      *
      * @return self The current Process instance
+     *
+     * @deprecated since Symfony 4.4, env variables are always inherited
      */
     public function inheritEnvironmentVariables($inheritEnv = true)
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.4, env variables are always inherited.', __METHOD__), E_USER_DEPRECATED);
+
         if (!$inheritEnv) {
             throw new InvalidArgumentException('Not inheriting environment variables is not supported.');
         }

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1405,7 +1405,6 @@ class ProcessTest extends TestCase
     {
         $process = $this->getProcess('echo hello');
         $process->setEnv(['bad%%' => '123']);
-        $process->inheritEnvironmentVariables(true);
 
         $process->run();
 
@@ -1419,7 +1418,6 @@ class ProcessTest extends TestCase
         $_ENV['existing_var'] = 'foo';
         $process = $this->getProcess('php -r "echo getenv(\'new_test_var\');"');
         $process->setEnv(['existing_var' => 'bar', 'new_test_var' => 'foo']);
-        $process->inheritEnvironmentVariables();
 
         $process->run();
 
@@ -1581,7 +1579,6 @@ EOTXT;
         } else {
             $process = new Process($commandline, $cwd, $env, $input, $timeout);
         }
-        $process->inheritEnvironmentVariables();
 
         if (self::$process) {
             self::$process->stop(0);

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
@@ -88,7 +88,6 @@ DUMP
             'COMPONENT_ROOT' => __DIR__.'/../../',
             'VAR_DUMPER_SERVER' => self::VAR_DUMPER_SERVER,
         ]);
-        $process->inheritEnvironmentVariables(true);
 
         return $process->setTimeout(9);
     }

--- a/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
@@ -81,7 +81,6 @@ DUMP
             'COMPONENT_ROOT' => __DIR__.'/../../',
             'VAR_DUMPER_SERVER' => self::VAR_DUMPER_SERVER,
         ]);
-        $process->inheritEnvironmentVariables(true);
 
         return $process->setTimeout(9);
     }

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "ext-iconv": "*",
         "symfony/console": "^3.4|^4.0|^5.0",
-        "symfony/process": "^3.4|^4.0|^5.0",
+        "symfony/process": "^4.4|^5.0",
         "twig/twig": "~1.34|~2.4"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

IIUC, this method was kept as a BC layer from 3.4 to 4.0 to switch to the "inherit env vars" behavior, inciting developers to opt-in in 3.4. Since 4.0, env vars are always inherited, and this method doesn't allow to opt-out. So, time to remove it?

---

refs:

- https://github.com/symfony/symfony/pull/21470
- https://github.com/symfony/symfony/pull/22836