### PR TITLE
[HttpClient] fix debug output added to stderr at shutdown

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -299,6 +299,12 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
         if (\defined('CURLMOPT_PUSHFUNCTION')) {
             curl_multi_setopt($this->multi->handle, CURLMOPT_PUSHFUNCTION, null);
         }
+
+        while (CURLM_CALL_MULTI_PERFORM === curl_multi_exec($this->multi->handle, $active));
+
+        foreach ($this->multi->openHandles as $ch) {
+            curl_setopt($ch, CURLOPT_VERBOSE, false);
+        }
     }
 
     private static function handlePush($parent, $pushed, array $requestHeaders, CurlClientState $multi, int $maxPendingPushes, ?LoggerInterface $logger): int


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When PHP is shutting down, the verbose output of curl can end up being added to stderr.
This prevents it.