### PR TITLE
Bump minimum version of symfony/phpunit-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "predis/predis": "~1.0",
         "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
-        "symfony/phpunit-bridge": "~3.4|~4.0|~5.0",
+        "symfony/phpunit-bridge": "^3.4.19|^4.1.8|~5.0",
         "symfony/security-acl": "~2.8|~3.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Before those versions, PHPUnit was downloaded directly on github (on `https://github.com/sebastianbergmann/phpunit/archive/$PHPUNIT_VERSION.zip`), not installed with composer.

However, this behavior is not working (anymore ?) because https://github.com/sebastianbergmann/phpunit/archive/6.5.zip is a 404 (`Warning: fopen(https://github.com/sebastianbergmann/phpunit/archive/6.5.zip): failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found`).

When installing lowest dependencies to run tests in local, you encounter this problem and you cannot launch the tests unless you set the `SYMFONY_PHPUNIT_VERSION` to `6.5.14`. But IMHO, it should work by default.