### PR TITLE
[Messenger] Fix incompatibility with FrameworkBundle <4.3.1

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -82,7 +82,7 @@
         </service>
 
         <service id="console.command.messenger_consume_messages" class="Symfony\Component\Messenger\Command\ConsumeMessagesCommand">
-            <argument type="service" id="messenger.routable_message_bus" />
+            <argument /> <!-- Routable message bus -->
             <argument type="service" id="messenger.receiver_locator" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="collection" /> <!-- Receiver names -->

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -57,6 +57,8 @@ class ConsumeMessagesCommand extends Command
         // to be deprecated in 4.4
         if ($routableBus instanceof ContainerInterface) {
             $routableBus = new RoutableMessageBus($routableBus);
+        } elseif (!$routableBus instanceof RoutableMessageBus) {
+            throw new \TypeError(sprintf('The first argument must be an instance of "%s".', RoutableMessageBus::class));
         }
 
         if (\is_array($retryStrategyLocator)) {

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -253,14 +253,19 @@ class MessengerPass implements CompilerPassInterface
             $buses[$busId] = new Reference($busId);
         }
 
-        if ($container->hasDefinition('messenger.routable_message_bus')) {
+        if ($hasRoutableMessageBus = $container->hasDefinition('messenger.routable_message_bus')) {
             $container->getDefinition('messenger.routable_message_bus')
                 ->replaceArgument(0, ServiceLocatorTagPass::register($container, $buses));
         }
 
         if ($container->hasDefinition('console.command.messenger_consume_messages')) {
-            $container->getDefinition('console.command.messenger_consume_messages')
-                ->replaceArgument(3, array_values($receiverNames));
+            $consumeCommandDefinition = $container->getDefinition('console.command.messenger_consume_messages');
+
+            if ($hasRoutableMessageBus) {
+                $consumeCommandDefinition->replaceArgument(0, new Reference('messenger.routable_message_bus'));
+            }
+
+            $consumeCommandDefinition->replaceArgument(3, array_values($receiverNames));
         }
 
         if ($container->hasDefinition('console.command.messenger_setup_transports')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32738 
| License       | MIT
| Doc PR        | -

Aims to fix an edge case where you install (or upgrade to) symfony/messenger >=4.3.1 while having symfony/framework-bundle <4.3.1 installed.