### PR TITLE
[Serializer] Adding `ignore_invalid_datetimes` flag to Serialization Context to avoid exceptions

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.4
+-----
+
+ * added a `ignore_invalid_datetimes` context option to allow invalid date strings when denormalizing without 
+   throwing an exception
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
- * added a `ignore_invalid_datetimes` context option to allow invalid date strings when denormalizing without 
+ * added a `datetime_allow_invalid` context option to allow invalid date strings when denormalizing without 
    throwing an exception
 
 4.3.0

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-4.4
+4.4.0
 -----
 
  * added a `ignore_invalid_datetimes` context option to allow invalid date strings when denormalizing without 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -33,7 +33,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
      * if the string is well formatted but will avoid exception if the string is not
      * well formatted.
      */
-    public const IGNORE_INVALID_DATETIMES = 'ignore_invalid_datetimes';
+    public const DATETIME_ALLOW_INVALID = 'datetime_allow_invalid';
 
     private $defaultContext;
 
@@ -51,6 +51,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         $this->defaultContext = [
             self::FORMAT_KEY => \DateTime::RFC3339,
             self::TIMEZONE_KEY => null,
+            self::DATETIME_ALLOW_INVALID => false,
         ];
 
         if (!\is_array($defaultContext)) {
@@ -128,7 +129,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
-            if ($context[self::IGNORE_INVALID_DATETIMES] ?? false) {
+            if ($context[self::DATETIME_ALLOW_INVALID] ?? $this->defaultContext[self::DATETIME_ALLOW_INVALID]) {
                 return $data;
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -33,7 +33,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
      * if the string is well formatted but will avoid exception if the string is not
      * well formatted.
      */
-    public const DATETIME_ALLOW_INVALID = 'datetime_allow_invalid';
+    public const ALLOW_INVALID = 'datetime_allow_invalid';
 
     private $defaultContext;
 
@@ -51,7 +51,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         $this->defaultContext = [
             self::FORMAT_KEY => \DateTime::RFC3339,
             self::TIMEZONE_KEY => null,
-            self::DATETIME_ALLOW_INVALID => false,
+            self::ALLOW_INVALID => false,
         ];
 
         if (!\is_array($defaultContext)) {
@@ -129,7 +129,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
-            if ($context[self::DATETIME_ALLOW_INVALID] ?? $this->defaultContext[self::DATETIME_ALLOW_INVALID]) {
+            if ($context[self::ALLOW_INVALID] ?? $this->defaultContext[self::ALLOW_INVALID]) {
                 return $data;
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -26,14 +26,14 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
     const TIMEZONE_KEY = 'datetime_timezone';
 
     /**
-     * While denormalizing, we try to cast strings into real DateTime instances 
-     * causing exception to be thrown if the string is not well formatted
-     * 
-     * Setting this tag to true will allow you to retrieve real instance of DateTime 
+     * While denormalizing, we try to cast strings into real DateTime instances
+     * causing exception to be thrown if the string is not well formatted.
+     *
+     * Setting this tag to true will allow you to retrieve real instance of DateTime
      * if the string is well formatted but will avoid exception if the string is not
      * well formatted.
      */
-    public const IGNORE_INVALID_DATETIMES = "ignore_invalid_datetimes";
+    public const IGNORE_INVALID_DATETIMES = 'ignore_invalid_datetimes';
 
     private $defaultContext;
 
@@ -117,7 +117,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
             $dateTimeErrors = \DateTime::class === $class ? \DateTime::getLastErrors() : \DateTimeImmutable::getLastErrors();
 
             throw new NotNormalizableValueException(sprintf(
-                'Parsing datetime string "%s" using format "%s" resulted in %d errors:' . "\n" . '%s',
+                'Parsing datetime string "%s" using format "%s" resulted in %d errors:'."\n".'%s',
                 $data,
                 $dateTimeFormat,
                 $dateTimeErrors['error_count'],
@@ -128,7 +128,6 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
-
             if ($context[self::IGNORE_INVALID_DATETIMES] ?? false) {
                 return $data;
             }

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -25,6 +25,16 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
     const FORMAT_KEY = 'datetime_format';
     const TIMEZONE_KEY = 'datetime_timezone';
 
+    /**
+     * While denormalizing, we try to cast strings into real DateTime instances 
+     * causing exception to be thrown if the string is not well formatted
+     * 
+     * Setting this tag to true will allow you to retrieve real instance of DateTime 
+     * if the string is well formatted but will avoid exception if the string is not
+     * well formatted.
+     */
+    public const IGNORE_INVALID_DATETIMES = "ignore_invalid_datetimes";
+
     private $defaultContext;
 
     private static $supportedTypes = [
@@ -107,7 +117,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
             $dateTimeErrors = \DateTime::class === $class ? \DateTime::getLastErrors() : \DateTimeImmutable::getLastErrors();
 
             throw new NotNormalizableValueException(sprintf(
-                'Parsing datetime string "%s" using format "%s" resulted in %d errors:'."\n".'%s',
+                'Parsing datetime string "%s" using format "%s" resulted in %d errors:' . "\n" . '%s',
                 $data,
                 $dateTimeFormat,
                 $dateTimeErrors['error_count'],
@@ -118,6 +128,11 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
+
+            if ($context[self::IGNORE_INVALID_DATETIMES] ?? false) {
+                return $data;
+            }
+
             throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
         }
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -34,7 +34,7 @@ interface DenormalizerInterface
      * @param string $format  Format the given data was extracted from
      * @param array  $context Options available to the denormalizer
      *
-     * @return object
+     * @return object|string
      *
      * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
      * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -278,6 +278,14 @@ class DateTimeNormalizerTest extends TestCase
         $this->normalizer->denormalize('invalid date', \DateTimeInterface::class);
     }
 
+    public function testDenormalizeInvalidDateWontThrowExceptionIfIgnoreInvalidDatetimes()
+    {
+        $data = 'invalid date';
+        $result = $this->normalizer->denormalize($data, \DateTimeInterface::class, null, [DateTimeNormalizer::IGNORE_INVALID_DATETIMES => true]);
+
+        $this->assertEquals($data, $result);
+    }
+
     /**
      * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
      * @expectedExceptionMessage The data is either an empty string or null, you should pass a string that can be parsed with the passed format or a valid DateTime string.

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -281,7 +281,7 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeInvalidDateWontThrowExceptionIfIgnoreInvalidDatetimes()
     {
         $data = 'invalid date';
-        $result = $this->normalizer->denormalize($data, \DateTimeInterface::class, null, [DateTimeNormalizer::IGNORE_INVALID_DATETIMES => true]);
+        $result = $this->normalizer->denormalize($data, \DateTimeInterface::class, null, [DateTimeNormalizer::DATETIME_ALLOW_INVALID => true]);
 
         $this->assertEquals($data, $result);
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -281,7 +281,7 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeInvalidDateWontThrowExceptionIfIgnoreInvalidDatetimes()
     {
         $data = 'invalid date';
-        $result = $this->normalizer->denormalize($data, \DateTimeInterface::class, null, [DateTimeNormalizer::DATETIME_ALLOW_INVALID => true]);
+        $result = $this->normalizer->denormalize($data, \DateTimeInterface::class, null, [DateTimeNormalizer::ALLOW_INVALID => true]);
 
         $this->assertEquals($data, $result);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #31596
| License       | MIT
| Doc PR        | TODO

I came to the idea of allowing invalid date strings to be denormalize _without throwing an exception_ because I often want to return a well formated violations list with real error messages to the end user/developer.

Actually, when someone submits an invalid date format, instead of receiving a cool violation message generated by the Validator Component (for instance), he receive an exception because the DateTimeNormalizer::denormalize method can't instanciate a DateTimeInterface instance.

This is a cool and normal behavior but we must allow API developers to choose how they want to manage this type of error and to be able to let it pass until Validation process handles it.

PS : I'm really sorry if I did something wrong here, this is my first PR and I would love to hear from you on what I can do next time to give it a better shape !