### PR TITLE
[Messenger] Extract Dsn object

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1768,7 +1768,7 @@ class FrameworkExtension extends Extension
             $serializerId = $transport['serializer'] ?? 'messenger.default_serializer';
 
             $transportDefinition = (new Definition(TransportInterface::class))
-                ->setFactory([new Reference('messenger.transport_factory'), 'createTransport'])
+                ->setFactory([new Reference('messenger.transport_factory'), 'fromString'])
                 ->setArguments([$transport['dsn'], $transport['options'] + ['transport_name' => $name], new Reference($serializerId)])
                 ->addTag('messenger.receiver', ['alias' => $name])
             ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -687,7 +687,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $transportFactory = $container->getDefinition('messenger.transport.customised')->getFactory();
         $transportArguments = $container->getDefinition('messenger.transport.customised')->getArguments();
 
-        $this->assertEquals([new Reference('messenger.transport_factory'), 'createTransport'], $transportFactory);
+        $this->assertEquals([new Reference('messenger.transport_factory'), 'fromString'], $transportFactory);
         $this->assertCount(3, $transportArguments);
         $this->assertSame('amqp://localhost/%2f/messages?exchange_name=exchange_name', $transportArguments[0]);
         $this->assertEquals(['queue' => ['name' => 'Queue'], 'transport_name' => 'customised'], $transportArguments[1]);
@@ -699,7 +699,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $transportFactory = $container->getDefinition('messenger.transport.redis')->getFactory();
         $transportArguments = $container->getDefinition('messenger.transport.redis')->getArguments();
 
-        $this->assertEquals([new Reference('messenger.transport_factory'), 'createTransport'], $transportFactory);
+        $this->assertEquals([new Reference('messenger.transport_factory'), 'fromString'], $transportFactory);
         $this->assertCount(3, $transportArguments);
         $this->assertSame('redis://127.0.0.1:6379/messages', $transportArguments[0]);
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -3,7 +3,10 @@ CHANGELOG
 
 4.4.0
 -----
-
+ * Added `Dsn` class which represents connection dsn.
+ * [BC BREAK] The `TransportFactoryInterface` interface
+   changed: `supports(Dsn $dsn)`, `createTransport(Dsn $dsn, SerializerInterface $serializer, string $name)`.
+ * [BC BREAK] Options from dsn overwrite options from options array in Doctrine transport.
  * Added support for auto trimming of Redis streams.
  * `InMemoryTransport` handle acknowledged and rejected messages.
  * Made all dispatched worker event classes final.

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportFactoryTest.php
@@ -15,26 +15,36 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransport;
 use Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory;
 use Symfony\Component\Messenger\Transport\AmqpExt\Connection;
