### PR TITLE
Allow non-string return value for RedisSessionHandler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -63,7 +63,7 @@ class RedisSessionHandler extends AbstractSessionHandler
     /**
      * {@inheritdoc}
      */
-    protected function doRead($sessionId): string
+    protected function doRead($sessionId)
     {
         return $this->redis->get($this->prefix.$sessionId) ?: '';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32483
| License       | MIT

As Redis (like a Memcached) can use different serializers (php, json, igbinary), 
RedisSessionHandler::doRead() string declared return type breaks possibility to return non-string value.
Of course it should be string but I suggest less restrictive approach, at least restriction should be as in MemcachedSessionHandler.