### PR TITLE
[Mime] rename Headers::getAll() to all()

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/Api/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/Api/MandrillTransport.php
@@ -82,7 +82,7 @@ class MandrillTransport extends AbstractApiTransport
         }
 
         $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type'];
-        foreach ($email->getHeaders()->getAll() as $name => $header) {
+        foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3"
+        "symfony/mailer": "^4.3.3"
     },
     "require-dev": {
         "symfony/http-client": "^4.3"

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/Api/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/Api/MailgunTransport.php
@@ -46,7 +46,7 @@ class MailgunTransport extends AbstractApiTransport
     {
         $body = new FormDataPart($this->getPayload($email, $envelope));
         $headers = [];
-        foreach ($body->getPreparedHeaders()->getAll() as $header) {
+        foreach ($body->getPreparedHeaders()->all() as $header) {
             $headers[] = $header->toString();
         }
 
@@ -97,7 +97,7 @@ class MailgunTransport extends AbstractApiTransport
         }
 
         $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type'];
-        foreach ($headers->getAll() as $name => $header) {
+        foreach ($headers->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
@@ -48,7 +48,7 @@ class MailgunTransport extends AbstractHttpTransport
             'message' => new DataPart($message->toString(), 'message.mime'),
         ]);
         $headers = [];
-        foreach ($body->getPreparedHeaders()->getAll() as $header) {
+        foreach ($body->getPreparedHeaders()->all() as $header) {
             $headers[] = $header->toString();
         }
         $endpoint = str_replace(['%domain%', '%region_dot%'], [urlencode($this->domain), 'us' !== ($this->region ?: 'us') ? $this->region.'.' : ''], self::ENDPOINT);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3"
+        "symfony/mailer": "^4.3.3"
     },
     "require-dev": {
         "symfony/http-client": "^4.3"

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Http/Api/PostmarkTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Http/Api/PostmarkTransport.php
@@ -68,7 +68,7 @@ class PostmarkTransport extends AbstractApiTransport
         ];
 
         $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender'];
-        foreach ($email->getHeaders()->getAll() as $name => $header) {
+        foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3"
+        "symfony/mailer": "^4.3.3"
     },
     "require-dev": {
         "symfony/http-client": "^4.3"

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
@@ -82,7 +82,7 @@ class SendgridTransport extends AbstractApiTransport
         // these headers can't be overwritten according to Sendgrid docs
         // see https://developers.pepipost.com/migration-api/new-subpage/email-send
         $headersToBypass = ['x-sg-id', 'x-sg-eid', 'received', 'dkim-signature', 'content-transfer-encoding', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to'];
-        foreach ($email->getHeaders()->getAll() as $name => $header) {
+        foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/mailer": "^4.3"
+        "symfony/mailer": "^4.3.3"
     },
     "require-dev": {
         "symfony/http-client": "^4.3"

--- a/src/Symfony/Component/Mailer/DelayedSmtpEnvelope.php
+++ b/src/Symfony/Component/Mailer/DelayedSmtpEnvelope.php
@@ -73,7 +73,7 @@ final class DelayedSmtpEnvelope extends SmtpEnvelope
     {
         $recipients = [];
         foreach (['to', 'cc', 'bcc'] as $name) {
-            foreach ($headers->getAll($name) as $header) {
+            foreach ($headers->all($name) as $header) {
                 foreach ($header->getAddresses() as $address) {
                     $recipients[] = new Address($address->getAddress());
                 }

--- a/src/Symfony/Component/Mailer/EventListener/MessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageListener.php
@@ -53,7 +53,7 @@ class MessageListener implements EventSubscriberInterface
         }
 
         $headers = $message->getHeaders();
-        foreach ($this->headers->getAll() as $name => $header) {
+        foreach ($this->headers->all() as $name => $header) {
             if (!$headers->has($name)) {
                 $headers->add($header);
             } else {

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -20,16 +20,16 @@
         "egulias/email-validator": "^2.0",
         "psr/log": "~1.0",
         "symfony/event-dispatcher": "^4.3",
-        "symfony/mime": "^4.3"
+        "symfony/mime": "^4.3.3"
     },
     "require-dev": {
         "symfony/amazon-mailer": "^4.3",
         "symfony/google-mailer": "^4.3",
         "symfony/http-client-contracts": "^1.1",
-        "symfony/mailgun-mailer": "^4.3.2",
-        "symfony/mailchimp-mailer": "^4.3",
-        "symfony/postmark-mailer": "^4.3",
-        "symfony/sendgrid-mailer": "^4.3"
+        "symfony/mailgun-mailer": "^4.3.3",
+        "symfony/mailchimp-mailer": "^4.3.3",
+        "symfony/postmark-mailer": "^4.3.3",
+        "symfony/sendgrid-mailer": "^4.3.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\": "" },

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -51,7 +51,7 @@ final class Headers
     public function setMaxLineLength(int $lineLength)
     {
         $this->lineLength = $lineLength;
-        foreach ($this->getAll() as $header) {
+        foreach ($this->all() as $header) {
             $header->setMaxLineLength($lineLength);
         }
     }
@@ -177,7 +177,7 @@ final class Headers
         return array_shift($values);
     }
 
-    public function getAll(string $name = null): iterable
+    public function all(string $name = null): iterable
     {
         if (null === $name) {
             foreach ($this->headers as $name => $collection) {
@@ -220,7 +220,7 @@ final class Headers
     public function toArray(): array
     {
         $arr = [];
-        foreach ($this->getAll() as $header) {
+        foreach ($this->all() as $header) {
             if ('' !== $header->getBodyAsString()) {
                 $arr[] = $header->toString();
             }

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -141,7 +141,7 @@ class HeadersTest extends TestCase
         $this->assertNull($headers->get('Message-ID'));
     }
 
-    public function testGetAllReturnsAllHeadersMatchingName()
+    public function testAllReturnsAllHeadersMatchingName()
     {
         $header0 = new UnstructuredHeader('X-Test', 'some@id');
         $header1 = new UnstructuredHeader('X-Test', 'other@id');
@@ -150,10 +150,10 @@ class HeadersTest extends TestCase
         $headers->addTextHeader('X-Test', 'some@id');
         $headers->addTextHeader('X-Test', 'other@id');
         $headers->addTextHeader('X-Test', 'more@id');
-        $this->assertEquals([$header0, $header1, $header2], iterator_to_array($headers->getAll('X-Test')));
+        $this->assertEquals([$header0, $header1, $header2], iterator_to_array($headers->all('X-Test')));
     }
 
-    public function testGetAllReturnsAllHeadersIfNoArguments()
+    public function testAllReturnsAllHeadersIfNoArguments()
     {
         $header0 = new IdentificationHeader('Message-ID', 'some@id');
         $header1 = new UnstructuredHeader('Subject', 'thing');
@@ -162,13 +162,13 @@ class HeadersTest extends TestCase
         $headers->addIdHeader('Message-ID', 'some@id');
         $headers->addTextHeader('Subject', 'thing');
         $headers->addMailboxListHeader('To', [new Address('person@example.org')]);
-        $this->assertEquals(['message-id' => $header0, 'subject' => $header1, 'to' => $header2], iterator_to_array($headers->getAll()));
+        $this->assertEquals(['message-id' => $header0, 'subject' => $header1, 'to' => $header2], iterator_to_array($headers->all()));
     }
 
-    public function testGetAllReturnsEmptyArrayIfNoneSet()
+    public function testAllReturnsEmptyArrayIfNoneSet()
     {
         $headers = new Headers();
-        $this->assertEquals([], iterator_to_array($headers->getAll('Received')));
+        $this->assertEquals([], iterator_to_array($headers->all('Received')));
     }
 
     public function testRemoveRemovesAllHeadersWithName()
@@ -199,12 +199,12 @@ class HeadersTest extends TestCase
         $this->assertEquals($header, $headers->get('message-id'));
     }
 
-    public function testGetAllIsNotCaseSensitive()
+    public function testAllIsNotCaseSensitive()
     {
         $header = new IdentificationHeader('Message-ID', 'some@id');
         $headers = new Headers();
         $headers->addIdHeader('Message-ID', 'some@id');
-        $this->assertEquals([$header], iterator_to_array($headers->getAll('message-id')));
+        $this->assertEquals([$header], iterator_to_array($headers->all('message-id')));
     }
 
     public function testRemoveIsNotCaseSensitive()

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -68,7 +68,7 @@ class MessageTest extends TestCase
         $message = new Message();
         $message->getHeaders()->addMailboxListHeader('From', ['fabien@symfony.com']);
         $h = $message->getPreparedHeaders();
-        $this->assertCount(4, iterator_to_array($h->getAll()));
+        $this->assertCount(4, iterator_to_array($h->all()));
         $this->assertEquals(new MailboxListHeader('From', [new Address('fabien@symfony.com')]), $h->get('From'));
         $this->assertEquals(new UnstructuredHeader('MIME-Version', '1.0'), $h->get('mime-version'));
         $this->assertTrue($h->has('Message-Id'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

For consistency with HttpFoundation.
On 4.3 to cut spreading the previous name asap.
Allowed because the component is experimental.