### PR TITLE
Remove experimental notice from components

### DIFF
--- a/src/Symfony/Component/HttpClient/README.md
+++ b/src/Symfony/Component/HttpClient/README.md
@@ -3,11 +3,6 @@ HttpClient component
 
 The HttpClient component provides powerful methods to fetch HTTP resources synchronously or asynchronously.
 
-**This Component is experimental**.
-[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
-are not covered by Symfony's
-[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
-
 Resources
 ---------
 

--- a/src/Symfony/Component/Mailer/README.md
+++ b/src/Symfony/Component/Mailer/README.md
@@ -3,11 +3,6 @@ Mailer Component
 
 The Mailer component helps sending emails.
 
-**This Component is experimental**.
-[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
-are not covered by Symfony's
-[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
-
 Resources
 ---------
 

--- a/src/Symfony/Component/Messenger/README.md
+++ b/src/Symfony/Component/Messenger/README.md
@@ -4,11 +4,6 @@ Messenger Component
 The Messenger component helps application send and receive messages to/from other applications or via
 message queues.
 
-**This Component is experimental**.
-[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
-are not covered by Symfony's
-[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
-
 Resources
 ---------
 

--- a/src/Symfony/Component/Mime/README.md
+++ b/src/Symfony/Component/Mime/README.md
@@ -3,11 +3,6 @@ MIME Component
 
 The MIME component allows manipulating MIME messages.
 
-**This Component is experimental**.
-[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
-are not covered by Symfony's
-[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
-
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

@fabpot:
> Nothing can be marked as experimental in 4.4.
>
> https://github.com/symfony/symfony/pull/32277
