### PR TITLE
[Intl][5.0] Add parameters type-hints

### DIFF
--- a/src/Symfony/Component/Intl/Collator/Collator.php
+++ b/src/Symfony/Component/Intl/Collator/Collator.php
@@ -90,7 +90,7 @@ class Collator
      *
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      */
-    public static function create($locale)
+    public static function create(?string $locale)
     {
         return new self($locale);
     }
@@ -106,7 +106,7 @@ class Collator
      *
      * @return bool True on success or false on failure
      */
-    public function asort(&$array, $sortFlag = self::SORT_REGULAR)
+    public function asort(array &$array, int $sortFlag = self::SORT_REGULAR)
     {
         $intlToPlainFlagMap = [
             self::SORT_REGULAR => \SORT_REGULAR,
@@ -134,7 +134,7 @@ class Collator
      *
      * @throws MethodNotImplementedException
      */
-    public function compare($str1, $str2)
+    public function compare(string $str1, string $str2)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -150,7 +150,7 @@ class Collator
      *
      * @throws MethodNotImplementedException
      */
-    public function getAttribute($attr)
+    public function getAttribute(int $attr)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -183,7 +183,7 @@ class Collator
      * @return string The locale used to create the collator. Currently always
      *                returns "en".
      */
-    public function getLocale($type = Locale::ACTUAL_LOCALE)
+    public function getLocale(int $type = Locale::ACTUAL_LOCALE)
     {
         return 'en';
     }
@@ -199,7 +199,7 @@ class Collator
      *
      * @throws MethodNotImplementedException
      */
-    public function getSortKey($string)
+    public function getSortKey(string $string)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -230,7 +230,7 @@ class Collator
      *
      * @throws MethodNotImplementedException
      */
-    public function setAttribute($attr, $val)
+    public function setAttribute(int $attr, int $val)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -252,7 +252,7 @@ class Collator
      *
      * @throws MethodNotImplementedException
      */
-    public function setStrength($strength)
+    public function setStrength(int $strength)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -268,7 +268,7 @@ class Collator
      *
      * @throws MethodNotImplementedException
      */
-    public function sortWithSortKeys(&$arr)
+    public function sortWithSortKeys(array &$arr)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -288,7 +288,7 @@ class Collator
      *
      * @throws MethodNotImplementedException
      */
-    public function sort(&$arr, $sortFlag = self::SORT_REGULAR)
+    public function sort(array &$arr, int $sortFlag = self::SORT_REGULAR)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }

--- a/src/Symfony/Component/Intl/Data/Bundle/Compiler/BundleCompilerInterface.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Compiler/BundleCompilerInterface.php
@@ -23,9 +23,6 @@ interface BundleCompilerInterface
     /**
      * Compiles a resource bundle at the given source to the given target
      * directory.
-     *
-     * @param string $sourcePath
-     * @param string $targetDir
      */
-    public function compile($sourcePath, $targetDir);
+    public function compile(string $sourcePath, string $targetDir);
 }

--- a/src/Symfony/Component/Intl/Data/Bundle/Compiler/GenrbCompiler.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Compiler/GenrbCompiler.php
@@ -46,7 +46,7 @@ class GenrbCompiler implements BundleCompilerInterface
     /**
      * {@inheritdoc}
      */
