### PR TITLE
[Messenger] Fix redis last error not cleared between calls

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -114,12 +114,15 @@ class Connection
                 1
             );
         } catch (\RedisException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
 
-        if ($e || false === $messages) {
-            throw new TransportException(
-                ($e ? $e->getMessage() : $this->connection->getLastError()) ?? 'Could not read messages from the redis stream.'
-            );
+        if (false === $messages) {
+            if ($error = $this->connection->getLastError() ?: null) {
+                $this->connection->clearLastError();
+            }
+
+            throw new TransportException($error ?? 'Could not read messages from the redis stream.');
         }
 
         if ($this->couldHavePendingMessages && empty($messages[$this->stream])) {
@@ -144,28 +147,34 @@ class Connection
 
     public function ack(string $id): void
     {
-        $e = null;
         try {
             $acknowledged = $this->connection->xack($this->stream, $this->group, [$id]);
         } catch (\RedisException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
 
-        if ($e || !$acknowledged) {
-            throw new TransportException(($e ? $e->getMessage() : $this->connection->getLastError()) ?? sprintf('Could not acknowledge redis message "%s".', $id), 0, $e);
+        if (!$acknowledged) {
+            if ($error = $this->connection->getLastError() ?: null) {
+                $this->connection->clearLastError();
+            }
+            throw new TransportException($error ?? sprintf('Could not acknowledge redis message "%s".', $id));
         }
     }
 
     public function reject(string $id): void
     {
-        $e = null;
         try {
             $deleted = $this->connection->xack($this->stream, $this->group, [$id]);
             $deleted = $this->connection->xdel($this->stream, [$id]) && $deleted;
         } catch (\RedisException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
 
-        if ($e || !$deleted) {
-            throw new TransportException(($e ? $e->getMessage() : $this->connection->getLastError()) ?? sprintf('Could not delete message "%s" from the redis stream.', $id), 0, $e);
+        if (!$deleted) {
+            if ($error = $this->connection->getLastError() ?: null) {
+                $this->connection->clearLastError();
+            }
+            throw new TransportException($error ?? sprintf('Could not delete message "%s" from the redis stream.', $id));
         }
     }
 
@@ -175,16 +184,19 @@ class Connection
             $this->setup();
         }
 
-        $e = null;
         try {
             $added = $this->connection->xadd($this->stream, '*', ['message' => json_encode(
                 ['body' => $body, 'headers' => $headers]
             )]);
         } catch (\RedisException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
 
-        if ($e || !$added) {
-            throw new TransportException(($e ? $e->getMessage() : $this->connection->getLastError()) ?? 'Could not add a message to the redis stream.', 0, $e);
+        if (!$added) {
+            if ($error = $this->connection->getLastError() ?: null) {
+                $this->connection->clearLastError();
+            }
+            throw new TransportException($error ?? 'Could not add a message to the redis stream.');
         }
     }
 
@@ -194,6 +206,11 @@ class Connection
             $this->connection->xgroup('CREATE', $this->stream, $this->group, 0, true);
         } catch (\RedisException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
+        }
+
+        // group might already exist, ignore
+        if ($this->connection->getLastError()) {
+            $this->connection->clearLastError();
         }
 
         $this->autoSetup = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Not clearing it gives misleading errors coming from previous calls which makes debugging hard.
@alexander-schranz FYI