### PR TITLE
[Security/Http] Don't mark AbstractAuthenticationListener as internal

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -48,8 +48,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
- *
- * @internal since Symfony 4.3
  */
 abstract class AbstractAuthenticationListener implements ListenerInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32662
| License       | MIT
| Doc PR        | -

This class is documented as useful to build custom listeners, and some projects do.
There's no need to have it internal (its "handle" method is already marked as deprecated in LegacyListenerTrait)