### PR TITLE
[Config] Do not use absolute path when computing the vendor freshness

### DIFF
--- a/src/Symfony/Component/Config/Resource/ComposerResource.php
+++ b/src/Symfony/Component/Config/Resource/ComposerResource.php
@@ -48,7 +48,7 @@ class ComposerResource implements SelfCheckingResourceInterface, \Serializable
     {
         self::refresh();
 
-        return self::$runtimeVendors === $this->vendors;
+        return array_values(self::$runtimeVendors) === array_values($this->vendors);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

When one uses Docker with a different mounting point between CLI & FPM,
the cache keeps regenerating because the ComposerResource class see a
different path for each SAPI. For example `/home/app/app/vendor` vs
`/var/www/app/vendor`.
So if you hit FPM, then the CLI, then FPM, each time a new cache is
generated. So the application is quite slow in dev env. And for people
on MacOSX (with docker) is a big pain! And obvisouly, this never
stabilizes !

This occurs a lot when you have a worker, that crash and reboot in the
background, and you browse the web interface. Or when you have something
that hit your API every X secondes, and you are working on a worker.