### PR TITLE
[Security] Revise UserPasswordEncoderInterface::needsRehash()

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
@@ -50,10 +50,10 @@ class UserPasswordEncoder implements UserPasswordEncoderInterface
     /**
      * {@inheritdoc}
      */
-    public function needsRehash(UserInterface $user, string $encoded): bool
+    public function needsRehash(UserInterface $user): bool
     {
         $encoder = $this->encoderFactory->getEncoder($user);
 
-        return method_exists($encoder, 'needsRehash') && $encoder->needsRehash($encoded);
+        return method_exists($encoder, 'needsRehash') && $encoder->needsRehash($user->getPassword());
     }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  *
  * @author Ariel Ferrandini <arielferrandini@gmail.com>
  *
- * @method bool needsRehash(UserInterface $user, string $encoded)
+ * @method bool needsRehash(UserInterface $user)
  */
 interface UserPasswordEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
@@ -85,9 +85,9 @@ class UserPasswordEncoderTest extends TestCase
 
         $passwordEncoder = new UserPasswordEncoder($mockEncoderFactory);
 
-        $hash = $passwordEncoder->encodePassword($user, 'foo', 'salt');
-        $this->assertFalse($passwordEncoder->needsRehash($user, $hash));
-        $this->assertTrue($passwordEncoder->needsRehash($user, $hash));
-        $this->assertFalse($passwordEncoder->needsRehash($user, $hash));
+        $user->setPassword($passwordEncoder->encodePassword($user, 'foo', 'salt'));
+        $this->assertFalse($passwordEncoder->needsRehash($user));
+        $this->assertTrue($passwordEncoder->needsRehash($user));
+        $this->assertFalse($passwordEncoder->needsRehash($user));
     }
 }

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -164,4 +164,9 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
 
         return true;
     }
+
+    public function setPassword(string $password)
+    {
+        $this->password = $password;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This reuses the encoded password from the user for the `UserPasswordEncoderInterface`, similar we dont pass the encoded string to `isPasswordValid()`.

This differs from the non-user aware `PasswordEncoderInterface`

cc @nicolas-grekas did i miss something?