### PR TITLE
[FrameworkBundle] Fix descriptor of routes described as callable array

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -540,7 +540,7 @@ class TextDescriptor extends Descriptor
 
         try {
             if (\is_array($controller)) {
-                $r = new \ReflectionMethod($controller);
+                $r = new \ReflectionMethod($controller[0], $controller[1]);
             } elseif ($controller instanceof \Closure) {
                 $r = new \ReflectionFunction($controller);
             } elseif (method_exists($controller, '__invoke')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32324
| License       | MIT
| Doc PR        | 

The recent changes introduced a bug when routes are defined as callable array. Even statically is possible to see that the previous code was broken. I did not introduced any new tests. The current test case already does not test describing route collection that has fileLinkFormatter defined. 
