### PR TITLE
[HttpClient] Let MockHttpClient have defaultoptions

### DIFF
--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -27,7 +27,6 @@ class MockHttpClient implements HttpClientInterface
 {
     use HttpClientTrait;
 
-    private $baseUri;
     private $defaultOptions = self::OPTIONS_DEFAULTS;
     private $responseFactory;
 
@@ -48,12 +47,13 @@ class MockHttpClient implements HttpClientInterface
             })();
         }
 
-        if ($defaultOptions) {
-            [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, self::OPTIONS_DEFAULTS);
+        if ($baseUri) {
+            $defaultOptions['base_uri'] = $baseUri;
         }
 
+        [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, self::OPTIONS_DEFAULTS, true);
+
         $this->responseFactory = $responseFactory;
-        $this->baseUri = $baseUri;
     }
 
     /**
@@ -61,10 +61,7 @@ class MockHttpClient implements HttpClientInterface
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
-        $defaultOptions = $this->defaultOptions;
-        $defaultOptions['base_uri'] = $this->baseUri;
-
-        [$url, $options] = $this->prepareRequest($method, $url, $options, $defaultOptions, true);
+        [$url, $options] = $this->prepareRequest($method, $url, $options, $this->defaultOptions, true);
         $url = implode('', $url);
 
         if (null === $this->responseFactory) {

--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -33,8 +33,8 @@ class MockHttpClient implements HttpClientInterface
 
     /**
      * @param callable|ResponseInterface|ResponseInterface[]|iterable|null $responseFactory
-     * @param string|null $baseUri
-     * @param array $defaultOptions
+     * @param string|null                                                  $baseUri
+     * @param array                                                        $defaultOptions
      */
     public function __construct($responseFactory = null, string $baseUri = null, array $defaultOptions = [])
     {

--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -27,13 +27,16 @@ class MockHttpClient implements HttpClientInterface
 {
     use HttpClientTrait;
 
-    private $responseFactory;
     private $baseUri;
+    private $defaultOptions = self::OPTIONS_DEFAULTS;
+    private $responseFactory;
 
     /**
      * @param callable|ResponseInterface|ResponseInterface[]|iterable|null $responseFactory
+     * @param string|null $baseUri
+     * @param array $defaultOptions
      */
-    public function __construct($responseFactory = null, string $baseUri = null)
+    public function __construct($responseFactory = null, string $baseUri = null, array $defaultOptions = [])
     {
         if ($responseFactory instanceof ResponseInterface) {
             $responseFactory = [$responseFactory];
@@ -45,6 +48,10 @@ class MockHttpClient implements HttpClientInterface
             })();
         }
 
+        if ($defaultOptions) {
+            [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, self::OPTIONS_DEFAULTS);
+        }
+
         $this->responseFactory = $responseFactory;
         $this->baseUri = $baseUri;
     }
@@ -54,7 +61,10 @@ class MockHttpClient implements HttpClientInterface
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
-        [$url, $options] = $this->prepareRequest($method, $url, $options, ['base_uri' => $this->baseUri], true);
+        $defaultOptions = $this->defaultOptions;
+        $defaultOptions['base_uri'] = $this->baseUri;
+
+        [$url, $options] = $this->prepareRequest($method, $url, $options, $defaultOptions, true);
         $url = implode('', $url);
 
         if (null === $this->responseFactory) {

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -87,7 +87,7 @@ class MockHttpClientTest extends HttpClientTestCase
                 $mock = $this->getMockBuilder(ResponseInterface::class)->getMock();
                 $mock->expects($this->any())
                     ->method('getStatusCode')
-                    ->willThrowException(new TransportException('DSN error'));
+                    ->willThrowException(new TransportException('DNS error'));
                 $mock->expects($this->any())
                     ->method('getInfo')
                     ->willReturn([]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

This small PR let the MockHttpClient have default options just like the other HTTP clients.
