### PR TITLE
[HttpClient] Allow enabling buffering conditionally with a Closure

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * added `$response->toStream()` to cast responses to regular PHP streams
  * made `Psr18Client` implement relevant PSR-17 factories and have streaming responses
  * added `TraceableHttpClient`, `HttpClientDataCollector` and `HttpClientPass` to integrate with the web profiler
+ * allow enabling buffering conditionally with a Closure
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -68,9 +68,8 @@ class CachingHttpClient implements HttpClientInterface
     {
         [$url, $options] = $this->prepareRequest($method, $url, $options, $this->defaultOptions, true);
         $url = implode('', $url);
-        $options['extra']['no_cache'] = $options['extra']['no_cache'] ?? !$options['buffer'];
 
-        if (!empty($options['body']) || $options['extra']['no_cache'] || !\in_array($method, ['GET', 'HEAD', 'OPTIONS'])) {
+        if (!empty($options['body']) || !empty($options['extra']['no_cache']) || !\in_array($method, ['GET', 'HEAD', 'OPTIONS'])) {
             return $this->client->request($method, $url, $options);
         }
 

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -37,7 +37,9 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
     use HttpClientTrait;
     use LoggerAwareTrait;
 
-    private $defaultOptions = self::OPTIONS_DEFAULTS + [
+    private $defaultOptions = [
+        'buffer' => null, // bool|\Closure - a boolean or a closure telling if the response should be buffered based on its headers
+    ] + self::OPTIONS_DEFAULTS + [
         'auth_ntlm' => null, // array|string - an array containing the username as first value, and optionally the
                              //   password as the second one; or string like username:password - enabling NTLM auth
     ];
@@ -62,8 +64,10 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
             throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\CurlHttpClient" as the "curl" extension is not installed.');
         }
 
+        $this->defaultOptions['buffer'] = \Closure::fromCallable([__CLASS__, 'shouldBuffer']);
+
         if ($defaultOptions) {
-            [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, self::OPTIONS_DEFAULTS);
+            [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, $this->defaultOptions);
         }
 
         $this->multi = $multi = new CurlClientState();

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -503,4 +503,15 @@ trait HttpClientTrait
 
         return implode('&', $replace ? array_replace($query, $queryArray) : ($query + $queryArray));
     }
+
+    private static function shouldBuffer(array $headers): bool
+    {
+        $contentType = $headers['content-type'][0] ?? null;
+
+        if (false !== $i = strpos($contentType, ';')) {
+            $contentType = substr($contentType, 0, $i);
+        }
+
+        return $contentType && preg_match('#^(?:text/|application/(?:.+\+)?(?:json|xml)$)#i', $contentType);
+    }
 }

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -35,7 +35,9 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
     use HttpClientTrait;
     use LoggerAwareTrait;
 
-    private $defaultOptions = self::OPTIONS_DEFAULTS;
+    private $defaultOptions = [
+        'buffer' => null, // bool|\Closure - a boolean or a closure telling if the response should be buffered based on its headers
+    ] + self::OPTIONS_DEFAULTS;
 
     /** @var NativeClientState */
     private $multi;
@@ -48,8 +50,10 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
      */
     public function __construct(array $defaultOptions = [], int $maxHostConnections = 6)
     {
+        $this->defaultOptions['buffer'] = \Closure::fromCallable([__CLASS__, 'shouldBuffer']);
+
         if ($defaultOptions) {
-            [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, self::OPTIONS_DEFAULTS);
+            [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, $this->defaultOptions);
         }
 
         $this->multi = new NativeClientState();

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -103,7 +103,12 @@ class MockResponse implements ResponseInterface
         $response = new self([]);
         $response->requestOptions = $options;
         $response->id = ++self::$idSequence;
-        $response->content = ($options['buffer'] ?? true) ? fopen('php://temp', 'w+') : null;
+
+        if (($options['buffer'] ?? null) instanceof \Closure) {
+            $response->content = $options['buffer']($mock->getHeaders(false)) ? fopen('php://temp', 'w+') : null;
+        } else {
+            $response->content = true === ($options['buffer'] ?? true) ? fopen('php://temp', 'w+') : null;
+        }
         $response->initializer = static function (self $response) {
             if (null !== $response->info['error']) {
                 throw new TransportException($response->info['error']);

--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -117,7 +117,7 @@ trait ResponseTrait
             }
 
             if (null === $content) {
-                throw new TransportException('Cannot get the content of the response twice: the request was issued with option "buffer" set to false.');
+                throw new TransportException('Cannot get the content of the response twice: buffering is disabled.');
             }
 
             return $content;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31883 
| License       | MIT
| Doc PR        | symfony/symfony-docs#12043

With this PR, responses can be buffered automatically from a closure passed to the `buffer` option.

```php
$resp = $client->request('GET', $url, [
    'buffer' => function (array $headers): bool { return true/false; },
]);
```

When no option is provided, buffering is now enabled only for json, xml and text/* content types.