### PR TITLE
[SecurityBundle] remove the deprecated "switch_user.stateless" option

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.0.0
 -----
 
+ * The `switch_user.stateless` firewall option has been removed.
  * Removed the ability to configure encoders using `argon2i` or `bcrypt` as algorithm, use `auto` instead
  * The `simple_form` and `simple_preauth` authentication listeners have been removed,
    use Guard instead.

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -244,10 +244,6 @@ class MainConfiguration implements ConfigurationInterface
                     ->scalarNode('provider')->end()
                     ->scalarNode('parameter')->defaultValue('_switch_user')->end()
                     ->scalarNode('role')->defaultValue('ROLE_ALLOWED_TO_SWITCH')->end()
-                    ->booleanNode('stateless')
-                        ->setDeprecated('The "%path%.%node%" configuration key has been deprecated in Symfony 4.1.')
-                        ->defaultValue(false)
-                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -675,7 +675,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $listener->replaceArgument(3, $id);
         $listener->replaceArgument(6, $config['parameter']);
         $listener->replaceArgument(7, $config['role']);
-        $listener->replaceArgument(9, $stateless ?: $config['stateless']);
+        $listener->replaceArgument(9, $stateless);
 
         return $switchUserListenerId;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 