### PR TITLE
[RFC][Translation] Deprecate resource_files in translator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1190,31 +1190,10 @@ class FrameworkExtension extends Extension
 
         // Register translation resources
         if ($dirs) {
-            $files = [];
-            $finder = Finder::create()
-                ->followLinks()
-                ->files()
-                ->filter(function (\SplFileInfo $file) {
-                    return 2 <= substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());
-                })
-                ->in($dirs)
-                ->sortByName()
-            ;
-
-            foreach ($finder as $file) {
-                $fileNameParts = explode('.', basename($file));
-                $locale = $fileNameParts[\count($fileNameParts) - 2];
-                if (!isset($files[$locale])) {
-                    $files[$locale] = [];
-                }
-
-                $files[$locale][] = (string) $file;
-            }
-
             $options = array_merge(
                 $translator->getArgument(4),
                 [
-                    'resource_files' => $files,
+                    'paths' => $dirs,
                     'scanned_directories' => array_merge($dirs, $nonExistingDirs),
                 ]
             );

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -801,38 +801,39 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('translator.default', (string) $container->getAlias('translator'), '->registerTranslatorConfiguration() redefines translator service from identity to real translator');
         $options = $container->getDefinition('translator.default')->getArgument(4);
 
-        $files = array_map('realpath', $options['resource_files']['en']);
+        $paths = array_map('realpath', $options['paths']);
         $ref = new \ReflectionClass('Symfony\Component\Validator\Validation');
+
         $this->assertContains(
-            strtr(\dirname($ref->getFileName()).'/Resources/translations/validators.en.xlf', '/', \DIRECTORY_SEPARATOR),
-            $files,
+            strtr(\dirname($ref->getFileName()).'/Resources/translations', '/', \DIRECTORY_SEPARATOR),
+            $paths,
             '->registerTranslatorConfiguration() finds Validator translation resources'
         );
         $ref = new \ReflectionClass('Symfony\Component\Form\Form');
         $this->assertContains(
-            strtr(\dirname($ref->getFileName()).'/Resources/translations/validators.en.xlf', '/', \DIRECTORY_SEPARATOR),
-            $files,
+            strtr(\dirname($ref->getFileName()).'/Resources/translations', '/', \DIRECTORY_SEPARATOR),
+            $paths,
             '->registerTranslatorConfiguration() finds Form translation resources'
         );
         $ref = new \ReflectionClass('Symfony\Component\Security\Core\Security');
         $this->assertContains(
-            strtr(\dirname($ref->getFileName()).'/Resources/translations/security.en.xlf', '/', \DIRECTORY_SEPARATOR),
-            $files,
+            strtr(\dirname($ref->getFileName()).'/Resources/translations', '/', \DIRECTORY_SEPARATOR),
+            $paths,
             '->registerTranslatorConfiguration() finds Security translation resources'
         );
         $this->assertContains(
-            strtr(__DIR__.'/Fixtures/translations/test_paths.en.yml', '/', \DIRECTORY_SEPARATOR),
-            $files,
+            strtr(__DIR__.'/Fixtures/translations', '/', \DIRECTORY_SEPARATOR),
+            $paths,
             '->registerTranslatorConfiguration() finds translation resources in custom paths'
         );
         $this->assertContains(
-            strtr(__DIR__.'/translations/test_default.en.xlf', '/', \DIRECTORY_SEPARATOR),
-            $files,
+            strtr(__DIR__.'/translations', '/', \DIRECTORY_SEPARATOR),
+            $paths,
             '->registerTranslatorConfiguration() finds translation resources in default path'
         );
         $this->assertContains(
-            strtr(__DIR__.'/Fixtures/translations/domain.with.dots.en.yml', '/', \DIRECTORY_SEPARATOR),
-            $files,
+            strtr(__DIR__.'/Fixtures/translations', '/', \DIRECTORY_SEPARATOR),
+            $paths,
             '->registerTranslatorConfiguration() finds translation resources with dots in domain'
         );
 
