### PR TITLE
[Console] allow answer to be trimmed by adding a flag

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.30
+------
+
+ * added `Question::setTrimmable` default to true to allow the answer to be trimmed or not
+
 3.4.0
 -----
 

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -64,7 +64,7 @@ class QuestionHelper extends Helper
 
                 $default = explode(',', $default);
                 foreach ($default as $k => $v) {
-                    $v = trim($v);
+                    $v = $question->isTrimmable() ? trim($v) : $v;
                     $default[$k] = isset($choices[$v]) ? $choices[$v] : $v;
                 }
             }
@@ -161,7 +161,8 @@ class QuestionHelper extends Helper
             $ret = false;
             if ($question->isHidden()) {
                 try {
-                    $ret = trim($this->getHiddenResponse($output, $inputStream));
+                    $hiddenResponse = $this->getHiddenResponse($output, $inputStream, $question->isTrimmable());
+                    $ret = $question->isTrimmable() ? trim($hiddenResponse) : $hiddenResponse;
                 } catch (RuntimeException $e) {
                     if (!$question->isHiddenFallback()) {
                         throw $e;
@@ -174,10 +175,13 @@ class QuestionHelper extends Helper
                 if (false === $ret) {
                     throw new RuntimeException('Aborted.');
                 }
-                $ret = trim($ret);
+                if ($question->isTrimmable()) {
+                    $ret = trim($ret);
+                }
             }
         } else {
-            $ret = trim($this->autocomplete($output, $question, $inputStream, \is_array($autocomplete) ? $autocomplete : iterator_to_array($autocomplete, false)));
+            $autocomplete = $this->autocomplete($output, $question, $inputStream, \is_array($autocomplete) ? $autocomplete : iterator_to_array($autocomplete, false));
+            $ret = $question->isTrimmable() ? trim($autocomplete) : $autocomplete;
         }
 
         $ret = \strlen($ret) > 0 ? $ret : $question->getDefault();
@@ -385,12 +389,13 @@ class QuestionHelper extends Helper
      *
      * @param OutputInterface $output      An Output instance
      * @param resource        $inputStream The handler resource
+     * @param bool            $trimmable   Is the answer trimmable
      *
      * @return string The answer
      *
      * @throws RuntimeException In case the fallback is deactivated and the response cannot be hidden
      */
-    private function getHiddenResponse(OutputInterface $output, $inputStream)
+    private function getHiddenResponse(OutputInterface $output, $inputStream, $trimmable = true)
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $exe = __DIR__.'/../Resources/bin/hiddeninput.exe';
@@ -402,7 +407,8 @@ class QuestionHelper extends Helper
                 $exe = $tmpExe;
             }
 
