### PR TITLE
[Validator] Added support for validation of giga values

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -102,8 +102,10 @@ class File extends Constraint
         $factors = [
             'k' => 1000,
             'ki' => 1 << 10,
-            'm' => 1000000,
+            'm' => 1000 * 1000,
             'mi' => 1 << 20,
+            'g' => 1000 * 1000 * 1000,
+            'gi' => 1 << 30,
         ];
         if (ctype_digit((string) $maxSize)) {
             $this->maxSize = (int) $maxSize;

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
@@ -97,6 +97,10 @@ class FileTest extends TestCase
             ['1MI', 1048576, true],
             ['3m', 3000000, false],
             ['3M', 3000000, false],
+            ['1gi', 1073741824, true],
+            ['1GI', 1073741824, true],
+            ['4g', 4000000000, false],
+            ['4G', 4000000000, false],
         ];
     }
 
@@ -107,8 +111,6 @@ class FileTest extends TestCase
             ['foo'],
             ['1Ko'],
             ['1kio'],
-            ['1G'],
-            ['1Gi'],
         ];
     }
 


### PR DESCRIPTION
As described in issue #32479

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | just tested on my presta and it works. if further tests are necessary, it would be great if someone could help!
| Fixed tickets | #32479 
| License       | MIT
| Doc PR        | 


The validation(function normalizeBinaryFormat) in symfony/src/Symfony/Component/Validator/Constraints/File.php doesn't work with gigabyte values in php.ini.
In the PHP documentation it says "PHP allows shortcuts for byte values, including K (kilo), M (mega) and G (giga). " so in my opinion these values should work.
Thanks to @kijamve for the fix.

