### PR TITLE
[ErrorHandler] Relax transition to the new Debug class

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/stubs/Debug.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/stubs/Debug.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug;
+
+if (!class_exists(Debug::class, false)) {
+    class_alias(\Symfony\Component\ErrorHandler\Debug::class, Debug::class);
+}
+
+if (false) {
+    /**
+     * @deprecated since Symfony 4.4, use Symfony\Component\ErrorHandler\Debug instead.
+     */
+    class Debug extends \Symfony\Component\ErrorHandler\Debug
+    {
+    }
+}

--- a/src/Symfony/Component/ErrorHandler/composer.json
+++ b/src/Symfony/Component/ErrorHandler/composer.json
@@ -20,14 +20,15 @@
         "psr/log": "~1.0",
         "symfony/error-renderer": "^4.4|^5.0"
     },
-    "conflict": {
-        "symfony/http-kernel": "<3.4"
-    },
     "require-dev": {
         "symfony/http-kernel": "^3.4|^4.0|^5.0"
     },
+    "conflict": {
+        "symfony/http-kernel": "<3.4"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\ErrorHandler\\": "" },
+        "classmap": [ "Resources/stubs/Debug.php" ],
         "exclude-from-classmap": [
             "/Tests/"
         ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Alternative of https://github.com/symfony/recipes/pull/630
This would solve the bug in `bin/console.php` and `public/index.php` for existing projects migrating to 4.4 without requiring symfony/debug.

/cc @nicolas-grekas 