-    public function compile($sourcePath, $targetDir)
+    public function compile(string $sourcePath, string $targetDir)
     {
         if (is_dir($sourcePath)) {
             $sourcePath .= '/*.txt';

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BufferedBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BufferedBundleReader.php
@@ -37,7 +37,7 @@ class BufferedBundleReader implements BundleReaderInterface
     /**
      * {@inheritdoc}
      */
-    public function read($path, $locale)
+    public function read(string $path, string $locale)
     {
         $hash = $path.'//'.$locale;
 

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleEntryReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleEntryReader.php
@@ -53,7 +53,7 @@ class BundleEntryReader implements BundleEntryReaderInterface
      *
      * @param array $localeAliases A mapping of locale aliases to locales
      */
-    public function setLocaleAliases($localeAliases)
+    public function setLocaleAliases(array $localeAliases)
     {
         $this->localeAliases = $localeAliases;
     }
@@ -61,7 +61,7 @@ class BundleEntryReader implements BundleEntryReaderInterface
     /**
      * {@inheritdoc}
      */
-    public function read($path, $locale)
+    public function read(string $path, string $locale)
     {
         return $this->reader->read($path, $locale);
     }
@@ -69,7 +69,7 @@ class BundleEntryReader implements BundleEntryReaderInterface
     /**
      * {@inheritdoc}
      */
-    public function readEntry($path, $locale, array $indices, $fallback = true)
+    public function readEntry(string $path, string $locale, array $indices, bool $fallback = true)
     {
         $entry = null;
         $isMultiValued = false;

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleEntryReaderInterface.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleEntryReaderInterface.php
@@ -38,7 +38,6 @@ interface BundleEntryReaderInterface extends BundleReaderInterface
      *     $reader->readEntry('...', 'en', ['TopLevel', 'NestedLevel', 'Entry']);
      *
      * @param string   $path     The path to the resource bundle
-     * @param string   $locale   The locale to read
      * @param string[] $indices  The indices to read from the bundle
      * @param bool     $fallback Whether to merge the value with the value from
      *                           the fallback locale (e.g. "en" for "en_GB").
@@ -51,5 +50,5 @@ interface BundleEntryReaderInterface extends BundleReaderInterface
      *
      * @throws MissingResourceException If the indices cannot be accessed
      */
-    public function readEntry($path, $locale, array $indices, $fallback = true);
+    public function readEntry(string $path, string $locale, array $indices, bool $fallback = true);
 }

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleReaderInterface.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleReaderInterface.php
@@ -21,13 +21,8 @@ namespace Symfony\Component\Intl\Data\Bundle\Reader;
 interface BundleReaderInterface
 {
     /**
-     * Reads a resource bundle.
-     *
-     * @param string $path   The path to the resource bundle
-     * @param string $locale The locale to read
-     *
      * @return mixed returns an array or {@link \ArrayAccess} instance for
      *               complex data, a scalar value otherwise
      */
-    public function read($path, $locale);
+    public function read(string $path, string $locale);
 }

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/IntlBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/IntlBundleReader.php
@@ -26,7 +26,7 @@ class IntlBundleReader implements BundleReaderInterface
     /**
      * {@inheritdoc}
      */
-    public function read($path, $locale)
+    public function read(string $path, string $locale)
     {
         // Point for future extension: Modify this class so that it works also
         // if the \ResourceBundle class is not available.

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/JsonBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/JsonBundleReader.php
@@ -26,7 +26,7 @@ class JsonBundleReader implements BundleReaderInterface
     /**
      * {@inheritdoc}
      */
-    public function read($path, $locale)
+    public function read(string $path, string $locale)
     {
         $fileName = $path.'/'.$locale.'.json';
 

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/PhpBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/PhpBundleReader.php
@@ -26,7 +26,7 @@ class PhpBundleReader implements BundleReaderInterface
     /**
      * {@inheritdoc}
      */
-    public function read($path, $locale)
+    public function read(string $path, string $locale)
     {
         $fileName = $path.'/'.$locale.'.php';
 

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/BundleWriterInterface.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/BundleWriterInterface.php
@@ -23,9 +23,7 @@ interface BundleWriterInterface
     /**
      * Writes data to a resource bundle.
      *
-     * @param string $path   The path to the resource bundle
-     * @param string $locale The locale to (over-)write
-     * @param mixed  $data   The data to write
+     * @param mixed $data The data to write
      */
-    public function write($path, $locale, $data);
+    public function write(string $path, string $locale, $data);
 }

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/JsonBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/JsonBundleWriter.php
@@ -23,7 +23,7 @@ class JsonBundleWriter implements BundleWriterInterface
     /**
      * {@inheritdoc}
      */
-    public function write($path, $locale, $data)
+    public function write(string $path, string $locale, $data)
     {
         if ($data instanceof \Traversable) {
             $data = iterator_to_array($data);

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/PhpBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/PhpBundleWriter.php
@@ -23,7 +23,7 @@ class PhpBundleWriter implements BundleWriterInterface
     /**
      * {@inheritdoc}
      */
-    public function write($path, $locale, $data)
+    public function write(string $path, string $locale, $data)
     {
         $template = <<<'TEMPLATE'
 <?php

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
@@ -29,7 +29,7 @@ class TextBundleWriter implements BundleWriterInterface
     /**
      * {@inheritdoc}
      */
-    public function write($path, $locale, $data, $fallback = true)
+    public function write(string $path, string $locale, $data, bool $fallback = true)
     {
         $file = fopen($path.'/'.$locale.'.txt', 'w');
 

--- a/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
@@ -91,39 +91,26 @@ abstract class AbstractDataGenerator
     }
 
     /**
-     * @param string $sourceDir
-     *
      * @return string[]
      */
-    abstract protected function scanLocales(LocaleScanner $scanner, $sourceDir);
+    abstract protected function scanLocales(LocaleScanner $scanner, string $sourceDir);
 
-    /**
-     * @param string $sourceDir
-     * @param string $tempDir
-     */
-    abstract protected function compileTemporaryBundles(BundleCompilerInterface $compiler, $sourceDir, $tempDir);
+    abstract protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir);
 
     abstract protected function preGenerate();
 
     /**
-     * @param string $tempDir
-     * @param string $displayLocale
-     *
      * @return array|null
      */
-    abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale);
+    abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale);
 
     /**
-     * @param string $tempDir
-     *
      * @return array|null
      */
-    abstract protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir);
+    abstract protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir);
 
     /**
-     * @param string $tempDir
-     *
      * @return array|null
      */
-    abstract protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir);
+    abstract protected function generateDataForMeta(BundleEntryReaderInterface $reader, string $tempDir);
 }

--- a/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
@@ -51,7 +51,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, string $sourceDir)
     {
         return $scanner->scanLocales($sourceDir.'/curr');
     }
@@ -59,7 +59,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, $sourceDir, $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
     {
         $compiler->compile($sourceDir.'/curr', $tempDir);
         $compiler->compile($sourceDir.'/misc/currencyNumericCodes.txt', $tempDir);
@@ -76,7 +76,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale)
     {
         $localeBundle = $reader->read($tempDir, $displayLocale);
 
@@ -95,7 +95,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir)
     {
         $rootBundle = $reader->read($tempDir, 'root');
 
@@ -108,7 +108,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, string $tempDir)
     {
         $rootBundle = $reader->read($tempDir, 'root');
         $supplementalDataBundle = $reader->read($tempDir, 'supplementalData');

--- a/src/Symfony/Component/Intl/Data/Generator/FallbackTrait.php
+++ b/src/Symfony/Component/Intl/Data/Generator/FallbackTrait.php
@@ -25,23 +25,18 @@ trait FallbackTrait
     private $generatingFallback = false;
 
     /**
-     * @param string $tempDir
-     * @param string $displayLocale
-     *
      * @return array|null
      *
      * @see AbstractDataGenerator::generateDataForLocale()
      */
-    abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale);
+    abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale);
 
     /**
-     * @param string $tempDir
-     *
      * @return array|null
      *
      * @see AbstractDataGenerator::generateDataForRoot()
      */
