### PR TITLE
Fix "Values of variables that depend on APP_ENV change according to its position"

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -193,6 +193,9 @@ final class Dotenv
 
                 case self::STATE_VALUE:
                     $this->values[$name] = $this->lexValue();
+                    if ('APP_ENV' == $name && isset($_ENV['APP_ENV'])) {
+                        $this->values[$name] = $_ENV['APP_ENV'];
+                    }
                     $state = self::STATE_VARNAME;
                     break;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4, 4.2 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no 
| Deprecations? | yes
| Tests pass?   | yes 
| Fixed tickets | #32595
| License       | MIT
| Doc PR        | N/A

I'm not sure if it's a bug or an expected behaviour.

In the first case they are putting the `APP_ENV` as `dev` and then defining `TEST` with the content of that variable, that's why the value resulting is `foo_dev`.

In the second case they are defining the `TEST` variable before they have `APP_ENV` defined, so it will take the value of the parameter in the `composer dump-env` command and getting as result `foo_prod`.

What I did was to check if the variable name is `APP_ENV` in order to override the file value and put the value passed as parameter through the composer command.