### PR TITLE
[Debug][DebugClassLoader] Include found files instead of requiring them

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -149,11 +149,11 @@ class DebugClassLoader
                 if (!$file = $this->classLoader[0]->findFile($class) ?: false) {
                     // no-op
                 } elseif (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($file)) {
-                    require $file;
+                    include $file;
 
                     return;
                 } else {
-                    require $file;
+                    include $file;
                 }
             } else {
                 \call_user_func($this->classLoader, $class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/32499
| License       | MIT
| Doc PR        | no

It fixes https://github.com/symfony/symfony/issues/32499 + it makes the `DebugClassLoader` behaves like composer `ClassLoader` that is very likely the wrapped class loader.