-    abstract protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir);
+    abstract protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir);
 
     private function generateFallbackData(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale): array
     {

--- a/src/Symfony/Component/Intl/Data/Generator/GeneratorConfig.php
+++ b/src/Symfony/Component/Intl/Data/Generator/GeneratorConfig.php
@@ -38,10 +38,8 @@ class GeneratorConfig
 
     /**
      * Adds a writer to be used during the data conversion.
-     *
-     * @param string $targetDir The output directory
      */
-    public function addBundleWriter($targetDir, BundleWriterInterface $writer)
+    public function addBundleWriter(string $targetDir, BundleWriterInterface $writer)
     {
         $this->bundleWriters[$targetDir] = $writer;
     }

--- a/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
@@ -101,7 +101,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, string $sourceDir)
     {
         return $scanner->scanLocales($sourceDir.'/lang');
     }
@@ -109,7 +109,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, $sourceDir, $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
     {
         $compiler->compile($sourceDir.'/lang', $tempDir);
         $compiler->compile($sourceDir.'/misc/metadata.txt', $tempDir);
@@ -126,7 +126,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale)
     {
         $localeBundle = $reader->read($tempDir, $displayLocale);
 
@@ -146,14 +146,14 @@ class LanguageDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, string $tempDir)
     {
         $rootBundle = $reader->read($tempDir, 'root');
         $metadataBundle = $reader->read($tempDir, 'metadata');

--- a/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
@@ -36,7 +36,7 @@ class LocaleDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, string $sourceDir)
     {
         $this->locales = $scanner->scanLocales($sourceDir.'/locales');
         $this->localeAliases = $scanner->scanAliases($sourceDir.'/locales');
@@ -48,7 +48,7 @@ class LocaleDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, $sourceDir, $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
     {
         $filesystem = new Filesystem();
         $filesystem->mkdir([
@@ -74,7 +74,7 @@ class LocaleDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale)
     {
         // Don't generate aliases, as they are resolved during runtime
         // Unless an alias is needed as fallback for de-duplication purposes
@@ -133,14 +133,14 @@ class LocaleDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, string $tempDir)
     {
         return [
             'Locales' => $this->locales,

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -71,7 +71,7 @@ class RegionDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, string $sourceDir)
     {
         return $scanner->scanLocales($sourceDir.'/region');
     }
@@ -79,7 +79,7 @@ class RegionDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, $sourceDir, $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
     {
         $compiler->compile($sourceDir.'/region', $tempDir);
     }
@@ -95,7 +95,7 @@ class RegionDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale)
     {
         $localeBundle = $reader->read($tempDir, $displayLocale);
 
@@ -115,14 +115,14 @@ class RegionDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, string $tempDir)
     {
         $rootBundle = $reader->read($tempDir, 'root');
 

--- a/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
@@ -38,7 +38,7 @@ class ScriptDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, string $sourceDir)
     {
         return $scanner->scanLocales($sourceDir.'/lang');
     }
@@ -46,7 +46,7 @@ class ScriptDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, $sourceDir, $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
     {
         $compiler->compile($sourceDir.'/lang', $tempDir);
     }
@@ -62,7 +62,7 @@ class ScriptDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale)
     {
         $localeBundle = $reader->read($tempDir, $displayLocale);
 
@@ -82,14 +82,14 @@ class ScriptDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, string $tempDir)
     {
         $rootBundle = $reader->read($tempDir, 'root');
 

--- a/src/Symfony/Component/Intl/Data/Generator/TimezoneDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/TimezoneDataGenerator.php
@@ -42,7 +42,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, string $sourceDir)
     {
         $this->localeAliases = $scanner->scanAliases($sourceDir.'/locales');
 
@@ -52,7 +52,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, $sourceDir, $tempDir)
+    protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir)
     {
         $filesystem = new Filesystem();
         $filesystem->mkdir($tempDir.'/region');
@@ -75,7 +75,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale)
     {
         if (!$this->zoneToCountryMapping) {
             $this->zoneToCountryMapping = self::generateZoneToCountryMapping($reader->read($tempDir, 'windowsZones'));
@@ -126,7 +126,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir)
     {
         $rootBundle = $reader->read($tempDir, 'root');
 
@@ -139,7 +139,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, string $tempDir)
     {
         $rootBundle = $reader->read($tempDir, 'root');
 

--- a/src/Symfony/Component/Intl/Data/Util/LocaleScanner.php
+++ b/src/Symfony/Component/Intl/Data/Util/LocaleScanner.php
@@ -40,7 +40,7 @@ class LocaleScanner
      *               {@link scanAliases()} to determine which of the locales
      *               are aliases
      */
-    public function scanLocales($sourceDir)
+    public function scanLocales(string $sourceDir)
     {
         $locales = glob($sourceDir.'/*.txt');
 
@@ -65,7 +65,7 @@ class LocaleScanner
      * @return array An array with the locale aliases as keys and the aliased
      *               locales as values
      */
-    public function scanAliases($sourceDir)
+    public function scanAliases(string $sourceDir)
     {
         $locales = $this->scanLocales($sourceDir);
         $aliases = [];

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
@@ -118,7 +118,7 @@ class FullTransformer
      *
      * @throws \InvalidArgumentException When the value can not be matched with pattern
      */
-    public function parse(\DateTime $dateTime, $value)
+    public function parse(\DateTime $dateTime, string $value)
     {
         $reverseMatchingRegExp = $this->getReverseMatchingRegExp($this->pattern);
         $reverseMatchingRegExp = '/^'.$reverseMatchingRegExp.'$/';

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour1200Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour1200Transformer.php
@@ -26,7 +26,7 @@ class Hour1200Transformer extends HourTransformer
     public function format(\DateTime $dateTime, int $length): string
     {
         $hourOfDay = $dateTime->format('g');
-        $hourOfDay = '12' == $hourOfDay ? '0' : $hourOfDay;
+        $hourOfDay = '12' === $hourOfDay ? '0' : $hourOfDay;
 
         return $this->padLeft($hourOfDay, $length);
     }

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2400Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2400Transformer.php
@@ -33,9 +33,9 @@ class Hour2400Transformer extends HourTransformer
      */
     public function normalizeHour(int $hour, string $marker = null): int
     {
-        if ('AM' == $marker) {
+        if ('AM' === $marker) {
             $hour = 0;
-        } elseif ('PM' == $marker) {
+        } elseif ('PM' === $marker) {
             $hour = 12;
         }
 

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2401Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2401Transformer.php
@@ -26,7 +26,7 @@ class Hour2401Transformer extends HourTransformer
     public function format(\DateTime $dateTime, int $length): string
     {
         $hourOfDay = $dateTime->format('G');
-        $hourOfDay = ('0' == $hourOfDay) ? '24' : $hourOfDay;
+        $hourOfDay = '0' === $hourOfDay ? '24' : $hourOfDay;
 
         return $this->padLeft($hourOfDay, $length);
     }
@@ -36,9 +36,9 @@ class Hour2401Transformer extends HourTransformer
      */
     public function normalizeHour(int $hour, string $marker = null): int
     {
-        if ((null === $marker && 24 === $hour) || 'AM' == $marker) {
+        if ((null === $marker && 24 === $hour) || 'AM' === $marker) {
             $hour = 0;
-        } elseif ('PM' == $marker) {
+        } elseif ('PM' === $marker) {
             $hour = 12;
         }
 

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimezoneTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimezoneTransformer.php
@@ -97,12 +97,12 @@ class TimezoneTransformer extends Transformer
      * @throws NotImplementedException   When the GMT time zone have minutes offset different than zero
      * @throws \InvalidArgumentException When the value can not be matched with pattern
      */
-    public static function getEtcTimeZoneId($formattedTimeZone)
+    public static function getEtcTimeZoneId(string $formattedTimeZone)
     {
         if (preg_match('/GMT(?P<signal>[+-])(?P<hours>\d{2}):?(?P<minutes>\d{2})/', $formattedTimeZone, $matches)) {
             $hours = (int) $matches['hours'];
             $minutes = (int) $matches['minutes'];
-            $signal = '-' == $matches['signal'] ? '+' : '-';
+            $signal = '-' === $matches['signal'] ? '+' : '-';
 
             if (0 < $minutes) {
                 throw new NotImplementedException(sprintf('It is not possible to use a GMT time zone with minutes offset different than zero (0). GMT time zone tried: %s.', $formattedTimeZone));

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -168,7 +168,7 @@ class IntlDateFormatter
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
-    public static function create($locale, $datetype, $timetype, $timezone = null, $calendar = self::GREGORIAN, $pattern = null)
+    public static function create(?string $locale, ?int $datetype, ?int $timetype, $timezone = null, int $calendar = self::GREGORIAN, ?string $pattern = null)
     {
         return new self($locale, $datetype, $timetype, $timezone, $calendar, $pattern);
     }
@@ -235,7 +235,7 @@ class IntlDateFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public function formatObject($object, $format = null, $locale = null)
+    public function formatObject(object $object, $format = null, string $locale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -313,7 +313,7 @@ class IntlDateFormatter
      *
      * @see https://php.net/intldateformatter.getlocale
      */
-    public function getLocale($type = Locale::ACTUAL_LOCALE)
+    public function getLocale(int $type = Locale::ACTUAL_LOCALE)
     {
         return 'en';
     }
@@ -401,7 +401,7 @@ class IntlDateFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public function localtime($value, &$position = 0)
+    public function localtime(string $value, int &$position = 0)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -421,7 +421,7 @@ class IntlDateFormatter
      *
      * @throws MethodArgumentNotImplementedException When $position different than null, behavior not implemented
      */
-    public function parse($value, &$position = null)
+    public function parse(string $value, int &$position = null)
     {
         // We don't calculate the position when parsing the value
         if (null !== $position) {
@@ -451,7 +451,7 @@ class IntlDateFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public function setCalendar($calendar)
+    public function setCalendar(string $calendar)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -473,7 +473,7 @@ class IntlDateFormatter
      *
      * @throws MethodArgumentValueNotImplementedException When $lenient is true
      */
-    public function setLenient($lenient)
+    public function setLenient(bool $lenient)
     {
         if ($lenient) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'lenient', $lenient, 'Only the strict parser is supported');
@@ -492,7 +492,7 @@ class IntlDateFormatter
      * @see https://php.net/intldateformatter.setpattern
      * @see http://userguide.icu-project.org/formatparse/datetime
      */
-    public function setPattern($pattern)
+    public function setPattern(?string $pattern)
     {
         if (null === $pattern) {
             $pattern = $this->getDefaultPattern();
@@ -514,7 +514,7 @@ class IntlDateFormatter
      *
      * @see https://php.net/intldateformatter.settimezoneid
      */
-    public function setTimeZoneId($timeZoneId)
+    public function setTimeZoneId(?string $timeZoneId)
     {
         if (null === $timeZoneId) {
             $timeZoneId = date_default_timezone_get();
@@ -580,11 +580,9 @@ class IntlDateFormatter
      * Create and returns a DateTime object with the specified timestamp and with the
      * current time zone.
      *
-     * @param int $timestamp
-     *
      * @return \DateTime
      */
-    protected function createDateTime($timestamp)
+    protected function createDateTime(int $timestamp)
     {
         $dateTime = new \DateTime();
         $dateTime->setTimestamp($timestamp);

--- a/src/Symfony/Component/Intl/Globals/IntlGlobals.php
+++ b/src/Symfony/Component/Intl/Globals/IntlGlobals.php
@@ -61,7 +61,7 @@ abstract class IntlGlobals
      *
      * @return bool
      */
-    public static function isFailure($errorCode)
+    public static function isFailure(int $errorCode)
     {
         return isset(self::$errorCodes[$errorCode])
             && $errorCode > self::U_ZERO_ERROR;
@@ -98,7 +98,7 @@ abstract class IntlGlobals
      *
      * @return string
      */
-    public static function getErrorName($code)
+    public static function getErrorName(int $code)
     {
         return self::$errorCodes[$code] ?? '[BOGUS UErrorCode]';
     }
@@ -111,7 +111,7 @@ abstract class IntlGlobals
      *
      * @throws \InvalidArgumentException If the code is not one of the error constants in this class
      */
-    public static function setError($code, $message = '')
+    public static function setError(int $code, string $message = '')
     {
         if (!isset(self::$errorCodes[$code])) {
             throw new \InvalidArgumentException(sprintf('No such error code: "%s"', $code));

--- a/src/Symfony/Component/Intl/Locale.php
+++ b/src/Symfony/Component/Intl/Locale.php
@@ -60,12 +60,10 @@ final class Locale extends \Locale
      * the default fallback locale configured with {@link setDefaultFallback()}.
      * The default fallback locale has no fallback.
      *
-     * @param string $locale The ICU locale code to find the fallback for
-     *
      * @return string|null The ICU locale code of the fallback locale, or null
      *                     if no fallback exists
      */
-    public static function getFallback($locale): ?string
+    public static function getFallback(string $locale): ?string
     {
         if (\function_exists('locale_parse')) {
             $localeSubTags = locale_parse($locale);

--- a/src/Symfony/Component/Intl/Locale/Locale.php
+++ b/src/Symfony/Component/Intl/Locale/Locale.php
@@ -52,7 +52,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function acceptFromHttp($header)
+    public static function acceptFromHttp(string $header)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -63,14 +63,10 @@ class Locale
      * This polyfill doesn't implement the full-spec algorithm. It only
      * canonicalizes locale strings handled by the `LocaleBundle` class.
      *
-     * @param string $locale
-     *
      * @return string
      */
-    public static function canonicalize($locale)
+    public static function canonicalize(string $locale)
     {
-        $locale = (string) $locale;
-
         if ('' === $locale || '.' === $locale[0]) {
             return self::getDefault();
         }
@@ -119,7 +115,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function filterMatches($langtag, $locale, $canonicalize = false)
+    public static function filterMatches(string $langtag, string $locale, bool $canonicalize = false)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -135,7 +131,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getAllVariants($locale)
+    public static function getAllVariants(string $locale)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -164,7 +160,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayLanguage($locale, $inLocale = null)
+    public static function getDisplayLanguage(string $locale, string $inLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -181,7 +177,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayName($locale, $inLocale = null)
+    public static function getDisplayName(string $locale, string $inLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -198,7 +194,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayRegion($locale, $inLocale = null)
+    public static function getDisplayRegion(string $locale, string $inLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -215,7 +211,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayScript($locale, $inLocale = null)
+    public static function getDisplayScript(string $locale, string $inLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -232,7 +228,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayVariant($locale, $inLocale = null)
+    public static function getDisplayVariant(string $locale, string $inLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -248,7 +244,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getKeywords($locale)
+    public static function getKeywords(string $locale)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -264,7 +260,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getPrimaryLanguage($locale)
+    public static function getPrimaryLanguage(string $locale)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -280,7 +276,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getRegion($locale)
+    public static function getRegion(string $locale)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -296,7 +292,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getScript($locale)
+    public static function getScript(string $locale)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -313,7 +309,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function lookup(array $langtag, $locale, $canonicalize = false, $default = null)
+    public static function lookup(array $langtag, string $locale, bool $canonicalize = false, string $default = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -329,7 +325,7 @@ class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function parseLocale($locale)
+    public static function parseLocale(string $locale)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -337,15 +333,13 @@ class Locale
     /**
      * Not supported. Sets the default runtime locale.
      *
-     * @param string $locale The locale code
-     *
      * @return bool true on success or false on failure
      *
      * @see https://php.net/locale.setdefault
      *
      * @throws MethodNotImplementedException
      */
-    public static function setDefault($locale)
+    public static function setDefault(string $locale)
     {
         if ('en' !== $locale) {
             throw new MethodNotImplementedException(__METHOD__);

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -257,7 +257,7 @@ class NumberFormatter
      * @throws MethodArgumentValueNotImplementedException When the $style is not supported
      * @throws MethodArgumentNotImplementedException      When the pattern value is different than null
      */
-    public function __construct(?string $locale = 'en', int $style = null, $pattern = null)
+    public function __construct(?string $locale = 'en', int $style = null, string $pattern = null)
     {
         if ('en' !== $locale && null !== $locale) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
@@ -278,13 +278,13 @@ class NumberFormatter
     /**
      * Static constructor.
      *
-     * @param string $locale  The locale code. The only supported locale is "en" (or null using the default locale, i.e. "en")
-     * @param int    $style   Style of the formatting, one of the format style constants.
-     *                        The only currently supported styles are NumberFormatter::DECIMAL
-     *                        and NumberFormatter::CURRENCY.
-     * @param string $pattern Not supported. A pattern string in case $style is NumberFormat::PATTERN_DECIMAL or
-     *                        NumberFormat::PATTERN_RULEBASED. It must conform to  the syntax
-     *                        described in the ICU DecimalFormat or ICU RuleBasedNumberFormat documentation
+     * @param string|null $locale  The locale code. The only supported locale is "en" (or null using the default locale, i.e. "en")
+     * @param int         $style   Style of the formatting, one of the format style constants.
+     *                             The only currently supported styles are NumberFormatter::DECIMAL
+     *                             and NumberFormatter::CURRENCY.
+     * @param string      $pattern Not supported. A pattern string in case $style is NumberFormat::PATTERN_DECIMAL or
+     *                             NumberFormat::PATTERN_RULEBASED. It must conform to  the syntax
+     *                             described in the ICU DecimalFormat or ICU RuleBasedNumberFormat documentation
      *
      * @return self
      *
@@ -296,7 +296,7 @@ class NumberFormatter
      * @throws MethodArgumentValueNotImplementedException When the $style is not supported
      * @throws MethodArgumentNotImplementedException      When the pattern value is different than null
      */
-    public static function create($locale = 'en', $style = null, $pattern = null)
+    public static function create(?string $locale = 'en', int $style = null, string $pattern = null)
     {
         return new self($locale, $style, $pattern);
     }
@@ -304,7 +304,6 @@ class NumberFormatter
     /**
      * Format a currency value.
      *
-     * @param float  $value    The numeric currency value
      * @param string $currency The 3-letter ISO 4217 currency code indicating the currency to use
      *
      * @return string The formatted currency value
@@ -312,9 +311,9 @@ class NumberFormatter
      * @see https://php.net/numberformatter.formatcurrency
      * @see https://en.wikipedia.org/wiki/ISO_4217#Active_codes
      */
-    public function formatCurrency($value, $currency)
+    public function formatCurrency(float $value, string $currency)
     {
-        if (self::DECIMAL == $this->style) {
+        if (self::DECIMAL === $this->style) {
             return $this->format($value);
         }
 
@@ -351,16 +350,16 @@ class NumberFormatter
      * @throws NotImplementedException                    If the method is called with the class $style 'CURRENCY'
      * @throws MethodArgumentValueNotImplementedException If the $type is different than TYPE_DEFAULT
      */
-    public function format($value, $type = self::TYPE_DEFAULT)
+    public function format($value, int $type = self::TYPE_DEFAULT)
     {
         // The original NumberFormatter does not support this format type
-        if (self::TYPE_CURRENCY == $type) {
+        if (self::TYPE_CURRENCY === $type) {
             trigger_error(__METHOD__.'(): Unsupported format type '.$type, \E_USER_WARNING);
 
             return false;
         }
 
-        if (self::CURRENCY == $this->style) {
+        if (self::CURRENCY === $this->style) {
             throw new NotImplementedException(sprintf('%s() method does not support the formatting of currencies (instance with CURRENCY style). %s', __METHOD__, NotImplementedException::INTL_INSTALL_MESSAGE));
         }
 
@@ -385,11 +384,11 @@ class NumberFormatter
      *
      * @param int $attr An attribute specifier, one of the numeric attribute constants
      *
-     * @return bool|int The attribute value on success or false on error
+     * @return int|false The attribute value on success or false on error
      *
      * @see https://php.net/numberformatter.getattribute
      */
-    public function getAttribute($attr)
+    public function getAttribute(int $attr)
     {
         return isset($this->attributes[$attr]) ? $this->attributes[$attr] : null;
     }
@@ -430,7 +429,7 @@ class NumberFormatter
      *
      * @see https://php.net/numberformatter.getlocale
      */
-    public function getLocale($type = Locale::ACTUAL_LOCALE)
+    public function getLocale(int $type = Locale::ACTUAL_LOCALE)
     {
         return 'en';
     }
@@ -438,7 +437,7 @@ class NumberFormatter
     /**
      * Not supported. Returns the formatter's pattern.
      *
-     * @return bool|string The pattern string used by the formatter or false on error
+     * @return string|false The pattern string used by the formatter or false on error
      *
      * @see https://php.net/numberformatter.getpattern
      *
@@ -454,11 +453,11 @@ class NumberFormatter
      *
      * @param int $attr A symbol specifier, one of the format symbol constants
      *
-     * @return bool|string The symbol value or false on error
+     * @return string|false The symbol value or false on error
      *
      * @see https://php.net/numberformatter.getsymbol
      */
-    public function getSymbol($attr)
+    public function getSymbol(int $attr)
     {
         return \array_key_exists($this->style, self::$enSymbols) && \array_key_exists($attr, self::$enSymbols[$this->style]) ? self::$enSymbols[$this->style][$attr] : false;
     }
@@ -468,11 +467,11 @@ class NumberFormatter
      *
      * @param int $attr An attribute specifier, one of the text attribute constants
      *
-     * @return bool|string The attribute value or false on error
+     * @return string|false The attribute value or false on error
      *
      * @see https://php.net/numberformatter.gettextattribute
      */
-    public function getTextAttribute($attr)
+    public function getTextAttribute(int $attr)
     {
         return \array_key_exists($this->style, self::$enTextAttributes) && \array_key_exists($attr, self::$enTextAttributes[$this->style]) ? self::$enTextAttributes[$this->style][$attr] : false;
     }
@@ -484,13 +483,13 @@ class NumberFormatter
      * @param string $currency Parameter to receive the currency name (reference)
      * @param int    $position Offset to begin the parsing on return this value will hold the offset at which the parsing ended
      *
-     * @return bool|string The parsed numeric value or false on error
+     * @return float|false The parsed numeric value or false on error
      *
      * @see https://php.net/numberformatter.parsecurrency
      *
      * @throws MethodNotImplementedException
      */
-    public function parseCurrency($value, &$currency, &$position = null)
+    public function parseCurrency(string $value, string &$currency, int &$position = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -506,9 +505,9 @@ class NumberFormatter
      *
      * @see https://php.net/numberformatter.parse
      */
-    public function parse($value, $type = self::TYPE_DOUBLE, &$position = 0)
+    public function parse(string $value, int $type = self::TYPE_DOUBLE, int &$position = 0)
     {
-        if (self::TYPE_DEFAULT == $type || self::TYPE_CURRENCY == $type) {
+        if (self::TYPE_DEFAULT === $type || self::TYPE_CURRENCY === $type) {
             trigger_error(__METHOD__.'(): Unsupported format type '.$type, \E_USER_WARNING);
 
             return false;
@@ -551,10 +550,9 @@ class NumberFormatter
     /**
      * Set an attribute.
      *
-     * @param int $attr  An attribute specifier, one of the numeric attribute constants.
-     *                   The only currently supported attributes are NumberFormatter::FRACTION_DIGITS,
-     *                   NumberFormatter::GROUPING_USED and NumberFormatter::ROUNDING_MODE.
-     * @param int $value The attribute value
+     * @param int $attr An attribute specifier, one of the numeric attribute constants.
+     *                  The only currently supported attributes are NumberFormatter::FRACTION_DIGITS,
+     *                  NumberFormatter::GROUPING_USED and NumberFormatter::ROUNDING_MODE.
      *
      * @return bool true on success or false on failure
      *
@@ -563,7 +561,7 @@ class NumberFormatter
      * @throws MethodArgumentValueNotImplementedException When the $attr is not supported
      * @throws MethodArgumentValueNotImplementedException When the $value is not supported
      */
-    public function setAttribute($attr, $value)
+    public function setAttribute(int $attr, int $value)
     {
         if (!\in_array($attr, self::$supportedAttributes)) {
             $message = sprintf(
@@ -574,7 +572,7 @@ class NumberFormatter
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'attr', $value, $message);
         }
 
-        if (self::$supportedAttributes['ROUNDING_MODE'] == $attr && $this->isInvalidRoundingMode($value)) {
+        if (self::$supportedAttributes['ROUNDING_MODE'] === $attr && $this->isInvalidRoundingMode($value)) {
             $message = sprintf(
                 'The supported values for ROUNDING_MODE are: %s',
                 implode(', ', array_keys(self::$roundingModes))
@@ -583,11 +581,11 @@ class NumberFormatter
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'attr', $value, $message);
         }
 
-        if (self::$supportedAttributes['GROUPING_USED'] == $attr) {
+        if (self::$supportedAttributes['GROUPING_USED'] === $attr) {
             $value = $this->normalizeGroupingUsedValue($value);
         }
 
-        if (self::$supportedAttributes['FRACTION_DIGITS'] == $attr) {
+        if (self::$supportedAttributes['FRACTION_DIGITS'] === $attr) {
             $value = $this->normalizeFractionDigitsValue($value);
             if ($value < 0) {
                 // ignore negative values but do not raise an error
@@ -613,7 +611,7 @@ class NumberFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public function setPattern($pattern)
+    public function setPattern(string $pattern)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -630,7 +628,7 @@ class NumberFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public function setSymbol($attr, $value)
+    public function setSymbol(int $attr, string $value)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -647,7 +645,7 @@ class NumberFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public function setTextAttribute($attr, $value)
+    public function setTextAttribute(int $attr, string $value)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -751,7 +749,7 @@ class NumberFormatter
      */
     private function getUninitializedPrecision($value, int $precision): int
     {
-        if (self::CURRENCY == $this->style) {
+        if (self::CURRENCY === $this->style) {
             return $precision;
         }
 
@@ -782,11 +780,11 @@ class NumberFormatter
      */
     private function convertValueDataType($value, int $type)
     {
-        if (self::TYPE_DOUBLE == $type) {
+        if (self::TYPE_DOUBLE === $type) {
             $value = (float) $value;
-        } elseif (self::TYPE_INT32 == $type) {
+        } elseif (self::TYPE_INT32 === $type) {
             $value = $this->getInt32Value($value);
-        } elseif (self::TYPE_INT64 == $type) {
+        } elseif (self::TYPE_INT64 === $type) {
             $value = $this->getInt64Value($value);
         }
 

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -379,7 +379,6 @@ abstract class AbstractNumberFormatterTest extends TestCase
             [1.123, '1.1', 1, 1],
             [1.123, '1.12', 2, 2],
             [1.123, '1.123', -1, 0],
-            [1.123, '1', 'abc', 0],
         ];
     }
 
@@ -411,7 +410,6 @@ abstract class AbstractNumberFormatterTest extends TestCase
             [1000, '1000', 0, 0],
             [1000, '1,000', 1, 1],
             [1000, '1,000', 2, 1],
-            [1000, '1000', 'abc', 0],
             [1000, '1,000', -1, 1],
         ];
     }

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -42,7 +42,7 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
-        $formatter->setAttribute(NumberFormatter::LENIENT_PARSE, null);
+        $formatter->setAttribute(NumberFormatter::LENIENT_PARSE, 100);
     }
 
     public function testSetAttributeInvalidRoundingMode()
@@ -145,28 +145,29 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
-        $formatter->parseCurrency(null, $currency);
+        $currency = 'USD';
+        $formatter->parseCurrency(3, $currency);
     }
 
     public function testSetPattern()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
-        $formatter->setPattern(null);
+        $formatter->setPattern('#0');
     }
 
     public function testSetSymbol()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
-        $formatter->setSymbol(null, null);
+        $formatter->setSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL, '*');
     }
 
     public function testSetTextAttribute()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
-        $formatter->setTextAttribute(null, null);
+        $formatter->setTextAttribute(NumberFormatter::NEGATIVE_PREFIX, '-');
     }
 
     protected function getNumberFormatter($locale = 'en', $style = null, $pattern = null)

--- a/src/Symfony/Component/Intl/Util/IcuVersion.php
+++ b/src/Symfony/Component/Intl/Util/IcuVersion.php
@@ -43,9 +43,6 @@ class IcuVersion
      *     IcuVersion::compare('1', '10', '==')
      *     // => true
      *
-     * @param string   $version1  A version string
-     * @param string   $version2  A version string to compare
-     * @param string   $operator  The comparison operator
      * @param int|null $precision The number of components to compare. Pass
      *                            NULL to compare the versions unchanged.
      *
@@ -53,7 +50,7 @@ class IcuVersion
      *
      * @see normalize()
      */
-    public static function compare($version1, $version2, $operator, $precision = null)
+    public static function compare(string $version1, string $version2, string $operator, ?int $precision = null)
     {
         $version1 = self::normalize($version1, $precision);
         $version2 = self::normalize($version2, $precision);
@@ -80,14 +77,13 @@ class IcuVersion
      *     IcuVersion::normalize('1.2.3.4', 2);
      *     // => '12.3'
      *
-     * @param string   $version   An ICU version string
      * @param int|null $precision The number of components to include. Pass
      *                            NULL to return the version unchanged.
      *
      * @return string|null the normalized ICU version or NULL if it couldn't be
      *                     normalized
      */
-    public static function normalize($version, $precision)
+    public static function normalize(string $version, ?int $precision)
     {
         $version = preg_replace('/^(\d)\.(\d)/', '$1$2', $version);
 

--- a/src/Symfony/Component/Intl/Util/Version.php
+++ b/src/Symfony/Component/Intl/Util/Version.php
@@ -33,9 +33,6 @@ class Version
      *     Version::compare('1.2.3', '1.2.4', '==', 2)
      *     // => true
      *
-     * @param string   $version1  A version string
-     * @param string   $version2  A version string to compare
-     * @param string   $operator  The comparison operator
      * @param int|null $precision The number of components to compare. Pass
      *                            NULL to compare the versions unchanged.
      *
@@ -43,7 +40,7 @@ class Version
      *
      * @see normalize()
      */
-    public static function compare($version1, $version2, $operator, $precision = null)
+    public static function compare(string $version1, string $version2, string $operator, ?int $precision = null)
     {
         $version1 = self::normalize($version1, $precision);
         $version2 = self::normalize($version2, $precision);
@@ -63,14 +60,13 @@ class Version
      *     Version::normalize('1.2.3', 2);
      *     // => '1.2'
      *
-     * @param string   $version   A version string
      * @param int|null $precision The number of components to include. Pass
      *                            NULL to return the version unchanged.
      *
      * @return string|null the normalized version or NULL if it couldn't be
      *                     normalized
      */
-    public static function normalize($version, $precision)
+    public static function normalize(string $version, ?int $precision)
     {
         if (null === $precision) {
             return $version;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | continuation of https://github.com/symfony/symfony/pull/24722 and checks for  #32179
| License       | MIT
| Doc PR        | N/A

This PR replaces docblocks by type hints in the Intl component considering #32179. Some docblocks without valuable information got also removed.