### PR TITLE
Ignore missing translation dependency in FrameworkBundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -23,7 +23,7 @@
                 <argument type="service" id="validator.validator_factory" />
             </call>
             <call method="setTranslator">
-                <argument type="service" id="translator" />
+                <argument type="service" id="translator" on-invalid="ignore" />
             </call>
             <call method="setTranslationDomain">
                 <argument>%validator.translation_domain%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -674,7 +674,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('setConstraintValidatorFactory', $calls[0][0]);
         $this->assertEquals([new Reference('validator.validator_factory')], $calls[0][1]);
         $this->assertSame('setTranslator', $calls[1][0]);
-        $this->assertEquals([new Reference('translator')], $calls[1][1]);
+        $this->assertEquals([new Reference('translator', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)], $calls[1][1]);
         $this->assertSame('setTranslationDomain', $calls[2][0]);
         $this->assertSame(['%validator.translation_domain%'], $calls[2][1]);
         $this->assertSame('addXmlMappings', $calls[3][0]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This applies the fix from #31156 to the validator.xml file. The error came up a couple of times in the test suite for DoctrineBundle. When using `symfony/framework-bundle` with `symfony/validator` installed but without `symfony/translation`, the call to `setTranslator` will error out because of the missing `translator` service. Thus, the call to `setTranslator` needs to ignore a missing translator dependency to support this scenario.

I don't know how to best test this since the translation component is present in the `require-dev` directive of FrameworkBundle's `composer.json`. If you have any suggestions how to achieve this, please let me know.