### PR TITLE
[Form] Deprecate passing ints

### DIFF
--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -79,9 +79,9 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param string|int|FormBuilderInterface $child
-     * @param string|FormTypeInterface        $type
-     * @param array                           $options
+     * @param string|FormBuilderInterface $child
+     * @param string|FormTypeInterface    $type
+     * @param array                       $options
      *
      * @throws BadMethodCallException
      */

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -77,7 +77,7 @@ class ResizeFormListener implements EventSubscriberInterface
 
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
-            $form->add($name, $this->type, array_replace([
+            $form->add((string) $name, $this->type, array_replace([
                 'property_path' => '['.$name.']',
             ], $this->options));
         }
@@ -105,7 +105,7 @@ class ResizeFormListener implements EventSubscriberInterface
         if ($this->allowAdd) {
             foreach ($data as $name => $value) {
                 if (!$form->has($name)) {
-                    $form->add($name, $this->type, array_replace([
+                    $form->add((string) $name, $this->type, array_replace([
                         'property_path' => '['.$name.']',
                     ], $this->options));
                 }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -843,8 +843,13 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
         }
 
         if (!$child instanceof FormInterface) {
-            if (!\is_string($child) && !\is_int($child)) {
-                throw new UnexpectedTypeException($child, 'string, integer or Symfony\Component\Form\FormInterface');
+            if (\is_int($child)) {
+                @trigger_error(sprintf('Passing an integer child name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+                $child = (string) $child;
+            }
+
+            if (!\is_string($child)) {
+                throw new UnexpectedTypeException($child, 'string or Symfony\Component\Form\FormInterface');
             }
 
             $child = (string) $child;

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -62,8 +62,13 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
             return $this;
         }
 
-        if (!\is_string($child) && !\is_int($child)) {
-            throw new UnexpectedTypeException($child, 'string, integer or Symfony\Component\Form\FormBuilderInterface');
+        if (\is_int($child)) {
+            @trigger_error(sprintf('Passing an integer child name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+            $child = (string) $child;
+        }
+
+        if (!\is_string($child)) {
+            throw new UnexpectedTypeException($child, 'string or Symfony\Component\Form\FormBuilderInterface');
         }
 
         if (null !== $type && !\is_string($type) && !$type instanceof FormTypeInterface) {
@@ -86,6 +91,11 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
             throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+            $name = (string) $name;
+        }
+
         if (null === $type && null === $this->getDataClass()) {
             $type = 'Symfony\Component\Form\Extension\Core\Type\TextType';
         }
@@ -104,6 +114,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     {
         if ($this->locked) {
             throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
         }
 
         if (isset($this->unresolvedChildren[$name])) {
@@ -126,6 +140,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
             throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+        }
+
         unset($this->unresolvedChildren[$name], $this->children[$name]);
 
         return $this;
@@ -138,6 +156,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     {
         if ($this->locked) {
             throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
         }
 
         return isset($this->unresolvedChildren[$name]) || isset($this->children[$name]);
@@ -241,7 +263,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     private function resolveChildren()
     {
         foreach ($this->unresolvedChildren as $name => $info) {
-            $this->children[$name] = $this->create($name, $info[0], $info[1]);
+            $this->children[$name] = $this->create((string) $name, $info[0], $info[1]);
         }
 
         $this->unresolvedChildren = [];

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -23,9 +23,9 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * If you add a nested group, this group should also be represented in the
      * object hierarchy.
      *
-     * @param string|int|FormBuilderInterface $child
-     * @param string|null                     $type
-     * @param array                           $options
+     * @param string|FormBuilderInterface $child
+     * @param string|null                 $type
+     * @param array                       $options
      *
      * @return self
      */

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -776,6 +776,11 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public static function validateName($name)
     {
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+            $name = (string) $name;
+        }
+
         if (null !== $name && !\is_string($name)) {
             throw new UnexpectedTypeException($name, 'string or null');
         }

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -35,6 +35,11 @@ class FormFactory implements FormFactoryInterface
      */
     public function createNamed($name, $type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = [])
     {
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+            $name = (string) $name;
+        }
+
         return $this->createNamedBuilder($name, $type, $data, $options)->getForm();
     }
 
@@ -63,6 +68,11 @@ class FormFactory implements FormFactoryInterface
      */
     public function createNamedBuilder($name, $type = 'Symfony\Component\Form\Extension\Core\Type\FormType', $data = null, array $options = [])
     {
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+            $name = (string) $name;
+        }
+
         if (null !== $data && !\array_key_exists('data', $options)) {
             $options['data'] = $data;
         }

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -38,10 +38,10 @@ interface FormFactoryInterface
      *
      * @see createNamedBuilder()
      *
-     * @param string|int $name    The name of the form
-     * @param string     $type    The type of the form
-     * @param mixed      $data    The initial data
-     * @param array      $options The options
+     * @param string $name    The name of the form
+     * @param string $type    The type of the form
+     * @param mixed  $data    The initial data
+     * @param array  $options The options
      *
      * @return FormInterface The form
      *
@@ -81,10 +81,10 @@ interface FormFactoryInterface
     /**
      * Returns a form builder.
      *
-     * @param string|int $name    The name of the form
-     * @param string     $type    The type of the form
-     * @param mixed      $data    The initial data
-     * @param array      $options The options
+     * @param string $name    The name of the form
+     * @param string $type    The type of the form
+     * @param mixed  $data    The initial data
+     * @param array  $options The options
      *
      * @return FormBuilderInterface The form builder
      *

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -43,9 +43,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Adds or replaces a child to the form.
      *
-     * @param FormInterface|string|int $child   The FormInterface instance or the name of the child
-     * @param string|null              $type    The child's type, if a name was passed
-     * @param array                    $options The child's options, if a name was passed
+     * @param FormInterface|string $child   The FormInterface instance or the name of the child
+     * @param string|null          $type    The child's type, if a name was passed
+     * @param array                $options The child's options, if a name was passed
      *
      * @return $this
      *

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -93,6 +93,11 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      */
     public function createBuilder(FormFactoryInterface $factory, $name, array $options = [])
     {
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+            $name = (string) $name;
+        }
+
         try {
             $options = $this->getOptionsResolver()->resolve($options);
         } catch (ExceptionInterface $e) {
@@ -218,6 +223,11 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      */
     protected function newBuilder($name, $dataClass, FormFactoryInterface $factory, array $options)
     {
+        if (\is_int($name)) {
+            @trigger_error(sprintf('Passing an integer name to "%s" is deprecated since Symfony 4.4. Pass a string instead.', __METHOD__), \E_USER_DEPRECATED);
+            $name = (string) $name;
+        }
+
         if ($this->innerType instanceof ButtonTypeInterface) {
             return new ButtonBuilder($name, $options);
         }

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -188,6 +188,9 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertSame(['foo' => $child], $this->form->all());
     }
 
+    /**
+     * @group legacy
+     */
     public function testAddUsingIntegerNameAndType()
     {
         $child = $this->getBuilder(0)->getForm();

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -81,6 +81,9 @@ class FormBuilderTest extends TestCase
         $this->assertTrue($this->builder->has('foo'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testAddIntegerName()
     {
         $this->assertFalse($this->builder->has(0));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | relates to https://github.com/symfony/symfony/pull/32237
| License       | MIT
| Doc PR        | todo?

This PR deprecates passing ints to form building methods to ease upgrade to 5.0.

ping @nicolas-grekas , @xabbuh 