### PR TITLE
Clarify deprecations for framework.templating

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -77,7 +77,7 @@ Form
 FrameworkBundle
 ---------------
 
- * Deprecated the `framework.templating` option, use Twig instead.
+ * Deprecated the `framework.templating` option, configure the Twig bundle instead.
  * Not passing the project directory to the constructor of the `AssetsInstallCommand` is deprecated. This argument will
    be mandatory in 5.0.
  * Deprecated the "Psr\SimpleCache\CacheInterface" / "cache.app.simple" service, use "Symfony\Contracts\Cache\CacheInterface" / "cache.app" instead.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -169,7 +169,7 @@ Form
 FrameworkBundle
 ---------------
 
- * Removed the `framework.templating` option, use Twig instead.
+ * Removed the `framework.templating` option, configure the Twig bundle instead.
  * The project dir argument of the constructor of `AssetsInstallCommand` is required.
  * Removed support for `bundle:controller:action` syntax to reference controllers. Use `serviceOrFqcn::method`
    instead where `serviceOrFqcn` is either the service ID when using controllers as services or the FQCN of the controller.

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 4.3.0
 -----
 
- * Deprecated the `framework.templating` option, use Twig instead.
+ * Deprecated the `framework.templating` option, configure the Twig bundle instead.
  * Added `WebTestAssertionsTrait` (included by default in `WebTestCase`)
  * Renamed `Client` to `KernelBrowser`
  * Not passing the project directory to the constructor of the `AssetsInstallCommand` is deprecated. This argument will

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -608,7 +608,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('templating')
                     ->info('templating configuration')
                     ->canBeEnabled()
-                    ->setDeprecated('The "%path%.%node%" configuration is deprecated since Symfony 4.3. Use the "twig" service directly instead.')
+                    ->setDeprecated('The "%path%.%node%" configuration is deprecated since Symfony 4.3. Configure the "twig" section provided by the Twig Bundle instead.')
                     ->beforeNormalization()
                         ->ifTrue(function ($v) { return false === $v || \is_array($v) && false === $v['enabled']; })
                         ->then(function () { return ['enabled' => false, 'engines' => false]; })


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

After updating to 4.3 I started receiving a bunch of deprecations:
 - `Enabling the Templating component is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.`
 - `The "templating.cache_warmer.template_paths" service is deprecated since Symfony 4.3 and will be removed in 5.0.`
 - `The Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplatePathsCacheWarmer class is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.`
 - `The "templating.finder" service is deprecated since Symfony 4.3 and will be removed in 5.0.`
 - `The "templating.locator" service is deprecated since Symfony 4.3 and will be removed in 5.0.`

The main gist here was _"use Twig instead"_, which I'm already doing. Hopefully the changed messages in the upgrade guides/config should guide developers to the solution, as it seems to be as simple as removing the config to prevent all these deprecations from triggering. After removing the templating config, it fixed all these deprecations for me without breaking anything else (from what I could tell).