+use Symfony\Component\Messenger\Transport\Dsn;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class AmqpTransportFactoryTest extends TestCase
 {
-    public function testSupportsOnlyAmqpTransports()
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(Dsn $dsn, bool $supports): void
     {
         $factory = new AmqpTransportFactory();
 
-        $this->assertTrue($factory->supports('amqp://localhost', []));
-        $this->assertFalse($factory->supports('sqs://localhost', []));
-        $this->assertFalse($factory->supports('invalid-dsn', []));
+        $this->assertSame($supports, $factory->supports($dsn));
     }
 
-    public function testItCreatesTheTransport()
+    public function supportsProvider(): iterable
+    {
+        yield [Dsn::fromString('amqp://localhost'), true];
+
+        yield [Dsn::fromString('foo://localhost'), false];
+    }
+
+    public function testCreate(): void
     {
         $factory = new AmqpTransportFactory();
         $serializer = $this->createMock(SerializerInterface::class);
 
-        $expectedTransport = new AmqpTransport(Connection::fromDsn('amqp://localhost', ['foo' => 'bar']), $serializer);
+        $dsn = Dsn::fromString('amqp://localhost', ['foo' => 'bar']);
+        $expectedTransport = new AmqpTransport(Connection::fromDsnObject($dsn), $serializer);
 
-        $this->assertEquals($expectedTransport, $factory->createTransport('amqp://localhost', ['foo' => 'bar'], $serializer));
+        $this->assertEquals($expectedTransport, $factory->createTransport($dsn, $serializer, 'amqp'));
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
@@ -28,7 +28,7 @@ class ConnectionTest extends TestCase
     public function testItCannotBeConstructedWithAWrongDsn()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('The given AMQP DSN "amqp://:" is invalid.');
+        $this->expectExceptionMessage('The "amqp://:" messenger DSN is invalid.');
         Connection::fromDsn('amqp://:');
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -207,7 +207,8 @@ class ConnectionTest extends TestCase
             'expectedAutoSetup' => false,
         ];
 
-        yield 'options from options array wins over options from dsn' => [
+        //FIXME: document BC-break in behavior
+        yield 'options from dsn wins over options from options array' => [
             'dsn' => 'doctrine://default?table_name=name_from_dsn&redeliver_timeout=1200&queue_name=normal&auto_setup=true',
             'options' => [
                 'table_name' => 'name_from_options',
@@ -216,10 +217,10 @@ class ConnectionTest extends TestCase
                 'auto_setup' => false,
             ],
             'expectedConnection' => 'default',
-            'expectedTableName' => 'name_from_options',
-            'expectedRedeliverTimeout' => 1800,
-            'expectedQueue' => 'important',
-            'expectedAutoSetup' => false,
+            'expectedTableName' => 'name_from_dsn',
+            'expectedRedeliverTimeout' => 1200,
+            'expectedQueue' => 'normal',
+            'expectedAutoSetup' => true,
         ];
 
         yield 'options from dsn with falsey boolean' => [

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -207,7 +207,6 @@ class ConnectionTest extends TestCase
             'expectedAutoSetup' => false,
         ];
 
-        //FIXME: document BC-break in behavior
         yield 'options from dsn wins over options from options array' => [
             'dsn' => 'doctrine://default?table_name=name_from_dsn&redeliver_timeout=1200&queue_name=normal&auto_setup=true',
             'options' => [

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -35,14 +35,6 @@ class ConnectionTest extends TestCase
         }
     }
 
-    public function testFromInvalidDsn()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given Redis DSN "redis://" is invalid.');
-
-        Connection::fromDsn('redis://');
-    }
-
     public function testFromDsn()
     {
         $this->assertEquals(
@@ -212,16 +204,16 @@ class ConnectionTest extends TestCase
 
         try {
             $connection->add('message', []);
+            $this->fail(sprintf('Expected that "%s" was thrown.', TransportException::class));
         } catch (TransportException $e) {
+            $this->assertSame('xadd error', $e->getMessage());
         }
-
-        $this->assertSame('xadd error', $e->getMessage());
 
         try {
             $connection->ack('1');
+            $this->fail(sprintf('Expected that "%s" was thrown.', TransportException::class));
         } catch (TransportException $e) {
+            $this->assertSame('xack error', $e->getMessage());
         }
-
-        $this->assertSame('xack error', $e->getMessage());
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sync/SyncTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sync/SyncTransportTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Transport\AmqpExt;
+namespace Symfony\Component\Messenger\Tests\Transport\Sync;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
+use Symfony\Component\Messenger\Transport\Dsn;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -20,15 +21,13 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  */
 class AmqpTransportFactory implements TransportFactoryInterface
 {
-    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    public function createTransport(Dsn $dsn, SerializerInterface $serializer, string $name): TransportInterface
     {
-        unset($options['transport_name']);
-
-        return new AmqpTransport(Connection::fromDsn($dsn, $options), $serializer);
+        return new AmqpTransport(Connection::fromDsnObject($dsn), $serializer);
     }
 
-    public function supports(string $dsn, array $options): bool
+    public function supports(Dsn $dsn): bool
     {
-        return 0 === strpos($dsn, 'amqp://');
+        return 'amqp' === $dsn->getScheme();
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/DoctrineTransportFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Transport\Doctrine;
 
 use Doctrine\Common\Persistence\ConnectionRegistry;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Dsn;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -29,10 +30,9 @@ class DoctrineTransportFactory implements TransportFactoryInterface
         $this->registry = $registry;
     }
 
-    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    public function createTransport(Dsn $dsn, SerializerInterface $serializer, string $name): TransportInterface
     {
-        unset($options['transport_name']);
-        $configuration = Connection::buildConfiguration($dsn, $options);
+        $configuration = Connection::buildConfigurationFromDsnObject($dsn);
 
         try {
             $driverConnection = $this->registry->getConnection($configuration['connection']);
@@ -45,8 +45,8 @@ class DoctrineTransportFactory implements TransportFactoryInterface
         return new DoctrineTransport($connection, $serializer);
     }
 
-    public function supports(string $dsn, array $options): bool
+    public function supports(Dsn $dsn): bool
     {
-        return 0 === strpos($dsn, 'doctrine://');
+        return 'doctrine' === $dsn->getScheme();
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Dsn.php
+++ b/src/Symfony/Component/Messenger/Transport/Dsn.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport;
+
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+
+/**
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ */
+final class Dsn
+{
+    private $scheme;
+    private $host;
+    private $user;
+    private $password;
+    private $port;
+    private $path;
+    private $options;
+
+    public function __construct(
+        string $scheme,
+        ?string $host = null,
+        ?string $user = null,
+        ?string $password = null,
+        ?int $port = null,
+        ?string $path = null,
+        array $options = []
+    ) {
+        $this->scheme = $scheme;
+        $this->host = $host;
+        $this->user = $user;
+        $this->password = $password;
+        $this->port = $port;
+        $this->path = $path;
+        $this->options = $options;
+    }
+
+    public static function fromString(string $dsn, array $options = []): self
+    {
+        if (preg_match('#^([a-z-+]+)://$#', $dsn, $matches)) {
+            return new self($matches[1]);
+        }
+
+        if ((false === $parsed = parse_url($dsn)) || empty($parsed['scheme'])) {
+            throw new InvalidArgumentException(sprintf('The "%s" messenger DSN is invalid.', $dsn));
+        }
+
+        $user = isset($parsed['user']) ? urldecode($parsed['user']) : null;
+        $password = isset($parsed['pass']) ? urldecode($parsed['pass']) : null;
+        $port = $parsed['port'] ?? null;
+        $path = $parsed['path'] ?? null;
+        parse_str($parsed['query'] ?? '', $query);
+
+        return new self(
+            $parsed['scheme'],
+            $parsed['host'],
+            $user,
+            $password,
+            $port,
+            $path,
+            array_replace_recursive($options, $query)
+        );
+    }
+
+    public function getScheme(): string
+    {
+        return $this->scheme;
+    }
+
+    public function getHost(): ?string
+    {
+        return $this->host;
+    }
+
+    public function getUser(): ?string
+    {
+        return $this->user;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    public function getPort(): ?int
+    {
+        return $this->port;
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->path;
+    }
+
+    public function getOption(string $key)
+    {
+        return $this->options[$key] ?? null;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function __toString()
+    {
+        $port = $this->port ? ':'.$this->port : '';
+
+        $user = '';
+        if ($this->user && $this->password) {
+            $user = $this->user.':'.$this->password.'@';
+        } elseif ($this->user) {
+            $user = $this->user.'@';
+        }
+
+        $query = $this->options ? '?'.http_build_query($this->options) : '';
+
+        return $this->scheme.'://'.$user.$this->host.$port.$this->path.$query;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/DsnTest.php
+++ b/src/Symfony/Component/Messenger/Transport/DsnTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Transport\Dsn;
+
+class DsnTest extends TestCase
+{
+    /**
+     * @dataProvider fromStringProvider
+     */
+    public function testFromString(string $string, Dsn $dsn, array $options = []): void
+    {
+        $this->assertEquals($dsn, Dsn::fromString($string, $options));
+    }
+
+    public function fromStringProvider(): iterable
+    {
+        yield 'amqp' => [
+            'amqp://',
+            new Dsn('amqp'),
+        ];
+
+        yield 'amqp with host' => [
+            'amqp://localhost',
+            new Dsn('amqp', 'localhost'),
+        ];
+
+        yield 'amqp with host, user and pass' => [
+            'amqp://guest:pass@localhost',
+            new Dsn('amqp', 'localhost', 'guest', 'pass'),
+        ];
+
+        yield 'redis with host and port' => [
+            'redis://localhost:6379',
+            new Dsn('redis', 'localhost', null, null, 6379),
+        ];
+
+        yield 'redis with host and option inside dsn' => [
+            'redis://localhost?stream=messages',
+            new Dsn('redis', 'localhost', null, null, null, null, ['stream' => 'messages']),
+        ];
+
+        yield 'redis with host and option inside options argument' => [
+            'redis://localhost',
+            new Dsn('redis', 'localhost', null, null, null, null, ['stream' => 'messages', 'auto_setup' => false]),
+            ['stream' => 'messages', 'auto_setup' => false],
+        ];
+
+        yield 'redis with host and same option inside dsn and options argument' => [
+            'redis://localhost?stream=stream_from_dsn',
+            new Dsn('redis', 'localhost', null, null, null, null, ['stream' => 'stream_from_dsn']),
+            ['stream' => 'stream_from_options'],
+        ];
+    }
+
+    /**
+     * @dataProvider toStringProvider
+     */
+    public function testToString(Dsn $dsn, string $string): void
+    {
+        $this->assertSame($string, (string) $dsn);
+    }
+
+    public function toStringProvider(): iterable
+    {
+        yield 'amqp' => [
+            new Dsn('amqp'),
+            'amqp://',
+        ];
+
+        yield 'amqp with host' => [
+            new Dsn('amqp', 'localhost'),
+            'amqp://localhost',
+        ];
+
+        yield 'amqp with host, user and pass' => [
+            new Dsn('amqp', 'localhost', 'guest', 'pass'),
+            'amqp://guest:pass@localhost',
+        ];
+
+        yield 'redis with host and port' => [
+            new Dsn('redis', 'localhost', null, null, 6379),
+            'redis://localhost:6379',
+        ];
+
+        yield 'redis with host and options' => [
+            new Dsn('redis', 'localhost', null, null, null, null, ['stream' => 'messages', 'auto_setup' => false]),
+            'redis://localhost?stream=messages&auto_setup=0',
+        ];
+    }
+
+    /**
+     * @dataProvider invalidDsnProvider
+     */
+    public function testInvalidDsn(string $dsn, string $exceptionMessage): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($exceptionMessage);
+        Dsn::fromString($dsn);
+    }
+
+    public function invalidDsnProvider(): iterable
+    {
+        yield [
+            'foo',
+            'The "foo" messenger DSN is invalid.',
+        ];
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/InMemoryTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/InMemoryTransportFactory.php
@@ -24,14 +24,14 @@ class InMemoryTransportFactory implements TransportFactoryInterface, ResetInterf
      */
     private $createdTransports = [];
 
-    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    public function createTransport(Dsn $dsn, SerializerInterface $serializer, string $name): TransportInterface
     {
         return $this->createdTransports[] = new InMemoryTransport();
     }
 
-    public function supports(string $dsn, array $options): bool
+    public function supports(Dsn $dsn): bool
     {
-        return 0 === strpos($dsn, 'in-memory://');
+        return 'in-memory' === $dsn->getScheme();
     }
 
     public function reset()

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/RedisTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/RedisTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\RedisExt;
 
+use Symfony\Component\Messenger\Transport\Dsn;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -21,15 +22,13 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  */
 class RedisTransportFactory implements TransportFactoryInterface
 {
-    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    public function createTransport(Dsn $dsn, SerializerInterface $serializer, string $name): TransportInterface
     {
-        unset($options['transport_name']);
-
-        return new RedisTransport(Connection::fromDsn($dsn, $options), $serializer);
+        return new RedisTransport(Connection::fromDsnObject($dsn), $serializer);
     }
 
-    public function supports(string $dsn, array $options): bool
+    public function supports(Dsn $dsn): bool
     {
-        return 0 === strpos($dsn, 'redis://');
+        return 'redis' === $dsn->getScheme();
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Sync/SyncTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/Sync/SyncTransportFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\Sync;
 
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\Dsn;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -28,13 +29,13 @@ class SyncTransportFactory implements TransportFactoryInterface
         $this->messageBus = $messageBus;
     }
 
-    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    public function createTransport(Dsn $dsn, SerializerInterface $serializer, string $name): TransportInterface
     {
         return new SyncTransport($this->messageBus);
     }
 
-    public function supports(string $dsn, array $options): bool
+    public function supports(Dsn $dsn): bool
     {
-        return 0 === strpos($dsn, 'sync://');
+        return 'sync' === $dsn->getScheme();
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/TransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/TransportFactory.php
@@ -29,21 +29,26 @@ class TransportFactory implements TransportFactoryInterface
         $this->factories = $factories;
     }
 
-    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    public function fromString(string $dsn, array $options, SerializerInterface $serializer, string $name): TransportInterface
+    {
+        return $this->createTransport(Dsn::fromString($dsn, $options), $serializer, $name);
+    }
+
+    public function createTransport(Dsn $dsn, SerializerInterface $serializer, string $name): TransportInterface
     {
         foreach ($this->factories as $factory) {
-            if ($factory->supports($dsn, $options)) {
-                return $factory->createTransport($dsn, $options, $serializer);
+            if ($factory->supports($dsn)) {
+                return $factory->createTransport($dsn, $serializer, $name);
             }
         }
 
         throw new InvalidArgumentException(sprintf('No transport supports the given Messenger DSN "%s".', $dsn));
     }
 
-    public function supports(string $dsn, array $options): bool
+    public function supports(Dsn $dsn): bool
     {
         foreach ($this->factories as $factory) {
-            if ($factory->supports($dsn, $options)) {
+            if ($factory->supports($dsn)) {
                 return true;
             }
         }

--- a/src/Symfony/Component/Messenger/Transport/TransportFactoryInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/TransportFactoryInterface.php
@@ -11,16 +11,23 @@
 
 namespace Symfony\Component\Messenger\Transport;
 
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
  * Creates a Messenger transport.
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
+ * @author Konstantin Myakshin <molodchick@gmail.com>
  */
 interface TransportFactoryInterface
 {
-    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface;
+    /**
+     * @param string $name Transport name
+     *
+     * @throws TransportException In case when transport couldn't be created
+     */
+    public function createTransport(Dsn $dsn, SerializerInterface $serializer, string $name): TransportInterface;
 
-    public function supports(string $dsn, array $options): bool;
+    public function supports(Dsn $dsn): bool;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes,  AppVeyor failure unrelated
| Fixed tickets | part of #32546
| License       | MIT
| Doc PR        | -

During implementing transport factories for Mailer component I decided to extract `Dsn` object in Messenger component also instead of string + array of options.