### PR TITLE
[VarDumper] Possibility to replace existing css style for HTMLDumper

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -94,6 +94,26 @@ class HtmlDumper extends CliDumper
         $this->styles = $styles + $this->styles;
     }
 
+    /**
+     * Replace a single css styles.
+     *
+     * @param string $class    Any existing css class like default, num, const, etc
+     * @param string $property CSS property existing within class
+     * @param string $value    Desired value of property
+     *
+     * @return static
+     */
+    public function changeStyle(string $class, string $property, string $value)
+    {
+        if (!isset($this->styles[$class])) {
+            return $this;
+        }
+
+        $this->styles[$class] = preg_replace('/'.preg_quote($property).':[a-zA-Z0-9#%-., ]+(;|$)/', "{$property}:{$value};", $this->styles[$class]);
+
+        return $this;
+    }
+
     public function setTheme(string $themeName)
     {
         if (!isset(static::$themes[$themeName])) {


### PR DESCRIPTION
[HTMLDumper]

Possibility to replace existing css style for a class without replacing the whole css class definition like changing background-color, font or word-break, etc

| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | N.A    <!-- please add some, will be required by reviewers -->
| Fixed tickets | ?? <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | ??  <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

Possibility to replace existing css style for HTMLDumper without replacing the whole css class definition like changing background-color, font or word-break, etc

e.g.
```$dumper->changeStyle('default', 'word-break', 'break-word')``` would change css style of `word-break` to `break-word` from `break-all`