### PR TITLE
[Form][DX] derive default timezone from reference_date option when possible

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -267,6 +267,18 @@ class TimeType extends AbstractType
             ];
         };
 
+        $modelTimezone = static function (Options $options, $value): ?string {
+            if (null !== $value) {
+                return $value;
+            }
+
+            if (null !== $options['reference_date']) {
+                return $options['reference_date']->getTimezone()->getName();
+            }
+
+            return null;
+        };
+
         $resolver->setDefaults([
             'hours' => range(0, 23),
             'minutes' => range(0, 59),
@@ -276,7 +288,7 @@ class TimeType extends AbstractType
             'input_format' => 'H:i:s',
             'with_minutes' => true,
             'with_seconds' => false,
-            'model_timezone' => null,
+            'model_timezone' => $modelTimezone,
             'view_timezone' => null,
             'reference_date' => null,
             'placeholder' => $placeholderDefault,
@@ -325,6 +337,8 @@ class TimeType extends AbstractType
         $resolver->setAllowedTypes('minutes', 'array');
         $resolver->setAllowedTypes('seconds', 'array');
         $resolver->setAllowedTypes('input_format', 'string');
+        $resolver->setAllowedTypes('model_timezone', ['null', 'string']);
+        $resolver->setAllowedTypes('view_timezone', ['null', 'string']);
         $resolver->setAllowedTypes('reference_date', ['null', \DateTimeInterface::class]);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -860,6 +860,16 @@ class TimeTypeTest extends BaseTypeTest
         ]);
     }
 
+    public function testModelTimezoneDefaultToReferenceDateTimezoneIfProvided()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'view_timezone' => 'Europe/Berlin',
+            'reference_date' => new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
+        ]);
+
+        $this->assertSame('Europe/Berlin', $form->getConfig()->getOption('model_timezone'));
+    }
+
     public function testPassDefaultChoiceTranslationDomain()
     {
         $form = $this->factory->create(static::TESTED_TYPE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Currently, when `reference_date` and `model_timezone` are provided but are not the same, we get a validation exception:
https://github.com/symfony/symfony/blob/9216cb75ac11db014262f2d7fe5cb77b0b54db59/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php#L48-L50

But that happen even if the `model_timezone` is `null` !

I propose to relax this behavior by passing the time zone of the configured `reference_date` to this `model_timezone` (by default), thus avoiding annoyances.