### PR TITLE
[Messenger] Retrieve table default options from the SchemaManager

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -15,6 +15,8 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -102,25 +104,26 @@ class ConnectionTest extends TestCase
 
     private function getDBALConnectionMock()
     {
-        $driverConnection = $this->getMockBuilder(\Doctrine\DBAL\Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $platform = $this->getMockBuilder(AbstractPlatform::class)
-            ->getMock();
+        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $platform = $this->createMock(AbstractPlatform::class);
         $platform->method('getWriteLockSQL')->willReturn('FOR UPDATE');
-        $configuration = $this->getMockBuilder(\Doctrine\DBAL\Configuration::class)
-            ->getMock();
+        $configuration = $this->createMock(\Doctrine\DBAL\Configuration::class);
         $driverConnection->method('getDatabasePlatform')->willReturn($platform);
         $driverConnection->method('getConfiguration')->willReturn($configuration);
+
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaConfig = $this->createMock(SchemaConfig::class);
+        $schemaConfig->method('getMaxIdentifierLength')->willReturn(63);
+        $schemaConfig->method('getDefaultTableOptions')->willReturn([]);
+        $schemaManager->method('createSchemaConfig')->willReturn($schemaConfig);
+        $driverConnection->method('getSchemaManager')->willReturn($schemaManager);
 
         return $driverConnection;
     }
 
     private function getQueryBuilderMock()
     {
-        $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $queryBuilder = $this->createMock(QueryBuilder::class);
 
         $queryBuilder->method('select')->willReturn($queryBuilder);
         $queryBuilder->method('update')->willReturn($queryBuilder);
@@ -138,9 +141,7 @@ class ConnectionTest extends TestCase
 
     private function getStatementMock($expectedResult)
     {
-        $stmt = $this->getMockBuilder(Statement::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $stmt = $this->createMock(Statement::class);
         $stmt->expects($this->once())
             ->method('fetch')
             ->willReturn($expectedResult);
@@ -150,8 +151,7 @@ class ConnectionTest extends TestCase
 
     private function getSchemaSynchronizerMock()
     {
-        return $this->getMockBuilder(SchemaSynchronizer::class)
-            ->getMock();
+        return $this->createMock(SchemaSynchronizer::class);
     }
 
     /**
@@ -307,9 +307,7 @@ class ConnectionTest extends TestCase
             'headers' => json_encode(['type' => DummyMessage::class]),
         ];
 
-        $stmt = $this->getMockBuilder(Statement::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $stmt = $this->createMock(Statement::class);
         $stmt->expects($this->once())
             ->method('fetchAll')
             ->willReturn([$message1, $message2]);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineReceiverTest.php
@@ -32,7 +32,7 @@ class DoctrineReceiverTest extends TestCase
         $serializer = $this->createSerializer();
 
         $doctrineEnvelope = $this->createDoctrineEnvelope();
-        $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $connection = $this->createMock(Connection::class);
         $connection->method('get')->willReturn($doctrineEnvelope);
 
         $receiver = new DoctrineReceiver($connection, $serializer);
@@ -62,7 +62,7 @@ class DoctrineReceiverTest extends TestCase
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
         $doctrineEnvelop = $this->createDoctrineEnvelope();
-        $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $connection = $this->createMock(Connection::class);
         $connection->method('get')->willReturn($doctrineEnvelop);
         $connection->expects($this->once())->method('reject');
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineSenderTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineSenderTest.php
@@ -27,12 +27,10 @@ class DoctrineSenderTest extends TestCase
         $envelope = new Envelope(new DummyMessage('Oy'));
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'])->willReturn(15);
 
-        $serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
+        $serializer = $this->createMock(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
 
         $sender = new DoctrineSender($connection, $serializer);
@@ -49,12 +47,10 @@ class DoctrineSenderTest extends TestCase
         $envelope = (new Envelope(new DummyMessage('Oy')))->with(new DelayStamp(500));
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'], 500);
 
-        $serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
+        $serializer = $this->createMock(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);
 
         $sender = new DoctrineSender($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineTransportFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Tests\Transport\Doctrine;
 
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\SchemaConfig;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Messenger\Transport\Doctrine\Connection;
@@ -23,7 +25,7 @@ class DoctrineTransportFactoryTest extends TestCase
     public function testSupports()
     {
         $factory = new DoctrineTransportFactory(
-            $this->getMockBuilder(RegistryInterface::class)->getMock()
+            $this->createMock(RegistryInterface::class)
         );
 
         $this->assertTrue($factory->supports('doctrine://default', []));
@@ -32,19 +34,21 @@ class DoctrineTransportFactoryTest extends TestCase
 
     public function testCreateTransport()
     {
-        $connection = $this->getMockBuilder(\Doctrine\DBAL\Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $registry = $this->getMockBuilder(RegistryInterface::class)->getMock();
+        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaConfig = $this->createMock(SchemaConfig::class);
+        $schemaManager->method('createSchemaConfig')->willReturn($schemaConfig);
+        $driverConnection->method('getSchemaManager')->willReturn($schemaManager);
+        $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->once())
             ->method('getConnection')
-            ->willReturn($connection);
+            ->willReturn($driverConnection);
 
         $factory = new DoctrineTransportFactory($registry);
         $serializer = $this->createMock(SerializerInterface::class);
 
         $this->assertEquals(
-            new DoctrineTransport(new Connection(Connection::buildConfiguration('doctrine://default'), $connection), $serializer),
+            new DoctrineTransport(new Connection(Connection::buildConfiguration('doctrine://default'), $driverConnection), $serializer),
             $factory->createTransport('doctrine://default', [], $serializer)
         );
     }
@@ -55,7 +59,7 @@ class DoctrineTransportFactoryTest extends TestCase
      */
     public function testCreateTransportMustThrowAnExceptionIfManagerIsNotFound()
     {
-        $registry = $this->getMockBuilder(RegistryInterface::class)->getMock();
+        $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->once())
             ->method('getConnection')
             ->willReturnCallback(function () {

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineTransportTest.php
@@ -31,8 +31,8 @@ class DoctrineTransportTest extends TestCase
     public function testReceivesMessages()
     {
         $transport = $this->getTransport(
-            $serializer = $this->getMockBuilder(SerializerInterface::class)->getMock(),
-            $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock()
+            $serializer = $this->createMock(SerializerInterface::class),
+            $connection = $this->createMock(Connection::class)
         );
 
         $decodedMessage = new DummyMessage('Decoded.');
@@ -52,8 +52,8 @@ class DoctrineTransportTest extends TestCase
 
     private function getTransport(SerializerInterface $serializer = null, Connection $connection = null)
     {
-        $serializer = $serializer ?: $this->getMockBuilder(SerializerInterface::class)->getMock();
-        $connection = $connection ?: $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $serializer = $serializer ?: $this->createMock(SerializerInterface::class);
+        $connection = $connection ?: $this->createMock(Connection::class);
 
         return new DoctrineTransport($connection, $serializer);
     }

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -304,7 +304,7 @@ class Connection
 
     private function getSchema(): Schema
     {
-        $schema = new Schema();
+        $schema = new Schema([], [], $this->driverConnection->getSchemaManager()->createSchemaConfig());
         $table = $schema->createTable($this->configuration['table_name']);
         $table->addColumn('id', Type::BIGINT)
             ->setAutoincrement(true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32321    <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This PR modify the Connection of the Doctrine Transport. It is now possible to specify a `SchemaConfig` that will be used when generating tables.

If Doctrine is configured as the following : 
```yml
# config/packages/doctrine.yaml
doctrine:
    dbal:
        default_table_options:
            charset: 'utf8mb4'
            collate: 'utf8mb4_unicode_ci'
```

Then those options are used to create the table.

ping @weaverryan :wink: 