### PR TITLE
[Ldap] Add security LdapUser and provider

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -141,6 +141,7 @@ Routing
 Security
 --------
 
+ * The `LdapUserProvider` class has been deprecated, use `Symfony\Component\Ldap\Security\LdapUserProvider` instead.
  * Implementations of `PasswordEncoderInterface` and `UserPasswordEncoderInterface` should add a new `needsRehash()` method
 
 Stopwatch

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -376,6 +376,7 @@ Routing
 Security
 --------
 
+ * The `LdapUserProvider` class has been removed, use `Symfony\Component\Ldap\Security\LdapUserProvider` instead.
  * Implementations of `PasswordEncoderInterface` and `UserPasswordEncoderInterface` must have a new `needsRehash()` method
  * The `Role` and `SwitchUserRole` classes have been removed.
  * The `getReachableRoles()` method of the `RoleHierarchy` class has been removed. It has been replaced by the new

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -175,7 +175,7 @@
             <deprecated>The "%service_id%" service is deprecated since Symfony 4.1.</deprecated>
         </service>
 
-        <service id="security.user.provider.ldap" class="Symfony\Component\Security\Core\User\LdapUserProvider" abstract="true">
+        <service id="security.user.provider.ldap" class="Symfony\Component\Ldap\Security\LdapUserProvider" abstract="true">
             <argument /> <!-- security.ldap.ldap -->
             <argument /> <!-- base dn -->
             <argument /> <!-- search dn -->

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -51,7 +51,8 @@
         "symfony/twig-bundle": "<4.4",
         "symfony/var-dumper": "<3.4",
         "symfony/framework-bundle": "<4.4",
-        "symfony/console": "<3.4"
+        "symfony/console": "<3.4",
+        "symfony/ldap": "<4.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\SecurityBundle\\": "" },

