### PR TITLE
Optimize production build by ignoring dev files

### DIFF
--- a/src/Symfony/Component/VarDumper/.gitattributes
+++ b/src/Symfony/Component/VarDumper/.gitattributes
@@ -1,0 +1,5 @@
+/Tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+CHANGELOG.md export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

This will rid production package of not needed dev files (tests and repo settings files). If you're OK, I could apply this everywhere (main repo and sub-repos), it would make Symfony installation faster and would save place on servers.