### PR TITLE
[Debug][ExceptionHandler] Add tests for custom handlers

### DIFF
--- a/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
@@ -76,7 +76,7 @@ class ExceptionHandlerTest extends TestCase
 
         ob_start();
         $handler->sendPhpResponse(new MethodNotAllowedHttpException(['POST']));
-        $response = ob_get_clean();
+        ob_get_clean();
 
         $expectedHeaders = [
             ['HTTP/1.0 405', true, null],
@@ -99,35 +99,65 @@ class ExceptionHandlerTest extends TestCase
 
     public function testHandle()
     {
-        $exception = new \Exception('foo');
+        $handler = new ExceptionHandler(true);
+        ob_start();
 
-        $handler = $this->getMockBuilder('Symfony\Component\Debug\ExceptionHandler')->setMethods(['sendPhpResponse'])->getMock();
-        $handler
-            ->expects($this->exactly(2))
-            ->method('sendPhpResponse');
+        $handler->handle(new \Exception('foo'));
 
-        $handler->handle($exception);
+        $this->assertThatTheExceptionWasOutput(ob_get_clean(), \Exception::class, 'Exception', 'foo');
+    }
 
-        $handler->setHandler(function ($e) use ($exception) {
-            $this->assertSame($exception, $e);
+    public function testHandleWithACustomHandlerThatOutputsSomething()
+    {
+        $handler = new ExceptionHandler(true);
+        ob_start();
+        $handler->setHandler(function () {
+            echo 'ccc';
         });
 
-        $handler->handle($exception);
+        $handler->handle(new \Exception());
+        ob_end_flush(); // Necessary because of this PHP bug : https://bugs.php.net/bug.php?id=76563
+        $this->assertSame('ccc', ob_get_clean());
+    }
+
+    public function testHandleWithACustomHandlerThatOutputsNothing()
+    {
+        $handler = new ExceptionHandler(true);
+        $handler->setHandler(function () {});
+
+        $handler->handle(new \Exception('ccc'));
+
+        $this->assertThatTheExceptionWasOutput(ob_get_clean(), \Exception::class, 'Exception', 'ccc');
+    }
+
+    public function testHandleWithACustomHandlerThatFails()
+    {
+        $handler = new ExceptionHandler(true);
+        $handler->setHandler(function () {
+            throw new \RuntimeException();
+        });
+
+        $handler->handle(new \Exception('ccc'));
+
+        $this->assertThatTheExceptionWasOutput(ob_get_clean(), \Exception::class, 'Exception', 'ccc');
     }
 
     public function testHandleOutOfMemoryException()
     {
-        $exception = new OutOfMemoryException('foo', 0, E_ERROR, __FILE__, __LINE__);
-
-        $handler = $this->getMockBuilder('Symfony\Component\Debug\ExceptionHandler')->setMethods(['sendPhpResponse'])->getMock();
-        $handler
-            ->expects($this->once())
-            ->method('sendPhpResponse');
-
-        $handler->setHandler(function ($e) {
+        $handler = new ExceptionHandler(true);
+        ob_start();
+        $handler->setHandler(function () {
             $this->fail('OutOfMemoryException should bypass the handler');
         });
 
-        $handler->handle($exception);
+        $handler->handle(new OutOfMemoryException('foo', 0, E_ERROR, __FILE__, __LINE__));
+
+        $this->assertThatTheExceptionWasOutput(ob_get_clean(), OutOfMemoryException::class, 'OutOfMemoryException', 'foo');
+    }
+
+    private function assertThatTheExceptionWasOutput($content, $expectedClass, $expectedTitle, $expectedMessage)
+    {
+        $this->assertContains(sprintf('<span class="exception_title"><abbr title="%s">%s</abbr></span>', $expectedClass, $expectedTitle), $content);
+        $this->assertContains(sprintf('<p class="break-long-words trace-message">%s</p>', $expectedMessage), $content);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In https://github.com/symfony/symfony/pull/31694 I mixed many things but the whole PR was closed. I wrote some tests for custom handlers + the handle tests don't use mock anymore

I think they are useful even if the `ExceptionHandler` will disappear in the new component because it will still exists in 4.4 for the next 3 years.