### PR TITLE
[Serializer] Adding support for "disable_type_enforcement" in the DateTimeNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,131 +1,121 @@
-CHANGELOG
-=========
+# CHANGELOG
 
-3.4.0
------
+## 3.4.0
 
- * added `AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT` context option
-   to disable throwing an `UnexpectedValueException` on a type mismatch
- * added support for serializing `DateInterval` objects
- * added getter for extra attributes in `ExtraAttributesException`
- * improved `CsvEncoder` to handle variable nested structures
- * CSV headers can be passed to the `CsvEncoder` via the `csv_headers` serialization context variable 
- * added `$context` when checking for encoding, decoding and normalizing in `Serializer`
+- added `AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT` context option
+  to disable throwing an `UnexpectedValueException` on a type mismatch and when an invalid datetime string is
+  casted into a DateTime object
+- added support for serializing `DateInterval` objects
+- added getter for extra attributes in `ExtraAttributesException`
+- improved `CsvEncoder` to handle variable nested structures
+- CSV headers can be passed to the `CsvEncoder` via the `csv_headers` serialization context variable
+- added `$context` when checking for encoding, decoding and normalizing in `Serializer`
 
-3.3.0
------
+## 3.3.0
 
- * added `SerializerPass`
+- added `SerializerPass`
 
-3.1.0
------
+## 3.1.0
 
- * added support for serializing objects that implement `JsonSerializable`
- * added the `DenormalizerAwareTrait` and `NormalizerAwareTrait` traits to
-   support normalizer/denormalizer awareness
- * added the `DenormalizerAwareInterface` and `NormalizerAwareInterface`
-   interfaces to support normalizer/denormalizer awareness
- * added a PSR-6 compatible adapter for caching metadata
- * added a `MaxDepth` option to limit the depth of the object graph when
-   serializing objects
- * added support for serializing `SplFileInfo` objects
- * added support for serializing objects that implement `DateTimeInterface`
- * added `AbstractObjectNormalizer` as a base class for normalizers that deal
-   with objects
- * added support to relation deserialization
+- added support for serializing objects that implement `JsonSerializable`
+- added the `DenormalizerAwareTrait` and `NormalizerAwareTrait` traits to
+  support normalizer/denormalizer awareness
+- added the `DenormalizerAwareInterface` and `NormalizerAwareInterface`
+  interfaces to support normalizer/denormalizer awareness
+- added a PSR-6 compatible adapter for caching metadata
+- added a `MaxDepth` option to limit the depth of the object graph when
+  serializing objects
+- added support for serializing `SplFileInfo` objects
+- added support for serializing objects that implement `DateTimeInterface`
+- added `AbstractObjectNormalizer` as a base class for normalizers that deal
+  with objects
+- added support to relation deserialization
 
-2.7.0
------
+## 2.7.0
 
- * added support for serialization and deserialization groups including
-   annotations, XML and YAML mapping.
- * added `AbstractNormalizer` to factorise code and ease normalizers development
- * added circular references handling for `PropertyNormalizer`
- * added support for a context key called `object_to_populate` in `AbstractNormalizer`
-   to reuse existing objects in the deserialization process
- * added `NameConverterInterface` and `CamelCaseToSnakeCaseNameConverter`
- * [DEPRECATION] `GetSetMethodNormalizer::setCamelizedAttributes()` and
-   `PropertyNormalizer::setCamelizedAttributes()` are replaced by
-   `CamelCaseToSnakeCaseNameConverter`
- * [DEPRECATION] the `Exception` interface has been renamed to `ExceptionInterface`
- * added `ObjectNormalizer` leveraging the `PropertyAccess` component to normalize
-   objects containing both properties and getters / setters / issers / hassers methods.
- * added `xml_type_cast_attributes` context option for allowing users to opt-out of typecasting
-   xml attributes.
+- added support for serialization and deserialization groups including
+  annotations, XML and YAML mapping.
+- added `AbstractNormalizer` to factorise code and ease normalizers development
+- added circular references handling for `PropertyNormalizer`
+- added support for a context key called `object_to_populate` in `AbstractNormalizer`
+  to reuse existing objects in the deserialization process
+- added `NameConverterInterface` and `CamelCaseToSnakeCaseNameConverter`
+- [DEPRECATION] `GetSetMethodNormalizer::setCamelizedAttributes()` and
+  `PropertyNormalizer::setCamelizedAttributes()` are replaced by
+  `CamelCaseToSnakeCaseNameConverter`
+- [DEPRECATION] the `Exception` interface has been renamed to `ExceptionInterface`
+- added `ObjectNormalizer` leveraging the `PropertyAccess` component to normalize
+  objects containing both properties and getters / setters / issers / hassers methods.
+- added `xml_type_cast_attributes` context option for allowing users to opt-out of typecasting
+  xml attributes.
 
