### PR TITLE
[Mailer][DX] Improve exception message for unsupported scheme

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Factory/SesTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Factory/SesTransportFactory.php
@@ -41,7 +41,7 @@ final class SesTransportFactory extends AbstractTransportFactory
             return new Amazon\Smtp\SesTransport($user, $password, $region, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn);
+        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Factory/SesTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Factory/SesTransportFactoryTest.php
@@ -86,7 +86,10 @@ class SesTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield [new Dsn('foo', 'ses', self::USER, self::PASSWORD)];
+        yield [
+            new Dsn('foo', 'ses', self::USER, self::PASSWORD),
+            'The "foo" scheme is not supported for mailer "ses". Supported schemes are: "api", "http", "smtp".',
+        ];
     }
 
     public function incompleteDsnProvider(): iterable

--- a/src/Symfony/Component/Mailer/Bridge/Google/Factory/GmailTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Factory/GmailTransportFactory.php
@@ -28,7 +28,7 @@ final class GmailTransportFactory extends AbstractTransportFactory
             return new GmailTransport($this->getUser($dsn), $this->getPassword($dsn), $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn);
+        throw new UnsupportedSchemeException($dsn, ['smtp']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Google/Tests/Factory/GmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Tests/Factory/GmailTransportFactoryTest.php
@@ -38,7 +38,10 @@ class GmailTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield [new Dsn('http', 'gmail', self::USER, self::PASSWORD)];
+        yield [
+            new Dsn('foo', 'gmail', self::USER, self::PASSWORD),
+            'The "foo" scheme is not supported for mailer "gmail". Supported schemes are: "smtp".',
+        ];
     }
 
     public function incompleteDsnProvider(): iterable

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Factory/MandrillTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Factory/MandrillTransportFactory.php
@@ -41,7 +41,7 @@ final class MandrillTransportFactory extends AbstractTransportFactory
             return new Mailchimp\Smtp\MandrillTransport($user, $password, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn);
+        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Factory/MandrillTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Factory/MandrillTransportFactoryTest.php
@@ -71,7 +71,10 @@ class MandrillTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield [new Dsn('foo', 'mandrill', self::USER)];
+        yield [
+            new Dsn('foo', 'mandrill', self::USER),
+            'The "foo" scheme is not supported for mailer "mandrill". Supported schemes are: "api", "http", "smtp".',
+        ];
     }
 
     public function incompleteDsnProvider(): iterable

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Factory/MailgunTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Factory/MailgunTransportFactory.php
@@ -41,7 +41,7 @@ final class MailgunTransportFactory extends AbstractTransportFactory
             return new Mailgun\Smtp\MailgunTransport($user, $password, $region, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn);
+        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Factory/MailgunTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Factory/MailgunTransportFactoryTest.php
@@ -76,7 +76,10 @@ class MailgunTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield [new Dsn('foo', 'mailgun', self::USER, self::PASSWORD)];
+        yield [
+            new Dsn('foo', 'mailgun', self::USER, self::PASSWORD),
+            'The "foo" scheme is not supported for mailer "mailgun". Supported schemes are: "api", "http", "smtp".',
+        ];
     }
 
     public function incompleteDsnProvider(): iterable

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Factory/PostmarkTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Factory/PostmarkTransportFactory.php
@@ -35,7 +35,7 @@ final class PostmarkTransportFactory extends AbstractTransportFactory
             return new Postmark\Smtp\PostmarkTransport($user, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn);
+        throw new UnsupportedSchemeException($dsn, ['api', 'smtp']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Factory/PostmarkTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Factory/PostmarkTransportFactoryTest.php
@@ -60,7 +60,10 @@ class PostmarkTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield [new Dsn('foo', 'postmark', self::USER)];
+        yield [
+            new Dsn('foo', 'postmark', self::USER),
+            'The "foo" scheme is not supported for mailer "postmark". Supported schemes are: "api", "smtp".',
+        ];
     }
 
     public function incompleteDsnProvider(): iterable

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Factory/SendgridTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Factory/SendgridTransportFactory.php
@@ -34,7 +34,7 @@ final class SendgridTransportFactory extends AbstractTransportFactory
             return new Sendgrid\Smtp\SendgridTransport($key, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn);
+        throw new UnsupportedSchemeException($dsn, ['api', 'smtp']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Factory/SendgridTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Factory/SendgridTransportFactoryTest.php
@@ -60,6 +60,9 @@ class SendgridTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield [new Dsn('foo', 'sendgrid', self::USER)];
+        yield [
+            new Dsn('foo', 'sendgrid', self::USER),
+            'The "foo" scheme is not supported for mailer "sendgrid". Supported schemes are: "api", "smtp".',
+        ];
     }
 }

--- a/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
@@ -18,8 +18,8 @@ use Symfony\Component\Mailer\Transport\Dsn;
  */
 class UnsupportedSchemeException extends LogicException
 {
-    public function __construct(Dsn $dsn)
+    public function __construct(Dsn $dsn, array $supported)
     {
-        parent::__construct(sprintf('The "%s" scheme is not supported for mailer "%s".', $dsn->getScheme(), $dsn->getHost()));
+        parent::__construct(sprintf('The "%s" scheme is not supported for mailer "%s". Supported schemes are: "%s".', $dsn->getScheme(), $dsn->getHost(), implode('", "', $supported)));
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/NullTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/NullTransportFactoryTest.php
@@ -47,6 +47,9 @@ class NullTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield [new Dsn('foo', 'null')];
+        yield [
+            new Dsn('foo', 'null'),
+            'The "foo" scheme is not supported for mailer "null". Supported schemes are: "smtp".',
+        ];
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportFactoryTest.php
@@ -47,6 +47,9 @@ class SendmailTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield [new Dsn('http', 'sendmail')];
+        yield [
+            new Dsn('http', 'sendmail'),
+            'The "http" scheme is not supported for mailer "sendmail". Supported schemes are: "smtp".',
+        ];
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportFactoryTestCase.php
@@ -69,11 +69,15 @@ abstract class TransportFactoryTestCase extends TestCase
     /**
      * @dataProvider unsupportedSchemeProvider
      */
-    public function testUnsupportedSchemeException(Dsn $dsn): void
+    public function testUnsupportedSchemeException(Dsn $dsn, string $message = null): void
     {
         $factory = $this->getFactory();
 
         $this->expectException(UnsupportedSchemeException::class);
+        if (null !== $message) {
+            $this->expectExceptionMessage($message);
+        }
+
         $factory->create($dsn);
     }
 

--- a/src/Symfony/Component/Mailer/Transport/NullTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/NullTransportFactory.php
@@ -24,7 +24,7 @@ final class NullTransportFactory extends AbstractTransportFactory
             return new NullTransport($this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn);
+        throw new UnsupportedSchemeException($dsn, ['smtp']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransportFactory.php
@@ -24,7 +24,7 @@ final class SendmailTransportFactory extends AbstractTransportFactory
             return new SendmailTransport(null, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn);
+        throw new UnsupportedSchemeException($dsn, ['smtp']);
     }
 
     public function supports(Dsn $dsn): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | waiting for Travis
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR improves exception message for unsupported schemes by providing list of available. Throw something like: ` 'The "foo" scheme is not supported for mailer "mailgun". Supported schemes are: "api", "http", "smtp".'`