### PR TITLE
[FrameworkBundle] Add --watch option to cache:clear command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -86,6 +86,7 @@
     },
     "suggest": {
         "ext-apcu": "For best performance of the system caches",
+        "ext-inotify": "For watching files and recompiling whenever they change",
         "symfony/console": "For using the console commands",
         "symfony/form": "For using forms",
         "symfony/serializer": "For using the serializer service",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

Inspired by [the watch of webpack](https://webpack.js.org/configuration/watch/), this PR allows to clear the cache immediately after touching the code base of the project. Indeed, from the DX perspective, the cache regeneration is always painful because it is started after an user action such as running a command or making a request through the browser, and we undergo the time of recompilation that should ideally be realised before.

![Peek 2019-07-26 15-16](https://user-images.githubusercontent.com/4578773/61957292-32f45b00-afbf-11e9-94ad-59d0339b6435.gif)