### PR TITLE
[Messenger] Flatten collection of stamps collected by the traceable middleware

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
@@ -56,7 +56,7 @@ class TraceableMessageBusTest extends TestCase
         $this->assertCount(1, $tracedMessages = $traceableBus->getDispatchedMessages());
         $this->assertArraySubset([
             'message' => $message,
-            'stamps' => [[$stamp]],
+            'stamps' => [$stamp],
             'caller' => [
                 'name' => 'TraceableMessageBusTest.php',
                 'file' => __FILE__,

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -33,7 +33,7 @@ class TraceableMessageBus implements MessageBusInterface
     {
         $envelope = $message instanceof Envelope ? $message : new Envelope($message);
         $context = [
-            'stamps' => array_values($envelope->all()),
+            'stamps' => array_merge([], ...array_values($envelope->all())),
             'message' => $envelope->getMessage(),
             'caller' => $this->getCaller(),
             'callTime' => microtime(true),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

### before
![Capture d’écran 2019-07-24 à 10 04 07](https://user-images.githubusercontent.com/2211145/61776018-65a12680-adfa-11e9-9efd-bd6682a0a296.png)

![Capture d’écran 2019-07-24 à 09 57 59](https://user-images.githubusercontent.com/2211145/61775695-b1070500-adf9-11e9-9bab-ac740f296684.png)

### after

![Capture d’écran 2019-07-24 à 09 57 37](https://user-images.githubusercontent.com/2211145/61775694-b1070500-adf9-11e9-95bf-14dc4d63c2ae.png)


Not sure how it qualifies, but I assume this wasn't entirely intentional when introducing the new `Envelope::all()` behavior in #29159.

Note it'll affect #32680 as well once merged.
