### PR TITLE
[WebProfilerBundle] Remove unneeded information in the routing panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
@@ -5,13 +5,6 @@
         <span class="value">{{ request.route ?: '(none)' }}</span>
         <span class="label">Matched route</span>
     </div>
-
-    {% if request.route %}
-        <div class="metric">
-            <span class="value">{{ traces|length }}</span>
-            <span class="label">Tested routes before match</span>
-        </div>
-    {% endif %}
 </div>
 
 {% if request.route %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26302
| License       | MIT
| Doc PR        | not needed

As explained in #26302, the number of routes tested before a mach is no longer relevant because of how the new routing matcher works ... so we can remove that information from the profiler panel.

The related issue mentioned the `router_match` command too ... but I can't find this information in that command.