-2.6.0
------
+## 2.6.0
 
- * added a new serializer: `PropertyNormalizer`. Like `GetSetMethodNormalizer`,
-   this normalizer will map an object's properties to an array.
- * added circular references handling for `GetSetMethodNormalizer`
+- added a new serializer: `PropertyNormalizer`. Like `GetSetMethodNormalizer`,
+  this normalizer will map an object's properties to an array.
+- added circular references handling for `GetSetMethodNormalizer`
 
-2.5.0
------
+## 2.5.0
 
- * added support for `is.*` getters in `GetSetMethodNormalizer`
+- added support for `is.*` getters in `GetSetMethodNormalizer`
 
-2.4.0
------
+## 2.4.0
 
- * added `$context` support for XMLEncoder.
- * [DEPRECATION] JsonEncode and JsonDecode where modified to throw
-   an exception if error found. No need for get*Error() functions
+- added `$context` support for XMLEncoder.
+- [DEPRECATION] JsonEncode and JsonDecode where modified to throw
+  an exception if error found. No need for get\*Error() functions
 
-2.3.0
------
+## 2.3.0
 
- * added `GetSetMethodNormalizer::setCamelizedAttributes` to allow calling
-   camel cased methods for underscored properties
+- added `GetSetMethodNormalizer::setCamelizedAttributes` to allow calling
+  camel cased methods for underscored properties
 
-2.2.0
------
+## 2.2.0
 
- * [BC BREAK] All Serializer, Normalizer and Encoder interfaces have been
-   modified to include an optional `$context` array parameter.
- * The XML Root name can now be configured with the `xml_root_name`
-   parameter in the context option to the `XmlEncoder`.
- * Options to `json_encode` and `json_decode` can be passed through
-   the context options of `JsonEncode` and `JsonDecode` encoder/decoders.
+- [BC BREAK] All Serializer, Normalizer and Encoder interfaces have been
+  modified to include an optional `$context` array parameter.
+- The XML Root name can now be configured with the `xml_root_name`
+  parameter in the context option to the `XmlEncoder`.
+- Options to `json_encode` and `json_decode` can be passed through
+  the context options of `JsonEncode` and `JsonDecode` encoder/decoders.
 
-2.1.0
------
+## 2.1.0
 
- * added DecoderInterface::supportsDecoding(),
-   EncoderInterface::supportsEncoding()
- * removed NormalizableInterface::denormalize(),
-   NormalizerInterface::denormalize(),
-   NormalizerInterface::supportsDenormalization()
- * removed normalize() denormalize() encode() decode() supportsSerialization()
-   supportsDeserialization() supportsEncoding() supportsDecoding()
-   getEncoder() from SerializerInterface
- * Serializer now implements NormalizerInterface, DenormalizerInterface,
-   EncoderInterface, DecoderInterface in addition to SerializerInterface
- * added DenormalizableInterface and DenormalizerInterface
- * [BC BREAK] changed `GetSetMethodNormalizer`'s key names from all lowercased
-   to camelCased (e.g. `mypropertyvalue` to `myPropertyValue`)
- * [BC BREAK] convert the `item` XML tag to an array
+- added DecoderInterface::supportsDecoding(),
+  EncoderInterface::supportsEncoding()
+- removed NormalizableInterface::denormalize(),
+  NormalizerInterface::denormalize(),
+  NormalizerInterface::supportsDenormalization()
+- removed normalize() denormalize() encode() decode() supportsSerialization()
+  supportsDeserialization() supportsEncoding() supportsDecoding()
+  getEncoder() from SerializerInterface
+- Serializer now implements NormalizerInterface, DenormalizerInterface,
+  EncoderInterface, DecoderInterface in addition to SerializerInterface
+- added DenormalizableInterface and DenormalizerInterface
+- [BC BREAK] changed `GetSetMethodNormalizer`'s key names from all lowercased
+  to camelCased (e.g. `mypropertyvalue` to `myPropertyValue`)
+- [BC BREAK] convert the `item` XML tag to an array
 
-    ``` xml
-    <?xml version="1.0"?>
-    <response>
-        <item><title><![CDATA[title1]]></title></item><item><title><![CDATA[title2]]></title></item>
-    </response>
-    ```
+  ```xml
+  <?xml version="1.0"?>
+  <response>
+      <item><title><![CDATA[title1]]></title></item><item><title><![CDATA[title2]]></title></item>
+  </response>
+  ```
 
