### PR TITLE
[Form][Validator] Generate accept attribute with file constraint and mime types option

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * deprecated using `int` or `float` as data for the `NumberType` when the `input` option is set to `string`
+ * The type guesser guesses the HTML accept attribute when a mime type is configured in the File or Image constraint.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -122,7 +122,12 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
 
             case 'Symfony\Component\Validator\Constraints\File':
             case 'Symfony\Component\Validator\Constraints\Image':
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\FileType', [], Guess::HIGH_CONFIDENCE);
+                $options = [];
+                if ($constraint->mimeTypes) {
+                    $options = ['attr' => ['accept' => implode(',', (array) $constraint->mimeTypes)]];
+                }
+
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\FileType', $options, Guess::HIGH_CONFIDENCE);
 
             case 'Symfony\Component\Validator\Constraints\Language':
                 return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\LanguageType', [], Guess::HIGH_CONFIDENCE);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -109,6 +110,43 @@ class ValidatorTypeGuesserTest extends TestCase
 
         $result = $this->guesser->guessMaxLengthForConstraint($constraint);
         $this->assertNull($result);
+    }
+
+    public function testGuessMimeTypesForConstraintWithMimeTypesValue()
+    {
+        $mineTypes = ['image/png', 'image/jpeg'];
+        $constraint = new File(['mimeTypes' => $mineTypes]);
+        $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\TypeGuess', $typeGuess);
+        $this->assertArrayHasKey('attr', $typeGuess->getOptions());
+        $this->assertArrayHasKey('accept', $typeGuess->getOptions()['attr']);
+        $this->assertEquals(implode(',', $mineTypes), $typeGuess->getOptions()['attr']['accept']);
+    }
+
+    public function testGuessMimeTypesForConstraintWithoutMimeTypesValue()
+    {
+        $constraint = new File();
+        $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\TypeGuess', $typeGuess);
+        $this->assertArrayNotHasKey('attr', $typeGuess->getOptions());
+    }
+
+    public function testGuessMimeTypesForConstraintWithMimeTypesStringValue()
+    {
+        $constraint = new File(['mimeTypes' => 'image/*']);
+        $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\TypeGuess', $typeGuess);
+        $this->assertArrayHasKey('attr', $typeGuess->getOptions());
+        $this->assertArrayHasKey('accept', $typeGuess->getOptions()['attr']);
+        $this->assertEquals('image/*', $typeGuess->getOptions()['attr']['accept']);
+    }
+
+    public function testGuessMimeTypesForConstraintWithMimeTypesEmptyStringValue()
+    {
+        $constraint = new File(['mimeTypes' => '']);
+        $typeGuess = $this->guesser->guessTypeForConstraint($constraint);
+        $this->assertInstanceOf('Symfony\Component\Form\Guess\TypeGuess', $typeGuess);
+        $this->assertArrayNotHasKey('attr', $typeGuess->getOptions());
     }
 
     public function maxLengthTypeProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes
| Fixed tickets | #29327
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Generate the html `accept` attribute based on the file constraint and mime types option.

Is it necessary to add this feature in the documentation ? 

Made with @Timherlaud

_Sorry I have recreated this pull request because I missed my rebase_