### PR TITLE
[DoctrineBridge] Invokable event listeners

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * added `DoctrineClearEntityManagerMiddleware`
  * deprecated `RegistryInterface`, use `Doctrine\Common\Persistence\ManagerRegistry`
-
+ * added support for invokable event listeners
 
 4.3.0
 -----

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -28,14 +28,29 @@ class ContainerAwareEventManagerTest extends TestCase
 
     public function testDispatchEvent()
     {
-        $this->container->set('lazy', $listener1 = new MyListener());
-        $this->evm->addEventListener('foo', 'lazy');
+        $this->container->set('lazy1', $listener1 = new MyListener());
+        $this->evm->addEventListener('foo', 'lazy1');
         $this->evm->addEventListener('foo', $listener2 = new MyListener());
+        $this->container->set('lazy2', $listener3 = new MyListener());
+        $this->evm->addEventListener('bar', 'lazy2');
+        $this->evm->addEventListener('bar', $listener4 = new MyListener());
+        $this->container->set('lazy3', $listener5 = new MyListener());
+        $this->evm->addEventListener('foo', $listener5 = new MyListener());
+        $this->evm->addEventListener('bar', $listener5);
 
         $this->evm->dispatchEvent('foo');
+        $this->evm->dispatchEvent('bar');
 
-        $this->assertTrue($listener1->called);
-        $this->assertTrue($listener2->called);
+        $this->assertSame(0, $listener1->calledByInvokeCount);
+        $this->assertSame(1, $listener1->calledByEventNameCount);
+        $this->assertSame(0, $listener2->calledByInvokeCount);
+        $this->assertSame(1, $listener2->calledByEventNameCount);
+        $this->assertSame(1, $listener3->calledByInvokeCount);
+        $this->assertSame(0, $listener3->calledByEventNameCount);
+        $this->assertSame(1, $listener4->calledByInvokeCount);
+        $this->assertSame(0, $listener4->calledByEventNameCount);
+        $this->assertSame(1, $listener5->calledByInvokeCount);
+        $this->assertSame(1, $listener5->calledByEventNameCount);
     }
 
     public function testAddEventListenerAfterDispatchEvent()
@@ -43,19 +58,50 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->container->set('lazy1', $listener1 = new MyListener());
         $this->evm->addEventListener('foo', 'lazy1');
         $this->evm->addEventListener('foo', $listener2 = new MyListener());
-
-        $this->evm->dispatchEvent('foo');
-
         $this->container->set('lazy2', $listener3 = new MyListener());
-        $this->evm->addEventListener('foo', 'lazy2');
-        $this->evm->addEventListener('foo', $listener4 = new MyListener());
+        $this->evm->addEventListener('bar', 'lazy2');
+        $this->evm->addEventListener('bar', $listener4 = new MyListener());
+        $this->container->set('lazy3', $listener5 = new MyListener());
+        $this->evm->addEventListener('foo', $listener5 = new MyListener());
+        $this->evm->addEventListener('bar', $listener5);
 
         $this->evm->dispatchEvent('foo');
+        $this->evm->dispatchEvent('bar');
 
-        $this->assertTrue($listener1->called);
-        $this->assertTrue($listener2->called);
-        $this->assertTrue($listener3->called);
-        $this->assertTrue($listener4->called);
+        $this->container->set('lazy4', $listener6 = new MyListener());
+        $this->evm->addEventListener('foo', 'lazy4');
+        $this->evm->addEventListener('foo', $listener7 = new MyListener());
+        $this->container->set('lazy5', $listener8 = new MyListener());
+        $this->evm->addEventListener('bar', 'lazy5');
+        $this->evm->addEventListener('bar', $listener9 = new MyListener());
+        $this->container->set('lazy6', $listener10 = new MyListener());
+        $this->evm->addEventListener('foo', $listener10 = new MyListener());
+        $this->evm->addEventListener('bar', $listener10);
+
+        $this->evm->dispatchEvent('foo');
+        $this->evm->dispatchEvent('bar');
+
+        $this->assertSame(0, $listener1->calledByInvokeCount);
+        $this->assertSame(2, $listener1->calledByEventNameCount);
+        $this->assertSame(0, $listener2->calledByInvokeCount);
+        $this->assertSame(2, $listener2->calledByEventNameCount);
+        $this->assertSame(2, $listener3->calledByInvokeCount);
+        $this->assertSame(0, $listener3->calledByEventNameCount);
+        $this->assertSame(2, $listener4->calledByInvokeCount);
+        $this->assertSame(0, $listener4->calledByEventNameCount);
+        $this->assertSame(2, $listener5->calledByInvokeCount);
+        $this->assertSame(2, $listener5->calledByEventNameCount);
+
+        $this->assertSame(0, $listener6->calledByInvokeCount);
+        $this->assertSame(1, $listener6->calledByEventNameCount);
+        $this->assertSame(0, $listener7->calledByInvokeCount);
+        $this->assertSame(1, $listener7->calledByEventNameCount);
+        $this->assertSame(1, $listener8->calledByInvokeCount);
+        $this->assertSame(0, $listener8->calledByEventNameCount);
+        $this->assertSame(1, $listener9->calledByInvokeCount);
+        $this->assertSame(0, $listener9->calledByEventNameCount);
+        $this->assertSame(1, $listener10->calledByInvokeCount);
+        $this->assertSame(1, $listener10->calledByEventNameCount);
     }
 
     public function testGetListenersForEvent()
@@ -107,10 +153,16 @@ class ContainerAwareEventManagerTest extends TestCase
 
 class MyListener
 {
-    public $called = false;
+    public $calledByInvokeCount = 0;
+    public $calledByEventNameCount = 0;
+
+    public function __invoke(): void
+    {
+        ++$this->calledByInvokeCount;
+    }
 
     public function foo()
     {
-        $this->called = true;
+        ++$this->calledByEventNameCount;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11992

Invokable Doctrine entity listeners will likely be supported in the next version of the DoctrineBundle (cf https://github.com/doctrine/DoctrineBundle/pull/989). 

I think it would also be great to support it for Doctrine event listeners.