-    Before:
+  Before:
 
-        Array()
+       Array()
 
-    After:
+  After:
 
-        Array(
-            [item] => Array(
-                [0] => Array(
-                    [title] => title1
-                )
-                [1] => Array(
-                    [title] => title2
-                )
-            )
-        )
+       Array(
+           [item] => Array(
+               [0] => Array(
+                   [title] => title1
+               )
+               [1] => Array(
+                   [title] => title2
+               )
+           )
+       )

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -103,7 +103,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
             $dateTimeErrors = \DateTime::class === $class ? \DateTime::getLastErrors() : \DateTimeImmutable::getLastErrors();
 
             throw new NotNormalizableValueException(sprintf(
-                'Parsing datetime string "%s" using format "%s" resulted in %d errors:'."\n".'%s',
+                'Parsing datetime string "%s" using format "%s" resulted in %d errors:' . "\n" . '%s',
                 $data,
                 $dateTimeFormat,
                 $dateTimeErrors['error_count'],
@@ -114,6 +114,11 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
+
+            if (true === $context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT]) {
+                return $data;
+            }
+
             throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
         }
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -103,7 +103,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
             $dateTimeErrors = \DateTime::class === $class ? \DateTime::getLastErrors() : \DateTimeImmutable::getLastErrors();
 
             throw new NotNormalizableValueException(sprintf(
-                'Parsing datetime string "%s" using format "%s" resulted in %d errors:'."\n".'%s',
+                'Parsing datetime string "%s" using format "%s" resulted in %d errors:' . "\n" . '%s',
                 $data,
                 $dateTimeFormat,
                 $dateTimeErrors['error_count'],
@@ -114,6 +114,10 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
+            if ($context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] ?? false) {
+                return $data;
+            }
+
             throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
         }
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -114,7 +114,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
-            if ($context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] ?? false) {
+            if (array_key_exists(AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT, $context) && $context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] == false) {
                 return $data;
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -103,7 +103,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
             $dateTimeErrors = \DateTime::class === $class ? \DateTime::getLastErrors() : \DateTimeImmutable::getLastErrors();
 
             throw new NotNormalizableValueException(sprintf(
-                'Parsing datetime string "%s" using format "%s" resulted in %d errors:' . "\n" . '%s',
+                'Parsing datetime string "%s" using format "%s" resulted in %d errors:'."\n".'%s',
                 $data,
                 $dateTimeFormat,
                 $dateTimeErrors['error_count'],
@@ -115,8 +115,8 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
             if (
-                array_key_exists(AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT, $context) && 
-                $context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] == true
+                \array_key_exists(AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT, $context) &&
+                true == $context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT]
             ) {
                 return $data;
             }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -115,7 +115,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
 
-            if (true === $context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT]) {
+            if ($context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] ?? false) {
                 return $data;
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -114,7 +114,6 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
-
             if ($context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] ?? false) {
                 return $data;
             }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 /**
@@ -241,6 +242,14 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeInvalidDataThrowsException()
     {
         $this->normalizer->denormalize('invalid date', \DateTimeInterface::class);
+    }
+
+    public function testDenormalizeInvalidDataWithoutTypeEnforcement()
+    {
+        $data = 'bonjour!';
+        $result = $this->normalizer->denormalize($data, \DateTimeInterface::class, null, [AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true]);
+
+        $this->assertEquals($result, $data);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -241,6 +242,14 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeInvalidDataThrowsException()
     {
         $this->normalizer->denormalize('invalid date', \DateTimeInterface::class);
+    }
+
+    public function testDenormalizeInvalidDataWithoutTypeEnforcement()
+    {
+        $data = "bonjour!";
+        $result = $this->normalizer->denormalize($data, \DateTimeInterface::class, null, [AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true]);
+
+        $this->assertEquals($result, $data);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31596
| License       | MIT
| Doc PR        | TODO

When we disable type enforcement, we expect the deserialization process not to crash when a formatting error is made on a datetime and delegate validation to other actors like the Validation Component etc. 

For now, trying to deserializing an invalid datetime string is throwing and Exception since the normalizer can't instanciate a new DateTime object with it. Thus, our validation process and custom message won't appear to the end user.

This PR aims to take into account the disable_type_enforcement attribute in the context in order to let the invalid datetime value continue it's way and then be stopped by other means like the Validator Component.

With this new code, when an invalid datetime string is submitted to the normalizer, we won't get an exception but a nice violation list created by our Entity or DTO validation process.

PS : I'm really sorry if I did something wrong here, this is my first PR and I would love to hear from you on what I can do next time to give it a better shape !