### PR TITLE
Use the tags pool to save cache tags

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -137,9 +137,9 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
         $f = $this->createCacheItem;
 
         foreach ($tagsByKey as $key => $tags) {
-            $this->pool->saveDeferred($f(static::TAGS_PREFIX.$key, array_intersect_key($tagVersions, $tags), $items[$key]));
+            $this->tags->saveDeferred($f(static::TAGS_PREFIX.$key, array_intersect_key($tagVersions, $tags), $items[$key]));
         }
-        $ok = $this->pool->commit() && $ok;
+        $ok = $this->tags->commit() && $ok;
 
         if ($invalidatedTags) {
             $f = $this->invalidateTags;

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -176,6 +176,31 @@ class TagAwareAdapterTest extends AdapterTestCase
         $this->assertFalse($cache->prune());
     }
 
+    public function testUsesTagsPoolForTags()
+    {
+        $tagsPool = $this->createMock(AdapterInterface::class);
+        $tagsPool
+            ->expects($this->once())
+            ->method('getItems')
+            ->with(["foo\0tags\0"])
+            ->willReturn(["foo\0tags\0" => new CacheItem()])
+        ;
+
+        $tagsPool
+            ->expects($this->once())
+            ->method('saveDeferred')
+        ;
+
+        $tagsPool
+            ->expects($this->exactly(2))
+            ->method('commit')
+        ;
+
+        $pool = new TagAwareAdapter(new FilesystemAdapter(), $tagsPool);
+        $item = $pool->getItem('item')->tag('foo');
+        $pool->save($item);
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|PruneableCacheInterface
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32712 (probably)
| License       | MIT
| Doc PR        | -

The TagAwareAdapter always uses the items pool to save tags, even if there is a separate tags pool. This PR fixes the issue.

@Toflar /cc