### PR TITLE
Create impersonation_exit_path() and *_url() functions

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.2.0
 -----
 
+ * added the `impersonation_exit_url()` and `impersonation_exit_path()` functions. They return a URL that allows to switch back to the original user.
  * added the `workflow_transition()` function to easily retrieve a specific transition object
  * added support for translating `Translatable` objects
  * added the `t()` function to easily create `Translatable` objects

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Twig\Extension;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Symfony\Component\Security\Http\Impersonate\ImpersonateUrlGenerator;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -26,9 +27,12 @@ final class SecurityExtension extends AbstractExtension
 {
     private $securityChecker;
 
-    public function __construct(AuthorizationCheckerInterface $securityChecker = null)
+    private $impersonateUrlGenerator;
+
+    public function __construct(AuthorizationCheckerInterface $securityChecker = null, ImpersonateUrlGenerator $impersonateUrlGenerator = null)
     {
         $this->securityChecker = $securityChecker;
+        $this->impersonateUrlGenerator = $impersonateUrlGenerator;
     }
 
     /**
@@ -51,6 +55,24 @@ final class SecurityExtension extends AbstractExtension
         }
     }
 
+    public function getImpersonateExitUrl(string $exitTo = null): string
+    {
+        if (null === $this->impersonateUrlGenerator) {
+            return '';
+        }
+
+        return $this->impersonateUrlGenerator->generateExitUrl($exitTo);
+    }
+
+    public function getImpersonateExitPath(string $exitTo = null): string
+    {
+        if (null === $this->impersonateUrlGenerator) {
+            return '';
+        }
+
+        return $this->impersonateUrlGenerator->generateExitPath($exitTo);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -58,6 +80,8 @@ final class SecurityExtension extends AbstractExtension
     {
         return [
             new TwigFunction('is_granted', [$this, 'isGranted']),
+            new TwigFunction('impersonation_exit_url', [$this, 'getImpersonateExitUrl']),
+            new TwigFunction('impersonation_exit_path', [$this, 'getImpersonateExitPath']),
         ];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -48,6 +48,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
 use Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Impersonate\ImpersonateUrlGenerator;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
@@ -159,6 +160,13 @@ return static function (ContainerConfigurator $container) {
                 service('security.role_hierarchy')->nullOnInvalid(),
             ])
             ->tag('security.voter', ['priority' => 245])
+
+        ->set('security.impersonate_url_generator', ImpersonateUrlGenerator::class)
+        ->args([
+            service('request_stack'),
+            service('security.firewall.map'),
+            service('security.token_storage'),
+        ])
 
         // Firewall related services
         ->set('security.firewall', FirewallListener::class)

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.php
@@ -25,6 +25,7 @@ return static function (ContainerConfigurator $container) {
         ->set('twig.extension.security', SecurityExtension::class)
             ->args([
                 service('security.authorization_checker')->ignoreOnInvalid(),
+                service('security.impersonate_url_generator')->ignoreOnInvalid(),
             ])
             ->tag('twig.extension')
     ;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
@@ -19,18 +19,21 @@ namespace Symfony\Component\Security\Core\Authentication\Token;
 class SwitchUserToken extends UsernamePasswordToken
 {
     private $originalToken;
+    private $originatedFromUri;
 
     /**
-     * @param string|object $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method
-     * @param mixed         $credentials This usually is the password of the user
+     * @param string|object $user              The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method
+     * @param mixed         $credentials       This usually is the password of the user
+     * @param string|null   $originatedFromUri The URI where was the user at the switch
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($user, $credentials, string $firewallName, array $roles, TokenInterface $originalToken)
+    public function __construct($user, $credentials, string $firewallName, array $roles, TokenInterface $originalToken, string $originatedFromUri = null)
     {
         parent::__construct($user, $credentials, $firewallName, $roles);
 
         $this->originalToken = $originalToken;
+        $this->originatedFromUri = $originatedFromUri;
     }
 
     public function getOriginalToken(): TokenInterface
@@ -38,12 +41,17 @@ class SwitchUserToken extends UsernamePasswordToken
         return $this->originalToken;
     }
 
+    public function getOriginatedFromUri(): ?string
+    {
+        return $this->originatedFromUri;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function __serialize(): array
     {
-        return [$this->originalToken, parent::__serialize()];
+        return [$this->originalToken, $this->originatedFromUri, parent::__serialize()];
     }
 
     /**
@@ -51,7 +59,7 @@ class SwitchUserToken extends UsernamePasswordToken
      */
     public function __unserialize(array $data): void
     {
-        [$this->originalToken, $parentData] = $data;
+        [$this->originalToken, $this->originatedFromUri, $parentData] = $data;
         $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
@@ -21,7 +21,7 @@ class SwitchUserTokenTest extends TestCase
     public function testSerialize()
     {
         $originalToken = new UsernamePasswordToken('user', 'foo', 'provider-key', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
-        $token = new SwitchUserToken('admin', 'bar', 'provider-key', ['ROLE_USER'], $originalToken);
+        $token = new SwitchUserToken('admin', 'bar', 'provider-key', ['ROLE_USER'], $originalToken, 'https://symfony.com/blog');
 
         $unserializedToken = unserialize(serialize($token));
 
@@ -30,6 +30,7 @@ class SwitchUserTokenTest extends TestCase
         $this->assertSame('bar', $unserializedToken->getCredentials());
         $this->assertSame('provider-key', $unserializedToken->getFirewallName());
         $this->assertEquals(['ROLE_USER'], $unserializedToken->getRoleNames());
+        $this->assertSame('https://symfony.com/blog', $unserializedToken->getOriginatedFromUri());
 
         $unserializedOriginalToken = $unserializedToken->getOriginalToken();
 
@@ -72,5 +73,15 @@ class SwitchUserTokenTest extends TestCase
         $token = new SwitchUserToken($impersonated, 'bar', 'provider-key', ['ROLE_USER', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
         $token->setUser($impersonated);
         $this->assertTrue($token->isAuthenticated());
+    }
+
+    public function testSerializeNullImpersonateUrl()
+    {
+        $originalToken = new UsernamePasswordToken('user', 'foo', 'provider-key', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
+        $token = new SwitchUserToken('admin', 'bar', 'provider-key', ['ROLE_USER'], $originalToken);
+
+        $unserializedToken = unserialize(serialize($token));
+
+        $this->assertNull($unserializedToken->getOriginatedFromUri());
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -181,7 +181,8 @@ class SwitchUserListener extends AbstractListener
 
         $roles = $user->getRoles();
         $roles[] = 'ROLE_PREVIOUS_ADMIN';
-        $token = new SwitchUserToken($user, $user->getPassword(), $this->firewallName, $roles, $token);
+        $originatedFromUri = str_replace('/&', '/?', preg_replace('#[&?]'.$this->usernameParameter.'=[^&]*#', '', $request->getRequestUri()));
+        $token = new SwitchUserToken($user, $user->getPassword(), $this->firewallName, $roles, $token, $originatedFromUri);
 
         if (null !== $this->dispatcher) {
             $switchEvent = new SwitchUserEvent($request, $token->getUser(), $token);

--- a/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Impersonate;
+
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
+
+/**
+ * Provides generator functions for the impersonate url exit.
+ *
+ * @author Amrouche Hamza <hamza.simperfit@gmail.com>
+ * @author Damien Fayet <damienf1521@gmail.com>
+ */
+class ImpersonateUrlGenerator
+{
+    private $requestStack;
+    private $tokenStorage;
+    private $firewallMap;
+
+    public function __construct(RequestStack $requestStack, FirewallMap $firewallMap, TokenStorageInterface $tokenStorage)
+    {
+        $this->requestStack = $requestStack;
+        $this->tokenStorage = $tokenStorage;
+        $this->firewallMap = $firewallMap;
+    }
+
+    public function generateExitPath(string $targetUri = null): string
+    {
+        return $this->buildExitPath($targetUri);
+    }
+
+    public function generateExitUrl(string $targetUri = null): string
+    {
+        if (null === $request = $this->requestStack->getCurrentRequest()) {
+            return '';
+        }
+
+        return $request->getUriForPath($this->buildExitPath($targetUri));
+    }
+
+    private function isImpersonatedUser(): bool
+    {
+        return $this->tokenStorage->getToken() instanceof SwitchUserToken;
+    }
+
+    private function buildExitPath(string $targetUri = null): string
+    {
+        if (null === ($request = $this->requestStack->getCurrentRequest()) || !$this->isImpersonatedUser()) {
+            return '';
+        }
+
+        if (null === $switchUserConfig = $this->firewallMap->getFirewallConfig($request)->getSwitchUser()) {
+            throw new \LogicException('Unable to generate the impersonate exit URL without a firewall configured for the user switch.');
+        }
+
+        if (null === $targetUri) {
+            $targetUri = $request->getRequestUri();
+        }
+
+        $targetUri .= (parse_url($targetUri, \PHP_URL_QUERY) ? '&' : '?').http_build_query([$switchUserConfig['parameter'] => SwitchUserListener::EXIT_VALUE]);
+
+        return $targetUri;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes (not added atm)   <!-- please add some, will be required by reviewers -->
| Fixed tickets | #24676   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | To come later <!-- symfony/symfony-docs#... --><!-- required for new features -->


This is a relaunch of the PR #24737

It adds more flexibility to the previous try.
You have two twig functions `impersonation_exit_url()` and `impersonation_exit_path()`

You can either leave on the same path, redirect to the path where was the user at the user switch, or to the path you want.

Example:

The following code
```twig
<p>{{ impersonation_exit_url() }}</p>
<p>{{ impersonation_exit_path() }}</p>
<p>&nbsp;</p>


<p>{{ impersonation_exit_url(path('app_default_other')) }}</p>
<p>{{ impersonation_exit_path(path('app_default_other')) }}</p>
<p>&nbsp;</p>

    
<p>{{ impersonation_exit_url('_use_impersonated_from_url') }}</p>
<p>{{ impersonation_exit_path('_use_impersonated_from_url') }}</p>
```

will output
![Capture d’écran de 2019-07-31 20-58-42](https://user-images.githubusercontent.com/7721219/62239914-1482cb00-b3d6-11e9-9b58-ea8d30a2e28a.png)

**Note:** If this proposal appears to be better, I'll add tests, update changelog, and prepare the doc.

**Bonus:**
As the "impersonated from url" is stored in the `SwitchUserToken` it might be possible to display it in the profiler:

![Capture d’écran de 2019-07-31 21-04-50](https://user-images.githubusercontent.com/7721219/62240294-efdb2300-b3d6-11e9-911a-bec48fd75327.png)

WDYT?



<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
