### PR TITLE
[Yaml] fix comment in multi line value

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -436,6 +436,9 @@ class Parser
                     $value = '';
 
                     foreach ($this->lines as $line) {
+                        if ('' !== ltrim($line) && '#' === ltrim($line)[0]) {
+                            continue;
+                        }
                         // If the indentation is not consistent at offset 0, it is to be considered as a ParseError
                         if (0 === $this->offset && !$deprecatedUsage && isset($line[0]) && ' ' === $line[0]) {
                             throw new ParseException('Unable to parse.', $this->getRealCurrentLineNb() + 1, $this->currentLine, $this->filename);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2292,6 +2292,18 @@ YAML;
 
         return $tests;
     }
+
+    public function testMultiLineComment()
+    {
+        $yaml = <<<YAML
+parameters:
+    abc
+
+# Comment 
+YAML;
+
+        $this->assertSame(['parameters' => 'abc'], $this->parser->parse($yaml));
+    }
 }
 
 class B


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.3 and lower <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32667    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
Comments after blank lines are read as value in yaml.

```
`$yaml = <<<YAML
parameters:
    abc

# Comment 
YAML;

var_dump(Symfony\Component\Yaml\Yaml::parse($yaml));`
```

**Result before fix:**

```
array(1) {
  ["parameters"]=>
  string(13) "abc
# Comment"
}
```
**Result after fix:**

```
array(1) {
  ["parameters"]=>
  string(3) "abc"
}
```