### PR TITLE
Added Nl translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -362,6 +362,10 @@
                 <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
                 <target>Dit wachtwoord is gelekt vanwege een data-inbreuk, het moet niet worden gebruikt. Kies een ander wachtwoord.</target>
             </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>Deze waarde moet zich tussen {{ min }} en {{ max }} bevinden.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Added NL translations for the validator when both `min` and `max` are set.

| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4, 4.2 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ~
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->