### PR TITLE
[Messenger] fix transport_name option not passing validation

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
@@ -24,6 +24,8 @@ class AmqpTransportFactory implements TransportFactoryInterface
 {
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
+        unset($options['transport_name']);
+
         return new AmqpTransport(Connection::fromDsn($dsn, $options), $serializer);
     }
 

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/DoctrineTransportFactory.php
@@ -33,6 +33,7 @@ class DoctrineTransportFactory implements TransportFactoryInterface
 
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
+        unset($options['transport_name']);
         $configuration = Connection::buildConfiguration($dsn, $options);
 
         try {

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/RedisTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/RedisTransportFactory.php
@@ -25,6 +25,8 @@ class RedisTransportFactory implements TransportFactoryInterface
 {
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
+        unset($options['transport_name']);
+
         return new RedisTransport(Connection::fromDsn($dsn, $options), $serializer);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32567
| License       | MIT
| Doc PR        | 

the doctrine transport connection validates the options and complains about this option, so we remove it before. the other transports will probably add the validation as well: #32575 
the purpose of the option is for custom transport factories anyway.