### PR TITLE
[FrameworkBundle] [SecurityBundle] Rename internal WebTestCase to avoid confusion

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group functional
  */
-class RouterDebugCommandTest extends WebTestCase
+class RouterDebugCommandTest extends AbstractWebTestCase
 {
     private $application;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServic
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\UnusedPrivateService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class TestServiceContainerTest extends WebTestCase
+class TestServiceContainerTest extends AbstractWebTestCase
 {
     public function testThatPrivateServicesAreUnavailableIfTestConfigIsDisabled()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class AbstractWebTestCase extends BaseWebTestCase
+abstract class AbstractWebTestCase extends BaseWebTestCase
 {
     public static function assertRedirect($response, $location)
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginLdapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginLdapTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Symfony\Component\HttpKernel\Kernel;
 
-class JsonLoginLdapTest extends WebTestCase
+class JsonLoginLdapTest extends AbstractWebTestCase
 {
     public function testKernelBoot()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/MissingUserProviderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/MissingUserProviderTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-class MissingUserProviderTest extends WebTestCase
+class MissingUserProviderTest extends AbstractWebTestCase
 {
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException


### PR DESCRIPTION
FrameworkBundle & SecurityBundle each had 2 classes called WebTestCase, 
one of which is only meant for internal tests. To avoid confusion the internal
class has been renamed to AbstractWebTestCase and made abstract.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no (or, yes, but internal class)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32577
| License       | MIT

This PR is to ease integration, as not all test classes are present in all currently 
maintained branches. This PR should patch relatively well onto 4.* branches.

See https://github.com/symfony/symfony/pull/32617