### PR TITLE
[FrameworkBundle] [SecurityBundle] Rename internal WebTestCase to avoid confusion

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class AbstractWebTestCase extends BaseWebTestCase
+abstract class AbstractWebTestCase extends BaseWebTestCase
 {
     public static function assertRedirect($response, $location)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class WebTestCase extends BaseWebTestCase
+class AbstractWebTestCase extends BaseWebTestCase
 {
     public static function assertRedirect($response, $location)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AnnotatedControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AnnotatedControllerTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-class AnnotatedControllerTest extends WebTestCase
+class AnnotatedControllerTest extends AbstractWebTestCase
 {
     /**
      * @dataProvider getRoutes

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 
-class AutowiringTypesTest extends WebTestCase
+class AutowiringTypesTest extends AbstractWebTestCase
 {
     public function testAnnotationReaderAutowiring()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group functional
  */
-class CachePoolClearCommandTest extends WebTestCase
+class CachePoolClearCommandTest extends AbstractWebTestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group functional
  */
-class CachePoolListCommandTest extends WebTestCase
+class CachePoolListCommandTest extends AbstractWebTestCase
 {
     protected function setUp()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
-class CachePoolsTest extends WebTestCase
+class CachePoolsTest extends AbstractWebTestCase
 {
     public function testCachePools()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group functional
  */
-class ConfigDebugCommandTest extends WebTestCase
+class ConfigDebugCommandTest extends AbstractWebTestCase
 {
     private $application;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group functional
  */
-class ConfigDumpReferenceCommandTest extends WebTestCase
+class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
 {
     private $application;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Tester\ApplicationTester;
 /**
  * @group functional
  */
-class ContainerDebugCommandTest extends WebTestCase
+class ContainerDebugCommandTest extends AbstractWebTestCase
 {
     public function testDumpContainerIfNotExists()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDumpTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDumpTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 /**
  * Checks that the container compiles correctly when all the bundle features are enabled.
  */
-class ContainerDumpTest extends WebTestCase
+class ContainerDumpTest extends AbstractWebTestCase
 {
     public function testContainerCompilationInDebug()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\ApplicationTester;
 /**
  * @group functional
  */
-class DebugAutowiringCommandTest extends WebTestCase
+class DebugAutowiringCommandTest extends AbstractWebTestCase
 {
     public function testBasicFunctionality()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-class FragmentTest extends WebTestCase
+class FragmentTest extends AbstractWebTestCase
 {
     /**
      * @dataProvider getConfigs

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 
-class MailerTest extends WebTestCase
+class MailerTest extends AbstractWebTestCase
 {
     public function testEnvelopeListener()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-class ProfilerTest extends WebTestCase
+class ProfilerTest extends AbstractWebTestCase
 {
     /**
      * @dataProvider getConfigs

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/PropertyInfoTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/PropertyInfoTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Component\PropertyInfo\Type;
 
-class PropertyInfoTest extends WebTestCase
+class PropertyInfoTest extends AbstractWebTestCase
 {
     public function testPhpDocPriority()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group functional
  */
-class RouterDebugCommandTest extends WebTestCase
+class RouterDebugCommandTest extends AbstractWebTestCase
 {
     private $application;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class SerializerTest extends WebTestCase
+class SerializerTest extends AbstractWebTestCase
 {
     public function testDeserializeArrayOfObject()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-class SessionTest extends WebTestCase
+class SessionTest extends AbstractWebTestCase
 {
     /**
      * Tests session attributes persist.

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SubRequestsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SubRequestsTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-class SubRequestsTest extends WebTestCase
+class SubRequestsTest extends AbstractWebTestCase
 {
     public function testStateAfterSubRequest()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServic
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\UnusedPrivateService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class TestServiceContainerTest extends WebTestCase
+class TestServiceContainerTest extends AbstractWebTestCase
 {
     public function testThatPrivateServicesAreUnavailableIfTestConfigIsDisabled()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TranslationDebugCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group functional
  */
-class TranslationDebugCommandTest extends WebTestCase
+class TranslationDebugCommandTest extends AbstractWebTestCase
 {
     private $application;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests;
 
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Symfony\Bundle\FrameworkBundle\Tests\Functional\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\AbstractWebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class KernelBrowserTest extends WebTestCase
+class KernelBrowserTest extends AbstractWebTestCase
 {
     public function testRebootKernelBetweenRequests()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class WebTestCase extends BaseWebTestCase
+abstract class AbstractWebTestCase extends BaseWebTestCase
 {
     public static function assertRedirect($response, $location)
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticationCommencingTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticationCommencingTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-class AuthenticationCommencingTest extends WebTestCase
+class AuthenticationCommencingTest extends AbstractWebTestCase
 {
     public function testAuthenticationIsCommencingIfAccessDeniedExceptionIsWrapped()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
 
-class AutowiringTypesTest extends WebTestCase
+class AutowiringTypesTest extends AbstractWebTestCase
 {
     public function testAccessDecisionManagerAutowiring()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-class CsrfFormLoginTest extends WebTestCase
+class CsrfFormLoginTest extends AbstractWebTestCase
 {
     /**
      * @dataProvider getConfigs

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FirewallEntryPointBundle\Security\EntryPointStub;
 
-class FirewallEntryPointTest extends WebTestCase
+class FirewallEntryPointTest extends AbstractWebTestCase
 {
     public function testItUsesTheConfiguredEntryPointWhenUsingUnknownCredentials()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-class FormLoginTest extends WebTestCase
+class FormLoginTest extends AbstractWebTestCase
 {
     /**
      * @dataProvider getConfigs

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginLdapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginLdapTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Symfony\Component\HttpKernel\Kernel;
 
-class JsonLoginLdapTest extends WebTestCase
+class JsonLoginLdapTest extends AbstractWebTestCase
 {
     public function testKernelBoot()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class JsonLoginTest extends WebTestCase
+class JsonLoginTest extends AbstractWebTestCase
 {
     public function testDefaultJsonLoginSuccess()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LocalizedRoutesAsPathTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LocalizedRoutesAsPathTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-class LocalizedRoutesAsPathTest extends WebTestCase
+class LocalizedRoutesAsPathTest extends AbstractWebTestCase
 {
     /**
      * @dataProvider getLocales

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-class LogoutTest extends WebTestCase
+class LogoutTest extends AbstractWebTestCase
 {
     public function testSessionLessRememberMeLogout()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/MissingUserProviderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/MissingUserProviderTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-class MissingUserProviderTest extends WebTestCase
+class MissingUserProviderTest extends AbstractWebTestCase
 {
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-class SecurityRoutingIntegrationTest extends WebTestCase
+class SecurityRoutingIntegrationTest extends AbstractWebTestCase
 {
     /**
      * @dataProvider getConfigs

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\User;
 
-class SecurityTest extends WebTestCase
+class SecurityTest extends AbstractWebTestCase
 {
     public function testServiceIsFunctional()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 
-class SwitchUserTest extends WebTestCase
+class SwitchUserTest extends AbstractWebTestCase
 {
     /**
      * @dataProvider getTestParameters

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
  *
  * @author Sarah Khalil <mkhalil.sarah@gmail.com>
  */
-class UserPasswordEncoderCommandTest extends WebTestCase
+class UserPasswordEncoderCommandTest extends AbstractWebTestCase
 {
     /** @var CommandTester */
     private $passwordEncoderCommandTester;


### PR DESCRIPTION
FrameworkBundle & SecurityBundle had 2 classes called WebTestCase, 
one of which is only meant for internal tests. To avoid confusion the internal
classes have been renamed to AbstractWebTestCase and made abstract.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no (or, yes, but internal class)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32577
| License       | MIT