### PR TITLE
Make sure trace_level is always defined

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -98,8 +98,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             'trace_header' => 'X-Symfony-Cache',
         ], $options);
 
-        if (!isset($options['trace_level']) && $this->options['debug']) {
-            $this->options['trace_level'] = 'full';
+        if (!isset($options['trace_level'])) {
+            $this->options['trace_level'] = $this->options['debug'] ? 'full' : 'none';
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32801
| License       | MIT
| Doc PR        | -

Fix bug introduced in https://github.com/symfony/symfony/commit/9a2fcc9392c3da4718ae2c4d4a5877a9962a70f8

When running the HttpCache kernel with debug option false and no explicit trace_level, the default does not get initialized. The kernel still unconditionally calls addTraces.

@andrerom found this while looking at tests output of FOSHttpCache: https://github.com/FriendsOfSymfony/FOSHttpCache/blob/master/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
https://travis-ci.org/FriendsOfSymfony/FOSHttpCache/jobs/565046971