### PR TITLE
[FrameworkBundle] add --deprecations on debug:container command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Added new `error_controller` configuration to handle system exceptions
  * Added sort option for `translation:update` command.
  * [BC Break] The `framework.messenger.routing.senders` config key is not deep merged anymore.
+ * Added `debug:container --deprecations` command to see compile-time deprecations
 
 4.3.0
 -----
@@ -42,8 +43,8 @@ CHANGELOG
    options if you're using Symfony's serializer.
  * [BC Break] Removed the `framework.messenger.routing.send_and_handle` configuration.
    Instead of setting it to true, configure a `SyncTransport` and route messages to it.
- * Added information about deprecated aliases in `debug:autowiring` 
- * Added php ini session options `sid_length` and `sid_bits_per_character` 
+ * Added information about deprecated aliases in `debug:autowiring`
+ * Added php ini session options `sid_length` and `sid_bits_per_character`
    to the `session` section of the configuration
  * Added support for Translator paths, Twig paths in translation commands.
  * Added support for PHP files with translations in translation commands.

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -62,12 +62,17 @@ class ContainerDebugCommand extends Command
                 new InputOption('env-vars', null, InputOption::VALUE_NONE, 'Displays environment variables used in the container'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, xml, json, or md)', 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw description'),
+                new InputOption('deprecations', null, InputOption::VALUE_NONE, 'To output the deprecations generated when compiling and warming the cache'),
             ])
             ->setDescription('Displays current services for an application')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays all configured <comment>public</comment> services:
 
   <info>php %command.full_name%</info>
+  
+To see deprecations generated during container compilation and cache warmup, use the <info>--deprecations</info> flag:
+  
+  <info>php %command.full_name% --deprecations</info>
 
 To get specific information about a service, specify its name:
 
