### PR TITLE
[Debug] Use mocks before replacing the error handler

### DIFF
--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -70,8 +70,8 @@ class ErrorHandlerTest extends TestCase
 
     public function testErrorGetLast()
     {
-        $handler = ErrorHandler::register();
         $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $handler = ErrorHandler::register();
         $handler->setDefaultLogger($logger);
         $handler->screamAt(E_ALL);
 
@@ -143,9 +143,8 @@ class ErrorHandlerTest extends TestCase
     public function testDefaultLogger()
     {
         try {
-            $handler = ErrorHandler::register();
-
             $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+            $handler = ErrorHandler::register();
 
             $handler->setDefaultLogger($logger, E_NOTICE);
             $handler->setDefaultLogger($logger, [E_USER_NOTICE => LogLevel::CRITICAL]);
@@ -334,11 +333,10 @@ class ErrorHandlerTest extends TestCase
     public function testHandleException()
     {
         try {
+            $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
             $handler = ErrorHandler::register();
 
             $exception = new \Exception('foo');
-
-            $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
             $logArgCheck = function ($level, $message, $context) {
                 $this->assertSame('Uncaught Exception: foo', $message);
@@ -483,6 +481,7 @@ class ErrorHandlerTest extends TestCase
     public function testHandleFatalError()
     {
         try {
+            $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
             $handler = ErrorHandler::register();
 
             $error = [
@@ -491,8 +490,6 @@ class ErrorHandlerTest extends TestCase
                 'file' => 'bar',
                 'line' => 123,
             ];
-
-            $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
             $logArgCheck = function ($level, $message, $context) {
                 $this->assertEquals('Fatal Parse Error: foo', $message);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4,
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

We want the bridge to mute the php 7.4 deprecations triggered when building mocks.