-            $value = rtrim(shell_exec($exe));
+            $sExec = shell_exec($exe);
+            $value = $trimmable ? rtrim($sExec) : $sExec;
             $output->writeln('');
 
             if (isset($tmpExe)) {
@@ -422,8 +428,9 @@ class QuestionHelper extends Helper
             if (false === $value) {
                 throw new RuntimeException('Aborted.');
             }
-
-            $value = trim($value);
+            if ($trimmable) {
+                $value = trim($value);
+            }
             $output->writeln('');
 
             return $value;
@@ -432,7 +439,8 @@ class QuestionHelper extends Helper
         if (false !== $shell = $this->getShell()) {
             $readCmd = 'csh' === $shell ? 'set mypassword = $<' : 'read -r mypassword';
             $command = sprintf("/usr/bin/env %s -c 'stty -echo; %s; stty echo; echo \$mypassword'", $shell, $readCmd);
-            $value = rtrim(shell_exec($command));
+            $sCommand = shell_exec($command);
+            $value = $trimmable ? rtrim($sCommand) : $sCommand;
             $output->writeln('');
 
             return $value;

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -29,6 +29,7 @@ class Question
     private $validator;
     private $default;
     private $normalizer;
+    private $trimmable = true;
 
     /**
      * @param string $question The question to ask to the user
@@ -242,5 +243,20 @@ class Question
     protected function isAssoc($array)
     {
         return (bool) \count(array_filter(array_keys($array), 'is_string'));
+    }
+
+    public function isTrimmable()
+    {
+        return $this->trimmable;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setTrimmable($trimmable)
+    {
+        $this->trimmable = $trimmable;
+
+        return $this;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -165,6 +165,20 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $this->assertEquals('What time is it?', stream_get_contents($output->getStream()));
     }
 
+    public function testAskNonTrimmed()
+    {
+        $dialog = new QuestionHelper();
+
+        $inputStream = $this->getInputStream(' 8AM ');
+
+        $question = new Question('What time is it?', '2PM');
+        $question->setTrimmable(false);
+        $this->assertEquals(' 8AM ', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $output = $this->createOutputInterface(), $question));
+
+        rewind($output->getStream());
+        $this->assertEquals('What time is it?', stream_get_contents($output->getStream()));
+    }
+
     public function testAskWithAutocomplete()
     {
         if (!$this->hasSttyAvailable()) {
@@ -194,6 +208,40 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $this->assertEquals('SecurityBundle', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
         $this->assertEquals('FooBundleTest', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
         $this->assertEquals('AcmeDemoBundle', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertEquals('AsseticBundle', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertEquals('FooBundle', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+    }
+
+    public function testAskWithAutocompleteTrimmable()
+    {
+        if (!$this->hasSttyAvailable()) {
+            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+        }
+
+        // Acm<NEWLINE>
+        // Ac<BACKSPACE><BACKSPACE>s<TAB>Test<NEWLINE>
+        // <NEWLINE>
+        // <UP ARROW><UP ARROW><NEWLINE>
+        // <UP ARROW><UP ARROW><UP ARROW><UP ARROW><UP ARROW><TAB>Test<NEWLINE>
+        // <DOWN ARROW><NEWLINE>
+        // S<BACKSPACE><BACKSPACE><DOWN ARROW><DOWN ARROW><NEWLINE>
+        // F00<BACKSPACE><BACKSPACE>oo<TAB><NEWLINE>
+        $inputStream = $this->getInputStream("Acm\nAc\177\177s\tTest\n\n\033[A\033[A\n\033[A\033[A\033[A\033[A\033[A\tTest\n\033[B\nS\177\177\033[B\033[B\nF00\177\177oo\t\n");
+
+        $dialog = new QuestionHelper();
+        $helperSet = new HelperSet([new FormatterHelper()]);
+        $dialog->setHelperSet($helperSet);
+
+        $question = new Question('Please select a bundle', 'FrameworkBundle');
+        $question->setAutocompleterValues(['AcmeDemoBundle ', 'AsseticBundle', ' SecurityBundle ', 'FooBundle']);
+        $question->setTrimmable(false);
+
+        $this->assertEquals('AcmeDemoBundle ', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertEquals('AsseticBundleTest', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertEquals('FrameworkBundle', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertEquals(' SecurityBundle ', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertEquals('FooBundleTest', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertEquals('AcmeDemoBundle ', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
         $this->assertEquals('AsseticBundle', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
         $this->assertEquals('FooBundle', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
     }
@@ -328,6 +376,21 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $question->setHidden(true);
 
         $this->assertEquals('8AM', $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream("8AM\n")), $this->createOutputInterface(), $question));
+    }
+
+    public function testAskHiddenResponseTrimmed()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test is not supported on Windows');
+        }
+
+        $dialog = new QuestionHelper();
+
+        $question = new Question('What time is it?');
+        $question->setHidden(true);
+        $question->setTrimmable(false);
+
+        $this->assertEquals(' 8AM', $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream(' 8AM')), $this->createOutputInterface(), $question));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes - I can't get at the real answer string with leading/trailing spaces ;)
| New feature?  | no - but maybe ;)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#... will be needed for 3.4 if it goes ahead, similar to docs for 4.4

According to https://github.com/symfony/symfony/issues/23210#issuecomment-495998087 we add a new flag in the Question class to be able to not trim the answer.

This is a "backport" request for #31626 - the code is completely backward-compatible, any existing use gets the answer trimmed. So this `setTrimmable(false)` ability would only come into effect if someone modifies their code to use it. All existing code using Symfony 3.4 will work without change.

I am proposing that this can be called a bug, because without this change the caller does not and cannot get the complete answer. The change here fixes the bug in a backward-compatible way, by preserving the existing `trim` behaviour by default, and providing the option for the caller to disable the `trim` behaviour.

(I have got the CI passing in PHP5.* now - so I am resubmitting to at least "document" what  code works against 3.4, and maybe get it accepted! Or most likely someone will just close this because it is considered a feature and not allowed for 3.4)