### PR TITLE
[HttpClient] rewind stream when using Psr18Client

### DIFF
--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -65,9 +65,15 @@ final class Psr18Client implements ClientInterface
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
         try {
+            $body = $request->getBody();
+
+            if ($body->isSeekable()) {
+                $body->seek(0);
+            }
+
             $response = $this->client->request($request->getMethod(), (string) $request->getUri(), [
                 'headers' => $request->getHeaders(),
-                'body' => (string) $request->getBody(),
+                'body' => $body->getContents(),
                 'http_version' => '1.0' === $request->getProtocolVersion() ? '1.0' : null,
             ]);
 
@@ -79,7 +85,13 @@ final class Psr18Client implements ClientInterface
                 }
             }
 
-            return $psrResponse->withBody($this->streamFactory->createStream($response->getContent(false)));
+            $body = $this->streamFactory->createStream($response->getContent(false));
+
+            if ($body->isSeekable()) {
+                $body->seek(0);
+            }
+
+            return $psrResponse->withBody($body);
         } catch (TransportExceptionInterface $e) {
             if ($e instanceof \InvalidArgumentException) {
                 throw new Psr18RequestException($e, $request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony-docs/issues/11996
| License       | MIT
| Doc PR        | -

This is not a bug fix technically but just how PSR-7 works.
I'm glad we did not make it a first-class thing in Symfony.
This makes it a bit more practicable if it can be...