### PR TITLE
[Mailer] Fix attachment content encoding for SendgridTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
@@ -113,9 +113,11 @@ class SendgridTransport extends AbstractApiTransport
             $headers = $attachment->getPreparedHeaders();
             $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
             $disposition = $headers->getHeaderBody('Content-Disposition');
+            // Sendgrid does not accept line breaks for base64 encoded attachments
+            $content = 'base64' === $attachment->getEncoding() ? base64_encode($attachment->getBody()) : $attachment->bodyToString();
 
             $att = [
-                'content' => $attachment->bodyToString(),
+                'content' => $content,
                 'type' => $headers->get('Content-Type')->getBody(),
                 'filename' => $filename,
                 'disposition' => $disposition,

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^4.3"
     },
+    "conflict": {
+        "symfony/mime": "<4.3.3"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Sendgrid\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -146,6 +146,14 @@ class TextPart extends AbstractPart
         return $headers;
     }
 
+    /**
+     * @internal
+     */
+    public function getEncoding(): string
+    {
+        return $this->encoding;
+    }
+
     private function getEncoder(): ContentEncoderInterface
     {
         if ('8bit' === $this->encoding) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Using the SendgridTransport (HTTP), emails cannot be sent as soon as they have attachments. 
This is due to Sendgrid not supporting line breaks in base64 encoded content (encoding is considered invalid, which results in a 400 response from the Sendgrid API).

> PHP Fatal error: Uncaught Symfony\Component\Mailer\Exception\TransportException: Unable to send an email: The attachment content must be base64 encoded. (code 400). in ./vendor/symfony/sendgrid-mailer/Http/Api/SendgridTransport.php:51 Stack trace: #0 ./vendor/symfony/mailer/Transport/Http/Api/AbstractApiTransport.php(59): Symfony\Component\Mailer\Bridge\Sendgrid\Http\Api\SendgridTransport->doSendEmail(Object(Symfony\Component\Mime\Email), Object(Symfony\Component\Mailer\DelayedSmtpEnvelope))

It has been reported multiple times in sendgrid official integrations, and the answer was always "please open a PR to document this in our troubleshooting section, strict base64 is required".
See limitation documented here https://github.com/sendgrid/sendgrid-ruby/blob/master/USE_CASES.md#adding-attachments and a bug report https://github.com/sendgrid/sendgrid-php/issues/272.