### PR TITLE
[Messenger][Profiler] Collect the stamps at the end of dispatch

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -4,11 +4,12 @@ CHANGELOG
 4.4.0
 -----
 
- * Added button to clear the ajax request tab
- * Deprecated the `ExceptionController::templateExists()` method
- * Deprecated the `TemplateManager::templateExists()` method
- * Deprecated the `ExceptionController` in favor of `ExceptionPanelController`
- * Marked all classes of the WebProfilerBundle as internal
+ * added button to clear the ajax request tab
+ * deprecated the `ExceptionController::templateExists()` method
+ * deprecated the `TemplateManager::templateExists()` method
+ * deprecated the `ExceptionController` in favor of `ExceptionPanelController`
+ * marked all classes of the WebProfilerBundle as internal
+ * added a section with the stamps of a message after it is dispatched in the Messenger panel
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -45,7 +45,7 @@
     {{ parent() }}
     <style>
         .message-item thead th { position: relative; cursor: pointer; user-select: none; padding-right: 35px; }
-        .message-item tbody tr td:first-child { width: 115px; }
+        .message-item tbody tr td:first-child { width: 170px; }
 
         .message-item .label { float: right; padding: 1px 5px; opacity: .75; margin-left: 5px; }
         .message-item .toggle-button { position: absolute; right: 6px; top: 6px; opacity: .5; pointer-events: none }
@@ -166,7 +166,7 @@
                 <td>{{ profiler_dump(dispatchCall.message.value, maxDepth=2) }}</td>
             </tr>
             <tr>
-                <td class="text-bold">Envelope stamps</td>
+                <td class="text-bold">Envelope stamps <span class="text-muted">when dispatching</span></td>
                 <td>
                     {% for item in dispatchCall.stamps %}
                         {{ profiler_dump(item) }}
@@ -175,6 +175,18 @@
                     {% endfor %}
                 </td>
             </tr>
+            {% if dispatchCall.stamps_after_dispatch is defined %}
+                <tr>
+                    <td class="text-bold">Envelope stamps <span class="text-muted">after dispatch</span></td>
+                    <td>
+                        {% for item in dispatchCall.stamps_after_dispatch %}
+                            {{ profiler_dump(item) }}
+                        {% else %}
+                            <span class="text-muted">No items</span>
+                        {% endfor %}
+                    </td>
+                </tr>
+            {% endif %}
             {% if dispatchCall.exception is defined %}
                 <tr>
                     <td class="text-bold">Exception</td>

--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -99,6 +99,7 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
         $debugRepresentation = [
             'bus' => $busName,
             'stamps' => $tracedMessage['stamps'] ?? null,
+            'stamps_after_dispatch' => $tracedMessage['stamps_after_dispatch'] ?? null,
             'message' => [
                 'type' => new ClassStub(\get_class($message)),
                 'value' => $message,

--- a/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
@@ -55,9 +55,10 @@ class MessengerDataCollectorTest extends TestCase
 
         $file = __FILE__;
         $expected = <<<DUMP
-array:4 [
+array:5 [
   "bus" => "default"
   "stamps" => []
+  "stamps_after_dispatch" => []
   "message" => array:2 [
     "type" => "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage"
     "value" => Symfony\Component\Messenger\Tests\Fixtures\DummyMessage %A
@@ -100,9 +101,10 @@ DUMP;
 
         $file = __FILE__;
         $this->assertStringMatchesFormat(<<<DUMP
-array:5 [
+array:6 [
   "bus" => "default"
   "stamps" => []
+  "stamps_after_dispatch" => []
   "message" => array:2 [
     "type" => "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage"
     "value" => Symfony\Component\Messenger\Tests\Fixtures\DummyMessage %A

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -38,13 +38,13 @@ class TraceableMessageBus implements MessageBusInterface
         ];
 
         try {
-            return $this->decoratedBus->dispatch($message, $stamps);
+            return $envelope = $this->decoratedBus->dispatch($message, $stamps);
         } catch (\Throwable $e) {
             $context['exception'] = $e;
 
             throw $e;
         } finally {
-            $this->dispatchedMessages[] = $context;
+            $this->dispatchedMessages[] = $context + ['stamps_after_dispatch' => array_merge([], ...array_values($envelope->all()))];
         }
     }
 

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added `VarDumperTestTrait::setUpVarDumper()` and `VarDumperTestTrait::tearDownVarDumper()` 
    to configure casters & flags to use in tests
+ * added the stamps of a message after it is dispatched in `TraceableMessageBus` and `MessengerDataCollector` collected data
 
 4.3.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Currently, only the stamps added before dispatching the message are shown in the profiler.
This PR adds a section to show stamps after dispatch (`HandledStamp`, `SentStamp`, ...).

![Capture d’écran 2019-07-23 à 15 44 04](https://user-images.githubusercontent.com/2211145/61717102-bb28f500-ad60-11e9-93ec-bb2875d176ce.png)

