### PR TITLE
[Intl] relax some date parser patterns

### DIFF
--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayTransformer.php
@@ -33,7 +33,7 @@ class DayTransformer extends Transformer
      */
     public function getReverseMatchingRegExp($length)
     {
-        return 1 === $length ? '\d{1,2}' : '\d{'.$length.'}';
+        return 1 === $length ? '\d{1,2}' : '\d{1,'.$length.'}';
     }
 
     /**

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/MonthTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/MonthTransformer.php
@@ -104,7 +104,7 @@ class MonthTransformer extends Transformer
                 $regExp = '[JFMASOND]';
                 break;
             default:
-                $regExp = '\d{'.$length.'}';
+                $regExp = '\d{1,'.$length.'}';
                 break;
         }
 

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/YearTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/YearTransformer.php
@@ -37,7 +37,7 @@ class YearTransformer extends Transformer
      */
     public function getReverseMatchingRegExp($length)
     {
-        return 2 === $length ? '\d{2}' : '\d{4}';
+        return 2 === $length ? '\d{2}' : '\d{1,4}';
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -618,6 +618,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     {
         return [
             ['y-M-d', '1970-1-1', 0],
+            ['y-MM-d', '1970-1-1', 0],
             ['y-MMM-d', '1970-Jan-1', 0],
             ['y-MMMM-d', '1970-January-1', 0],
         ];
@@ -636,6 +637,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     {
         return [
             ['y-M-d', '1970-1-1', 0],
+            ['y-M-dd', '1970-1-1', 0],
             ['y-M-dd', '1970-1-01', 0],
             ['y-M-ddd', '1970-1-001', 0],
         ];

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -183,6 +183,17 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         return $this->notImplemented(parent::parseQuarterProvider());
     }
 
+    public function testParseThreeDigitsYears()
+    {
+        if (PHP_INT_SIZE < 8) {
+            $this->markTestSkipped('Parsing three digits years requires a 64bit PHP.');
+        }
+
+        $formatter = $this->getDefaultDateFormatter('yyyy-M-d');
+        $this->assertSame(-32157648000, $formatter->parse('950-12-19'));
+        $this->assertIsIntlSuccess($formatter, 'U_ZERO_ERROR', IntlGlobals::U_ZERO_ERROR);
+    }
+
     protected function getDateFormatter($locale, $datetype, $timetype, $timezone = null, $calendar = IntlDateFormatter::GREGORIAN, $pattern = null)
     {
         return new IntlDateFormatter($locale, $datetype, $timetype, $timezone, $calendar, $pattern);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

While debugging the failures in #31374 I realised that the `IntlDateFormatter` from the Intl component parses dates more strictly than PHP's `IntlDateFormatter` class does.