### PR TITLE
[Messenger] DispatchAfterCurrentBusMiddleware does not cancel messages from delayed handlers 

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -81,12 +81,16 @@ class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface
         // "Root dispatch" call is finished, dispatch stored messages.
         $exceptions = [];
         while (null !== $queueItem = array_shift($this->queue)) {
+            // Save how many messages are left in queue before handling the message
+            $queueLengthBefore = \count($this->queue);
             try {
                 // Execute the stored messages
                 $queueItem->getStack()->next()->handle($queueItem->getEnvelope(), $queueItem->getStack());
             } catch (\Exception $exception) {
                 // Gather all exceptions
                 $exceptions[] = $exception;
+                // Restore queue to previous state
+                $this->queue = \array_slice($this->queue, 0, $queueLengthBefore);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? |no
| Tests pass?   | yes  (thanks @Nyholm)
| Fixed tickets | #32370 
| License       | MIT
| Doc PR        | -

This is a fix for #32370. There is no need for anything sophisticated. There is no recursion or fancy stuff going on, just a queue of message handled sequentially. A simple variable is enough to keep track of the queue state.

Thanks @Nyholm for the test, it would clearly have been the hardest part of the job.