### PR TITLE
[Console] fix warning on PHP 7.4

### DIFF
--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -132,7 +132,7 @@ class ArrayInput extends Input
             }
             if (0 === strpos($key, '--')) {
                 $this->addLongOption(substr($key, 2), $value);
-            } elseif ('-' === $key[0]) {
+            } elseif (0 === strpos($key, '-')) {
                 $this->addShortOption(substr($key, 1), $value);
             } else {
                 $this->addArgument($key, $value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| License       | MIT

Fixes #32750 

In php 7.4rc, accessing an array by key, sometimes causes an error.
Rarely this error occurs on php 7.2.

```bash
ErrorException: Trying to access array offset on value of type int

/app/vendor/symfony/console/Input/ArrayInput.php:135
/app/vendor/symfony/console/Input/Input.php:55
/app/vendor/symfony/console/Application.php:208
/app/vendor/symfony/console/Application.php:149
/app/vendor/laravel/framework/src/Illuminate/Console/Application.php:90
/app/vendor/laravel/framework/src/Illuminate/Console/Application.php:182
/app/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:275
/app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/PendingCommand.php:136
/app/vendor/orchestra/testbench-core/src/Database/MigrateProcessor.php:73
/app/vendor/orchestra/testbench-core/src/Database/MigrateProcessor.php:44
/app/vendor/orchestra/testbench-core/src/Concerns/WithLoadMigrationsFrom.php:27
```