### PR TITLE
[WebProfilerBundle] Generate profiler urls with an useful panel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -24,6 +24,9 @@
             <argument>null</argument>
             <argument>%profiler_listener.only_exceptions%</argument>
             <argument>%profiler_listener.only_master_requests%</argument>
+            <argument type="service" id="profile_stack" />
         </service>
+
+        <service id="profile_stack" class="Symfony\Component\HttpKernel\Profiler\ProfileStack" />
     </services>
 </container>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
@@ -15,6 +15,7 @@
             <argument type="service" id="router" on-invalid="ignore" />
             <argument /> <!-- paths that should be excluded from the AJAX requests shown in the toolbar -->
             <argument type="service" id="web_profiler.csp.handler" />
+            <argument type="service" id="profile_stack" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -267,7 +267,7 @@
             if (request.profilerUrl) {
                 profilerCell.textContent = '';
                 var profilerLink = document.createElement('a');
-                profilerLink.setAttribute('href', request.statusCode < 400 ? request.profilerUrl : request.profilerUrl + '?panel=exception');
+                profilerLink.setAttribute('href', request.profilerUrl);
                 profilerLink.textContent = request.profile;
                 profilerCell.appendChild(profilerLink);
             }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ErrorRenderer\ErrorRenderer\HtmlErrorRenderer;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\Profiler\ProfileStack;
 
 class WebProfilerExtensionTest extends TestCase
 {
@@ -73,6 +74,7 @@ class WebProfilerExtensionTest extends TestCase
         $this->container->setParameter('data_collector.templates', []);
         $this->container->set('kernel', $this->kernel);
         $this->container->addCompilerPass(new RegisterListenersPass());
+        $this->container->register('profile_stack', ProfileStack::class);
     }
 
     protected function tearDown(): void

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfileStack.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfileStack.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Profiler;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+final class ProfileStack
+{
+    /**
+     * @var \SplObjectStorage
+     */
+    private $profiles;
+
+    public function __construct()
+    {
+        $this->reset();
+    }
+
+    public function has(Request $request): bool
+    {
+        return isset($this->profiles[$request]);
+    }
+
+    public function get(Request $request): Profile
+    {
+        try {
+            return $this->profiles[$request];
+        } catch (\UnexpectedValueException $e) {
+            throw new \InvalidArgumentException('There is no profile in the stack for the passed request.');
+        }
+    }
+
+    public function set(Request $request, Profile $profile): void
+    {
+        $this->profiles[$request] = $profile;
+    }
+
+    public function reset(): void
+    {
+        $this->profiles = new \SplObjectStorage();
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfileStackTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfileStackTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Profiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\Profiler\ProfileStack;
+
+class ProfileStackTest extends TestCase
+{
+    public function test()
+    {
+        $profileStack = new ProfileStack();
+
+        $this->assertFalse($profileStack->has($request = new Request()));
+
+        $profileStack->set($request, $profile = new Profile('foo'));
+
+        $this->assertTrue($profileStack->has($request));
+
+        $this->assertSame($profile, $profileStack->get($request));
+
+        $profileStack->reset();
+
+        $this->assertFalse($profileStack->has($request));
+    }
+
+    public function testGetWitUnknownRequest()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('There is no profile in the stack for the passed request.');
+
+        (new ProfileStack())->get(new Request());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

So I did this quickly to get feedback. It could probably be splitted for clarity.

The goal of this work is to provide a better DX with Ajax requests in the WDT.

Having a private profile stack allow us to pass it to the `WebDebugToolbarListener` to process collected data and to directly build the profiler link with the useful panel.

I think that adding a direct link to the dumps panel when there are dumps in an Ajax request would be very useful.

It would also impove the work done in https://github.com/symfony/symfony/pull/26665 by being sure there is actually an exception in the exception panel.

Since all impacted classes were made `@final` in 4.3, it is easy to drop the current behavior (ie remove the double usage of the `$profiles` / `ProfileStack` in the `ProfilerListener` and the optional `ProfileStack` in the `WebDebugToolbarListener`) and to fully switch to the new one in 5.0.

👍 or 👎 ?