### PR TITLE
[Messenger][Profiler] Attempt to give more useful source info when using HandleTrait

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Fixtures/TestTracesWithHandleTraitAction.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/TestTracesWithHandleTraitAction.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\HandleTrait;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @see \Symfony\Component\Messenger\Tests\TraceableMessageBusTest::testItTracesDispatchWhenHandleTraitIsUsed
+ */
+class TestTracesWithHandleTraitAction
+{
+    use HandleTrait;
+
+    public function __construct(MessageBusInterface $messageBus)
+    {
+        $this->messageBus = $messageBus;
+    }
+
+    public function __invoke($message)
+    {
+        $this->handle($message);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
@@ -15,8 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\AnEnvelopeStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\TestTracesWithHandleTraitAction;
 use Symfony\Component\Messenger\TraceableMessageBus;
 
 class TraceableMessageBusTest extends TestCase
@@ -42,6 +44,29 @@ class TraceableMessageBusTest extends TestCase
                 'name' => 'TraceableMessageBusTest.php',
                 'file' => __FILE__,
                 'line' => $line,
+            ],
+        ], $actualTracedMessage);
+    }
+
+    public function testItTracesDispatchWhenHandleTraitIsUsed()
+    {
+        $message = new DummyMessage('Hello');
+
+        $bus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+        $bus->expects($this->once())->method('dispatch')->with($message)->willReturn((new Envelope($message))->with(new HandledStamp('result', 'handlerName')));
+
+        $traceableBus = new TraceableMessageBus($bus);
+        (new TestTracesWithHandleTraitAction($traceableBus))($message);
+        $this->assertCount(1, $tracedMessages = $traceableBus->getDispatchedMessages());
+        $actualTracedMessage = $tracedMessages[0];
+        unset($actualTracedMessage['callTime']); // don't check, too variable
+        $this->assertEquals([
+            'message' => $message,
+            'stamps' => [],
+            'caller' => [
+                'name' => 'TestTracesWithHandleTraitAction.php',
+                'file' => (new \ReflectionClass(TestTracesWithHandleTraitAction::class))->getFileName(),
+                'line' => (new \ReflectionMethod(TestTracesWithHandleTraitAction::class, '__invoke'))->getStartLine() + 2,
             ],
         ], $actualTracedMessage);
     }

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -65,7 +65,19 @@ class TraceableMessageBus implements MessageBusInterface
         $file = $trace[1]['file'];
         $line = $trace[1]['line'];
 
-        for ($i = 2; $i < 8; ++$i) {
+        $handleTraitFile = (new \ReflectionClass(HandleTrait::class))->getFileName();
+        $found = false;
+        for ($i = 1; $i < 8; ++$i) {
+            if (isset($trace[$i]['file'], $trace[$i + 1]['file'], $trace[$i + 1]['line']) && $trace[$i]['file'] === $handleTraitFile) {
+                $file = $trace[$i + 1]['file'];
+                $line = $trace[$i + 1]['line'];
+                $found = true;
+
+                break;
+            }
+        }
+
+        for ($i = 2; $i < 8 && !$found; ++$i) {
             if (isset($trace[$i]['class'], $trace[$i]['function'])
                 && 'dispatch' === $trace[$i]['function']
                 && is_a($trace[$i]['class'], MessageBusInterface::class, true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

### Before

<img width="1052" alt="Capture d’écran 2019-07-25 à 15 02 03" src="https://user-images.githubusercontent.com/2211145/61883193-3e318300-aefa-11e9-9179-a40c7c5aac93.png">

### After

<img width="1054" alt="Capture d’écran 2019-07-25 à 14 59 27" src="https://user-images.githubusercontent.com/2211145/61883192-3d98ec80-aefa-11e9-8f29-df9c417e8025.png">

which works for both examples using the trait in https://symfony.com/doc/current/messenger/handler_results.html