--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Security;
+
+use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @final
+ */
+class LdapUser implements UserInterface
+{
+    private $entry;
+    private $username;
+    private $password;
+    private $roles;
+    private $extraFields;
+
+    public function __construct(Entry $entry, string $username, ?string $password, array $roles = [], array $extraFields = [])
+    {
+        if (!$username) {
+            throw new \InvalidArgumentException('The username cannot be empty.');
+        }
+
+        $this->entry = $entry;
+        $this->username = $username;
+        $this->password = $password;
+        $this->roles = $roles;
+        $this->extraFields = $extraFields;
+    }
+
+    public function getEntry(): Entry
+    {
+        return $this->entry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSalt()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eraseCredentials()
+    {
+        $this->password = null;
+    }
+
+    public function getExtraFields(): array
+    {
+        return $this->extraFields;
+    }
+}

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Security;
+
+use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\ConnectionException;
+use Symfony\Component\Ldap\LdapInterface;
+use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * LdapUserProvider is a simple user provider on top of ldap.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Charles Sarrazin <charles@sarraz.in>
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class LdapUserProvider implements UserProviderInterface
+{
+    private $ldap;
+    private $baseDn;
+    private $searchDn;
+    private $searchPassword;
+    private $defaultRoles;
+    private $uidKey;
+    private $defaultSearch;
+    private $passwordAttribute;
+    private $extraFields;
+
+    public function __construct(LdapInterface $ldap, string $baseDn, string $searchDn = null, string $searchPassword = null, array $defaultRoles = [], string $uidKey = null, string $filter = null, string $passwordAttribute = null, array $extraFields = [])
+    {
+        if (null === $uidKey) {
+            $uidKey = 'sAMAccountName';
+        }
+
+        if (null === $filter) {
+            $filter = '({uid_key}={username})';
+        }
+
+        $this->ldap = $ldap;
+        $this->baseDn = $baseDn;
+        $this->searchDn = $searchDn;
+        $this->searchPassword = $searchPassword;
+        $this->defaultRoles = $defaultRoles;
+        $this->uidKey = $uidKey;
+        $this->defaultSearch = str_replace('{uid_key}', $uidKey, $filter);
+        $this->passwordAttribute = $passwordAttribute;
+        $this->extraFields = $extraFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByUsername($username)
+    {
+        try {
+            $this->ldap->bind($this->searchDn, $this->searchPassword);
+            $username = $this->ldap->escape($username, '', LdapInterface::ESCAPE_FILTER);
+            $query = str_replace('{username}', $username, $this->defaultSearch);
+            $search = $this->ldap->query($this->baseDn, $query);
+        } catch (ConnectionException $e) {
+            throw new UsernameNotFoundException(sprintf('User "%s" not found.', $username), 0, $e);
+        }
+
+        $entries = $search->execute();
+        $count = \count($entries);
+
+        if (!$count) {
+            throw new UsernameNotFoundException(sprintf('User "%s" not found.', $username));
+        }
+
+        if ($count > 1) {
+            throw new UsernameNotFoundException('More than one user found');
+        }
+
+        $entry = $entries[0];
+
+        try {
+            if (null !== $this->uidKey) {
+                $username = $this->getAttributeValue($entry, $this->uidKey);
+            }
+        } catch (InvalidArgumentException $e) {
+        }
+
+        return $this->loadUser($username, $entry);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        if (!$user instanceof LdapUser) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
+        }
+
+        return new LdapUser($user->getEntry(), $user->getUsername(), $user->getPassword(), $user->getRoles());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        return LdapUser::class === $class;
+    }
+
+    /**
+     * Loads a user from an LDAP entry.
+     *
+     * @return LdapUser
+     */
+    protected function loadUser($username, Entry $entry)
+    {
+        $password = null;
+        $extraFields = [];
+
+        if (null !== $this->passwordAttribute) {
+            $password = $this->getAttributeValue($entry, $this->passwordAttribute);
+        }
+
+        foreach ($this->extraFields as $field) {
+            $extraFields[$field] = $this->getAttributeValue($entry, $field);
+        }
+
+        return new LdapUser($entry, $username, $password, $this->defaultRoles, $extraFields);
+    }
+
+    private function getAttributeValue(Entry $entry, string $attribute)
+    {
+        if (!$entry->hasAttribute($attribute)) {
+            throw new InvalidArgumentException(sprintf('Missing attribute "%s" for user "%s".', $attribute, $entry->getDn()));
+        }
+
+        $values = $entry->getAttribute($attribute);
+
+        if (1 !== \count($values)) {
+            throw new InvalidArgumentException(sprintf('Attribute "%s" has multiple values.', $attribute));
+        }
+
+        return $values[0];
+    }
+}

--- a/src/Symfony/Component/Ldap/Tests/Security/User/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/User/LdapUserProviderTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Security\Core\Tests\User;
+namespace Symfony\Component\Ldap\Tests\Security\User;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Ldap\Adapter\CollectionInterface;
@@ -17,7 +17,8 @@ use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Entry;
 use Symfony\Component\Ldap\Exception\ConnectionException;
 use Symfony\Component\Ldap\LdapInterface;
-use Symfony\Component\Security\Core\User\LdapUserProvider;
+use Symfony\Component\Ldap\Security\LdapUser;
+use Symfony\Component\Ldap\Security\LdapUserProvider;
 
 /**
  * @group legacy
@@ -30,7 +31,7 @@ class LdapUserProviderTest extends TestCase
      */
     public function testLoadUserByUsernameFailsIfCantConnectToLdap()
     {
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $ldap
             ->expects($this->once())
             ->method('bind')
@@ -46,8 +47,8 @@ class LdapUserProviderTest extends TestCase
      */
     public function testLoadUserByUsernameFailsIfNoLdapEntries()
     {
-        $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
-        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $result = $this->createMock(CollectionInterface::class);
+        $query = $this->createMock(QueryInterface::class);
         $query
             ->expects($this->once())
             ->method('execute')
@@ -58,7 +59,7 @@ class LdapUserProviderTest extends TestCase
             ->method('count')
             ->willReturn(0)
         ;
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $ldap
             ->expects($this->once())
             ->method('escape')
@@ -79,8 +80,8 @@ class LdapUserProviderTest extends TestCase
      */
     public function testLoadUserByUsernameFailsIfMoreThanOneLdapEntry()
     {
-        $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
-        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $result = $this->createMock(CollectionInterface::class);
+        $query = $this->createMock(QueryInterface::class);
         $query
             ->expects($this->once())
             ->method('execute')
@@ -91,7 +92,7 @@ class LdapUserProviderTest extends TestCase
             ->method('count')
             ->willReturn(2)
         ;
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $ldap
             ->expects($this->once())
             ->method('escape')
@@ -112,14 +113,14 @@ class LdapUserProviderTest extends TestCase
      */
     public function testLoadUserByUsernameFailsIfMoreThanOneLdapPasswordsInEntry()
     {
-        $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
-        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $result = $this->createMock(CollectionInterface::class);
+        $query = $this->createMock(QueryInterface::class);
         $query
             ->expects($this->once())
             ->method('execute')
             ->willReturn($result)
         ;
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $result
             ->expects($this->once())
             ->method('offsetGet')
@@ -127,8 +128,7 @@ class LdapUserProviderTest extends TestCase
             ->willReturn(new Entry('foo', [
                     'sAMAccountName' => ['foo'],
                     'userpassword' => ['bar', 'baz'],
-                ]
-            ))
+            ]))
         ;
         $result
             ->expects($this->once())
@@ -147,22 +147,19 @@ class LdapUserProviderTest extends TestCase
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword');
-        $this->assertInstanceOf(
-            'Symfony\Component\Security\Core\User\User',
-            $provider->loadUserByUsername('foo')
-        );
+        $this->assertInstanceOf(LdapUser::class, $provider->loadUserByUsername('foo'));
     }
 
     public function testLoadUserByUsernameShouldNotFailIfEntryHasNoUidKeyAttribute()
     {
-        $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
-        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $result = $this->createMock(CollectionInterface::class);
+        $query = $this->createMock(QueryInterface::class);
         $query
             ->expects($this->once())
             ->method('execute')
             ->willReturn($result)
         ;
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $result
             ->expects($this->once())
             ->method('offsetGet')
@@ -186,10 +183,7 @@ class LdapUserProviderTest extends TestCase
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})');
-        $this->assertInstanceOf(
-            'Symfony\Component\Security\Core\User\User',
-            $provider->loadUserByUsername('foo')
-        );
+        $this->assertInstanceOf(LdapUser::class, $provider->loadUserByUsername('foo'));
     }
 
     /**
@@ -197,22 +191,19 @@ class LdapUserProviderTest extends TestCase
      */
     public function testLoadUserByUsernameFailsIfEntryHasNoPasswordAttribute()
     {
-        $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
-        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $result = $this->createMock(CollectionInterface::class);
+        $query = $this->createMock(QueryInterface::class);
         $query
             ->expects($this->once())
             ->method('execute')
             ->willReturn($result)
         ;
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->willReturn(new Entry('foo', [
-                    'sAMAccountName' => ['foo'],
-                ]
-            ))
+            ->willReturn(new Entry('foo', ['sAMAccountName' => ['foo']]))
         ;
         $result
             ->expects($this->once())
@@ -231,30 +222,24 @@ class LdapUserProviderTest extends TestCase
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword');
-        $this->assertInstanceOf(
-            'Symfony\Component\Security\Core\User\User',
-            $provider->loadUserByUsername('foo')
-        );
+        $this->assertInstanceOf(LdapUser::class, $provider->loadUserByUsername('foo'));
     }
 
     public function testLoadUserByUsernameIsSuccessfulWithoutPasswordAttribute()
     {
-        $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
-        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $result = $this->createMock(CollectionInterface::class);
+        $query = $this->createMock(QueryInterface::class);
         $query
             ->expects($this->once())
             ->method('execute')
             ->willReturn($result)
         ;
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->willReturn(new Entry('foo', [
-                    'sAMAccountName' => ['foo'],
-                ]
-            ))
+            ->willReturn(new Entry('foo', ['sAMAccountName' => ['foo']]))
         ;
         $result
             ->expects($this->once())
@@ -273,30 +258,24 @@ class LdapUserProviderTest extends TestCase
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');
-        $this->assertInstanceOf(
-            'Symfony\Component\Security\Core\User\User',
-            $provider->loadUserByUsername('foo')
-        );
+        $this->assertInstanceOf(LdapUser::class, $provider->loadUserByUsername('foo'));
     }
 
     public function testLoadUserByUsernameIsSuccessfulWithoutPasswordAttributeAndWrongCase()
     {
-        $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
-        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $result = $this->createMock(CollectionInterface::class);
+        $query = $this->createMock(QueryInterface::class);
         $query
             ->expects($this->once())
             ->method('execute')
             ->willReturn($result)
         ;
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $result
             ->expects($this->once())
             ->method('offsetGet')
             ->with(0)
-            ->willReturn(new Entry('foo', [
-                    'sAMAccountName' => ['foo'],
-                ]
-            ))
+            ->willReturn(new Entry('foo', ['sAMAccountName' => ['foo']]))
         ;
         $result
             ->expects($this->once())
@@ -320,14 +299,14 @@ class LdapUserProviderTest extends TestCase
 
     public function testLoadUserByUsernameIsSuccessfulWithPasswordAttribute()
     {
-        $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
-        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $result = $this->createMock(CollectionInterface::class);
+        $query = $this->createMock(QueryInterface::class);
         $query
             ->expects($this->once())
             ->method('execute')
             ->willReturn($result)
         ;
-        $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
+        $ldap = $this->createMock(LdapInterface::class);
         $result
             ->expects($this->once())
             ->method('offsetGet')
@@ -336,8 +315,7 @@ class LdapUserProviderTest extends TestCase
                     'sAMAccountName' => ['foo'],
                     'userpassword' => ['bar'],
                     'email' => ['elsa@symfony.com'],
-                ]
-            ))
+            ]))
         ;
         $result
             ->expects($this->once())
