### PR TITLE
[HttpKernel] trim the leading backslash in the controller init

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ContainerControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ContainerControllerResolver.php
@@ -47,6 +47,8 @@ class ContainerControllerResolver extends ControllerResolver
      */
     protected function instantiateController($class)
     {
+        $class = ltrim($class, '\\');
+
         if ($this->container->has($class)) {
             return $this->container->get($class);
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
@@ -119,6 +119,36 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $this->assertSame($service, $controller);
     }
 
+    /**
+     * @dataProvider getControllers
+     */
+    public function testInstantiateControllerWhenControllerStartsWithABackslash($controller)
+    {
+        $service = new ControllerTestService('foo');
+        $class = ControllerTestService::class;
+
+        $container = $this->createMockContainer();
+        $container->expects($this->once())->method('has')->with($class)->willReturn(true);
+        $container->expects($this->once())->method('get')->with($class)->willReturn($service);
+
+        $resolver = $this->createControllerResolver(null, $container);
+        $request = Request::create('/');
+        $request->attributes->set('_controller', $controller);
+
+        $controller = $resolver->getController($request);
+
+        $this->assertInstanceOf(ControllerTestService::class, $controller[0]);
+        $this->assertSame('action', $controller[1]);
+    }
+
+    public function getControllers()
+    {
+        return [
+            ['\\'.ControllerTestService::class.'::action'],
+            ['\\'.ControllerTestService::class.':action'],
+        ];
+    }
+
     public function testExceptionWhenUsingRemovedControllerServiceWithClassNameAsName()
     {
         $this->expectException('InvalidArgumentException');

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -38,6 +38,18 @@ class ControllerResolverTest extends TestCase
         $this->assertSame($lambda, $controller);
     }
 
+    public function testGetControllerWithStartingBackslash()
+    {
+        $resolver = $this->createControllerResolver();
+
+        $request = Request::create('/');
+        $request->attributes->set('_controller', '\\'.ControllerTest::class.'::publicAction');
+        $controller = $resolver->getController($request);
+
+        $this->assertInstanceOf(ControllerTest::class, $controller[0]);
+        $this->assertSame('publicAction', $controller[1]);
+    }
+
     public function testGetControllerWithObjectAndInvokeMethod()
     {
         $resolver = $this->createControllerResolver();
@@ -66,6 +78,17 @@ class ControllerResolverTest extends TestCase
 
         $request = Request::create('/');
         $request->attributes->set('_controller', [ControllerTest::class, 'publicAction']);
+        $controller = $resolver->getController($request);
+        $this->assertInstanceOf(ControllerTest::class, $controller[0]);
+        $this->assertSame('publicAction', $controller[1]);
+    }
+
+    public function testGetControllerWithClassAndMethodAsArrayWithBackslash()
+    {
+        $resolver = $this->createControllerResolver();
+
+        $request = Request::create('/');
+        $request->attributes->set('_controller', ['\\'.ControllerTest::class, 'publicAction']);
         $controller = $resolver->getController($request);
         $this->assertInstanceOf(ControllerTest::class, $controller[0]);
         $this->assertSame('publicAction', $controller[1]);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -38,18 +38,6 @@ class ControllerResolverTest extends TestCase
         $this->assertSame($lambda, $controller);
     }
 
-    public function testGetControllerWithStartingBackslash()
-    {
-        $resolver = $this->createControllerResolver();
-
-        $request = Request::create('/');
-        $request->attributes->set('_controller', '\\'.ControllerTest::class.'::publicAction');
-        $controller = $resolver->getController($request);
-
-        $this->assertInstanceOf(ControllerTest::class, $controller[0]);
-        $this->assertSame('publicAction', $controller[1]);
-    }
-
     public function testGetControllerWithObjectAndInvokeMethod()
     {
         $resolver = $this->createControllerResolver();
@@ -78,17 +66,6 @@ class ControllerResolverTest extends TestCase
 
         $request = Request::create('/');
         $request->attributes->set('_controller', [ControllerTest::class, 'publicAction']);
-        $controller = $resolver->getController($request);
-        $this->assertInstanceOf(ControllerTest::class, $controller[0]);
-        $this->assertSame('publicAction', $controller[1]);
-    }
-
-    public function testGetControllerWithClassAndMethodAsArrayWithBackslash()
-    {
-        $resolver = $this->createControllerResolver();
-
-        $request = Request::create('/');
-        $request->attributes->set('_controller', ['\\'.ControllerTest::class, 'publicAction']);
         $controller = $resolver->getController($request);
         $this->assertInstanceOf(ControllerTest::class, $controller[0]);
         $this->assertSame('publicAction', $controller[1]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29945
| License       | MIT
| Doc PR        | none <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This fixes an error where the classes exists when using a leading backslash in the controller, it's not invalid to do so.

see https://github.com/symfony/symfony/pull/30045#discussion_r271716906

