### PR TITLE
[Routing] Match uri with query string

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -104,6 +104,7 @@ EOF;
         \$context = \$this->context;
         \$request = \$this->request ?: \$this->createRequest(\$pathinfo);
         \$requestMethod = \$canonicalMethod = \$context->getMethod();
+        \$pathinfo = \$request->getPathInfo();
 
         if ('HEAD' === \$requestMethod) {
             \$canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher0.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher0.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request ?: $this->createRequest($pathinfo);
         $requestMethod = $canonicalMethod = $context->getMethod();
+        $pathinfo = $request->getPathInfo();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request ?: $this->createRequest($pathinfo);
         $requestMethod = $canonicalMethod = $context->getMethod();
+        $pathinfo = $request->getPathInfo();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $context = $this->context;
         $request = $this->request ?: $this->createRequest($pathinfo);
         $requestMethod = $canonicalMethod = $context->getMethod();
+        $pathinfo = $request->getPathInfo();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request ?: $this->createRequest($pathinfo);
         $requestMethod = $canonicalMethod = $context->getMethod();
+        $pathinfo = $request->getPathInfo();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request ?: $this->createRequest($pathinfo);
         $requestMethod = $canonicalMethod = $context->getMethod();
+        $pathinfo = $request->getPathInfo();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher5.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher5.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $context = $this->context;
         $request = $this->request ?: $this->createRequest($pathinfo);
         $requestMethod = $canonicalMethod = $context->getMethod();
+        $pathinfo = $request->getPathInfo();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher6.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher6.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request ?: $this->createRequest($pathinfo);
         $requestMethod = $canonicalMethod = $context->getMethod();
+        $pathinfo = $request->getPathInfo();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher7.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher7.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $context = $this->context;
         $request = $this->request ?: $this->createRequest($pathinfo);
         $requestMethod = $canonicalMethod = $context->getMethod();
+        $pathinfo = $request->getPathInfo();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32635   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

At the moment when we want to match with query string, example:
```php
$router->match('/test?query=abc');
```
we will get `ResourceNotFoundException` exception no matter if uri `/test` matches an existing url.
Matcher for Request works well and match urls with query string. Both should work the same and should ignore query string.