### PR TITLE
Ensure $request->hasSession() is always checked before calling getSession() 

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -112,10 +112,9 @@ class AppVariable
         if (null === $this->requestStack) {
             throw new \RuntimeException('The "app.session" variable is not available.');
         }
+        $request = $this->getRequest();
 
-        if ($request = $this->getRequest()) {
-            return $request->getSession();
-        }
+        return $request && $request->hasSession() ? $request->getSession() : null;
     }
 
     /**
@@ -157,8 +156,7 @@ class AppVariable
     public function getFlashes($types = null)
     {
         try {
-            $session = $this->getSession();
-            if (null === $session) {
+            if (null === $session = $this->getSession()) {
                 return [];
             }
         } catch (\RuntimeException $e) {

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -51,6 +51,7 @@ class AppVariableTest extends TestCase
     public function testGetSession()
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
+        $request->method('hasSession')->willReturn(true);
         $request->method('getSession')->willReturn($session = new Session());
 
         $this->setRequestStack($request);
@@ -267,6 +268,7 @@ class AppVariableTest extends TestCase
         $session->method('getFlashBag')->willReturn($flashBag);
 
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
+        $request->method('hasSession')->willReturn(true);
         $request->method('getSession')->willReturn($session);
         $this->setRequestStack($request);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -75,9 +75,9 @@ class GlobalVariables
      */
     public function getSession()
     {
-        if ($request = $this->getRequest()) {
-            return $request->getSession();
-        }
+        $request = $this->getRequest();
+
+        return $request && $request->hasSession() ? $request->getSession() : null;
     }
 
     /**

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -123,7 +123,7 @@ class ProfilerController
             throw new NotFoundHttpException('The profiler must be enabled.');
         }
 
-        if ($request->hasSession() && ($session = $request->getSession()) && $session->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
+        if ($request->hasSession() && ($session = $request->getSession())->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
             // keep current flashes for one more request if using AutoExpireFlashBag
             $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
         }

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -88,8 +88,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
         }
 
         if ($response->headers->has('X-Debug-Token') && $response->isRedirect() && $this->interceptRedirects && 'html' === $request->getRequestFormat()) {
-            $session = $request->getSession();
-            if (null !== $session && $session->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
+            if ($request->hasSession() && ($session = $request->getSession())->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
                 // keep current flashes for one more request if using AutoExpireFlashBag
                 $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
             }

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -46,8 +46,7 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
         }
 
         // bootstrap the session
-        $session = $this->getSession();
-        if (!$session) {
+        if (!$session = $this->getSession()) {
             return;
         }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/SaveSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SaveSessionListener.php
@@ -30,8 +30,8 @@ class SaveSessionListener implements EventSubscriberInterface
             return;
         }
 
-        $session = $event->getRequest()->getSession();
-        if ($session && $session->isStarted()) {
+        $request = $event->getRequest();
+        if ($request->hasSession() && ($session = $request->getSession())->isStarted()) {
             $session->save();
         }
     }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -38,12 +38,11 @@ class AuthenticationUtils
     public function getLastAuthenticationError($clearSession = true)
     {
         $request = $this->getRequest();
-        $session = $request->getSession();
         $authenticationException = null;
 
         if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
             $authenticationException = $request->attributes->get(Security::AUTHENTICATION_ERROR);
-        } elseif (null !== $session && $session->has(Security::AUTHENTICATION_ERROR)) {
+        } elseif ($request->hasSession() && ($session = $request->getSession())->has(Security::AUTHENTICATION_ERROR)) {
             $authenticationException = $session->get(Security::AUTHENTICATION_ERROR);
 
             if ($clearSession) {
@@ -65,9 +64,7 @@ class AuthenticationUtils
             return $request->attributes->get(Security::LAST_USERNAME, '');
         }
 
-        $session = $request->getSession();
-
-        return null === $session ? '' : $session->get(Security::LAST_USERNAME, '');
+        return $request->hasSession() ? $request->getSession()->get(Security::LAST_USERNAME, '') : '';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
