### PR TITLE
Allow to rename uploaded files using common patterns

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -238,33 +238,18 @@ class UploadedFile extends File
 
     public function moveAndRename(string $targetDirectory, string $fileNamePattern)
     {
-        $fileName = str_replace(
-            [
-                '[contenthash]',
-                '[day]',
-                '[extension]',
-                '[month]',
-                '[name]',
-                '[randomhash]',
-                '[slug]',
-                '[timestamp]',
-                '[uuid]',
-                '[year]',
-            ],
-            [
-                sha1_file($this->getRealPath()),
-                date('d'),
-                $this->getExtension(),
-                date('m'),
-                $this->getBasename(),
-                bin2hex(random_bytes(20)),
-                transliterator_transliterate('Any-Latin; Latin-ASCII; [^A-Za-z0-9_] remove; Lower()', $this->getBasename()),
-                time(),
-                $this->generateUuid4(),
-                date('Y'),
-            ],
-            $fileNamePattern
-        );
+        $fileName = strtr($fileNamePattern, [
+            '[contenthash]' => sha1_file($this->getRealPath()),,
+            '[day]' => date('d'),
+            '[extension]' => $this->getExtension(),
+            '[month]' => date('m'),
+            '[name]' => $this->getBasename(),
+            '[randomhash]' => bin2hex(random_bytes(20)),
+            '[slug]' => transliterator_transliterate('Any-Latin; Latin-ASCII; [^A-Za-z0-9_] remove; Lower()', $this->getBasename()),
+            '[timestamp]' => time(),
+            '[uuid]' => $this->generateUuid4(),
+            '[year]' => date('Y'),
+        ]);
 
         return $this->move($targetDirectory, $fileName);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

If you read the [SymfonyDocs about uploading files](https://symfony.com/doc/current/controller/upload_file.html), you'll find code like this:

```php
$originalFilename = pathinfo($uploadedFile->getClientOriginalName(), PATHINFO_FILENAME);
$safeFilename = transliterator_transliterate('Any-Latin; Latin-ASCII; [^A-Za-z0-9_] remove; Lower()', $originalFilename);
$newFilename = $safeFilename.'-'.uniqid().'.'.$uploadedFile->guessExtension();

$uploadedFile->move('/path/to/uploads', $newFilename);
``` 

This code is verbose and repetitive, so I propose to add a little method to `UploadFile` class to simplify the previous code. If this PR is approved, the previous code will look like this:

```php
$uploadedFile->moveAndRename(
    '/path/to/uploads',
    '[slug]-[randomhash].[extension]'
);
```

The new method would be small, but it will allow lots of different solutions:

```php
$uploadedFile->moveAndRename('...', '[name]-[timestamp].[extension]');
$uploadedFile->moveAndRename('...', 'photo-[contenthash].[extension]');
$uploadedFile->moveAndRename('...', '[year]/[month]/file-[day]-[randomhash].[extension]');
$uploadedFile->moveAndRename('...', '[uuid].[extension]');
$uploadedFile->moveAndRename('...', 'contract-[randomhash]-[timestamp].[extension]');
```

## Next steps

If this proposal is approved:

* I'll finish it adding tests and docs.
* We need to think if the given patterns are enough to cover the most common cases.
* Should we allow defining the `[extension]` pattern .. or should we always add the guessed extension as a mandatory behavior?
* We need to think if adding a new method (`moveAndRename()`) is OK or if we could solve this differently with the existing methods.

Thanks!