@@ -149,6 +154,8 @@ EOF
         } elseif ($name = $input->getArgument('name')) {
             $name = $this->findProperServiceName($input, $errorIo, $object, $name, $input->getOption('show-hidden'));
             $options = ['id' => $name];
+        } elseif ($input->getOption('deprecations')) {
+            $options = ['deprecations' => true];
         } else {
             $options = [];
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -64,6 +64,9 @@ abstract class Descriptor implements DescriptorInterface
             case $object instanceof ContainerBuilder && isset($options['parameter']):
                 $this->describeContainerParameter($object->resolveEnvPlaceholders($object->getParameter($options['parameter'])), $options);
                 break;
+            case $object instanceof ContainerBuilder && isset($options['deprecations']):
+                $this->describeContainerDeprecations($object, $options);
+                break;
             case $object instanceof ContainerBuilder:
                 $this->describeContainerServices($object, $options);
                 break;
@@ -131,6 +134,11 @@ abstract class Descriptor implements DescriptorInterface
      * * tag: filters described services by given tag
      */
     abstract protected function describeContainerServices(ContainerBuilder $builder, array $options = []);
+
+    /**
+     * Describes container deprecations.
+     */
+    abstract protected function describeContainerDeprecations(ContainerBuilder $builder, array $options = []);
 
     /**
      * Describes a service definition.

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -191,6 +191,14 @@ class JsonDescriptor extends Descriptor
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function describeContainerDeprecations(ContainerBuilder $builder, array $options = []): void
+    {
+        throw new LogicException('Using the JSON format to print the deprecations is not supported.');
+    }
+
+    /**
      * Writes data as json.
      */
     private function writeData(array $data, array $options)

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -122,6 +122,14 @@ class MarkdownDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
+    protected function describeContainerDeprecations(ContainerBuilder $builder, array $options = []): void
+    {
+        throw new LogicException('Using the Markdown format to print the deprecations is not supported.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function describeContainerServices(ContainerBuilder $builder, array $options = [])
     {
         $showHidden = isset($options['show_hidden']) && $options['show_hidden'];

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -377,6 +377,35 @@ class TextDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
+    protected function describeContainerDeprecations(ContainerBuilder $builder, array $options = []): void
+    {
+        $containerDeprecationFilePath = sprintf('%s/%sDeprecations.log', $builder->getParameter('kernel.cache_dir'), $builder->getParameter('kernel.container_class'));
+        if (!file_exists($containerDeprecationFilePath)) {
+            $options['output']->warning('The deprecation file does not exist, please try warming the cache first.');
+
+            return;
+        }
+
+        $logs = unserialize(file_get_contents($containerDeprecationFilePath));
+        if (0 === \count($logs)) {
+            $options['output']->success('There are no deprecations in the logs!');
+
+            return;
+        }
+
+        $formattedLogs = [];
+        $remainingCount = 0;
+        foreach ($logs as $log) {
+            $formattedLogs[] = sprintf("%sx: %s \n      in %s:%s", $log['count'], $log['message'], $log['file'], $log['line']);
+            $remainingCount += $log['count'];
+        }
+        $options['output']->title(sprintf('Remaining deprecations (%s)', $remainingCount));
+        $options['output']->listing($formattedLogs);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null)
     {
         if ($alias->isPublic()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -143,6 +143,14 @@ class XmlDescriptor extends Descriptor
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function describeContainerDeprecations(ContainerBuilder $builder, array $options = []): void
+    {
+        throw new LogicException('Using the XML format to print the deprecations is not supported.');
+    }
+
+    /**
      * Writes DOM document.
      */
     private function writeDocument(\DOMDocument $dom)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -136,6 +136,88 @@ TXT
         $this->assertStringContainsString(file_get_contents(__DIR__.'/Fixtures/describe_env_vars.txt'), $tester->getDisplay(true));
     }
 
+    public function testGetDeprecation()
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => true]);
+        $path = sprintf('%s/%sDeprecations.log', static::$kernel->getContainer()->getParameter('kernel.cache_dir'), static::$kernel->getContainer()->getParameter('kernel.container_class'));
+        touch($path);
+        file_put_contents($path, serialize([[
+            'type' => 16384,
+            'message' => 'The "Symfony\Bundle\FrameworkBundle\Controller\Controller" class is deprecated since Symfony 4.2, use Symfony\Bundle\FrameworkBundle\Controller\AbstractController instead.',
+            'file' => '/home/hamza/projet/contrib/sf/vendor/symfony/framework-bundle/Controller/Controller.php',
+            'line' => 17,
+            'trace' => [[
+                'file' => '/home/hamza/projet/contrib/sf/src/Controller/DefaultController.php',
+                'line' => 9,
+                'function' => 'spl_autoload_call',
+            ]],
+            'count' => 1,
+        ]]));
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        @unlink(static::$container->getParameter('debug.container.dump'));
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'debug:container', '--deprecations' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertContains('Symfony\Bundle\FrameworkBundle\Controller\Controller', $tester->getDisplay());
+        $this->assertContains('/home/hamza/projet/contrib/sf/vendor/symfony/framework-bundle/Controller/Controller.php', $tester->getDisplay());
+    }
+
+    public function testGetDeprecationNone()
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => true]);
+        $path = sprintf('%s/%sDeprecations.log', static::$kernel->getContainer()->getParameter('kernel.cache_dir'), static::$kernel->getContainer()->getParameter('kernel.container_class'));
+        touch($path);
+        file_put_contents($path, serialize([]));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        @unlink(static::$container->getParameter('debug.container.dump'));
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'debug:container', '--deprecations' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertContains('[OK] There are no deprecations in the logs!', $tester->getDisplay());
+    }
+
+    public function testGetDeprecationNoFile(): void
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => true]);
+        $path = sprintf('%s/%sDeprecations.log', static::$kernel->getContainer()->getParameter('kernel.cache_dir'), static::$kernel->getContainer()->getParameter('kernel.container_class'));
+        @unlink($path);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        @unlink(static::$container->getParameter('debug.container.dump'));
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'debug:container', '--deprecations' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertContains('[WARNING] The deprecation file does not exist', $tester->getDisplay());
+    }
+
+    public function testGetDeprecationXml(): void
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => true]);
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        @unlink(static::$container->getParameter('debug.container.dump'));
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'debug:container', '--deprecations' => true, '--format' => 'xml']);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertContains('Using the XML format to print the deprecations is not supported.', $tester->getDisplay());
+    }
+
     public function provideIgnoreBackslashWhenFindingService()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #30089 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

Two question for this:
- ~is a table output enough ?~ 
- do we need to create a trait to share the code to the cache:warmup ? or maybe add a notice if there deprecation to check them with this command ?

Edit: new output
![Capture d’écran de 2019-07-17 23-15-27](https://user-images.githubusercontent.com/3451634/61412343-f2268300-a8e8-11e9-952d-003e9d0300be.png)
