### PR TITLE
[Messenger] Removed named parameters and replaced with `?` placeholders for sqlsrv compatibility

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -111,19 +111,19 @@ class Connection
         $queryBuilder = $this->driverConnection->createQueryBuilder()
             ->insert($this->configuration['table_name'])
             ->values([
-                'body' => ':body',
-                'headers' => ':headers',
-                'queue_name' => ':queue_name',
-                'created_at' => ':created_at',
-                'available_at' => ':available_at',
+                'body' => '?',
+                'headers' => '?',
+                'queue_name' => '?',
+                'created_at' => '?',
+                'available_at' => '?',
             ]);
 
         $this->executeQuery($queryBuilder->getSQL(), [
-            ':body' => $body,
-            ':headers' => json_encode($headers),
-            ':queue_name' => $this->configuration['queue_name'],
-            ':created_at' => self::formatDateTime($now),
-            ':available_at' => self::formatDateTime($availableAt),
+            $body,
+            json_encode($headers),
+            $this->configuration['queue_name'],
+            self::formatDateTime($now),
+            self::formatDateTime($availableAt),
         ]);
 
         return $this->driverConnection->lastInsertId();
@@ -156,12 +156,12 @@ class Connection
 
             $queryBuilder = $this->driverConnection->createQueryBuilder()
                 ->update($this->configuration['table_name'])
-                ->set('delivered_at', ':delivered_at')
-                ->where('id = :id');
+                ->set('delivered_at', '?')
+                ->where('id = ?');
             $now = new \DateTime();
             $this->executeQuery($queryBuilder->getSQL(), [
-                ':id' => $doctrineEnvelope['id'],
-                ':delivered_at' => self::formatDateTime($now),
+                self::formatDateTime($now),
+                $doctrineEnvelope['id'],
             ]);
 
             $this->driverConnection->commit();
@@ -249,10 +249,10 @@ class Connection
         }
 
         $queryBuilder = $this->createQueryBuilder()
-            ->where('m.id = :id');
+            ->where('m.id = ?');
 
         $data = $this->executeQuery($queryBuilder->getSQL(), [
-            'id' => $id,
+            $id,
         ])->fetch();
 
         return false === $data ? null : $this->decodeEnvelopeHeaders($data);
@@ -264,13 +264,13 @@ class Connection
         $redeliverLimit = (clone $now)->modify(sprintf('-%d seconds', $this->configuration['redeliver_timeout']));
 
         return $this->createQueryBuilder()
-            ->where('m.delivered_at is null OR m.delivered_at < :redeliver_limit')
-            ->andWhere('m.available_at <= :now')
-            ->andWhere('m.queue_name = :queue_name')
+            ->where('m.delivered_at is null OR m.delivered_at < ?')
+            ->andWhere('m.available_at <= ?')
+            ->andWhere('m.queue_name = ?')
             ->setParameters([
-                ':now' => self::formatDateTime($now),
-                ':queue_name' => $this->configuration['queue_name'],
-                ':redeliver_limit' => self::formatDateTime($redeliverLimit),
+                self::formatDateTime($redeliverLimit),
+                self::formatDateTime($now),
+                $this->configuration['queue_name'],
             ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32585
| License       | MIT
| Doc PR        | 

I edited the Doctrine Transport Connection class to use `?` placeholders in the query builder instead of named repositories as this resulted in a compatibility issue with SQL Server.
