### PR TITLE
Properly handle optional tag attributes for !tagged_iterator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -736,7 +736,7 @@ class YamlFileLoader extends FileLoader
                         throw new InvalidArgumentException(sprintf('"!%s" tag contains unsupported key "%s"; supported ones are "tag", "index_by" and "default_index_method".', $value->getTag(), implode('"", "', $diff)));
                     }
 
-                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'], $argument['default_index_method'] ?? null, $forLocator);
+                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null, $forLocator);
 
                     if ($forLocator) {
                         $argument = new ServiceLocatorArgument($argument);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/tagged_iterator_optional.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/tagged_iterator_optional.yml
@@ -1,0 +1,4 @@
+services:
+    iterator_service:
+        class: FooClass
+        arguments: [!tagged {tag: test.tag}]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -852,4 +852,18 @@ class YamlFileLoaderTest extends TestCase
 
         $this->assertSame('overridden', $container->get('bar')->quz);
     }
+
+    /**
+     * When creating a tagged iterator using the array syntax, all optional parameters should be properly handled.
+     */
+    public function testDefaultValueOfTagged()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('tagged_iterator_optional.yml');
+
+        $iteratorArgument = $container->getDefinition('iterator_service')->getArgument(0);
+        $this->assertInstanceOf(TaggedIteratorArgument::class, $iteratorArgument);
+        $this->assertNull($iteratorArgument->getIndexAttribute());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32603
| License       | MIT
| Doc PR        | —

Properly handles all optional array keys when using `!tagged_iterator` in YAML service definitions.
This fixes a regression and adds a test case preventing it from coming up again