### PR TITLE
[Debug][DebugClassLoader] Don't check class if the included file doesn't exist

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -152,8 +152,8 @@ class DebugClassLoader
                     include $file;
 
                     return;
-                } else {
-                    include $file;
+                } elseif (false === include $file) {
+                    return;
                 }
             } else {
                 \call_user_func($this->classLoader, $class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Follow up to https://github.com/symfony/symfony/pull/32500.

If the included file doesn't exist, we need to return or the execution continues (if warnings are not thrown as exceptions) and then an invalid exception is thrown when the class is checked.

For example : "The autoloader expected class "App\Foo\Bar" to be defined in file "/var/www/html/vendor/composer/../../src/Foo/Bar.php". The file was found but the class was not in it, the class name or namespace probably has a typo".