### PR TITLE
[FrameworkBundle] Detect indirect env vars in routing

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -147,7 +147,7 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
                 return '%%';
             }
 
-            if (preg_match('/^env\(\w+\)$/', $match[1])) {
+            if (preg_match('/^env\((?:\w++:)*+\w++\)$/', $match[1])) {
                 throw new RuntimeException(sprintf('Using "%%%s%%" is not allowed in routing configuration.', $match[1]));
             }
 
@@ -156,7 +156,7 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
             if (\is_string($resolved) || is_numeric($resolved)) {
                 $this->collectedParameters[$match[1]] = $resolved;
 
-                return (string) $resolved;
+                return (string) $this->resolve($resolved);
             }
 
             throw new RuntimeException(sprintf('The container parameter "%s", used in the route configuration value "%s", must be a string or numeric, but it is of type %s.', $match[1], $value, \gettype($resolved)));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Routing;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -122,13 +123,13 @@ class RouterTest extends TestCase
         $routes->add('foo', new Route('/before/%parameter.foo%/after/%%escaped%%'));
 
         $sc = $this->getServiceContainer($routes);
-        $sc->setParameter('parameter.foo', 'foo');
+        $sc->setParameter('parameter.foo', 'foo-%%escaped%%');
 
         $router = new Router($sc, 'foo');
         $route = $router->getRouteCollection()->get('foo');
 
         $this->assertEquals(
-            '/before/foo/after/%escaped%',
+            '/before/foo-%escaped%/after/%escaped%',
             $route->getPath()
         );
     }
@@ -144,6 +145,22 @@ class RouterTest extends TestCase
         $routes->add('foo', new Route('/%env(FOO)%'));
 
         $router = new Router($this->getServiceContainer($routes), 'foo');
+        $router->getRouteCollection();
+    }
+
+    public function testIndirectEnvPlaceholders()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route('/%foo%'));
+
+        $router = new Router($container = $this->getServiceContainer($routes), 'foo');
+        $container->setParameter('foo', 'foo-%bar%');
+        $container->setParameter('bar', '%env(string:FOO)%');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Using "%env(string:FOO)%" is not allowed in routing configuration.');
+
         $router->getRouteCollection();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32366
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This detects indirect env parameters in routing, which doesnt work according to #32366.

cc @nicolas-grekas @bendavies please verify, as im not really into routing internals