### PR TITLE
[Console] Get dimensions from stty on windows if possible

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Terminal;
 
 /**
  * The QuestionHelper class provides helpers to interact with the user.
@@ -157,7 +158,7 @@ class QuestionHelper extends Helper
         $inputStream = $this->inputStream ?: STDIN;
         $autocomplete = $question->getAutocompleterValues();
 
-        if (null === $autocomplete || !$this->hasSttyAvailable()) {
+        if (null === $autocomplete || !Terminal::hasSttyAvailable()) {
             $ret = false;
             if ($question->isHidden()) {
                 try {
@@ -409,7 +410,7 @@ class QuestionHelper extends Helper
             return $value;
         }
 
-        if ($this->hasSttyAvailable()) {
+        if (Terminal::hasSttyAvailable()) {
             $sttyMode = shell_exec('stty -g');
 
             shell_exec('stty -echo');
@@ -494,21 +495,5 @@ class QuestionHelper extends Helper
         }
 
         return self::$shell;
-    }
-
-    /**
-     * Returns whether Stty is available or not.
-     *
-     * @return bool
-     */
-    private function hasSttyAvailable()
-    {
-        if (null !== self::$stty) {
-            return self::$stty;
-        }
-
-        exec('stty 2>&1', $output, $exitcode);
-
-        return self::$stty = 0 === $exitcode;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Terminal;
 
 /**
  * @group tty
@@ -167,7 +168,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
 
     public function testAskWithAutocomplete()
     {
-        if (!$this->hasSttyAvailable()) {
+        if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
@@ -200,7 +201,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
 
     public function testAskWithAutocompleteWithNonSequentialKeys()
     {
-        if (!$this->hasSttyAvailable()) {
+        if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
@@ -219,7 +220,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
 
     public function testAskWithAutocompleteWithExactMatch()
     {
-        if (!$this->hasSttyAvailable()) {
+        if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
@@ -255,7 +256,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
      */
     public function testAskWithAutocompleteWithMultiByteCharacter($character)
     {
-        if (!$this->hasSttyAvailable()) {
+        if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
@@ -279,7 +280,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
 
     public function testAutocompleteWithTrailingBackslash()
     {
-        if (!$this->hasSttyAvailable()) {
+        if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
@@ -672,7 +673,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
      */
     public function testLegacyAskWithAutocomplete()
     {
-        if (!$this->hasSttyAvailable()) {
+        if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
@@ -709,7 +710,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
      */
     public function testLegacyAskWithAutocompleteWithNonSequentialKeys()
     {
-        if (!$this->hasSttyAvailable()) {
+        if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
@@ -977,7 +978,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
 
     public function testTraversableAutocomplete()
     {
-        if (!$this->hasSttyAvailable()) {
+        if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('`stty` is required to test autocomplete functionality');
         }
 
@@ -1061,13 +1062,6 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
             ->willReturn($interactive);
 
         return $mock;
-    }
-
-    private function hasSttyAvailable()
-    {
-        exec('stty 2>&1', $output, $exitcode);
-
-        return 0 === $exitcode;
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -18,17 +18,31 @@ class TerminalTest extends TestCase
 {
     private $colSize;
     private $lineSize;
+    private $ansiCon;
 
     protected function setUp()
     {
         $this->colSize = getenv('COLUMNS');
         $this->lineSize = getenv('LINES');
+        $this->ansiCon = getenv('ANSICON');
+        $this->resetStatics();
     }
 
     protected function tearDown()
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
         putenv($this->lineSize ? 'LINES' : 'LINES='.$this->lineSize);
+        putenv($this->ansiCon ? 'ANSICON='.$this->ansiCon : 'ANSICON');
+        $this->resetStatics();
+    }
+
+    private function resetStatics()
+    {
+        foreach (['height', 'width', 'stty'] as $name) {
+            $property = new \ReflectionProperty(Terminal::class, $name);
+            $property->setAccessible(true);
+            $property->setValue(null);
+        }
     }
 
     public function test()
@@ -55,5 +69,29 @@ class TerminalTest extends TestCase
 
         $this->assertSame(0, $terminal->getWidth());
         $this->assertSame(0, $terminal->getHeight());
+    }
+
+    public function testSttyOnWindows()
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Must be on windows');
+        }
+
+        $sttyString = exec('(stty -a | grep columns) 2>&1', $output, $exitcode);
+        if (0 !== $exitcode) {
+            $this->markTestSkipped('Must have stty support');
+        }
+
+        $matches = [];
+        if (0 === preg_match('/columns.(\d+)/i', $sttyString, $matches)) {
+            $this->fail('Could not determine existing stty columns');
+        }
+
+        putenv('COLUMNS');
+        putenv('LINES');
+        putenv('ANSICON');
+
+        $terminal = new Terminal();
+        $this->assertSame((int) $matches[1], $terminal->getWidth());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`Console\Terminal` is modified to extract width/height settings to from `stty` on windows if possible. Previously such values were extracted from `mode CON`. If another terminal is in use (eg, gitbash) then the incorrect values would be applied.