### PR TITLE
[HttpFoundation] Fix `getMaxFilesize`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -214,13 +214,26 @@ class UploadedFile extends File
      */
     public static function getMaxFilesize()
     {
-        $iniMax = strtolower(ini_get('upload_max_filesize'));
+        $sizePostMax = self::parseFilesize(ini_get('post_max_size'));
+        $sizeUploadMax = self::parseFilesize(ini_get('upload_max_filesize'));
 
-        if ('' === $iniMax) {
-            return PHP_INT_MAX;
+        return min([$sizePostMax, $sizeUploadMax]);
+    }
+
+    /**
+     * Returns the given size from an ini value in bytes.
+     *
+     * @return int The given size in bytes
+     */
+    private static function parseFilesize($size)
+    {
+        if ('' === $size) {
+            return 0;
         }
 
-        $max = ltrim($iniMax, '+');
+        $size = strtolower($size);
+
+        $max = ltrim($size, '+');
         if (0 === strpos($max, '0x')) {
             $max = \intval($max, 16);
         } elseif (0 === strpos($max, '0')) {
@@ -229,7 +242,7 @@ class UploadedFile extends File
             $max = (int) $max;
         }
 
-        switch (substr($iniMax, -1)) {
+        switch (substr($size, -1)) {
             case 't': $max *= 1024;
             // no break
             case 'g': $max *= 1024;


### PR DESCRIPTION
When checking for the maximum size of an uploaded file you can't just rely on `upload_max_filesize` since the request might also exceed `post_max_size`. Also discussed in contao/contao#498

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