@@ -356,9 +334,6 @@ class LdapUserProviderTest extends TestCase
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword', ['email']);
-        $this->assertInstanceOf(
-            'Symfony\Component\Security\Core\User\User',
-            $provider->loadUserByUsername('foo')
-        );
+        $this->assertInstanceOf(LdapUser::class, $provider->loadUserByUsername('foo'));
     }
 }

--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -20,6 +20,9 @@
         "symfony/options-resolver": "^4.2|^5.0",
         "ext-ldap": "*"
     },
+    "require-dev": {
+        "symfony/security-core": "^4.4"
+    },
     "conflict": {
         "symfony/options-resolver": "<4.2"
     },

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * Deprecated class `LdapUserProvider`, use `Symfony\Component\Ldap\Security\LdapUserProvider` instead
  * Added method `needsRehash()` to `PasswordEncoderInterface` and `UserPasswordEncoderInterface`
  * Added `MigratingPasswordEncoder`
 

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -25,13 +25,14 @@
         "symfony/event-dispatcher": "^4.3",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
-        "symfony/ldap": "^3.4|^4.0|^5.0",
+        "symfony/ldap": "^4.4|^5.0",
         "symfony/validator": "^3.4|^4.0|^5.0",
         "psr/log": "~1.0"
     },
     "conflict": {
         "symfony/event-dispatcher": "<4.3|>=5",
-        "symfony/security-guard": "<4.3"
+        "symfony/security-guard": "<4.3",
+        "symfony/ldap": "<4.4"
     },
     "suggest": {
         "psr/container-implementation": "To instantiate the Security class",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -37,11 +37,12 @@
         "symfony/routing": "^3.4|^4.0|^5.0",
         "symfony/validator": "^3.4|^4.0|^5.0",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
-        "symfony/ldap": "^3.4|^4.0|^5.0",
+        "symfony/ldap": "^4.4|^5.0",
         "psr/log": "~1.0"
     },
     "conflict": {
-        "symfony/event-dispatcher": ">=5"
+        "symfony/event-dispatcher": ">=5",
+        "symfony/ldap": "<4.4"
     },
     "suggest": {
         "psr/container-implementation": "To instantiate the Security class",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Moves `LdapUserProvider` from `Security\Core` to the Ldap component, the provider now deals with a new `LdapUser` aware of its ldap `Entry` (should help in #31843). 