### PR TITLE
[Messenger] add event for all handled messages even failing one

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -168,6 +168,8 @@ Messenger
 
  * Deprecated passing a `ContainerInterface` instance as first argument of the `ConsumeMessagesCommand` constructor,
    pass a `RoutableMessageBus`  instance instead.
+ * `WorkerMessageHandledEvent` is now dispatched on each handled message instead of only successful one. Use `WorkerMessageHandledSuccessfullyEvent`
+   to get the same behavior as before.
 
 Mime
 ----

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
  * Made all dispatched worker event classes final.
  * Added support for `from_transport` attribute on `messenger.message_handler` tag.
  * Added support for passing `dbindex` as a query parameter to the redis transport DSN.
+ * [BC BREAK] `WorkerMessageHandledEvent` is now dispatched on each handled message instead of only successful one.
+ * Added `WorkerMessageHandledSuccessfullyEvent` dispatched for each successful message.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Messenger/Event/WorkerMessageHandledSuccessfullyEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerMessageHandledSuccessfullyEvent.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Messenger\Event;
 
 /**
- * Dispatched after a message was received from a transport and handled.
+ * Dispatched after a message was received from a transport and successfully handled.
  *
  * The event name is the class name.
  */
-final class WorkerMessageHandledEvent extends AbstractWorkerMessageEvent
+class WorkerMessageHandledSuccessfullyEvent extends AbstractWorkerMessageEvent
 {
 }

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledSuccessfullyEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
@@ -226,10 +227,11 @@ class WorkerTest extends TestCase
 
         $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
 
-        $eventDispatcher->expects($this->exactly(3))
+        $eventDispatcher->expects($this->exactly(4))
             ->method('dispatch')
             ->withConsecutive(
                 [$this->isInstanceOf(WorkerMessageReceivedEvent::class)],
+                [$this->isInstanceOf(WorkerMessageHandledSuccessfullyEvent::class)],
                 [$this->isInstanceOf(WorkerMessageHandledEvent::class)],
                 [$this->isInstanceOf(WorkerStoppedEvent::class)]
             );
@@ -254,11 +256,12 @@ class WorkerTest extends TestCase
 
         $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
 
-        $eventDispatcher->expects($this->exactly(3))
+        $eventDispatcher->expects($this->exactly(4))
             ->method('dispatch')
             ->withConsecutive(
                 [$this->isInstanceOf(WorkerMessageReceivedEvent::class)],
                 [$this->isInstanceOf(WorkerMessageFailedEvent::class)],
+                [$this->isInstanceOf(WorkerMessageHandledEvent::class)],
                 [$this->isInstanceOf(WorkerStoppedEvent::class)]
             );
 

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -16,6 +16,7 @@ use Symfony\Component\ErrorRenderer\Exception\FlattenException;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledSuccessfullyEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
@@ -91,6 +92,7 @@ class Worker implements WorkerInterface
                     $envelopeHandled = true;
 
                     $this->handleMessage($envelope, $receiver, $transportName, $this->retryStrategies[$transportName] ?? null);
+                    $this->dispatchEvent(new WorkerMessageHandledEvent($envelope, $transportName));
                     $onHandled($envelope);
 
                     if ($this->shouldStop) {
@@ -170,7 +172,7 @@ class Worker implements WorkerInterface
             return;
         }
 
-        $this->dispatchEvent(new WorkerMessageHandledEvent($envelope, $transportName));
+        $this->dispatchEvent(new WorkerMessageHandledSuccessfullyEvent($envelope, $transportName));
 
         if (null !== $this->logger) {
             $this->logger->info('{class} was handled successfully (acknowledging to transport).', $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #32560
| License       | MIT
| Doc PR        | TODO symfony/symfony-docs#

fix #32560 by dispatching `WorkerMessageHandledEvent` on every handled messages instead of successful ones.

I rename the current `WorkerMessageHandledEvent` to `WorkerMessageHandledSuccessfullyEvent` to make things more explicit and keep that extension point.
