### PR TITLE
[ErrorRenderer] Making debug = false by default and cleanup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.xml
@@ -31,7 +31,6 @@
         <service id="error_renderer.renderer.txt" class="Symfony\Component\ErrorRenderer\ErrorRenderer\TxtErrorRenderer">
             <tag name="error_renderer.renderer" />
             <argument>%kernel.debug%</argument>
-            <argument>%kernel.charset%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/HtmlErrorRenderer.php
@@ -33,7 +33,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     private $charset;
     private $fileLinkFormat;
 
-    public function __construct(bool $debug = true, string $charset = null, $fileLinkFormat = null)
+    public function __construct(bool $debug = false, string $charset = null, $fileLinkFormat = null)
     {
         $this->debug = $debug;
         $this->charset = $charset ?: (ini_get('default_charset') ?: 'UTF-8');

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/JsonErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/JsonErrorRenderer.php
@@ -20,7 +20,7 @@ class JsonErrorRenderer implements ErrorRendererInterface
 {
     private $debug;
 
-    public function __construct(bool $debug = true)
+    public function __construct(bool $debug = false)
     {
         $this->debug = $debug;
     }

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/TxtErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/TxtErrorRenderer.php
@@ -19,12 +19,10 @@ use Symfony\Component\ErrorRenderer\Exception\FlattenException;
 class TxtErrorRenderer implements ErrorRendererInterface
 {
     private $debug;
-    private $charset;
 
-    public function __construct(bool $debug = true, string $charset = null)
+    public function __construct(bool $debug = false)
     {
         $this->debug = $debug;
-        $this->charset = $charset ?: (ini_get('default_charset') ?: 'UTF-8');
     }
 
     /**

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/XmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/XmlErrorRenderer.php
@@ -21,7 +21,7 @@ class XmlErrorRenderer implements ErrorRendererInterface
     private $debug;
     private $charset;
 
-    public function __construct(bool $debug = true, string $charset = null)
+    public function __construct(bool $debug = false, string $charset = null)
     {
         $this->debug = $debug;
         $this->charset = $charset ?: (ini_get('default_charset') ?: 'UTF-8');

--- a/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/HtmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/HtmlErrorRendererTest.php
@@ -22,6 +22,6 @@ class HtmlErrorRendererTest extends TestCase
         $exception = FlattenException::createFromThrowable(new \RuntimeException('Foo'));
         $expected = '<!DOCTYPE html>%A<html>%A<head>%A<title>Internal Server Error</title>%A<h1 class="break-long-words exception-message">Foo</h1>%A<abbr title="RuntimeException">RuntimeException</abbr>%A';
 
-        $this->assertStringMatchesFormat($expected, (new HtmlErrorRenderer())->render($exception));
+        $this->assertStringMatchesFormat($expected, (new HtmlErrorRenderer(true))->render($exception));
     }
 }

--- a/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/JsonErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/JsonErrorRendererTest.php
@@ -32,6 +32,6 @@ class JsonErrorRendererTest extends TestCase
             "trace":
 JSON;
 
-        $this->assertStringStartsWith($expected, (new JsonErrorRenderer())->render($exception));
+        $this->assertStringStartsWith($expected, (new JsonErrorRenderer(true))->render($exception));
     }
 }

--- a/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/TxtErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/TxtErrorRendererTest.php
@@ -22,6 +22,6 @@ class TxtErrorRendererTest extends TestCase
         $exception = FlattenException::createFromThrowable(new \RuntimeException('Foo'));
         $expected = '[title] Internal Server Error%A[status] 500%A[detail] Foo%A[1] RuntimeException: Foo%A';
 
-        $this->assertStringMatchesFormat($expected, (new TxtErrorRenderer())->render($exception));
+        $this->assertStringMatchesFormat($expected, (new TxtErrorRenderer(true))->render($exception));
     }
 }

--- a/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/XmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/XmlErrorRendererTest.php
@@ -22,6 +22,6 @@ class XmlErrorRendererTest extends TestCase
         $exception = FlattenException::createFromThrowable(new \RuntimeException('Foo'));
         $expected = '<?xml version="1.0" encoding="UTF-8" ?>%A<problem xmlns="urn:ietf:rfc:7807">%A<title>Internal Server Error</title>%A<status>500</status>%A<detail>Foo</detail>%A';
 
-        $this->assertStringMatchesFormat($expected, (new XmlErrorRenderer())->render($exception));
+        $this->assertStringMatchesFormat($expected, (new XmlErrorRenderer(true))->render($exception));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Consistent with other places where the default value is `false`.
