### PR TITLE
Previous error handler not callable

### DIFF
--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -52,35 +52,36 @@ class CacheWarmerAggregate implements CacheWarmerInterface
     {
         if ($this->debug) {
             $collectedLogs = [];
-            $previousHandler = \defined('PHPUNIT_COMPOSER_INSTALL');
-            $previousHandler = $previousHandler ?: set_error_handler(function ($type, $message, $file, $line) use (&$collectedLogs, &$previousHandler) {
-                if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
-                    return $previousHandler ? $previousHandler($type, $message, $file, $line) : false;
-                }
-
-                if (isset($collectedLogs[$message])) {
-                    ++$collectedLogs[$message]['count'];
-
-                    return;
-                }
-
-                $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
-                // Clean the trace by removing first frames added by the error handler itself.
-                for ($i = 0; isset($backtrace[$i]); ++$i) {
-                    if (isset($backtrace[$i]['file'], $backtrace[$i]['line']) && $backtrace[$i]['line'] === $line && $backtrace[$i]['file'] === $file) {
-                        $backtrace = \array_slice($backtrace, 1 + $i);
-                        break;
+            $previousHandler = \defined('PHPUNIT_COMPOSER_INSTALL') ?
+                constant('PHPUNIT_COMPOSER_INSTALL') :
+                set_error_handler(function ($type, $message, $file, $line) use (&$collectedLogs, &$previousHandler) {
+                    if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
+                        return $previousHandler ? $previousHandler($type, $message, $file, $line) : false;
                     }
-                }
 
-                $collectedLogs[$message] = [
-                    'type' => $type,
-                    'message' => $message,
-                    'file' => $file,
-                    'line' => $line,
-                    'trace' => $backtrace,
-                    'count' => 1,
-                ];
+                    if (isset($collectedLogs[$message])) {
+                        ++$collectedLogs[$message]['count'];
+
+                        return null;
+                    }
+
+                    $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+                    // Clean the trace by removing first frames added by the error handler itself.
+                    for ($i = 0; isset($backtrace[$i]); ++$i) {
+                        if (isset($backtrace[$i]['file'], $backtrace[$i]['line']) && $backtrace[$i]['line'] === $line && $backtrace[$i]['file'] === $file) {
+                            $backtrace = \array_slice($backtrace, 1 + $i);
+                            break;
+                        }
+                    }
+
+                    $collectedLogs[$message] = [
+                        'type' => $type,
+                        'message' => $message,
+                        'file' => $file,
+                        'line' => $line,
+                        'trace' => $backtrace,
+                        'count' => 1,
+                    ];
             });
         }
 
@@ -96,7 +97,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
                 $warmer->warmUp($cacheDir);
             }
         } finally {
-            if ($this->debug && true !== $previousHandler) {
+            if ($this->debug && constant('PHPUNIT_COMPOSER_INSTALL') !== $previousHandler) {
                 restore_error_handler();
 
                 if (file_exists($this->deprecationLogsFilepath)) {

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -53,7 +53,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
         if ($this->debug) {
             $collectedLogs = [];
             $previousHandler = \defined('PHPUNIT_COMPOSER_INSTALL') ?
-                constant('PHPUNIT_COMPOSER_INSTALL') :
+                \constant('PHPUNIT_COMPOSER_INSTALL') :
                 set_error_handler(function ($type, $message, $file, $line) use (&$collectedLogs, &$previousHandler) {
                     if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
                         return $previousHandler ? $previousHandler($type, $message, $file, $line) : false;
@@ -97,7 +97,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
                 $warmer->warmUp($cacheDir);
             }
         } finally {
-            if ($this->debug && constant('PHPUNIT_COMPOSER_INSTALL') !== $previousHandler) {
+            if ($this->debug && \constant('PHPUNIT_COMPOSER_INSTALL') !== $previousHandler) {
                 restore_error_handler();
 
                 if (file_exists($this->deprecationLogsFilepath)) {

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -82,7 +82,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
                         'trace' => $backtrace,
                         'count' => 1,
                     ];
-            });
+                });
         }
 
         try {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -506,7 +506,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         if ($this->debug) {
             $collectedLogs = [];
             $previousHandler = \defined('PHPUNIT_COMPOSER_INSTALL') ?
-                constant('PHPUNIT_COMPOSER_INSTALL') :
+                \constant('PHPUNIT_COMPOSER_INSTALL') :
                 set_error_handler(function ($type, $message, $file, $line) use (&$collectedLogs, &$previousHandler) {
                     if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
                         return $previousHandler ? $previousHandler($type, $message, $file, $line) : false;
@@ -550,7 +550,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             $container = $this->buildContainer();
             $container->compile();
         } finally {
-            if ($this->debug && constant('PHPUNIT_COMPOSER_INSTALL') !== $previousHandler) {
+            if ($this->debug && \constant('PHPUNIT_COMPOSER_INSTALL') !== $previousHandler) {
                 restore_error_handler();
 
                 file_put_contents($cacheDir.'/'.$class.'Deprecations.log', serialize(array_values($collectedLogs)));

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -542,7 +542,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                         'trace' => [$backtrace[0]],
                         'count' => 1,
                     ];
-            });
+                });
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Previous calls to the `$previousHandler` would have resulted in a fatal error (see e.g. ln 512 in Kernel.php), as a boolean value was saved to the `$previousHandler` variable due to the `defined` method. Check for method was left in place, now the actual error_handler method defined in the `PHPUNIT_COMPOSER_INSTALL` will be used in case of existence.
If-statement for resetting the error_handler was changed too, as there's no boolean in the variable anymore.
Apart from that a `return;` was changed to `return null;` as it won't throw errors in various cases but return the same result as before.