### PR TITLE
[Form][Validator] Generate accept attribute with file constraint and mime types option

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
@@ -5,13 +5,6 @@
         <span class="value">{{ request.route ?: '(none)' }}</span>
         <span class="label">Matched route</span>
     </div>
-
-    {% if request.route %}
-        <div class="metric">
-            <span class="value">{{ traces|length }}</span>
-            <span class="label">Tested routes before match</span>
-        </div>
-    {% endif %}
 </div>
 
 {% if request.route %}

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * deprecated using `int` or `float` as data for the `NumberType` when the `input` option is set to `string`
+ * Render accept attribute for `FileType` if mime types is used in assert validator
 
 4.3.0
 -----

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -122,7 +122,13 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
 
             case 'Symfony\Component\Validator\Constraints\File':
             case 'Symfony\Component\Validator\Constraints\Image':
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\FileType', [], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess(
+                    'Symfony\Component\Form\Extension\Core\Type\FileType',
+                    ($constraint->mimeTypes && \is_array($constraint->mimeTypes)) ?
+                        ['attr' => ['accept' => implode(', ', $constraint->mimeTypes)]] :
+                        [],
+                    Guess::HIGH_CONFIDENCE
+                );
 
             case 'Symfony\Component\Validator\Constraints\Language':
                 return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\LanguageType', [], Guess::HIGH_CONFIDENCE);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -109,6 +110,38 @@ class ValidatorTypeGuesserTest extends TestCase
 
         $result = $this->guesser->guessMaxLengthForConstraint($constraint);
         $this->assertNull($result);
+    }
+
+    /**
+     * Check if FileType contains accept attribute.
+     */
+    public function testGuessMimeTypesForConstraintWithMimeTypesValue()
+    {
+        $mineTypes = ['image/png', 'image/jpeg'];
+        $constraint = new File(['mimeTypes' => $mineTypes]);
+
+        $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
+
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\TypeGuess', $typeGuess);
+        $this->assertArrayHasKey('attr', $typeGuess->getOptions());
+        $this->assertArrayHasKey('accept', $typeGuess->getOptions()['attr']);
+        $this->assertEquals(implode(',', $mineTypes), $typeGuess->getOptions()['attr']['accept']);
+    }
+
+    /**
+     * Check if file assert not contains mime types.
+     */
+    public function testGuessMimeTypesForConstraintWithoutMimeTypesValue()
+    {
+        $constraint = new File();
+
+        $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
+
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\TypeGuess', $typeGuess);
+
+        if (isset($typeGuess->getOptions()['attr'])) {
+            $this->assertArrayNotHasKey('accept', $typeGuess->getOptions()['attr']);
+        }
     }
 
     public function maxLengthTypeProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes
| Fixed tickets | #29327
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Generate the html `accept` attribute based on the file constraint and mime types option.

Is it necessary to add this feature in the documentation ? 

Made with @Timherlaud