@@ -868,10 +869,10 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('full', ['kernel.root_dir' => __DIR__.'/Fixtures']);
         $options = $container->getDefinition('translator.default')->getArgument(4);
-        $files = array_map('realpath', $options['resource_files']['en']);
+        $paths = array_map('realpath', $options['paths']);
 
-        $dir = str_replace('/', \DIRECTORY_SEPARATOR, __DIR__.'/Fixtures/Resources/translations/test_default.en.xlf');
-        $this->assertContains($dir, $files, '->registerTranslatorConfiguration() finds translation resources in legacy directory');
+        $dir = str_replace('/', \DIRECTORY_SEPARATOR, __DIR__.'/Fixtures/Resources/translations');
+        $this->assertContains($dir, $paths, '->registerTranslatorConfiguration() finds translation resources in legacy directory');
     }
 
     public function testTranslatorMultipleFallbacks()

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Translation;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileExistenceResource;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
@@ -27,6 +28,7 @@ use Symfony\Component\Translation\Translator as BaseTranslator;
 class Translator extends BaseTranslator implements WarmableInterface
 {
     protected $container;
+
     protected $loaderIds;
 
     protected $options = [
@@ -34,12 +36,8 @@ class Translator extends BaseTranslator implements WarmableInterface
         'debug' => false,
         'resource_files' => [],
         'scanned_directories' => [],
+        'paths' => [],
     ];
-
-    /**
-     * @var array
-     */
-    private $resourceLocales;
 
     /**
      * Holds parameters from addResource() calls so we can defer the actual
@@ -50,11 +48,17 @@ class Translator extends BaseTranslator implements WarmableInterface
     private $resources = [];
 
     private $resourceFiles;
+    private $trackedResources = [];
 
     /**
      * @var string[]
      */
     private $scannedDirectories;
+
+    /**
+     * @var string[]
+     */
+    private $paths;
 
     /**
      * Constructor.
@@ -63,7 +67,6 @@ class Translator extends BaseTranslator implements WarmableInterface
      *
      *   * cache_dir: The cache directory (or null to disable caching)
      *   * debug:     Whether to enable debugging or not (false by default)
-     *   * resource_files: List of translation resources available grouped by locale.
      *
      * @param ContainerInterface        $container     A ContainerInterface instance
      * @param MessageFormatterInterface $formatter     The message formatter
@@ -84,9 +87,14 @@ class Translator extends BaseTranslator implements WarmableInterface
         }
 
         $this->options = array_merge($this->options, $options);
-        $this->resourceLocales = array_keys($this->options['resource_files']);
         $this->resourceFiles = $this->options['resource_files'];
+
+        if ($this->resourceFiles) {
+            @trigger_error(sprintf('Passing the "resource_files" option to "%s" is deprecated since version 4.4 and will be unsupported in version 5. Pass a list of directories instead in the "paths" option.', __CLASS__), E_USER_DEPRECATED);
+        }
+
         $this->scannedDirectories = $this->options['scanned_directories'];
+        $this->paths = $this->options['paths'];
 
         parent::__construct($defaultLocale, $formatter, $this->options['cache_dir'], $this->options['debug']);
     }
@@ -101,7 +109,15 @@ class Translator extends BaseTranslator implements WarmableInterface
             return;
         }
 
-        $locales = array_merge($this->getFallbackLocales(), [$this->getLocale()], $this->resourceLocales);
+        $resourceLocales = [];
+
+        if ($this->paths) {
+            $resourceLocales = iterator_to_array($this->getResourceLocales());
+        }
+
+        $resourceLocales += array_keys($this->resourceFiles);
+
+        $locales = array_merge($this->getFallbackLocales(), [$this->getLocale()], $resourceLocales);
         foreach (array_unique($locales) as $locale) {
             // reset catalogue in case it's already loaded during the dump of the other locales.
             if (isset($this->catalogues[$locale])) {
@@ -114,7 +130,7 @@ class Translator extends BaseTranslator implements WarmableInterface
 
     public function addResource($format, $resource, $locale, $domain = null)
     {
-        if ($this->resourceFiles) {
+        if ($this->resourceFiles || $this->paths) {
             $this->addResourceFiles();
         }
         $this->resources[] = [$format, $resource, $locale, $domain];
@@ -133,7 +149,7 @@ class Translator extends BaseTranslator implements WarmableInterface
     {
         parent::doLoadCatalogue($locale);
 
-        foreach ($this->scannedDirectories as $directory) {
+        foreach (array_unique(array_merge($this->scannedDirectories, $this->paths)) as $directory) {
             $resourceClass = file_exists($directory) ? DirectoryResource::class : FileExistenceResource::class;
             $this->catalogues[$locale]->addResource(new $resourceClass($directory));
         }
@@ -141,7 +157,7 @@ class Translator extends BaseTranslator implements WarmableInterface
 
     protected function initialize()
     {
-        if ($this->resourceFiles) {
+        if ($this->resourceFiles || $this->paths) {
             $this->addResourceFiles();
         }
         foreach ($this->resources as $key => $params) {
@@ -162,8 +178,10 @@ class Translator extends BaseTranslator implements WarmableInterface
         $filesByLocale = $this->resourceFiles;
         $this->resourceFiles = [];
 
-        foreach ($filesByLocale as $locale => $files) {
-            foreach ($files as $key => $file) {
+        if ($this->paths) {
+            foreach ($this->getResourceFiles() as $locale => $file) {
+                $this->trackedResources[$file] = true;
+
                 // filename is domain.locale.format
                 $fileNameParts = explode('.', basename($file));
                 $format = array_pop($fileNameParts);
@@ -172,5 +190,56 @@ class Translator extends BaseTranslator implements WarmableInterface
                 $this->addResource($format, $file, $locale, $domain);
             }
         }
+
+        foreach ($filesByLocale as $locale => $files) {
+            foreach ($files as $file) {
+                if (isset($this->trackedResources[$file])) {
+                    continue;
+                }
+
+                $fileNameParts = explode('.', basename($file));
+                $format = array_pop($fileNameParts);
+                $locale = array_pop($fileNameParts);
+                $domain = implode('.', $fileNameParts);
+
+                $this->addResource($format, $file, $locale, $domain);
+            }
+        }
+    }
+
+    private function getResourceLocales()
+    {
+        foreach ($this->findResources() as $file) {
+            $fileNameParts = explode('.', basename($file));
+            $locale = $fileNameParts[\count($fileNameParts) - 2];
+
+            yield $locale;
+        }
+    }
+
+    private function getResourceFiles()
+    {
+        $finder = $this->findResources();
+
+        $this->paths = [];
+
+        foreach ($finder as $file) {
+            $fileNameParts = explode('.', basename($file));
+            $locale = $fileNameParts[\count($fileNameParts) - 2];
+
+            yield $locale => (string) $file;
+        }
+    }
+
+    private function findResources()
+    {
+        return $finder = Finder::create()
+            ->followLinks()
+            ->files()
+            ->filter(function (\SplFileInfo $file) {
+                return 2 <= substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());
+            })
+            ->in($this->paths)
+            ->sortByName();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/32708#issuecomment-514948191
| License       | MIT
| Doc PR        | TBD

The list of resource files is cached by the container at compile time. This means that any change in translation files (adding/removing a file) needs a rebuilt container t take effect.
This PR proposes to deprecate this behaviour and let the translator manage its own resources fully.

This approach is to pass a list of directories to the translator instead, which the translator can use to determine if the cache needs to be rebuilt. Any change in the directories means only the translator cache will be rebuilt while the container cache stays untouched.

The only time the container needs to be rebuilt is when a new translation directory is added (E.G when adding a new bundle).

I'm not 100% sure what effect this will have on 3rd-party bundles (I.E if a bundle explicitly requires this behaviour and can't pass directories instead), so any insights would be appreciated.