### PR TITLE
[FrameworkBundle] Rename Symfony\Bundle\FrameworkBundle\Test\WebTestCase to AbstractWeb…

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/AbstractWebTestCase.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class WebTestCase extends KernelTestCase
+abstract class AbstractWebTestCase extends KernelTestCase
 {
     use WebTestAssertionsTrait;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\AbstractWebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 class WebTestCase extends BaseWebTestCase

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestAssertionsTrait;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\AbstractWebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\DomCrawler\Crawler;
@@ -235,7 +235,7 @@ class WebTestCaseTest extends TestCase
         $this->getRequestTester()->assertRouteSame('articles');
     }
 
-    private function getResponseTester(Response $response): WebTestCase
+    private function getResponseTester(Response $response): AbstractWebTestCase
     {
         $client = $this->createMock(KernelBrowser::class);
         $client->expects($this->any())->method('getResponse')->willReturn($response);
@@ -243,7 +243,7 @@ class WebTestCaseTest extends TestCase
         return $this->getTester($client);
     }
 
-    private function getCrawlerTester(Crawler $crawler): WebTestCase
+    private function getCrawlerTester(Crawler $crawler): AbstractWebTestCase
     {
         $client = $this->createMock(KernelBrowser::class);
         $client->expects($this->any())->method('getCrawler')->willReturn($crawler);
@@ -251,7 +251,7 @@ class WebTestCaseTest extends TestCase
         return $this->getTester($client);
     }
 
-    private function getClientTester(): WebTestCase
+    private function getClientTester(): AbstractWebTestCase
     {
         $client = $this->createMock(KernelBrowser::class);
         $jar = new CookieJar();
@@ -261,7 +261,7 @@ class WebTestCaseTest extends TestCase
         return $this->getTester($client);
     }
 
-    private function getRequestTester(): WebTestCase
+    private function getRequestTester(): AbstractWebTestCase
     {
         $client = $this->createMock(KernelBrowser::class);
         $request = new Request();
@@ -272,9 +272,9 @@ class WebTestCaseTest extends TestCase
         return $this->getTester($client);
     }
 
-    private function getTester(KernelBrowser $client): WebTestCase
+    private function getTester(KernelBrowser $client): AbstractWebTestCase
     {
-        return new class($client) extends WebTestCase {
+        return new class($client) extends AbstractWebTestCase {
             use WebTestAssertionsTrait;
 
             public function __construct(KernelBrowser $client)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\AbstractWebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 class WebTestCase extends BaseWebTestCase


### PR DESCRIPTION
…TestCase

| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4, 4.2 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #3257777 
| License       | MIT


Rename `Symfony\Bundle\FrameworkBundle\Test\WebTestCase` to `AbstractWebTestCase`
