### PR TITLE
[Validator][DX] Add isEmpty() method to ConstraintViolationListInterface

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
    `maxPropertyPath` options
  * added a new `notInRangeMessage` option to the `Range` constraint that will
    be used in the violation builder when both `min` and `max` are not null
+ * Added `isEmpty()` method to `ConstraintViolationListInterface`.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -107,6 +107,14 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
 
     /**
      * {@inheritdoc}
+     */
+    public function isEmpty(): bool
+    {
+        return [] === $this->violations;
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @return \ArrayIterator|ConstraintViolationInterface[]
      */

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Validator;
  * A list of constraint violations.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @method bool isEmpty() whether the list is empty or not - not implementing it is deprecated since Symfony 4.4
  */
 interface ConstraintViolationListInterface extends \Traversable, \Countable, \ArrayAccess
 {

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -155,6 +155,19 @@ EOF;
         ];
     }
 
+    public function testIsEmpty()
+    {
+        $list = new ConstraintViolationList();
+
+        $this->assertTrue($list->isEmpty());
+
+        $list->set(0, $this->getViolation('Error'));
+        $this->assertFalse($list->isEmpty());
+
+        $list->remove(0);
+        $this->assertTrue($list->isEmpty());
+    }
+
     protected function getViolation($message, $root = null, $propertyPath = null, $code = null)
     {
         return new ConstraintViolation($message, $message, [], $root, $propertyPath, null, null, $code);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The goal is to improve the DX (a little) with constraint violation lists.

I always find myself doing : `if ($constraintViolationList->count() > 0)` or `if (0 === $constraintViolationList->count())`

It would be nice if we could do : `if (!$constraintViolationList->isEmpty())` or `if ($constraintViolationList->isEmpty())`

`hasViolations()` could be an alternative name but `isEmpty()` is a common name used in many places in Sf code, so it seems more logical to me.