### PR TITLE
[Mailer] Logger vs debug mailer

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Http/Api/SesTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Http/Api/SesTransport.php
@@ -12,12 +12,13 @@
 namespace Symfony\Component\Mailer\Bridge\Amazon\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Http\Api\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Kevin Verschaeve
@@ -42,7 +43,7 @@ class SesTransport extends AbstractApiTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    protected function doSendEmail(Email $email, SmtpEnvelope $envelope): void
+    protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface
     {
         $date = gmdate('D, d M Y H:i:s e');
         $auth = sprintf('AWS3-HTTPS AWSAccessKeyId=%s,Algorithm=HmacSHA256,Signature=%s', $this->accessKey, $this->getSignature($date));
@@ -60,8 +61,10 @@ class SesTransport extends AbstractApiTransport
         if (200 !== $response->getStatusCode()) {
             $error = new \SimpleXMLElement($response->getContent(false));
 
-            throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $error->Error->Message, $error->Error->Code));
+            throw new HttpTransportException(sprintf('Unable to send an email: %s (code %s).', $error->Error->Message, $error->Error->Code), $response);
         }
+
+        return $response;
     }
 
     private function getSignature(string $string): string

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Http/Api/PostmarkTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Http/Api/PostmarkTransport.php
@@ -12,12 +12,13 @@
 namespace Symfony\Component\Mailer\Bridge\Postmark\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Http\Api\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Kevin Verschaeve
@@ -35,7 +36,7 @@ class PostmarkTransport extends AbstractApiTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    protected function doSendEmail(Email $email, SmtpEnvelope $envelope): void
+    protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface
     {
         $response = $this->client->request('POST', self::ENDPOINT, [
             'headers' => [
@@ -48,8 +49,10 @@ class PostmarkTransport extends AbstractApiTransport
         if (200 !== $response->getStatusCode()) {
             $error = $response->toArray(false);
 
-            throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $error['Message'], $error['ErrorCode']));
+            throw new HttpTransportException(sprintf('Unable to send an email: %s (code %s).', $error['Message'], $error['ErrorCode']), $response);
         }
+
+        return $response;
     }
 
     private function getPayload(Email $email, SmtpEnvelope $envelope): array

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\Mailer\Bridge\Sendgrid\Http\Api;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Http\Api\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Kevin Verschaeve
@@ -36,7 +37,7 @@ class SendgridTransport extends AbstractApiTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    protected function doSendEmail(Email $email, SmtpEnvelope $envelope): void
+    protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface
     {
         $response = $this->client->request('POST', self::ENDPOINT, [
             'json' => $this->getPayload($email, $envelope),
@@ -46,8 +47,10 @@ class SendgridTransport extends AbstractApiTransport
         if (202 !== $response->getStatusCode()) {
             $errors = $response->toArray(false);
 
-            throw new TransportException(sprintf('Unable to send an email: %s (code %s).', implode('; ', array_column($errors['errors'], 'message')), $response->getStatusCode()));
+            throw new HttpTransportException(sprintf('Unable to send an email: %s (code %s).', implode('; ', array_column($errors['errors'], 'message')), $response->getStatusCode()), $response);
         }
+
+        return $response;
     }
 
     private function getPayload(Email $email, SmtpEnvelope $envelope): array

--- a/src/Symfony/Component/Mailer/Exception/HttpTransportException.php
+++ b/src/Symfony/Component/Mailer/Exception/HttpTransportException.php
@@ -11,9 +11,24 @@
 
 namespace Symfony\Component\Mailer\Exception;
 
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class HttpTransportException extends TransportException
 {
+    private $response;
+
+    public function __construct(string $message = null, ResponseInterface $response, int $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->response = $response;
+    }
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
 }

--- a/src/Symfony/Component/Mailer/SentMessage.php
+++ b/src/Symfony/Component/Mailer/SentMessage.php
@@ -22,6 +22,7 @@ class SentMessage
     private $original;
     private $raw;
     private $envelope;
+    private $debug = '';
 
     /**
      * @internal
@@ -46,6 +47,16 @@ class SentMessage
     public function getEnvelope(): SmtpEnvelope
     {
         return $this->envelope;
+    }
+
+    public function getDebug(): string
+    {
+        return $this->debug;
+    }
+
+    public function appendDebug(string $debug): void
+    {
+        $this->debug .= $debug;
     }
 
     public function toString(): string

--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
@@ -28,8 +28,16 @@ abstract class AbstractStream
     protected $in;
     protected $out;
 
-    public function write(string $bytes): void
+    private $debug = '';
+
+    public function write(string $bytes, $debug = true): void
     {
+        if ($debug) {
+            foreach (explode("\n", trim($bytes)) as $line) {
+                $this->debug .= sprintf("> %s\n", $line);
+            }
+        }
+
         $bytesToWrite = \strlen($bytes);
         $totalBytesWritten = 0;
         while ($totalBytesWritten < $bytesToWrite) {
@@ -74,7 +82,17 @@ abstract class AbstractStream
             }
         }
 
+        $this->debug .= sprintf('< %s', $line);
+
         return $line;
+    }
+
+    public function getDebug(): string
+    {
+        $debug = $this->debug;
+        $this->debug = '';
+
+        return $debug;
     }
 
     public static function replace(string $from, string $to, iterable $chunks): \Generator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently, there is no way to get the network data for the HTTP calls done by the HTTP transports (which makes debugging harder). For SMTP, we do have the network data, but as logs (each SMTP command/response is its own log line which means that the logs are "polluted" and the data is not tied with the sent message).

This pull request adds a `getDebug()` method on `SentMessage`. That allows to get the debug data conveniently in a standardized way (for both SMTP and HTTP transports). I have moved the SMTP logs to this new mechanism and added support for HTTP transports.
