### PR TITLE
[Serializer] DatetimeNormalizer should not throw exception when a bad formatted string is parsed but disable_type_enforcement is true

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,7 +5,8 @@ CHANGELOG
 -----
 
  * added `AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT` context option
-   to disable throwing an `UnexpectedValueException` on a type mismatch
+   to disable throwing an `UnexpectedValueException` on a type mismatch and when an 
+   invalid datetime string is casted into a DateTime object
  * added support for serializing `DateInterval` objects
  * added getter for extra attributes in `ExtraAttributesException`
  * improved `CsvEncoder` to handle variable nested structures

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -114,6 +114,12 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
+            $isTypeEnforcementDisabled = isset($context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT]) ? $context[AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT] : false;
+
+            if (true == $isTypeEnforcementDisabled) {
+                return $data;
+            }
+
             throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
         }
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 /**
@@ -241,6 +242,14 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeInvalidDataThrowsException()
     {
         $this->normalizer->denormalize('invalid date', \DateTimeInterface::class);
+    }
+
+    public function testDenormalizeInvalidDataWithoutTypeEnforcement()
+    {
+        $data = 'bonjour!';
+        $result = $this->normalizer->denormalize($data, \DateTimeInterface::class, null, [AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true]);
+
+        $this->assertEquals($result, $data);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31596
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11998

When we disable type enforcement, we expect the deserialization process not to crash when a formatting error is made on a datetime and delegate validation to other actors like the Validation Component etc. 

For now, trying to deserializing an invalid datetime string is throwing and Exception since the normalizer can't instanciate a new DateTime object with it. Thus, our validation process and custom message won't appear to the end user.

This PR aims to take into account the disable_type_enforcement attribute in the context in order to let the invalid datetime value continue it's way and then be stopped by other means like the Validator Component.

With this new code, when an invalid datetime string is submitted to the normalizer, we won't get an exception but a nice violation list created by our Entity or DTO validation process.

PS : I'm really sorry if I did something wrong here, this is my first PR and I would love to hear from you on what I can do next time to give it a better shape !