### PR TITLE
[Messenger][Profiler] Remove cutting caster to dump full objects

### DIFF
--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -79,6 +79,19 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCasters()
+    {
+        $casters = parent::getCasters();
+
+        // Unset the default caster truncating collectors data.
+        unset($casters['*']);
+
+        return $casters;
+    }
+
     private function collectMessage(string $busName, array $tracedMessage)
     {
         $message = $tracedMessage['message'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Obviously, not the ideal solution, but might open the discussion. Not being able to inspect more than 1 level deep in the profiler when dealing with DTOs and VOs in your messages is a pain 😕. You can't either access the `HandledStamp` `result` for instance.

This caster truncating collectors data was originally added in #23465 to mitigate performances issues, especially with the Form profiler. But actually a lot of useful information are now hidden to the developper.
Opting-out per collector might be a start. Either allowing to do it through config, or directly in code where sensible.
