### PR TITLE
[Console][Lock] Fixed PHPDoc for LockableTrait::lock

### DIFF
--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -25,7 +25,7 @@ use Symfony\Component\Lock\Store\SemaphoreStore;
  */
 trait LockableTrait
 {
-    /** @var Lock */
+    /** @var Lock|null */
     private $lock;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32586
| License       | MIT
| Doc PR        | n/a

Fixed wrong PHPDoc for LockableTrait::lock, allow null.