### PR TITLE
[ErrorRenderer] Allow disabling debug content in debug mode (preview mode)

### DIFF
--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/HtmlErrorRenderer.php
@@ -91,10 +91,11 @@ class HtmlErrorRenderer implements ErrorRendererInterface
 
     private function renderException(FlattenException $exception, string $debugTemplate = 'views/exception_full.html.php'): string
     {
+        $debug = $this->debug && ($exception->getHeaders()['X-Debug'] ?? true);
         $statusText = $this->escape($exception->getTitle());
         $statusCode = $this->escape($exception->getStatusCode());
 
-        if (!$this->debug) {
+        if (!$debug) {
             return $this->include('views/error.html.php', [
                 'statusText' => $statusText,
                 'statusCode' => $statusCode,

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/JsonErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/JsonErrorRenderer.php
@@ -38,12 +38,14 @@ class JsonErrorRenderer implements ErrorRendererInterface
      */
     public function render(FlattenException $exception): string
     {
+        $debug = $this->debug && ($exception->getHeaders()['X-Debug'] ?? true);
+
         $content = [
             'title' => $exception->getTitle(),
             'status' => $exception->getStatusCode(),
             'detail' => $exception->getMessage(),
         ];
-        if ($this->debug) {
+        if ($debug) {
             $content['exceptions'] = $exception->toArray();
         }
 

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/TxtErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/TxtErrorRenderer.php
@@ -38,11 +38,12 @@ class TxtErrorRenderer implements ErrorRendererInterface
      */
     public function render(FlattenException $exception): string
     {
+        $debug = $this->debug && ($exception->getHeaders()['X-Debug'] ?? true);
         $content = sprintf("[title] %s\n", $exception->getTitle());
         $content .= sprintf("[status] %s\n", $exception->getStatusCode());
         $content .= sprintf("[detail] %s\n", $exception->getMessage());
 
-        if ($this->debug) {
+        if ($debug) {
             foreach ($exception->toArray() as $i => $e) {
                 $content .= sprintf("[%d] %s: %s\n", $i + 1, $e['class'], $e['message']);
                 foreach ($e['trace'] as $trace) {

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/XmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/XmlErrorRenderer.php
@@ -40,13 +40,14 @@ class XmlErrorRenderer implements ErrorRendererInterface
      */
     public function render(FlattenException $exception): string
     {
+        $debug = $this->debug && ($exception->getHeaders()['X-Debug'] ?? true);
         $title = $this->escapeXml($exception->getTitle());
         $message = $this->escapeXml($exception->getMessage());
         $statusCode = $this->escapeXml($exception->getStatusCode());
         $charset = $this->escapeXml($this->charset);
 
         $exceptions = '';
-        if ($this->debug) {
+        if ($debug) {
             $exceptions .= '<exceptions>';
             foreach ($exception->toArray() as $e) {
                 $exceptions .= sprintf('<exception class="%s" message="%s"><traces>', $e['class'], $this->escapeXml($e['message']));

--- a/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/XmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/XmlErrorRendererTest.php
@@ -12,16 +12,64 @@
 namespace Symfony\Component\ErrorRenderer\Tests\ErrorRenderer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ErrorRenderer\ErrorRenderer\ErrorRendererInterface;
 use Symfony\Component\ErrorRenderer\ErrorRenderer\XmlErrorRenderer;
 use Symfony\Component\ErrorRenderer\Exception\FlattenException;
 
 class XmlErrorRendererTest extends TestCase
 {
-    public function testRender()
+    /**
+     * @dataProvider getRenderData
+     */
+    public function testRender(FlattenException $exception, ErrorRendererInterface $errorRenderer, string $expected)
     {
-        $exception = FlattenException::createFromThrowable(new \RuntimeException('Foo'));
-        $expected = '<?xml version="1.0" encoding="UTF-8" ?>%A<problem xmlns="urn:ietf:rfc:7807">%A<title>Internal Server Error</title>%A<status>500</status>%A<detail>Foo</detail>%A';
+        $this->assertStringMatchesFormat($expected, $errorRenderer->render($exception));
+    }
 
-        $this->assertStringMatchesFormat($expected, (new XmlErrorRenderer(true))->render($exception));
+    public function getRenderData()
+    {
+        $expectedDebug = <<<XML
+<?xml version="1.0" encoding="UTF-8" ?>
+<problem xmlns="urn:ietf:rfc:7807">
+    <title>Internal Server Error</title>
+    <status>500</status>
+    <detail>Foo</detail>
+    <exceptions><exception class="RuntimeException" message="Foo"><traces><trace>%A</trace></traces></exception></exceptions>
+</problem>
+XML;
+
+        $expectedNonDebug = <<<XML
+<?xml version="1.0" encoding="UTF-8" ?>
+<problem xmlns="urn:ietf:rfc:7807">
+    <title>Internal Server Error</title>
+    <status>500</status>
+    <detail>Foo</detail>
+    
+</problem>
+XML;
+
+        yield '->render() returns the XML content WITH stack traces in debug mode' => [
+            FlattenException::createFromThrowable(new \RuntimeException('Foo')),
+            new XmlErrorRenderer(true),
+            $expectedDebug,
+        ];
+
+        yield '->render() returns the XML content WITHOUT stack traces in non-debug mode' => [
+            FlattenException::createFromThrowable(new \RuntimeException('Foo')),
+            new XmlErrorRenderer(false),
+            $expectedNonDebug,
+        ];
+
+        yield '->render() returns the XML content WITHOUT stack traces in debug mode FORCING non-debug via X-Debug header' => [
+            FlattenException::createFromThrowable(new \RuntimeException('Foo'), null, ['X-Debug' => false]),
+            new XmlErrorRenderer(true),
+            $expectedNonDebug,
+        ];
+
+        yield '->render() returns the XML content WITHOUT stack traces in non-debug mode EVEN FORCING debug via X-Debug header' => [
+            FlattenException::createFromThrowable(new \RuntimeException('Foo'), null, ['X-Debug' => true]),
+            new XmlErrorRenderer(false),
+            $expectedNonDebug,
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Required by https://github.com/symfony/symfony/pull/31398 to show a preview mode of the error for each content format.

Usage: https://github.com/symfony/symfony/pull/31398/files#diff-9ff5216ab011f5e48c7835d4138bf825R42

Note that you can't enable the debug content in non-debug mode via `X-Debug`. I also added more tests.