### PR TITLE
[Debug] minor fix for wrong method name case

### DIFF
--- a/src/Symfony/Component/Debug/Exception/SilencedErrorContext.php
+++ b/src/Symfony/Component/Debug/Exception/SilencedErrorContext.php
@@ -54,7 +54,7 @@ class SilencedErrorContext implements \JsonSerializable
         return $this->trace;
     }
 
-    public function JsonSerialize()
+    public function jsonSerialize()
     {
         return [
             'severity' => $this->severity,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Minor replacement of wrong case for function name, needs to be fixed in 3.4 as hinten [here](https://github.com/symfony/symfony/pull/32812#discussion_r308815666).