### PR TITLE
[Messenger] Fix UnrecoverableExceptionInterface handling

### DIFF
--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -191,6 +191,20 @@ class Worker implements WorkerInterface
 
     private function shouldRetry(\Throwable $e, Envelope $envelope, RetryStrategyInterface $retryStrategy): bool
     {
+        // if ALL nested Exceptions are an instance of UnrecoverableExceptionInterface we should not retry
+        if ($e instanceof HandlerFailedException) {
+            $shouldNotRetry = true;
+            foreach ($e->getNestedExceptions() as $nestedException) {
+                if (!$nestedException instanceof UnrecoverableExceptionInterface) {
+                    $shouldNotRetry = false;
+                    break;
+                }
+            }
+            if ($shouldNotRetry) {
+                return false;
+            }
+        }
+
         if ($e instanceof UnrecoverableExceptionInterface) {
             return false;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32325
| License       | MIT
| Doc PR        | no

Fixed the handling of UnrecoverableExceptionInterface-Exceptions like suggested in [the issue thread](https://github.com/symfony/symfony/issues/32325#issuecomment-509351321).