### PR TITLE
[TwigBundle] Remove useless "format" attribute

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/PreviewErrorController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/PreviewErrorController.php
@@ -47,7 +47,6 @@ class PreviewErrorController
             '_controller' => $this->controller,
             'exception' => $exception,
             'logger' => null,
-            'format' => $request->getRequestFormat(),
             'showException' => false,
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | not needed

spotted in https://github.com/symfony/symfony/pull/31398#discussion_r281634933