### PR TITLE
Make tests support phpunit 8

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -13,14 +13,17 @@ namespace Symfony\Bridge\Doctrine\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Container;
 
 class ContainerAwareEventManagerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $container;
     private $evm;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->container = new Container();
         $this->evm = new ContainerAwareEventManager($this->container);

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -21,12 +22,14 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class DoctrineExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension
      */
     private $extension;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\IdReader;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
 
@@ -26,6 +27,8 @@ use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
  */
 class DoctrineChoiceLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ChoiceListFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -71,7 +74,7 @@ class DoctrineChoiceLoaderTest extends TestCase
      */
     private $obj3;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface')->getMock();
         $this->om = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
@@ -14,18 +14,21 @@ namespace Symfony\Bridge\Doctrine\Tests\Form\DataTransformer;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\DataTransformer\CollectionToArrayTransformer;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class CollectionToArrayTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var CollectionToArrayTransformer
      */
     private $transformer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->transformer = new CollectionToArrayTransformer();
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/EventListener/MergeDoctrineCollectionListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/EventListener/MergeDoctrineCollectionListenerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Tests\Form\EventListener;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\EventListener\MergeDoctrineCollectionListener;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormEvent;
@@ -21,6 +22,8 @@ use Symfony\Component\Form\FormEvents;
 
 class MergeDoctrineCollectionListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var \Doctrine\Common\Collections\ArrayCollection */
     private $collection;
     /** @var \Symfony\Component\EventDispatcher\EventDispatcher */
@@ -28,7 +31,7 @@ class MergeDoctrineCollectionListenerTest extends TestCase
     private $factory;
     private $form;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->collection = new ArrayCollection(['test']);
         $this->dispatcher = new EventDispatcher();
@@ -37,7 +40,7 @@ class MergeDoctrineCollectionListenerTest extends TestCase
             ->getForm();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->collection = null;
         $this->dispatcher = null;

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\CoreExtension;
 use Symfony\Component\Form\Test\FormPerformanceTestCase;
 
@@ -23,6 +24,8 @@ use Symfony\Component\Form\Test\FormPerformanceTestCase;
  */
 class EntityTypePerformanceTest extends FormPerformanceTestCase
 {
+    use ForwardCompatTestTrait;
+
     const ENTITY_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity';
 
     /**
@@ -50,7 +53,7 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
         ];
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->em = DoctrineTestHelper::createTestEntityManager();
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -28,6 +28,7 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringCastableIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Forms;
@@ -36,6 +37,8 @@ use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
 
 class EntityTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Bridge\Doctrine\Form\Type\EntityType';
 
     const ITEM_GROUP_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\GroupableEntity';
@@ -59,7 +62,7 @@ class EntityTypeTest extends BaseTypeTest
 
     protected static $supportedFeatureSetVersion = 304;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->em = DoctrineTestHelper::createTestEntityManager();
         $this->emRegistry = $this->createRegistryMock('default', $this->em);
@@ -89,7 +92,7 @@ class EntityTypeTest extends BaseTypeTest
         }
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
@@ -13,11 +13,14 @@ namespace Symfony\Bridge\Doctrine\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\ProxyManager\Tests\LazyProxy\Dumper\PhpDumperTest;
 
 class ManagerRegistryTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         if (!class_exists('PHPUnit_Framework_TestCase')) {
             self::markTestSkipped('proxy-manager-bridge is not yet compatible with namespaced phpunit versions.');

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Setup;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -23,12 +24,14 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class DoctrineExtractorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var DoctrineExtractor
      */
     private $extractor;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $config = Setup::createAnnotationMetadataConfiguration([__DIR__.\DIRECTORY_SEPARATOR.'Fixtures'], true);
         $entityManager = EntityManager::create(['driver' => 'pdo_sqlite'], $config);

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -32,6 +32,7 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdStringWrapperNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\StringWrapper;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 /**
@@ -39,6 +40,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     const EM_NAME = 'foo';
 
     /**
@@ -58,7 +61,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     protected $repositoryFactory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->repositoryFactory = new TestRepositoryFactory();
 

--- a/src/Symfony/Bridge/PhpUnit/ForwardCompatTestTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/ForwardCompatTestTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+use PHPUnit\Framework\TestCase;
+
+// A trait to provide forward compatibility with newest PHPUnit versions
+
+if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {
+    trait ForwardCompatTestTrait
+    {
+        use Legacy\ForwardCompatTestTraitForV8;
+    }
+} else {
+    trait ForwardCompatTestTrait
+    {
+        use Legacy\ForwardCompatTestTraitForV5;
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV5.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+/**
+ * @internal
+ */
+trait ForwardCompatTestTraitForV5
+{
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        self::doSetUpBeforeClass();
+    }
+
+    /**
+     * @return void
+     */
+    public static function tearDownAfterClass()
+    {
+        self::doTearDownAfterClass();
+    }
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        self::doSetUp();
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown()
+    {
+        self::doTearDown();
+    }
+
+    /**
+     * @return void
+     */
+    private static function doSetUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+    }
+
+    /**
+     * @return void
+     */
+    private static function doTearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * @return void
+     */
+    private function doSetUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @return void
+     */
+    private function doTearDown()
+    {
+        parent::tearDown();
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV8.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV8.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+/**
+ * @internal
+ */
+trait ForwardCompatTestTraitForV8
+{
+    public static function setUpBeforeClass(): void
+    {
+        self::doSetUpBeforeClass();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::doTearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        self::doSetUp();
+    }
+
+    protected function tearDown(): void
+    {
+        self::doTearDown();
+    }
+
+    private static function doSetUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+    }
+
+    private static function doTearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+    }
+
+    private function doSetUp(): void
+    {
+        parent::setUp();
+    }
+
+    private function doTearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\PhpUnit\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 /**
  * @author Dominic Tubach <dominic.tubach@to.com>
@@ -21,12 +22,14 @@ use Symfony\Bridge\PhpUnit\ClockMock;
  */
 class ClockMockTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         ClockMock::register(__CLASS__);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         ClockMock::withClockMock(1234567890.125);
     }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
@@ -13,10 +13,13 @@ namespace Symfony\Bridge\PhpUnit\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\DnsMock;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 class DnsMockTest extends TestCase
 {
-    protected function tearDown()
+    use ForwardCompatTestTrait;
+
+    private function doTearDown()
     {
         DnsMock::withMockedHosts(array());
     }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\ProxyManager\Tests\LazyProxy\Instantiator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -22,6 +23,8 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class RuntimeInstantiatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var RuntimeInstantiator
      */
@@ -30,7 +33,7 @@ class RuntimeInstantiatorTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    private function doSetUp()
     {
         $this->instantiator = new RuntimeInstantiator();
     }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\ProxyManager\Tests\LazyProxy\PhpDumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -24,6 +25,8 @@ use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
  */
 class ProxyDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ProxyDumper
      */
@@ -32,7 +35,7 @@ class ProxyDumperTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dumper = new ProxyDumper();
     }

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Bridge\Twig\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
@@ -10,12 +11,14 @@ use Symfony\Component\HttpFoundation\Session\Session;
 
 class AppVariableTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var AppVariable
      */
     protected $appVariable;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->appVariable = new AppVariable();
     }

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Command\LintCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,6 +22,8 @@ use Twig\Loader\FilesystemLoader;
 
 class LintCommandTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $files;
 
     public function testLintCorrectFile()
@@ -113,12 +116,12 @@ class LintCommandTest extends TestCase
         return $filename;
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->files = [];
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
@@ -22,6 +23,8 @@ use Twig\Environment;
 
 class FormExtensionBootstrap3HorizontalLayoutTest extends AbstractBootstrap3HorizontalLayoutTest
 {
+    use ForwardCompatTestTrait;
+
     use RuntimeLoaderProvider;
 
     protected $testableFeatures = [
@@ -33,7 +36,7 @@ class FormExtensionBootstrap3HorizontalLayoutTest extends AbstractBootstrap3Hori
      */
     private $renderer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
@@ -22,6 +23,7 @@ use Twig\Environment;
 
 class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTest
 {
+    use ForwardCompatTestTrait;
     use RuntimeLoaderProvider;
 
     /**
@@ -29,7 +31,7 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTest
      */
     private $renderer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
@@ -27,6 +28,7 @@ use Twig\Environment;
  */
 class FormExtensionBootstrap4HorizontalLayoutTest extends AbstractBootstrap4HorizontalLayoutTest
 {
+    use ForwardCompatTestTrait;
     use RuntimeLoaderProvider;
 
     protected $testableFeatures = [
@@ -35,7 +37,7 @@ class FormExtensionBootstrap4HorizontalLayoutTest extends AbstractBootstrap4Hori
 
     private $renderer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
@@ -27,13 +28,14 @@ use Twig\Environment;
  */
 class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTest
 {
+    use ForwardCompatTestTrait;
     use RuntimeLoaderProvider;
     /**
      * @var FormRenderer
      */
     private $renderer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
@@ -24,6 +25,7 @@ use Twig\Environment;
 
 class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
 {
+    use ForwardCompatTestTrait;
     use RuntimeLoaderProvider;
 
     /**
@@ -33,7 +35,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
 
     protected static $supportedFeatureSetVersion = 304;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
@@ -23,6 +24,7 @@ use Twig\Environment;
 
 class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
 {
+    use ForwardCompatTestTrait;
     use RuntimeLoaderProvider;
 
     /**
@@ -32,7 +34,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
 
     protected static $supportedFeatureSetVersion = 304;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WebLinkExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WebLinkExtensionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Fig\Link\Link;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\WebLinkExtension;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -22,6 +23,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class WebLinkExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var Request
      */
@@ -32,7 +35,7 @@ class WebLinkExtensionTest extends TestCase
      */
     private $extension;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->request = new Request();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\WorkflowExtension;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Registry;
@@ -21,9 +22,11 @@ use Symfony\Component\Workflow\Workflow;
 
 class WorkflowExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $extension;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $places = ['ordered', 'waiting_for_payment', 'processed'];
         $transitions = [

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ForwardCompatTestTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ForwardCompatTestTrait.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use PHPUnit\Framework\TestCase;
 
-// Auto-adapt to PHPUnit 8 that added a `void` return-type to the tearDown method
+// Auto-adapt to PHPUnit 8 that added a `void` return-type to the setUp/tearDown methods
 
 if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {
     eval('
@@ -22,11 +22,24 @@ if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \Reflection
     /**
      * @internal
      */
-    trait KernelShutdownOnTearDownTrait
+    trait ForwardCompatTestTrait
     {
+        private function doSetUp(): void
+        {
+        }
+
+        private function doTearDown(): void
+        {
+        }
+
+        protected function setUp(): void
+        {
+            $this->doSetUp();
+        }
+
         protected function tearDown(): void
         {
-            static::ensureKernelShutdown();
+            $this->doTearDown();
         }
     }
 ');
@@ -34,14 +47,36 @@ if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \Reflection
     /**
      * @internal
      */
-    trait KernelShutdownOnTearDownTrait
+    trait ForwardCompatTestTrait
     {
+        /**
+         * @return void
+         */
+        private function doSetUp()
+        {
+        }
+
+        /**
+         * @return void
+         */
+        private function doTearDown()
+        {
+        }
+
+        /**
+         * @return void
+         */
+        protected function setUp()
+        {
+            $this->doSetUp();
+        }
+
         /**
          * @return void
          */
         protected function tearDown()
         {
-            static::ensureKernelShutdown();
+            $this->doTearDown();
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 abstract class KernelTestCase extends TestCase
 {
-    use KernelShutdownOnTearDownTrait;
+    use ForwardCompatTestTrait;
 
     protected static $class;
 
@@ -31,6 +31,11 @@ abstract class KernelTestCase extends TestCase
      * @var KernelInterface
      */
     protected static $kernel;
+
+    private function doTearDown()
+    {
+        static::ensureKernelShutdown();
+    }
 
     /**
      * Finds the directory where the phpunit.xml(.dist) is stored.

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -5,6 +5,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -15,9 +16,11 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class AnnotationsCacheWarmerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $cacheDir;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->cacheDir = sys_get_temp_dir().'/'.uniqid();
         $fs = new Filesystem();
@@ -25,7 +28,7 @@ class AnnotationsCacheWarmerTest extends TestCase
         parent::setUp();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $fs = new Filesystem();
         $fs->remove($this->cacheDir);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinderInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplatePathsCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator;
@@ -21,6 +22,8 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class TemplatePathsCacheWarmerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var Filesystem */
     private $filesystem;
 
@@ -35,7 +38,7 @@ class TemplatePathsCacheWarmerTest extends TestCase
 
     private $tmpDir;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->templateFinder = $this
             ->getMockBuilder(TemplateFinderInterface::class)
@@ -56,7 +59,7 @@ class TemplatePathsCacheWarmerTest extends TestCase
         $this->filesystem->mkdir($this->tmpDir);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->filesystem->remove($this->tmpDir);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand\Fixture\TestAppKernel;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
@@ -23,13 +24,15 @@ use Symfony\Component\Finder\Finder;
 
 class CacheClearCommandTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var TestAppKernel */
     private $kernel;
     /** @var Filesystem */
     private $fs;
     private $rootDir;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->fs = new Filesystem();
         $this->kernel = new TestAppKernel('test', true);
@@ -38,7 +41,7 @@ class CacheClearCommandTest extends TestCase
         $this->fs->mkdir($this->rootDir);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->fs->remove($this->rootDir);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpKernel;
 
 class TranslationDebugCommandTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $fs;
     private $translationDir;
 
@@ -109,7 +112,7 @@ class TranslationDebugCommandTest extends TestCase
         $tester->execute(['locale' => 'en', 'bundle' => 'dir']);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->fs = new Filesystem();
         $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf2_translation', true);
@@ -119,7 +122,7 @@ class TranslationDebugCommandTest extends TestCase
         $this->fs->mkdir($this->translationDir.'/templates');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->fs->remove($this->translationDir);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpKernel;
 
 class TranslationUpdateCommandTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $fs;
     private $translationDir;
 
@@ -87,7 +90,7 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertRegExp('/Translation files were successfully updated./', $tester->getDisplay());
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->fs = new Filesystem();
         $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf2_translation', true);
@@ -97,7 +100,7 @@ class TranslationUpdateCommandTest extends TestCase
         $this->fs->mkdir($this->translationDir.'/templates');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->fs->remove($this->translationDir);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -28,6 +29,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class YamlLintCommandTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $files;
 
     public function testLintCorrectFile()
@@ -183,13 +186,13 @@ EOF;
         return $application;
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         @mkdir(sys_get_temp_dir().'/yml-lint-test');
         $this->files = [];
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -11,16 +11,19 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Descriptor\TextDescriptor;
 
 class TextDescriptorTest extends AbstractDescriptorTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         putenv('COLUMNS=121');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         putenv('COLUMNS');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Composer\Autoload\ClassLoader;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\HttpKernel\Kernel;
 
 class ControllerNameParserTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $loader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->loader = new ClassLoader();
         $this->loader->add('TestBundle', __DIR__.'/../Fixtures');
@@ -28,7 +31,7 @@ class ControllerNameParserTest extends TestCase
         $this->loader->register();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->loader->unregister();
         $this->loader = null;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -21,9 +22,11 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class CachePoolPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $cachePoolPass;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->cachePoolPass = new CachePoolPass();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/DataCollectorTranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/DataCollectorTranslatorPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -19,10 +20,12 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class DataCollectorTranslatorPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $container;
     private $dataCollectorTranslatorPass;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->container = new ContainerBuilder();
         $this->dataCollectorTranslatorPass = new DataCollectorTranslatorPass();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\WorkflowGuardListenerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
@@ -22,10 +23,12 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class WorkflowGuardListenerPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $container;
     private $compilerPass;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->container = new ContainerBuilder();
         $this->compilerPass = new WorkflowGuardListenerPass();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
@@ -11,23 +11,26 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 abstract class AbstractWebTestCase extends BaseWebTestCase
 {
+    use ForwardCompatTestTrait;
+
     public static function assertRedirect($response, $location)
     {
         self::assertTrue($response->isRedirect(), 'Response is not a redirect, got status code: '.$response->getStatusCode());
         self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         static::deleteTmpDir();
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         static::deleteTmpDir();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -20,7 +21,9 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class CachePoolClearCommandTest extends AbstractWebTestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         static::bootKernel(['test_case' => 'CachePoolClear', 'root_config' => 'config.yml']);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -21,9 +22,11 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class ConfigDebugCommandTest extends AbstractWebTestCase
 {
+    use ForwardCompatTestTrait;
+
     private $application;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $kernel = static::createKernel(['test_case' => 'ConfigDump', 'root_config' => 'config.yml']);
         $this->application = new Application($kernel);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -21,9 +22,11 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
 {
+    use ForwardCompatTestTrait;
+
     private $application;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $kernel = static::createKernel(['test_case' => 'ConfigDump', 'root_config' => 'config.yml']);
         $this->application = new Application($kernel);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
@@ -11,16 +11,19 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 
 class GlobalVariablesTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $container;
     private $globals;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->container = new Container();
         $this->globals = new GlobalVariables($this->container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\Asset\Packages;
@@ -19,9 +20,11 @@ use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 
 class AssetsHelperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $helper;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $fooPackage = new Package(new StaticVersionStrategy('42', '%s?v=%s'));
         $barPackage = new Package(new StaticVersionStrategy('22', '%s?%s'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper;
 use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTemplateNameParser;
 use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTranslator;
@@ -22,6 +23,8 @@ use Symfony\Component\Templating\PhpEngine;
 
 class FormHelperDivLayoutTest extends AbstractDivLayoutTest
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PhpEngine
      */
@@ -52,7 +55,7 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
         ]);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->engine = null;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper;
 use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTemplateNameParser;
 use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTranslator;
@@ -22,6 +23,8 @@ use Symfony\Component\Templating\PhpEngine;
 
 class FormHelperTableLayoutTest extends AbstractTableLayoutTest
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PhpEngine
      */
@@ -77,7 +80,7 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
         ]);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->engine = null;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/RequestHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/RequestHelperTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\RequestHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class RequestHelperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $requestStack;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->requestStack = new RequestStack();
         $request = new Request();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/SessionHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/SessionHelperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\SessionHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -20,9 +21,11 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class SessionHelperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $requestStack;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $request = new Request();
 
@@ -36,7 +39,7 @@ class SessionHelperTest extends TestCase
         $this->requestStack->push($request);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->requestStack = null;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateFilenameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateFilenameParserTest.php
@@ -11,20 +11,23 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateFilenameParser;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
 class TemplateFilenameParserTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $parser;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->parser = new TemplateFilenameParser();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->parser = null;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
@@ -18,9 +19,11 @@ use Symfony\Component\Templating\TemplateReference as BaseTemplateReference;
 
 class TemplateNameParserTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $parser;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel
@@ -37,7 +40,7 @@ class TemplateNameParserTest extends TestCase
         $this->parser = new TemplateNameParser($kernel);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->parser = null;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Translation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\Formatter\MessageFormatter;
@@ -20,15 +21,17 @@ use Symfony\Component\Translation\MessageCatalogue;
 
 class TranslatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $tmpDir;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->tmpDir = sys_get_temp_dir().'/sf2_translation';
         $this->deleteTmpDir();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->deleteTmpDir();
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
@@ -11,23 +11,26 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 class AbstractWebTestCase extends BaseWebTestCase
 {
+    use ForwardCompatTestTrait;
+
     public static function assertRedirect($response, $location)
     {
         self::assertTrue($response->isRedirect(), 'Response is not a redirect, got status code: '.substr($response, 0, 2000));
         self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         static::deleteTmpDir();
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         static::deleteTmpDir();
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand;
 use Symfony\Component\Console\Application as ConsoleApplication;
@@ -27,6 +28,8 @@ use Symfony\Component\Security\Core\Encoder\Pbkdf2PasswordEncoder;
  */
 class UserPasswordEncoderCommandTest extends AbstractWebTestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var CommandTester */
     private $passwordEncoderCommandTester;
 
@@ -249,7 +252,7 @@ EOTXT
         $this->assertContains('Encoder used       Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder', $tester->getDisplay());
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         putenv('COLUMNS='.(119 + \strlen(PHP_EOL)));
         $kernel = $this->createKernel(['test_case' => 'PasswordEncode']);
@@ -262,7 +265,7 @@ EOTXT
         $this->passwordEncoderCommandTester = new CommandTester($passwordEncoderCommand);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->passwordEncoderCommandTester = null;
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigLoaderPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 class TwigLoaderPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ContainerBuilder
      */
@@ -31,7 +34,7 @@ class TwigLoaderPassTest extends TestCase
      */
     private $pass;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->builder = new ContainerBuilder();
         $this->builder->register('twig');

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class CacheWarmingTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCacheIsProperlyWarmedWhenTemplatingIsAvailable()
     {
         $kernel = new CacheWarmingKernel(true);
@@ -44,12 +47,12 @@ class CacheWarmingTest extends TestCase
         $this->assertFileExists($kernel->getCacheDir().'/twig');
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->deleteTempDir();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->deleteTempDir();
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class NoTemplatingEntryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function test()
     {
         $kernel = new NoTemplatingEntryKernel('dev', true);
@@ -30,12 +33,12 @@ class NoTemplatingEntryTest extends TestCase
         $this->assertContains('{ a: b }', $content);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->deleteTempDir();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->deleteTempDir();
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Tests\DependencyInjection;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\WebProfilerBundle\DependencyInjection\WebProfilerExtension;
 use Symfony\Bundle\WebProfilerBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\Container;
@@ -22,6 +23,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class WebProfilerExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $kernel;
     /**
      * @var \Symfony\Component\DependencyInjection\Container
@@ -46,7 +49,7 @@ class WebProfilerExtensionTest extends TestCase
         self::assertEquals([], $errors, $message);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -73,7 +76,7 @@ class WebProfilerExtensionTest extends TestCase
         $this->container->addCompilerPass(new RegisterListenersPass());
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Tests\Profiler;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\WebProfilerBundle\Profiler\TemplateManager;
 use Symfony\Bundle\WebProfilerBundle\Tests\TestCase;
 use Symfony\Component\HttpKernel\Profiler\Profile;
@@ -23,6 +24,8 @@ use Twig\Environment;
  */
 class TemplateManagerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var Environment
      */
@@ -38,7 +41,7 @@ class TemplateManagerTest extends TestCase
      */
     protected $templateManager;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -11,10 +11,13 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 abstract class AbstractRedisAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testExpiration' => 'Testing expiration slows down the test suite',
         'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
@@ -28,7 +31,7 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
         return new RedisAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
@@ -39,7 +42,7 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         self::$redis = null;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -13,11 +13,14 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Cache\IntegrationTests\CachePoolTest;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\PruneableInterface;
 
 abstract class AdapterTestCase extends CachePoolTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/FilesystemAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/FilesystemAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 /**
@@ -19,12 +20,14 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  */
 class FilesystemAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function createCachePool($defaultLifetime = 0)
     {
         return new FilesystemAdapter('', $defaultLifetime);
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         self::rmdir(sys_get_temp_dir().'/symfony-cache');
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 
 class MemcachedAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
@@ -23,7 +26,7 @@ class MemcachedAdapterTest extends AdapterTestCase
 
     protected static $client;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if (!MemcachedAdapter::isSupported()) {
             self::markTestSkipped('Extension memcached >=2.2.0 required.');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
 
@@ -19,11 +20,12 @@ use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
  */
 class PdoAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
     use PdoPruneableTrait;
 
     protected static $dbFile;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
@@ -35,7 +37,7 @@ class PdoAdapterTest extends AdapterTestCase
         $pool->createTable();
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Doctrine\DBAL\DriverManager;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
 
@@ -20,11 +21,12 @@ use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
  */
 class PdoDbalAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
     use PdoPruneableTrait;
 
     protected static $dbFile;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
@@ -36,7 +38,7 @@ class PdoDbalAdapterTest extends AdapterTestCase
         $pool->createTable();
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
  */
 class PhpArrayAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testBasicUsage' => 'PhpArrayAdapter is read-only.',
         'testBasicUsageWithLongKey' => 'PhpArrayAdapter is read-only.',
@@ -55,12 +58,12 @@ class PhpArrayAdapterTest extends AdapterTestCase
 
     protected static $file;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$file = sys_get_temp_dir().'/symfony-cache/php-array-adapter-test.php';
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (file_exists(sys_get_temp_dir().'/symfony-cache')) {
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
@@ -19,6 +20,8 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
  */
 class PhpArrayAdapterWithFallbackTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testGetItemInvalidKeys' => 'PhpArrayAdapter does not throw exceptions on invalid key.',
         'testGetItemsInvalidKeys' => 'PhpArrayAdapter does not throw exceptions on invalid key.',
@@ -30,12 +33,12 @@ class PhpArrayAdapterWithFallbackTest extends AdapterTestCase
 
     protected static $file;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$file = sys_get_temp_dir().'/symfony-cache/php-array-adapter-test.php';
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (file_exists(sys_get_temp_dir().'/symfony-cache')) {
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
  */
 class PhpFilesAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testDefaultLifeTime' => 'PhpFilesAdapter does not allow configuring a default lifetime.',
     ];
@@ -32,7 +35,7 @@ class PhpFilesAdapterTest extends AdapterTestCase
         return new PhpFilesAdapter('sf-cache');
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Predis\Connection\StreamConnection;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 class PredisAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setupBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         parent::setupBeforeClass();
         self::$redis = new \Predis\Client(['host' => getenv('REDIS_HOST')]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
@@ -11,15 +11,19 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class PredisClusterAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setupBeforeClass()
+	use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         parent::setupBeforeClass();
         self::$redis = new \Predis\Client([['host' => getenv('REDIS_HOST')]]);
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         self::$redis = null;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setupBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
             self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
@@ -21,7 +25,7 @@ class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
         self::$redis = new \Predis\Client(explode(' ', $hosts), ['cluster' => 'redis']);
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         self::$redis = null;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -11,13 +11,16 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Traits\RedisProxy;
 
 class RedisAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setupBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         parent::setupBeforeClass();
         self::$redis = AbstractAdapter::createConnection('redis://'.getenv('REDIS_HOST'), ['lazy' => true]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class RedisArrayAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setupBeforeClass()
+	use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         parent::setupBeforeClass();
         if (!class_exists('RedisArray')) {

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class RedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setupBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         if (!class_exists('RedisCluster')) {
             self::markTestSkipped('The RedisCluster class is required.');

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
@@ -20,12 +21,14 @@ use Symfony\Component\Cache\Adapter\TagAwareAdapter;
  */
 class TagAwareAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function createCachePool($defaultLifetime = 0)
     {
         return new TagAwareAdapter(new FilesystemAdapter('', $defaultLifetime));
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -11,10 +11,13 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Simple\RedisCache;
 
 abstract class AbstractRedisCacheTest extends CacheTestCase
 {
+	use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testSetTtl' => 'Testing expiration slows down the test suite',
         'testSetMultipleTtl' => 'Testing expiration slows down the test suite',
@@ -28,7 +31,7 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
         return new RedisCache(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
@@ -39,7 +42,7 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         self::$redis = null;
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/CacheTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/CacheTestCase.php
@@ -13,11 +13,14 @@ namespace Symfony\Component\Cache\Tests\Simple;
 
 use Cache\IntegrationTests\SimpleCacheTest;
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\PruneableInterface;
 
 abstract class CacheTestCase extends SimpleCacheTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Simple\MemcachedCache;
 
 class MemcachedCacheTest extends CacheTestCase
 {
+	use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testSetTtl' => 'Testing expiration slows down the test suite',
         'testSetMultipleTtl' => 'Testing expiration slows down the test suite',
@@ -24,7 +27,7 @@ class MemcachedCacheTest extends CacheTestCase
 
     protected static $client;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if (!MemcachedCache::isSupported()) {
             self::markTestSkipped('Extension memcached >=2.2.0 required.');

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Simple\PdoCache;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
 
@@ -19,11 +20,12 @@ use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
  */
 class PdoCacheTest extends CacheTestCase
 {
+	use ForwardCompatTestTrait;
     use PdoPruneableTrait;
 
     protected static $dbFile;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
@@ -35,7 +37,7 @@ class PdoCacheTest extends CacheTestCase
         $pool->createTable();
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Simple;
 
 use Doctrine\DBAL\DriverManager;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Simple\PdoCache;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
 
@@ -20,11 +21,12 @@ use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
  */
 class PdoDbalCacheTest extends CacheTestCase
 {
+	use ForwardCompatTestTrait;
     use PdoPruneableTrait;
 
     protected static $dbFile;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
@@ -36,7 +38,7 @@ class PdoDbalCacheTest extends CacheTestCase
         $pool->createTable();
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Simple\NullCache;
 use Symfony\Component\Cache\Simple\PhpArrayCache;
 use Symfony\Component\Cache\Tests\Adapter\FilesystemAdapterTest;
@@ -20,6 +21,8 @@ use Symfony\Component\Cache\Tests\Adapter\FilesystemAdapterTest;
  */
 class PhpArrayCacheTest extends CacheTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testBasicUsageWithLongKey' => 'PhpArrayCache does no writes',
 
@@ -49,12 +52,12 @@ class PhpArrayCacheTest extends CacheTestCase
 
     protected static $file;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$file = sys_get_temp_dir().'/symfony-cache/php-array-adapter-test.php';
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (file_exists(sys_get_temp_dir().'/symfony-cache')) {
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWithFallbackTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 use Symfony\Component\Cache\Simple\PhpArrayCache;
 use Symfony\Component\Cache\Tests\Adapter\FilesystemAdapterTest;
@@ -20,6 +21,8 @@ use Symfony\Component\Cache\Tests\Adapter\FilesystemAdapterTest;
  */
 class PhpArrayCacheWithFallbackTest extends CacheTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testGetInvalidKeys' => 'PhpArrayCache does no validation',
         'testGetMultipleInvalidKeys' => 'PhpArrayCache does no validation',
@@ -36,12 +39,12 @@ class PhpArrayCacheWithFallbackTest extends CacheTestCase
 
     protected static $file;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$file = sys_get_temp_dir().'/symfony-cache/php-array-adapter-test.php';
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (file_exists(sys_get_temp_dir().'/symfony-cache')) {
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisArrayCacheTest.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class RedisArrayCacheTest extends AbstractRedisCacheTest
 {
-    public static function setupBeforeClass()
+	use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         parent::setupBeforeClass();
         if (!class_exists('RedisArray')) {

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Simple\RedisCache;
 
 class RedisCacheTest extends AbstractRedisCacheTest
 {
-    public static function setupBeforeClass()
+	use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         parent::setupBeforeClass();
         self::$redis = RedisCache::createConnection('redis://'.getenv('REDIS_HOST'));

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisClusterCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisClusterCacheTest.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class RedisClusterCacheTest extends AbstractRedisCacheTest
 {
-    public static function setupBeforeClass()
+	use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         if (!class_exists('RedisCluster')) {
             self::markTestSkipped('The RedisCluster class is required.');

--- a/src/Symfony/Component/ClassLoader/Tests/ApcClassLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ApcClassLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\ClassLoader\ClassLoader;
 
@@ -20,7 +21,9 @@ use Symfony\Component\ClassLoader\ClassLoader;
  */
 class ApcClassLoaderTest extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         if (!(filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) && filter_var(ini_get('apc.enable_cli'), FILTER_VALIDATE_BOOLEAN))) {
             $this->markTestSkipped('The apc extension is not enabled.');
@@ -29,7 +32,7 @@ class ApcClassLoaderTest extends TestCase
         }
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) && filter_var(ini_get('apc.enable_cli'), FILTER_VALIDATE_BOOLEAN)) {
             apcu_clear_cache();

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -12,19 +12,22 @@
 namespace Symfony\Component\Config\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Tests\Resource\ResourceStub;
 
 class ConfigCacheTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $cacheFile = null;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'config_');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $files = [$this->cacheFile, $this->cacheFile.'.meta'];
 

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -12,13 +12,16 @@
 namespace Symfony\Component\Config\Tests\Resource;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\DirectoryResource;
 
 class DirectoryResourceTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $directory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->directory = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'symfonyDirectoryIterator';
         if (!file_exists($this->directory)) {
@@ -27,7 +30,7 @@ class DirectoryResourceTest extends TestCase
         touch($this->directory.'/tmp.xml');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (!is_dir($this->directory)) {
             return;

--- a/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
@@ -12,22 +12,25 @@
 namespace Symfony\Component\Config\Tests\Resource;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileExistenceResource;
 
 class FileExistenceResourceTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $resource;
     protected $file;
     protected $time;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->file = realpath(sys_get_temp_dir()).'/tmp.xml';
         $this->time = time();
         $this->resource = new FileExistenceResource($this->file);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (file_exists($this->file)) {
             unlink($this->file);

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Component\Config\Tests\Resource;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 
 class FileResourceTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $resource;
     protected $file;
     protected $time;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->file = sys_get_temp_dir().'/tmp.xml';
         $this->time = time();
@@ -28,7 +31,7 @@ class FileResourceTest extends TestCase
         $this->resource = new FileResource($this->file);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (!file_exists($this->file)) {
             return;

--- a/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Config\Tests\Resource;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\GlobResource;
 
 class GlobResourceTest extends TestCase
 {
-    protected function tearDown()
+    use ForwardCompatTestTrait;
+
+    private function doTearDown()
     {
         $dir = \dirname(__DIR__).'/Fixtures';
         @rmdir($dir.'/TmpGlob');

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -12,20 +12,23 @@
 namespace Symfony\Component\Config\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\ResourceCheckerConfigCache;
 use Symfony\Component\Config\Tests\Resource\ResourceStub;
 
 class ResourceCheckerConfigCacheTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $cacheFile = null;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'config_');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $files = [$this->cacheFile, "{$this->cacheFile}.meta"];
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\FactoryCommandLoader;
@@ -39,16 +40,18 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ApplicationTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
     private $colSize;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->colSize = getenv('COLUMNS');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
         putenv('SHELL_VERBOSITY');
@@ -56,7 +59,7 @@ class ApplicationTest extends TestCase
         unset($_SERVER['SHELL_VERBOSITY']);
     }
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/Fixtures/');
         require_once self::$fixturesPath.'/FooCommand.php';

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -26,9 +27,11 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class CommandTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = __DIR__.'/../Fixtures/';
         require_once self::$fixturesPath.'/TestCommand.php';

--- a/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Store\FlockStore;
@@ -19,9 +20,11 @@ use Symfony\Component\Lock\Store\SemaphoreStore;
 
 class LockableTraitTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = __DIR__.'/../Fixtures/';
         require_once self::$fixturesPath.'/FooLockCommand.php';

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -21,15 +22,17 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class ProgressBarTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $colSize;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->colSize = getenv('COLUMNS');
         putenv('COLUMNS=120');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
     }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Helper\TableSeparator;
@@ -20,14 +21,16 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 class TableTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $stream;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->stream = fopen('php://memory', 'r+');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         fclose($this->stream);
         $this->stream = null;

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Console\Tests\Input;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 
 class InputDefinitionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixtures;
 
     protected $foo;
@@ -25,7 +28,7 @@ class InputDefinitionTest extends TestCase
     protected $foo1;
     protected $foo2;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixtures = __DIR__.'/../Fixtures/';
     }

--- a/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
@@ -12,19 +12,22 @@
 namespace Symfony\Component\Console\Tests\Output;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\StreamOutput;
 
 class StreamOutputTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $stream;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->stream = fopen('php://memory', 'a', false);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->stream = null;
     }

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Style;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,13 +23,15 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class SymfonyStyleTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var Command */
     protected $command;
     /** @var CommandTester */
     protected $tester;
     private $colSize;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->colSize = getenv('COLUMNS');
         putenv('COLUMNS=121');
@@ -36,7 +39,7 @@ class SymfonyStyleTest extends TestCase
         $this->tester = new CommandTester($this->command);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
         $this->command = null;

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -12,20 +12,23 @@
 namespace Symfony\Component\Console\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Terminal;
 
 class TerminalTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $colSize;
     private $lineSize;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->colSize = getenv('COLUMNS');
         $this->lineSize = getenv('LINES');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
         putenv($this->lineSize ? 'LINES' : 'LINES='.$this->lineSize);

--- a/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\Console\Tests\Tester;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
 class ApplicationTesterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $application;
     protected $tester;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->application = new Application();
         $this->application->setAutoExit(false);
@@ -34,7 +37,7 @@ class ApplicationTesterTest extends TestCase
         $this->tester->run(['command' => 'foo', 'foo' => 'bar'], ['interactive' => false, 'decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE]);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->application = null;
         $this->tester = null;

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Tester;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -24,10 +25,12 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class CommandTesterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $command;
     protected $tester;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->command = new Command('foo');
         $this->command->addArgument('command');
@@ -38,7 +41,7 @@ class CommandTesterTest extends TestCase
         $this->tester->execute(['foo' => 'bar'], ['interactive' => false, 'decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE]);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->command = null;
         $this->tester = null;

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Debug\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Debug\DebugClassLoader;
 use Symfony\Component\Debug\ErrorHandler;
 
 class DebugClassLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var int Error reporting level before running tests
      */
@@ -24,7 +27,7 @@ class DebugClassLoaderTest extends TestCase
 
     private $loader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->errorReporting = error_reporting(E_ALL);
         $this->loader = new ClassLoader();
@@ -32,7 +35,7 @@ class DebugClassLoaderTest extends TestCase
         DebugClassLoader::enable();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         DebugClassLoader::disable();
         spl_autoload_unregister([$this->loader, 'loadClass']);

--- a/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Debug\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Debug\Exception\OutOfMemoryException;
 use Symfony\Component\Debug\ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -21,12 +22,14 @@ require_once __DIR__.'/HeaderMock.php';
 
 class ExceptionHandlerTest extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         testHeader();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         testHeader();
     }

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -13,13 +13,16 @@ namespace Symfony\Component\Debug\Tests\FatalErrorHandler;
 
 use Composer\Autoload\ClassLoader as ComposerClassLoader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Debug\DebugClassLoader;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\Debug\FatalErrorHandler\ClassNotFoundFatalErrorHandler;
 
 class ClassNotFoundFatalErrorHandlerTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         foreach (spl_autoload_functions() as $function) {
             if (!\is_array($function)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ExtensionCompilerPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ExtensionCompilerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,10 +23,12 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
  */
 class ExtensionCompilerPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $container;
     private $pass;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->container = new ContainerBuilder();
         $this->pass = new ExtensionCompilerPass();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ResolveParameterPlaceHoldersPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $compilerPass;
     private $container;
     private $fooDefinition;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->compilerPass = new ResolveParameterPlaceHoldersPass();
         $this->container = $this->createContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/AutowireServiceResourceTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/AutowireServiceResourceTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Config;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\AutowirePass;
 use Symfony\Component\DependencyInjection\Config\AutowireServiceResource;
 
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\Config\AutowireServiceResource;
  */
 class AutowireServiceResourceTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var AutowireServiceResource
      */
@@ -28,7 +31,7 @@ class AutowireServiceResourceTest extends TestCase
     private $class;
     private $time;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->file = realpath(sys_get_temp_dir()).'/tmp.php';
         $this->time = time();
@@ -101,7 +104,7 @@ class AutowireServiceResourceTest extends TestCase
         $this->assertFalse($resource->isFresh($this->getStaleFileTime()), '->isFresh() returns false if the class no longer exists');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (!file_exists($this->file)) {
             return;

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Config;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\ResourceCheckerInterface;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResourceChecker;
@@ -19,6 +20,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ContainerParametersResourceCheckerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var ContainerParametersResource */
     private $resource;
 
@@ -28,7 +31,7 @@ class ContainerParametersResourceCheckerTest extends TestCase
     /** @var ContainerInterface */
     private $container;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->resource = new ContainerParametersResource(['locales' => ['fr', 'en'], 'default_locale' => 'fr']);
         $this->container = $this->getMockBuilder(ContainerInterface::class)->getMock();

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceTest.php
@@ -12,14 +12,17 @@
 namespace Symfony\Component\DependencyInjection\Tests\Config;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
 
 class ContainerParametersResourceTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var ContainerParametersResource */
     private $resource;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->resource = new ContainerParametersResource(['locales' => ['fr', 'en'], 'default_locale' => 'fr']);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
@@ -12,14 +12,17 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class CrossCheckTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = __DIR__.'/Fixtures/';
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Dumper\GraphvizDumper;
@@ -19,9 +20,11 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class GraphvizDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = __DIR__.'/../Fixtures/';
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
@@ -41,9 +42,11 @@ require_once __DIR__.'/../Fixtures/includes/classes.php';
 
 class PhpDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -21,9 +22,11 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class XmlDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -24,9 +25,11 @@ use Symfony\Component\Yaml\Yaml;
 
 class YamlDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,17 +23,19 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class DirectoryLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private static $fixturesPath;
 
     private $container;
     private $loader;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $locator = new FileLocator(self::$fixturesPath);
         $this->container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -35,9 +36,11 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\BarInterf
 
 class FileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 
 class IniFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $container;
     protected $loader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->container = new ContainerBuilder();
         $this->loader = new IniFileLoader($this->container, new FileLocator(realpath(__DIR__.'/../Fixtures/').'/ini'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/LoaderResolverTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/LoaderResolverTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -23,12 +24,14 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class LoaderResolverTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private static $fixturesPath;
 
     /** @var LoaderResolver */
     private $resolver;
 
-    protected function setUp()
+    private function doSetUp()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Resource\FileResource;
@@ -33,9 +34,11 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 class XmlFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
         require_once self::$fixturesPath.'/includes/foo.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Resource\FileResource;
@@ -33,9 +34,11 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 class YamlFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
         require_once self::$fixturesPath.'/includes/foo.php';

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\DomCrawler\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\FormFieldRegistry;
 
 class FormTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         // Ensure that the private helper class FormFieldRegistry is loaded
         class_exists('Symfony\\Component\\DomCrawler\\Form');

--- a/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\EventDispatcher\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 abstract class AbstractEventDispatcherTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /* Some pseudo events */
     const preFoo = 'pre.foo';
     const postFoo = 'post.foo';
@@ -31,13 +34,13 @@ abstract class AbstractEventDispatcherTest extends TestCase
 
     private $listener;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = $this->createEventDispatcher();
         $this->listener = new TestEventListener();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->dispatcher = null;
         $this->listener = null;

--- a/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\EventDispatcher\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class EventTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \Symfony\Component\EventDispatcher\Event
      */
@@ -28,7 +31,7 @@ class EventTest extends TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    private function doSetUp()
     {
         $this->event = new Event();
     }
@@ -37,7 +40,7 @@ class EventTest extends TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->event = null;
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\EventDispatcher\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class GenericEventTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var GenericEvent
      */
@@ -29,7 +32,7 @@ class GenericEventTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    private function doSetUp()
     {
         $this->subject = new \stdClass();
         $this->event = new GenericEvent($this->subject, ['name' => 'Event']);
@@ -38,7 +41,7 @@ class GenericEventTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->subject = null;
         $this->event = null;

--- a/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\EventDispatcher\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\ImmutableEventDispatcher;
 
@@ -20,6 +21,8 @@ use Symfony\Component\EventDispatcher\ImmutableEventDispatcher;
  */
 class ImmutableEventDispatcherTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -30,7 +33,7 @@ class ImmutableEventDispatcherTest extends TestCase
      */
     private $dispatcher;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->innerDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->dispatcher = new ImmutableEventDispatcher($this->innerDispatcher);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -12,18 +12,21 @@
 namespace Symfony\Component\ExpressionLanguage\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\ExpressionLanguage\Lexer;
 use Symfony\Component\ExpressionLanguage\Token;
 use Symfony\Component\ExpressionLanguage\TokenStream;
 
 class LexerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var Lexer
      */
     private $lexer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->lexer = new Lexer();
     }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Filesystem\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Filesystem\Filesystem;
 
 class FilesystemTestCase extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $umask;
 
     protected $longPathNamesWindows = [];
@@ -40,7 +43,7 @@ class FilesystemTestCase extends TestCase
      */
     private static $symlinkOnWindows = null;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
             self::$linkOnWindows = true;
@@ -69,7 +72,7 @@ class FilesystemTestCase extends TestCase
         }
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->umask = umask(0);
         $this->filesystem = new Filesystem();
@@ -78,7 +81,7 @@ class FilesystemTestCase extends TestCase
         $this->workspace = realpath($this->workspace);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (!empty($this->longPathNamesWindows)) {
             foreach ($this->longPathNamesWindows as $path) {

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -11,12 +11,16 @@
 
 namespace Symfony\Component\Finder\Tests\Iterator;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 abstract class RealIteratorTestCase extends IteratorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $tmpDir;
     protected static $files;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$tmpDir = realpath(sys_get_temp_dir()).\DIRECTORY_SEPARATOR.'symfony_finder';
 
@@ -58,7 +62,7 @@ abstract class RealIteratorTestCase extends IteratorTestCase
         touch(self::toAbsolute('test.php'), strtotime('2005-10-15'));
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         $paths = new \RecursiveIteratorIterator(
              new \RecursiveDirectoryIterator(self::$tmpDir, \RecursiveDirectoryIterator::SKIP_DOTS),

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -70,7 +70,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
             if ($error instanceof FormError) {
                 $string .= 'ERROR: '.$error->getMessage()."\n";
             } else {
-                /** @var self $error */
+                /* @var self $error */
                 $string .= $error->form->getName().":\n";
                 $string .= self::indent((string) $error);
             }

--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\Forms;
  */
 abstract class FormIntegrationTestCase extends TestCase
 {
-    use TestCaseSetUpTearDownTrait;
+    use ForwardCompatTestTrait;
 
     /**
      * @var FormFactoryInterface

--- a/src/Symfony/Component/Form/Test/ForwardCompatTestTrait.php
+++ b/src/Symfony/Component/Form/Test/ForwardCompatTestTrait.php
@@ -22,7 +22,7 @@ if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \Reflection
     /**
      * @internal
      */
-    trait TestCaseSetUpTearDownTrait
+    trait ForwardCompatTestTrait
     {
         private function doSetUp(): void
         {
@@ -47,7 +47,7 @@ if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \Reflection
     /**
      * @internal
      */
-    trait TestCaseSetUpTearDownTrait
+    trait ForwardCompatTestTrait
     {
         /**
          * @return void

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 abstract class TypeTestCase extends FormIntegrationTestCase
 {
-    use TestCaseSetUpTearDownTrait;
+    use ForwardCompatTestTrait;
 
     /**
      * @var FormBuilder

--- a/src/Symfony/Component/Form/Tests/AbstractFormTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractFormTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormBuilder;
 
 abstract class AbstractFormTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -33,14 +36,14 @@ abstract class AbstractFormTest extends TestCase
      */
     protected $form;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = new EventDispatcher();
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
         $this->form = $this->createForm();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->dispatcher = null;
         $this->factory = null;

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormView;
@@ -18,12 +19,13 @@ use Symfony\Component\Form\Test\FormIntegrationTestCase;
 
 abstract class AbstractLayoutTest extends FormIntegrationTestCase
 {
+    use ForwardCompatTestTrait;
     use VersionAwareTest;
 
     protected $csrfTokenManager;
     protected $testableFeatures = [];
 
-    protected function setUp()
+    private function doSetUp()
     {
         if (!\extension_loaded('intl')) {
             $this->markTestSkipped('Extension intl is required.');
@@ -43,7 +45,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         ];
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->csrfTokenManager = null;
 

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
 use Symfony\Component\Form\Form;
@@ -26,6 +27,8 @@ use Symfony\Component\Form\RequestHandlerInterface;
  */
 abstract class AbstractRequestHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var RequestHandlerInterface
      */
@@ -40,7 +43,7 @@ abstract class AbstractRequestHandlerTest extends TestCase
 
     protected $serverParams;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->serverParams = $this->getMockBuilder('Symfony\Component\Form\Util\ServerParams')->setMethods(['getNormalizedIniPostMaxSize', 'getContentLength'])->getMock();
         $this->requestHandler = $this->getRequestHandler();

--- a/src/Symfony/Component/Form/Tests/ButtonTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ButtonBuilder;
 use Symfony\Component\Form\FormBuilder;
 
@@ -20,11 +21,13 @@ use Symfony\Component\Form\FormBuilder;
  */
 class ButtonTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $dispatcher;
 
     private $factory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Form\Tests\ChoiceList;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class AbstractChoiceListTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \Symfony\Component\Form\ChoiceList\ChoiceListInterface
      */
@@ -103,7 +106,7 @@ abstract class AbstractChoiceListTest extends TestCase
      */
     protected $key4;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\ChoiceList;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 
 /**
@@ -18,9 +19,11 @@ use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
  */
 class ArrayChoiceListTest extends AbstractChoiceListTest
 {
+    use ForwardCompatTestTrait;
+
     private $object;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->object = new \stdClass();
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\ChoiceList\Factory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\Factory\CachingFactoryDecorator;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\Form\ChoiceList\Factory\CachingFactoryDecorator;
  */
 class CachingFactoryDecoratorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -29,7 +32,7 @@ class CachingFactoryDecoratorTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->decoratedFactory = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface')->getMock();
         $this->factory = new CachingFactoryDecorator($this->decoratedFactory);

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\ChoiceList\Factory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Factory\DefaultChoiceListFactory;
@@ -22,6 +23,8 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 
 class DefaultChoiceListFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $obj1;
 
     private $obj2;
@@ -84,7 +87,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             : new DefaultChoiceListFactoryTest_Castable('Group 2');
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->obj1 = (object) ['label' => 'A', 'index' => 'w', 'value' => 'a', 'preferred' => false, 'group' => 'Group 1', 'attr' => []];
         $this->obj2 = (object) ['label' => 'B', 'index' => 'x', 'value' => 'b', 'preferred' => true, 'group' => 'Group 1', 'attr' => ['attr1' => 'value1']];

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\ChoiceList\Factory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
@@ -20,6 +21,8 @@ use Symfony\Component\PropertyAccess\PropertyPath;
  */
 class PropertyAccessDecoratorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -30,7 +33,7 @@ class PropertyAccessDecoratorTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->decoratedFactory = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface')->getMock();
         $this->factory = new PropertyAccessDecorator($this->decoratedFactory);

--- a/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\ChoiceList;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\LazyChoiceList;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Form\ChoiceList\LazyChoiceList;
  */
 class LazyChoiceListTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var LazyChoiceList
      */
@@ -37,7 +40,7 @@ class LazyChoiceListTest extends TestCase
 
     private $value;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->loadedList = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
         $this->loader = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\ChoiceList\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\LazyChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
  */
 class CallbackChoiceLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader
      */
@@ -45,7 +48,7 @@ class CallbackChoiceLoaderTest extends TestCase
      */
     private static $lazyChoiceList;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$loader = new CallbackChoiceLoader(function () {
             return self::$choices;
@@ -91,7 +94,7 @@ class CallbackChoiceLoaderTest extends TestCase
         );
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         self::$loader = null;
         self::$value = null;

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/JsonDescriptorTest.php
@@ -11,16 +11,19 @@
 
 namespace Symfony\Component\Form\Tests\Console\Descriptor;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Console\Descriptor\JsonDescriptor;
 
 class JsonDescriptorTest extends AbstractDescriptorTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         putenv('COLUMNS=121');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         putenv('COLUMNS');
     }

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -11,16 +11,19 @@
 
 namespace Symfony\Component\Form\Tests\Console\Descriptor;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Console\Descriptor\TextDescriptor;
 
 class TextDescriptorTest extends AbstractDescriptorTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         putenv('COLUMNS=121');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         putenv('COLUMNS');
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataMapper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
@@ -23,6 +24,8 @@ use Symfony\Component\PropertyAccess\PropertyPath;
 
 class PropertyPathMapperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PropertyPathMapper
      */
@@ -38,7 +41,7 @@ class PropertyPathMapperTest extends TestCase
      */
     private $propertyAccessor;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = new EventDispatcher();
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
@@ -12,13 +12,16 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ArrayToPartsTransformer;
 
 class ArrayToPartsTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $transformer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->transformer = new ArrayToPartsTransformer([
             'first' => ['a', 'b', 'c'],
@@ -26,7 +29,7 @@ class ArrayToPartsTransformerTest extends TestCase
         ]);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->transformer = null;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
 
 class BooleanToStringTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const TRUE_VALUE = '1';
 
     /**
@@ -23,12 +26,12 @@ class BooleanToStringTransformerTest extends TestCase
      */
     protected $transformer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->transformer = new BooleanToStringTransformer(self::TRUE_VALUE);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->transformer = null;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToValueTransformer;
 
 class ChoiceToValueTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $transformer;
     protected $transformerWithNull;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $list = new ArrayChoiceList(['', false, 'X', true]);
         $listWithNull = new ArrayChoiceList(['', false, 'X', null]);
@@ -29,7 +32,7 @@ class ChoiceToValueTransformerTest extends TestCase
         $this->transformerWithNull = new ChoiceToValueTransformer($listWithNull);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->transformer = null;
         $this->transformerWithNull = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoicesToValuesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoicesToValuesTransformerTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToValuesTransformer;
 
 class ChoicesToValuesTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $transformer;
     protected $transformerWithNull;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $list = new ArrayChoiceList(['', false, 'X']);
         $listWithNull = new ArrayChoiceList(['', false, 'X', null]);
@@ -29,7 +32,7 @@ class ChoicesToValuesTransformerTest extends TestCase
         $this->transformerWithNull = new ChoicesToValuesTransformer($listWithNull);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->transformer = null;
         $this->transformerWithNull = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -12,18 +12,21 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
 use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class DateTimeToLocalizedStringTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     use DateTimeEqualsTrait;
 
     protected $dateTime;
     protected $dateTimeWithoutSeconds;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -36,7 +39,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
         $this->dateTimeWithoutSeconds = new \DateTime('2010-02-03 04:05:00 UTC');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->dateTime = null;
         $this->dateTimeWithoutSeconds = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -12,17 +12,20 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToRfc3339Transformer;
 use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 
 class DateTimeToRfc3339TransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     use DateTimeEqualsTrait;
 
     protected $dateTime;
     protected $dateTimeWithoutSeconds;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -30,7 +33,7 @@ class DateTimeToRfc3339TransformerTest extends TestCase
         $this->dateTimeWithoutSeconds = new \DateTime('2010-02-03 04:05:00 UTC');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->dateTime = null;
         $this->dateTimeWithoutSeconds = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -12,20 +12,23 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\IntegerToLocalizedStringTransformer;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class IntegerToLocalizedStringTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $defaultLocale;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         \Locale::setDefault($this->defaultLocale);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -12,19 +12,22 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class MoneyToLocalizedStringTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $previousLocale;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->previousLocale = setlocale(LC_ALL, '0');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         setlocale(LC_ALL, $this->previousLocale);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -12,20 +12,23 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class NumberToLocalizedStringTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $defaultLocale;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         \Locale::setDefault($this->defaultLocale);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -12,20 +12,23 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\PercentToLocalizedStringTransformer;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class PercentToLocalizedStringTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $defaultLocale;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         \Locale::setDefault($this->defaultLocale);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -12,18 +12,21 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ValueToDuplicatesTransformer;
 
 class ValueToDuplicatesTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $transformer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->transformer = new ValueToDuplicatesTransformer(['a', 'b', 'c']);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->transformer = null;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
@@ -12,19 +12,22 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\EventListener\MergeCollectionListener;
 use Symfony\Component\Form\FormEvent;
 
 abstract class MergeCollectionListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $form;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->form = $this->getForm('axes');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->form = null;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
 use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
@@ -23,10 +24,12 @@ use Symfony\Component\Form\FormFactoryBuilder;
 
 class ResizeFormListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $factory;
     private $form;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->factory = (new FormFactoryBuilder())->getFormFactory();
         $this->form = $this->getBuilder()
@@ -35,7 +38,7 @@ class ResizeFormListenerTest extends TestCase
             ->getForm();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->factory = null;
         $this->form = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 
 class ChoiceTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
 
     private $choices = [
@@ -60,7 +63,7 @@ class ChoiceTypeTest extends BaseTypeTest
         ],
     ];
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -73,7 +76,7 @@ class ChoiceTypeTest extends BaseTypeTest
         ];
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -11,15 +11,18 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class CountryTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CountryType';
 
-    protected function setUp()
+    private function doSetUp()
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -11,15 +11,18 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class CurrencyTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CurrencyType';
 
-    protected function setUp()
+    private function doSetUp()
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -11,13 +11,16 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\FormError;
 
 class DateTimeTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\DateTimeType';
 
-    protected function setUp()
+    private function doSetUp()
     {
         \Locale::setDefault('en');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -11,25 +11,28 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class DateTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\DateType';
 
     private $defaultTimezone;
     private $defaultLocale;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
         $this->defaultTimezone = date_default_timezone_get();
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         date_default_timezone_set($this->defaultTimezone);
         \Locale::setDefault($this->defaultLocale);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -11,13 +11,16 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class IntegerTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\IntegerType';
 
-    protected function setUp()
+    private function doSetUp()
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -11,15 +11,18 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Extension\Core\Type\LanguageType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class LanguageTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\LanguageType';
 
-    protected function setUp()
+    private function doSetUp()
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -11,15 +11,18 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Extension\Core\Type\LocaleType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class LocaleTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\LocaleType';
 
-    protected function setUp()
+    private function doSetUp()
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -11,15 +11,18 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class MoneyTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\MoneyType';
 
     private $defaultLocale;
 
-    protected function setUp()
+    private function doSetUp()
     {
         // we test against different locales, so we need the full
         // implementation
@@ -30,7 +33,7 @@ class MoneyTypeTest extends BaseTypeTest
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -11,15 +11,18 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class NumberTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\NumberType';
 
     private $defaultLocale;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -30,7 +33,7 @@ class NumberTypeTest extends BaseTypeTest
         \Locale::setDefault('de_DE');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -11,10 +11,13 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Form;
 
 class RepeatedTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\RepeatedType';
 
     /**
@@ -22,7 +25,7 @@ class RepeatedTypeTest extends BaseTypeTest
      */
     protected $form;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Csrf\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
 use Symfony\Component\Form\Extension\Csrf\EventListener\CsrfValidationListener;
@@ -22,12 +23,14 @@ use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
 class CsrfValidationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $dispatcher;
     protected $factory;
     protected $tokenManager;
     protected $form;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = new EventDispatcher();
         $this->factory = (new FormFactoryBuilder())->getFormFactory();
@@ -37,7 +40,7 @@ class CsrfValidationListenerTest extends TestCase
             ->getForm();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->dispatcher = null;
         $this->factory = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Csrf\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -30,6 +31,8 @@ class FormTypeCsrfExtensionTest_ChildType extends AbstractType
 
 class FormTypeCsrfExtensionTest extends TypeTestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -40,7 +43,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
      */
     protected $translator;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->tokenManager = $this->getMockBuilder('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')->getMock();
         $this->translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
@@ -48,7 +51,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->tokenManager = null;
         $this->translator = null;

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/DataCollectorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/DataCollectorExtensionTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Form\Tests\Extension\DataCollector;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\DataCollector\DataCollectorExtension;
 
 class DataCollectorExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var DataCollectorExtension
      */
@@ -26,7 +29,7 @@ class DataCollectorExtensionTest extends TestCase
      */
     private $dataCollector;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dataCollector = $this->getMockBuilder('Symfony\Component\Form\Extension\DataCollector\FormDataCollectorInterface')->getMock();
         $this->extension = new DataCollectorExtension($this->dataCollector);

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\DataCollector;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\DataCollector\FormDataCollector;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
@@ -19,6 +20,8 @@ use Symfony\Component\Form\FormView;
 
 class FormDataCollectorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -64,7 +67,7 @@ class FormDataCollectorTest extends TestCase
      */
     private $childView;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dataExtractor = $this->getMockBuilder('Symfony\Component\Form\Extension\DataCollector\FormDataExtractorInterface')->getMock();
         $this->dataCollector = new FormDataCollector($this->dataExtractor);

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\DataCollector;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\DataCollector\FormDataExtractor;
@@ -27,6 +28,7 @@ use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
  */
 class FormDataExtractorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
     use VarDumperTestTrait;
 
     /**
@@ -44,7 +46,7 @@ class FormDataExtractorTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dataExtractor = new FormDataExtractor();
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Form\Tests\Extension\DataCollector\Type;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\DataCollector\Type\DataCollectorTypeExtension;
 
 class DataCollectorTypeExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var DataCollectorTypeExtension
      */
@@ -26,7 +29,7 @@ class DataCollectorTypeExtensionTest extends TestCase
      */
     private $dataCollector;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dataCollector = $this->getMockBuilder('Symfony\Component\Form\Extension\DataCollector\FormDataCollectorInterface')->getMock();
         $this->extension = new DataCollectorTypeExtension($this->dataCollector);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\CallbackTransformer;
@@ -38,6 +39,8 @@ use Symfony\Component\Validator\Validation;
  */
 class FormValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -48,7 +51,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
      */
     private $factory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = new EventDispatcher();
         $this->factory = (new FormFactoryBuilder())->getFormFactory();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
@@ -32,6 +33,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ValidationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -58,7 +61,7 @@ class ValidationListenerTest extends TestCase
 
     private $params;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = new EventDispatcher();
         $this->factory = (new FormFactoryBuilder())->getFormFactory();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\ValueGuess;
@@ -32,6 +33,8 @@ use Symfony\Component\Validator\Tests\Fixtures\FakeMetadataFactory;
  */
 class ValidatorTypeGuesserTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const TEST_CLASS = 'Symfony\Component\Form\Tests\Extension\Validator\ValidatorTypeGuesserTest_TestClass';
 
     const TEST_PROPERTY = 'property';
@@ -51,7 +54,7 @@ class ValidatorTypeGuesserTest extends TestCase
      */
     private $metadataFactory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->metadata = new ClassMetadata(self::TEST_CLASS);
         $this->metadataFactory = new FakeMetadataFactory();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\ViolationMapper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\CallbackTransformer;
@@ -31,6 +32,8 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
  */
 class ViolationMapperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const LEVEL_0 = 0;
     const LEVEL_1 = 1;
     const LEVEL_1B = 2;
@@ -61,7 +64,7 @@ class ViolationMapperTest extends TestCase
      */
     private $params;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = new EventDispatcher();
         $this->mapper = new ViolationMapper();

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -12,24 +12,27 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ButtonBuilder;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\SubmitButtonBuilder;
 
 class FormBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $dispatcher;
     private $factory;
     private $builder;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
         $this->builder = new FormBuilder('name', null, $this->dispatcher, $this->factory);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->dispatcher = null;
         $this->factory = null;

--- a/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\FormFactoryBuilder;
 use Symfony\Component\Form\Tests\Fixtures\FooType;
 
 class FormFactoryBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $registry;
     private $guesser;
     private $type;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $factory = new \ReflectionClass('Symfony\Component\Form\FormFactory');
         $this->registry = $factory->getProperty('registry');

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormTypeGuesserChain;
 use Symfony\Component\Form\Guess\Guess;
@@ -23,6 +24,8 @@ use Symfony\Component\Form\Guess\ValueGuess;
  */
 class FormFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -48,7 +51,7 @@ class FormFactoryTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->guesser1 = $this->getMockBuilder('Symfony\Component\Form\FormTypeGuesserInterface')->getMock();
         $this->guesser2 = $this->getMockBuilder('Symfony\Component\Form\FormTypeGuesserInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\FormRegistry;
 use Symfony\Component\Form\FormTypeGuesserChain;
 use Symfony\Component\Form\ResolvedFormType;
@@ -31,6 +32,8 @@ use Symfony\Component\Form\Tests\Fixtures\TestExtension;
  */
 class FormRegistryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var FormRegistry
      */
@@ -61,7 +64,7 @@ class FormRegistryTest extends TestCase
      */
     private $extension2;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->resolvedTypeFactory = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeFactory')->getMock();
         $this->guesser1 = $this->getMockBuilder('Symfony\Component\Form\FormTypeGuesserInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\NativeRequestHandler;
 
 /**
@@ -18,14 +19,16 @@ use Symfony\Component\Form\NativeRequestHandler;
  */
 class NativeRequestHandlerTest extends AbstractRequestHandlerTest
 {
+    use ForwardCompatTestTrait;
+
     private static $serverBackup;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$serverBackup = $_SERVER;
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -38,7 +41,7 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
         ];
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\Form\FormTypeExtensionInterface;
@@ -24,6 +25,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ResolvedFormTypeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -69,7 +72,7 @@ class ResolvedFormTypeTest extends TestCase
      */
     private $resolvedType;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\Stream;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,6 +20,8 @@ use Symfony\Component\HttpFoundation\Tests\File\FakeFile;
 
 class BinaryFileResponseTest extends ResponseTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstruction()
     {
         $file = __DIR__.'/../README.md';
@@ -356,7 +359,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         return new BinaryFileResponse(__DIR__.'/../README.md', 200, ['Content-Type' => 'application/octet-stream']);
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         $path = __DIR__.'/../Fixtures/to_delete';
         if (file_exists($path)) {

--- a/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\File\MimeType;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\File\MimeType\FileBinaryMimeTypeGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 
@@ -20,6 +21,8 @@ use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
  */
 class MimeTypeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $path;
 
     public function testGuessImageWithoutExtension()
@@ -79,7 +82,7 @@ class MimeTypeTest extends TestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         $path = __DIR__.'/../Fixtures/to_delete';
         if (file_exists($path)) {

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\HttpFoundation\Tests\File;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class UploadedFileTest extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         if (!ini_get('file_uploads')) {
             $this->markTestSkipped('file_uploads is disabled in php.ini');

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\FileBag;
 
@@ -23,6 +24,8 @@ use Symfony\Component\HttpFoundation\FileBag;
  */
 class FileBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -159,12 +162,12 @@ class FileBagTest extends TestCase
         return tempnam(sys_get_temp_dir().'/form_test', 'FormTest');
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         mkdir(sys_get_temp_dir().'/form_test', 0777, true);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         foreach (glob(sys_get_temp_dir().'/form_test/*') as $file) {
             unlink($file);

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class JsonResponseTest extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -19,7 +20,9 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class RequestTest extends TestCase
 {
-    protected function tearDown()
+    use ForwardCompatTestTrait;
+
+    private function doTearDown()
     {
         Request::setTrustedProxies([], -1);
         Request::setTrustedHosts([]);

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 /**
  * @requires PHP 7.0
  */
 class ResponseFunctionalTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private static $server;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         $spec = [
             1 => ['file', '/dev/null', 'w'],
@@ -32,7 +35,7 @@ class ResponseFunctionalTest extends TestCase
         sleep(1);
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         if (self::$server) {
             proc_terminate(self::$server);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/AttributeBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/AttributeBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Attribute;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 
 /**
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
  */
 class AttributeBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $array = [];
 
     /**
@@ -28,7 +31,7 @@ class AttributeBagTest extends TestCase
      */
     private $bag;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->array = [
             'hello' => 'world',
@@ -49,7 +52,7 @@ class AttributeBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->bag = null;
         $this->array = [];

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/NamespacedAttributeBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/NamespacedAttributeBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Attribute;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
 
 /**
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
  */
 class NamespacedAttributeBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $array = [];
 
     /**
@@ -28,7 +31,7 @@ class NamespacedAttributeBagTest extends TestCase
      */
     private $bag;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->array = [
             'hello' => 'world',
@@ -49,7 +52,7 @@ class NamespacedAttributeBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->bag = null;
         $this->array = [];

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Flash;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag as FlashBag;
 
 /**
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag as FlashBa
  */
 class AutoExpireFlashBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag
      */
@@ -28,7 +31,7 @@ class AutoExpireFlashBagTest extends TestCase
 
     protected $array = [];
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
         $this->bag = new FlashBag();
@@ -36,7 +39,7 @@ class AutoExpireFlashBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->bag = null;
         parent::tearDown();

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Flash;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 
 /**
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
  */
 class FlashBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface
      */
@@ -28,7 +31,7 @@ class FlashBagTest extends TestCase
 
     protected $array = [];
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
         $this->bag = new FlashBag();
@@ -36,7 +39,7 @@ class FlashBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->bag = null;
         parent::tearDown();

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -27,6 +28,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
  */
 class SessionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface
      */
@@ -37,13 +40,13 @@ class SessionTest extends TestCase
      */
     protected $session;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->storage = new MockArraySessionStorage();
         $this->session = new Session($this->storage, new AttributeBag(), new FlashBag());
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->storage = null;
         $this->session = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 /**
  * @requires PHP 7.0
  */
 class AbstractSessionHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private static $server;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         $spec = [
             1 => ['file', '/dev/null', 'w'],
@@ -32,7 +35,7 @@ class AbstractSessionHandlerTest extends TestCase
         sleep(1);
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         if (self::$server) {
             proc_terminate(self::$server);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcacheSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcacheSessionHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcacheSessionHandler;
 
 /**
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcacheSessionHand
  */
 class MemcacheSessionHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const PREFIX = 'prefix_';
     const TTL = 1000;
 
@@ -31,7 +34,7 @@ class MemcacheSessionHandlerTest extends TestCase
 
     protected $memcache;
 
-    protected function setUp()
+    private function doSetUp()
     {
         if (\defined('HHVM_VERSION')) {
             $this->markTestSkipped('PHPUnit_MockObject cannot mock the Memcache class on HHVM. See https://github.com/sebastianbergmann/phpunit-mock-objects/pull/289');
@@ -45,7 +48,7 @@ class MemcacheSessionHandlerTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->memcache = null;
         $this->storage = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcachedSessionHandler;
 
 /**
@@ -20,6 +21,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcachedSessionHan
  */
 class MemcachedSessionHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const PREFIX = 'prefix_';
     const TTL = 1000;
 
@@ -30,7 +33,7 @@ class MemcachedSessionHandlerTest extends TestCase
 
     protected $memcached;
 
-    protected function setUp()
+    private function doSetUp()
     {
         if (\defined('HHVM_VERSION')) {
             $this->markTestSkipped('PHPUnit_MockObject cannot mock the Memcached class on HHVM. See https://github.com/sebastianbergmann/phpunit-mock-objects/pull/289');
@@ -49,7 +52,7 @@ class MemcachedSessionHandlerTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->memcached = null;
         $this->storage = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
 /**
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandl
  */
 class MongoDbSessionHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -28,7 +31,7 @@ class MongoDbSessionHandlerTest extends TestCase
     private $storage;
     public $options;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
 /**
@@ -20,9 +21,11 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
  */
 class PdoSessionHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $dbFile;
 
-    protected function tearDown()
+    private function doTearDown()
     {
         // make sure the temporary database file is deleted when it has been created (even when a test fails)
         if ($this->dbFile) {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MetadataBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MetadataBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 
 /**
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
  */
 class MetadataBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var MetadataBag
      */
@@ -28,7 +31,7 @@ class MetadataBagTest extends TestCase
 
     protected $array = [];
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
         $this->bag = new MetadataBag();
@@ -36,7 +39,7 @@ class MetadataBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->array = [];
         $this->bag = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -23,6 +24,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
  */
 class MockArraySessionStorageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var MockArraySessionStorage
      */
@@ -40,7 +43,7 @@ class MockArraySessionStorageTest extends TestCase
 
     private $data;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->attributes = new AttributeBag();
         $this->flashes = new FlashBag();
@@ -56,7 +59,7 @@ class MockArraySessionStorageTest extends TestCase
         $this->storage->setSessionData($this->data);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->data = null;
         $this->flashes = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
@@ -23,6 +24,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
  */
 class MockFileSessionStorageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var string
      */
@@ -33,13 +36,13 @@ class MockFileSessionStorageTest extends TestCase
      */
     protected $storage;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->sessionDir = sys_get_temp_dir().'/sf2test';
         $this->storage = $this->getStorage();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->sessionDir = null;
         $this->storage = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler;
@@ -31,9 +32,11 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
  */
 class NativeSessionStorageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $savePath;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->iniSet('session.save_handler', 'files');
         $this->iniSet('session.save_path', $this->savePath = sys_get_temp_dir().'/sf2test');
@@ -42,7 +45,7 @@ class NativeSessionStorageTest extends TestCase
         }
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         session_write_close();
         array_map('unlink', glob($this->savePath.'/*'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage;
 
@@ -27,9 +28,11 @@ use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage;
  */
 class PhpBridgeSessionStorageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $savePath;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->iniSet('session.save_handler', 'files');
         $this->iniSet('session.save_path', $this->savePath = sys_get_temp_dir().'/sf2test');
@@ -38,7 +41,7 @@ class PhpBridgeSessionStorageTest extends TestCase
         }
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         session_write_close();
         array_map('unlink', glob($this->savePath.'/*'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Proxy;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
@@ -22,17 +23,19 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
  */
 class AbstractProxyTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var AbstractProxy
      */
     protected $proxy;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->proxy = $this->getMockForAbstractClass(AbstractProxy::class);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->proxy = null;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Proxy;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
 /**
@@ -24,6 +25,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
  */
 class SessionHandlerProxyTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_Matcher
      */
@@ -34,13 +37,13 @@ class SessionHandlerProxyTest extends TestCase
      */
     private $proxy;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->mock = $this->getMockBuilder('SessionHandlerInterface')->getMock();
         $this->proxy = new SessionHandlerProxy($this->mock);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->mock = null;
         $this->proxy = null;

--- a/src/Symfony/Component/HttpKernel/Tests/CacheClearer/ChainCacheClearerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheClearer/ChainCacheClearerTest.php
@@ -12,18 +12,21 @@
 namespace Symfony\Component\HttpKernel\Tests\CacheClearer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer;
 
 class ChainCacheClearerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $cacheDir;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$cacheDir = tempnam(sys_get_temp_dir(), 'sf2_cache_clearer_dir');
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         @unlink(self::$cacheDir);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
@@ -12,18 +12,21 @@
 namespace Symfony\Component\HttpKernel\Tests\CacheWarmer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
 
 class CacheWarmerAggregateTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $cacheDir;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$cacheDir = tempnam(sys_get_temp_dir(), 'sf2_cache_warmer_dir');
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         @unlink(self::$cacheDir);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
@@ -12,18 +12,21 @@
 namespace Symfony\Component\HttpKernel\Tests\CacheWarmer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
 
 class CacheWarmerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $cacheFile;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$cacheFile = tempnam(sys_get_temp_dir(), 'sf2_cache_warmer_dir');
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         @unlink(self::$cacheFile);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Config/EnvParametersResourceTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Config/EnvParametersResourceTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Config;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\Config\EnvParametersResource;
 
 /**
@@ -19,11 +20,13 @@ use Symfony\Component\HttpKernel\Config\EnvParametersResource;
  */
 class EnvParametersResourceTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $prefix = '__DUMMY_';
     protected $initialEnv;
     protected $resource;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->initialEnv = [
             $this->prefix.'1' => 'foo',
@@ -37,7 +40,7 @@ class EnvParametersResourceTest extends TestCase
         $this->resource = new EnvParametersResource($this->prefix);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         foreach ($_SERVER as $key => $value) {
             if (0 === strpos($key, $this->prefix)) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -27,10 +28,12 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\VariadicController;
 
 class ArgumentResolverTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var ArgumentResolver */
     private static $resolver;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         $factory = new ArgumentMetadataFactory();
 

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\ControllerMetadata;
 
 use Fake\ImportedAndFake;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\BasicTypesController;
@@ -21,12 +22,14 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\VariadicController;
 
 class ArgumentMetadataFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ArgumentMetadataFactory
      */
     private $factory;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->factory = new ArgumentMetadataFactory();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/Util/ValueExporterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/Util/ValueExporterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\DataCollector\Util;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
 
 /**
@@ -19,12 +20,14 @@ use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
  */
 class ValueExporterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ValueExporter
      */
     private $valueExporter;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->valueExporter = new ValueExporter();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ServicesResetterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ServicesResetterTest.php
@@ -12,13 +12,16 @@
 namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ClearableService;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ResettableService;
 
 class ServicesResetterTest extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         ResettableService::$counter = 0;
         ClearableService::$counter = 0;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\EventListener\AddRequestFormatsListener;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -23,17 +24,19 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class AddRequestFormatsListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var AddRequestFormatsListener
      */
     private $listener;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->listener = new AddRequestFormatsListener(['csv' => ['text/csv', 'text/plain']]);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->listener = null;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
@@ -19,9 +20,11 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class LocaleListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $requestStack;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->disableOriginalConstructor()->getMock();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,11 +23,13 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class ResponseListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $dispatcher;
 
     private $kernel;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dispatcher = new EventDispatcher();
         $listener = new ResponseListener('UTF-8');
@@ -35,7 +38,7 @@ class ResponseListenerTest extends TestCase
         $this->kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->dispatcher = null;
         $this->kernel = null;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -29,9 +30,11 @@ use Symfony\Component\Routing\RequestContext;
 
 class RouterListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $requestStack;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->disableOriginalConstructor()->getMock();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,6 +32,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class TestSessionListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var TestSessionListener
      */
@@ -41,7 +44,7 @@ class TestSessionListenerTest extends TestCase
      */
     private $session;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->listener = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\EventListener\AbstractTestSessionListener');
         $this->session = $this->getSession();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -20,11 +21,13 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class TranslatorListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $listener;
     private $translator;
     private $requestStack;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
         $this->requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ValidateRequestListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ValidateRequestListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -21,7 +22,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class ValidateRequestListenerTest extends TestCase
 {
-    protected function tearDown()
+    use ForwardCompatTestTrait;
+
+    private function doTearDown()
     {
         Request::setTrustedProxies([], -1);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Fragment;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
@@ -21,9 +22,11 @@ use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
  */
 class FragmentHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $requestStack;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->requestStack = $this->getMockBuilder('Symfony\\Component\\HttpFoundation\\RequestStack')
             ->disableOriginalConstructor()

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class HttpCacheTestCase extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $kernel;
     protected $cache;
     protected $caches;
@@ -35,7 +38,7 @@ class HttpCacheTestCase extends TestCase
      */
     protected $store;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->kernel = null;
 
@@ -53,7 +56,7 @@ class HttpCacheTestCase extends TestCase
         $this->clearDirectory(sys_get_temp_dir().'/http_cache');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if ($this->cache) {
             $this->cache->getStore()->cleanup();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\Store;
 
 class StoreTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $request;
     protected $response;
 
@@ -26,7 +29,7 @@ class StoreTest extends TestCase
      */
     protected $store;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->request = Request::create('/');
         $this->response = new Response('hello world', 200, []);
@@ -36,7 +39,7 @@ class StoreTest extends TestCase
         $this->store = new Store(sys_get_temp_dir().'/http_cache');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->store = null;
         $this->request = null;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SubRequestHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SubRequestHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\SubRequestHandler;
@@ -19,14 +20,16 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class SubRequestHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private static $globalState;
 
-    protected function setUp()
+    private function doSetUp()
     {
         self::$globalState = $this->getGlobalState();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         Request::setTrustedProxies(self::$globalState[0], self::$globalState[1]);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -31,7 +32,9 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\ResettableService;
 
 class KernelTest extends TestCase
 {
-    public static function tearDownAfterClass()
+    use ForwardCompatTestTrait;
+
+    private static function doTearDownAfterClass()
     {
         $fs = new Filesystem();
         $fs->remove(__DIR__.'/Fixtures/cache');

--- a/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\Tests\Log;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\Log\Logger;
 
 /**
@@ -22,6 +23,8 @@ use Symfony\Component\HttpKernel\Log\Logger;
  */
 class LoggerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var LoggerInterface
      */
@@ -32,13 +35,13 @@ class LoggerTest extends TestCase
      */
     private $tmpFile;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->tmpFile = tempnam(sys_get_temp_dir(), 'log');
         $this->logger = new Logger(LogLevel::DEBUG, $this->tmpFile);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (!@unlink($this->tmpFile)) {
             file_put_contents($this->tmpFile, '');

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Component\HttpKernel\Tests\Profiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
 class FileProfilerStorageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $tmpDir;
     private $storage;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->tmpDir = sys_get_temp_dir().'/sf2_profiler_file_storage';
         if (is_dir($this->tmpDir)) {
@@ -30,7 +33,7 @@ class FileProfilerStorageTest extends TestCase
         $this->storage->purge();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         self::cleanDir();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Profiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
@@ -21,6 +22,8 @@ use Symfony\Component\HttpKernel\Profiler\Profiler;
 
 class ProfilerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $tmp;
     private $storage;
 
@@ -82,7 +85,7 @@ class ProfilerTest extends TestCase
         $this->assertCount(0, $profiler->find(null, null, null, null, null, null, '204'));
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->tmp = tempnam(sys_get_temp_dir(), 'sf2_profiler');
         if (file_exists($this->tmp)) {
@@ -93,7 +96,7 @@ class ProfilerTest extends TestCase
         $this->storage->purge();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (null !== $this->storage) {
             $this->storage->purge();

--- a/src/Symfony/Component/Intl/Tests/Collator/Verification/CollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/Verification/CollatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\Collator\Verification;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Tests\Collator\AbstractCollatorTest;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
@@ -22,7 +23,9 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class CollatorTest extends AbstractCollatorTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Reader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReader;
 use Symfony\Component\Intl\Exception\ResourceBundleNotFoundException;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Intl\Exception\ResourceBundleNotFoundException;
  */
 class BundleEntryReaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const RES_DIR = '/res/dir';
 
     /**
@@ -61,7 +64,7 @@ class BundleEntryReaderTest extends TestCase
         'Foo' => 'Bar',
     ];
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->readerImpl = $this->getMockBuilder('Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReaderInterface')->getMock();
         $this->reader = new BundleEntryReader($this->readerImpl);

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Reader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Bundle\Reader\IntlBundleReader;
 
 /**
@@ -20,12 +21,14 @@ use Symfony\Component\Intl\Data\Bundle\Reader\IntlBundleReader;
  */
 class IntlBundleReaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var IntlBundleReader
      */
     private $reader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->reader = new IntlBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Reader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Bundle\Reader\JsonBundleReader;
 
 /**
@@ -19,12 +20,14 @@ use Symfony\Component\Intl\Data\Bundle\Reader\JsonBundleReader;
  */
 class JsonBundleReaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var JsonBundleReader
      */
     private $reader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->reader = new JsonBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Reader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Bundle\Reader\PhpBundleReader;
 
 /**
@@ -19,12 +20,14 @@ use Symfony\Component\Intl\Data\Bundle\Reader\PhpBundleReader;
  */
 class PhpBundleReaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PhpBundleReader
      */
     private $reader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->reader = new PhpBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Writer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Intl\Data\Bundle\Writer\JsonBundleWriter;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Intl\Data\Bundle\Writer\JsonBundleWriter;
  */
 class JsonBundleWriterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var JsonBundleWriter
      */
@@ -32,7 +35,7 @@ class JsonBundleWriterTest extends TestCase
      */
     private $filesystem;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->writer = new JsonBundleWriter();
         $this->directory = sys_get_temp_dir().'/JsonBundleWriterTest/'.mt_rand(1000, 9999);
@@ -41,7 +44,7 @@ class JsonBundleWriterTest extends TestCase
         $this->filesystem->mkdir($this->directory);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->filesystem->remove($this->directory);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/PhpBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/PhpBundleWriterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Writer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Intl\Data\Bundle\Writer\PhpBundleWriter;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Intl\Data\Bundle\Writer\PhpBundleWriter;
  */
 class PhpBundleWriterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PhpBundleWriter
      */
@@ -32,7 +35,7 @@ class PhpBundleWriterTest extends TestCase
      */
     private $filesystem;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->writer = new PhpBundleWriter();
         $this->directory = sys_get_temp_dir().'/PhpBundleWriterTest/'.mt_rand(1000, 9999);
@@ -41,7 +44,7 @@ class PhpBundleWriterTest extends TestCase
         $this->filesystem->mkdir($this->directory);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->filesystem->remove($this->directory);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/TextBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/TextBundleWriterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Writer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Intl\Data\Bundle\Writer\TextBundleWriter;
 
@@ -22,6 +23,8 @@ use Symfony\Component\Intl\Data\Bundle\Writer\TextBundleWriter;
  */
 class TextBundleWriterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var TextBundleWriter
      */
@@ -34,7 +37,7 @@ class TextBundleWriterTest extends TestCase
      */
     private $filesystem;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->writer = new TextBundleWriter();
         $this->directory = sys_get_temp_dir().'/TextBundleWriterTest/'.mt_rand(1000, 9999);
@@ -43,7 +46,7 @@ class TextBundleWriterTest extends TestCase
         $this->filesystem->mkdir($this->directory);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->filesystem->remove($this->directory);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\Data\Provider;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Provider\CurrencyDataProvider;
 use Symfony\Component\Intl\Intl;
 
@@ -19,6 +20,8 @@ use Symfony\Component\Intl\Intl;
  */
 abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
 {
+    use ForwardCompatTestTrait;
+
     // The below arrays document the state of the ICU data bundled with this package.
 
     protected static $currencies = [
@@ -590,7 +593,7 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
      */
     protected $dataProvider;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReader;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleReaderInterface;
 use Symfony\Component\Intl\Locale;
@@ -21,6 +22,8 @@ use Symfony\Component\Intl\Locale;
  */
 abstract class AbstractDataProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     // Include the locales statically so that the data providers are decoupled
     // from the Intl class. Otherwise tests will fail if the intl extension is
     // not loaded, because it is NOT possible to skip the execution of data
@@ -701,7 +704,7 @@ abstract class AbstractDataProviderTest extends TestCase
 
     private static $rootLocales;
 
-    protected function setUp()
+    private function doSetUp()
     {
         \Locale::setDefault('en');
         Locale::setDefaultFallback('en');

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLanguageDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLanguageDataProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\Data\Provider;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Provider\LanguageDataProvider;
 use Symfony\Component\Intl\Intl;
 
@@ -19,6 +20,8 @@ use Symfony\Component\Intl\Intl;
  */
 abstract class AbstractLanguageDataProviderTest extends AbstractDataProviderTest
 {
+    use ForwardCompatTestTrait;
+
     // The below arrays document the state of the ICU data bundled with this package.
 
     protected static $languages = [
@@ -832,7 +835,7 @@ abstract class AbstractLanguageDataProviderTest extends AbstractDataProviderTest
      */
     protected $dataProvider;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLocaleDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLocaleDataProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\Data\Provider;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Provider\LocaleDataProvider;
 use Symfony\Component\Intl\Intl;
 
@@ -19,12 +20,14 @@ use Symfony\Component\Intl\Intl;
  */
 abstract class AbstractLocaleDataProviderTest extends AbstractDataProviderTest
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var LocaleDataProvider
      */
     protected $dataProvider;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractRegionDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractRegionDataProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\Data\Provider;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Provider\RegionDataProvider;
 use Symfony\Component\Intl\Intl;
 
@@ -19,6 +20,8 @@ use Symfony\Component\Intl\Intl;
  */
 abstract class AbstractRegionDataProviderTest extends AbstractDataProviderTest
 {
+    use ForwardCompatTestTrait;
+
     // The below arrays document the state of the ICU data bundled with this package.
 
     protected static $territories = [
@@ -284,7 +287,7 @@ abstract class AbstractRegionDataProviderTest extends AbstractDataProviderTest
      */
     protected $dataProvider;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractScriptDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractScriptDataProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\Data\Provider;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Provider\ScriptDataProvider;
 use Symfony\Component\Intl\Intl;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Intl\Intl;
  */
 abstract class AbstractScriptDataProviderTest extends AbstractDataProviderTest
 {
+    use ForwardCompatTestTrait;
+
     // The below arrays document the state of the ICU data bundled with this package.
 
     protected static $scripts = [
@@ -220,7 +223,7 @@ abstract class AbstractScriptDataProviderTest extends AbstractDataProviderTest
      */
     protected $dataProvider;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Util/LocaleScannerTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Util/LocaleScannerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Util;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Intl\Data\Util\LocaleScanner;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Intl\Data\Util\LocaleScanner;
  */
 class LocaleScannerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $directory;
 
     /**
@@ -32,7 +35,7 @@ class LocaleScannerTest extends TestCase
      */
     private $scanner;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->directory = sys_get_temp_dir().'/LocaleScannerTest/'.mt_rand(1000, 9999);
         $this->filesystem = new Filesystem();
@@ -56,7 +59,7 @@ class LocaleScannerTest extends TestCase
         file_put_contents($this->directory.'/fr_alias.txt', 'fr_alias{"%%ALIAS"{"fr"}}');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->filesystem->remove($this->directory);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Util/RingBufferTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Util/RingBufferTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\Data\Util;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Data\Util\RingBuffer;
 
 /**
@@ -19,12 +20,14 @@ use Symfony\Component\Intl\Data\Util\RingBuffer;
  */
 class RingBufferTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var RingBuffer
      */
     private $buffer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->buffer = new RingBuffer(2);
     }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Intl\Tests\DateFormatter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\DateFormatter\IntlDateFormatter;
 use Symfony\Component\Intl\Globals\IntlGlobals;
 use Symfony\Component\Intl\Intl;
@@ -24,7 +25,9 @@ use Symfony\Component\Intl\Util\IcuVersion;
  */
 abstract class AbstractIntlDateFormatterTest extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         \Locale::setDefault('en');
     }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\DateFormatter\Verification;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\DateFormatter\IntlDateFormatter;
 use Symfony\Component\Intl\Tests\DateFormatter\AbstractIntlDateFormatterTest;
 use Symfony\Component\Intl\Util\IntlTestHelper;
@@ -23,7 +24,9 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Intl/Tests/Globals/Verification/IntlGlobalsTest.php
+++ b/src/Symfony/Component/Intl/Tests/Globals/Verification/IntlGlobalsTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\Globals\Verification;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Tests\Globals\AbstractIntlGlobalsTest;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
@@ -22,7 +23,9 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class IntlGlobalsTest extends AbstractIntlGlobalsTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Intl/Tests/Locale/Verification/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/Verification/LocaleTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\Locale\Verification;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Tests\Locale\AbstractLocaleTest;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
@@ -22,7 +23,9 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class LocaleTest extends AbstractLocaleTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\NumberFormatter\Verification;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Tests\NumberFormatter\AbstractNumberFormatterTest;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
@@ -20,7 +21,9 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class NumberFormatterTest extends AbstractNumberFormatterTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         IntlTestHelper::requireFullIntl($this, '55.1');
 

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Ldap\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Collection;
 use Symfony\Component\Ldap\Entry;
@@ -22,10 +23,12 @@ use Symfony\Component\Ldap\Exception\NotBoundException;
  */
 class LdapManagerTest extends LdapTestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var Adapter */
     private $adapter;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->adapter = new Adapter($this->getLdapConfig());
         $this->adapter->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');

--- a/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Ldap\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Ldap\Adapter\CollectionInterface;
 use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Entry;
@@ -22,12 +23,14 @@ use Symfony\Component\Ldap\LdapInterface;
  */
 class LdapClientTest extends LdapTestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var LdapClient */
     private $client;
     /** @var \PHPUnit_Framework_MockObject_MockObject */
     private $ldap;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
 

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Ldap\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Ldap\Adapter\AdapterInterface;
 use Symfony\Component\Ldap\Adapter\ConnectionInterface;
 use Symfony\Component\Ldap\Exception\DriverNotFoundException;
@@ -19,13 +20,15 @@ use Symfony\Component\Ldap\Ldap;
 
 class LdapTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var \PHPUnit_Framework_MockObject_MockObject */
     private $adapter;
 
     /** @var Ldap */
     private $ldap;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->adapter = $this->getMockBuilder(AdapterInterface::class)->getMock();
         $this->ldap = new Ldap($this->adapter);

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\Store\CombinedStore;
@@ -24,6 +25,7 @@ use Symfony\Component\Lock\Strategy\UnanimousStrategy;
  */
 class CombinedStoreTest extends AbstractStoreTest
 {
+    use ForwardCompatTestTrait;
     use ExpiringStoreTestTrait;
 
     /**
@@ -58,7 +60,7 @@ class CombinedStoreTest extends AbstractStoreTest
     /** @var CombinedStore */
     private $store;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->strategy = $this->getMockBuilder(StrategyInterface::class)->getMock();
         $this->store1 = $this->getMockBuilder(StoreInterface::class)->getMock();

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Store\MemcachedStore;
 
 /**
@@ -20,9 +21,10 @@ use Symfony\Component\Lock\Store\MemcachedStore;
  */
 class MemcachedStoreTest extends AbstractStoreTest
 {
+    use ForwardCompatTestTrait;
     use ExpiringStoreTestTrait;
 
-    public static function setupBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         $memcached = new \Memcached();
         $memcached->addServer(getenv('MEMCACHED_HOST'), 11211);

--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
@@ -11,12 +11,16 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
 class PredisStoreTest extends AbstractRedisStoreTest
 {
-    public static function setupBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         $redis = new \Predis\Client('tcp://'.getenv('REDIS_HOST').':6379');
         try {

--- a/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -18,7 +20,9 @@ namespace Symfony\Component\Lock\Tests\Store;
  */
 class RedisArrayStoreTest extends AbstractRedisStoreTest
 {
-    public static function setupBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         if (!class_exists('RedisArray')) {
             self::markTestSkipped('The RedisArray class is required.');

--- a/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -18,7 +20,9 @@ namespace Symfony\Component\Lock\Tests\Store;
  */
 class RedisClusterStoreTest extends AbstractRedisStoreTest
 {
-    public static function setupBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         if (!class_exists('RedisCluster')) {
             self::markTestSkipped('The RedisCluster class is required.');

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -18,7 +20,9 @@ namespace Symfony\Component\Lock\Tests\Store;
  */
 class RedisStoreTest extends AbstractRedisStoreTest
 {
-    public static function setupBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
             $e = error_get_last();

--- a/src/Symfony/Component/Lock/Tests/Strategy/ConsensusStrategyTest.php
+++ b/src/Symfony/Component/Lock/Tests/Strategy/ConsensusStrategyTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Strategy;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Strategy\ConsensusStrategy;
 
 /**
@@ -19,10 +20,12 @@ use Symfony\Component\Lock\Strategy\ConsensusStrategy;
  */
 class ConsensusStrategyTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var ConsensusStrategy */
     private $strategy;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->strategy = new ConsensusStrategy();
     }

--- a/src/Symfony/Component/Lock/Tests/Strategy/UnanimousStrategyTest.php
+++ b/src/Symfony/Component/Lock/Tests/Strategy/UnanimousStrategyTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Strategy;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Strategy\UnanimousStrategy;
 
 /**
@@ -19,10 +20,12 @@ use Symfony\Component\Lock\Strategy\UnanimousStrategy;
  */
 class UnanimousStrategyTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var UnanimousStrategy */
     private $strategy;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->strategy = new UnanimousStrategy();
     }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -13,18 +13,21 @@ namespace Symfony\Component\OptionsResolver\Tests;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class OptionsResolverTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var OptionsResolver
      */
     private $resolver;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->resolver = new OptionsResolver();
     }

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Process\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Process\ExecutableFinder;
 
 /**
@@ -19,9 +20,11 @@ use Symfony\Component\Process\ExecutableFinder;
  */
 class ExecutableFinderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $path;
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if ($this->path) {
             // Restore path if it was changed.

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Process\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Exception\RuntimeException;
@@ -25,12 +26,14 @@ use Symfony\Component\Process\Process;
  */
 class ProcessTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private static $phpBin;
     private static $process;
     private static $sigchild;
     private static $notEnhancedSigchild = false;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         $phpBin = new PhpExecutableFinder();
         self::$phpBin = getenv('SYMFONY_PROCESS_PHP_TEST_BINARY') ?: ('phpdbg' === \PHP_SAPI ? 'php' : $phpBin->find());
@@ -40,7 +43,7 @@ class ProcessTest extends TestCase
         self::$sigchild = false !== strpos(ob_get_clean(), '--enable-sigchild');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         if (self::$process) {
             self::$process->stop(0);

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
@@ -12,17 +12,20 @@
 namespace Symfony\Component\PropertyAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 abstract class PropertyAccessorArrayAccessTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PropertyAccessor
      */
     protected $propertyAccessor;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->propertyAccessor = new PropertyAccessor();
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
@@ -12,23 +12,26 @@
 namespace Symfony\Component\PropertyAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccessorBuilder;
 
 class PropertyAccessorBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PropertyAccessorBuilder
      */
     protected $builder;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->builder = new PropertyAccessorBuilder();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->builder = null;
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -28,12 +29,14 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TypeHinted;
 
 class PropertyAccessorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PropertyAccessor
      */
     private $propertyAccessor;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->propertyAccessor = new PropertyAccessor();
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyPathBuilder;
 
@@ -20,6 +21,8 @@ use Symfony\Component\PropertyAccess\PropertyPathBuilder;
  */
 class PropertyPathBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const PREFIX = 'old1[old2].old3[old4][old5].old6';
 
     /**
@@ -27,7 +30,7 @@ class PropertyPathBuilderTest extends TestCase
      */
     private $builder;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->builder = new PropertyPathBuilder(new PropertyPath(self::PREFIX));
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/AbstractPropertyInfoExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/AbstractPropertyInfoExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NullExtractor;
@@ -22,12 +23,14 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class AbstractPropertyInfoExtractorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PropertyInfoExtractor
      */
     protected $propertyInfo;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $extractors = [new NullExtractor(), new DummyExtractor()];
         $this->propertyInfo = new PropertyInfoExtractor($extractors, $extractors, $extractors, $extractors);

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\PhpDocExtractor;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -20,12 +21,14 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class PhpDocExtractorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PhpDocExtractor
      */
     private $extractor;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->extractor = new PhpDocExtractor();
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Type;
@@ -21,12 +22,14 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class ReflectionExtractorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ReflectionExtractor
      */
     private $extractor;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->extractor = new ReflectionExtractor();
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -22,12 +23,14 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
  */
 class SerializerExtractorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var SerializerExtractor
      */
     private $extractor;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $this->extractor = new SerializerExtractor($classMetadataFactory);

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\PropertyInfo\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor;
 
@@ -19,7 +20,9 @@ use Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor;
  */
 class PropertyInfoCacheExtractorTest extends AbstractPropertyInfoExtractorTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Tests\Generator\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Generator\Dumper\PhpGeneratorDumper;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -20,6 +21,8 @@ use Symfony\Component\Routing\RouteCollection;
 
 class PhpGeneratorDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var RouteCollection
      */
@@ -40,7 +43,7 @@ class PhpGeneratorDumperTest extends TestCase
      */
     private $largeTestTmpFilepath;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -52,7 +55,7 @@ class PhpGeneratorDumperTest extends TestCase
         @unlink($this->largeTestTmpFilepath);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -11,14 +11,17 @@
 
 namespace Symfony\Component\Routing\Tests\Loader;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Annotation\Route;
 
 class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 {
+    use ForwardCompatTestTrait;
+
     protected $loader;
     private $reader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -11,15 +11,18 @@
 
 namespace Symfony\Component\Routing\Tests\Loader;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
 
 class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 {
+    use ForwardCompatTestTrait;
+
     protected $loader;
     protected $reader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -11,16 +11,19 @@
 
 namespace Symfony\Component\Routing\Tests\Loader;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Loader\AnnotationFileLoader;
 
 class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
 {
+    use ForwardCompatTestTrait;
+
     protected $loader;
     protected $reader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/DirectoryLoaderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Tests\Loader;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Routing\Loader\AnnotationFileLoader;
@@ -20,10 +21,12 @@ use Symfony\Component\Routing\RouteCollection;
 
 class DirectoryLoaderTest extends AbstractAnnotationLoaderTest
 {
+    use ForwardCompatTestTrait;
+
     private $loader;
     private $reader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Tests\Matcher\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper;
 use Symfony\Component\Routing\Matcher\RedirectableUrlMatcherInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
@@ -21,6 +22,8 @@ use Symfony\Component\Routing\RouteCollection;
 
 class PhpMatcherDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var string
      */
@@ -31,7 +34,7 @@ class PhpMatcherDumperTest extends TestCase
      */
     private $dumpPath;
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -39,7 +42,7 @@ class PhpMatcherDumperTest extends TestCase
         $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_matcher.'.$this->matcherClass.'.php';
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -12,17 +12,20 @@
 namespace Symfony\Component\Routing\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Router;
 
 class RouterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $router = null;
 
     private $loader = null;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
         $this->router = new Router($this->loader, 'routing.yml');

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -12,17 +12,20 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 
 class AuthorizationCheckerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $authenticationManager;
     private $accessDecisionManager;
     private $authorizationChecker;
     private $tokenStorage;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
         $this->accessDecisionManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock();

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class VoterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $token;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
     }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Encoder\Argon2iPasswordEncoder;
 
 /**
@@ -19,9 +20,11 @@ use Symfony\Component\Security\Core\Encoder\Argon2iPasswordEncoder;
  */
 class Argon2iPasswordEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const PASSWORD = 'password';
 
-    protected function setUp()
+    private function doSetUp()
     {
         if (!Argon2iPasswordEncoder::isSupported()) {
             $this->markTestSkipped('Argon2i algorithm is not supported.');

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Tests\Validator\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
@@ -23,6 +24,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     const PASSWORD = 's3Cr3t';
     const SALT = '^S4lt$';
 
@@ -46,7 +49,7 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         return new UserPasswordValidator($this->tokenStorage, $this->encoderFactory);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $user = $this->createUser();
         $this->tokenStorage = $this->createTokenStorage($user);

--- a/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Csrf\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -22,6 +23,8 @@ use Symfony\Component\Security\Csrf\CsrfTokenManager;
  */
 class CsrfTokenManagerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getManagerGeneratorAndStorage
      */
@@ -210,12 +213,12 @@ class CsrfTokenManagerTest extends TestCase
         ];
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $_SERVER['HTTPS'] = 'on';
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Csrf\Tests\TokenGenerator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
  */
 class UriSafeTokenGeneratorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const ENTROPY = 1000;
 
     /**
@@ -33,17 +36,17 @@ class UriSafeTokenGeneratorTest extends TestCase
      */
     private $generator;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$bytes = base64_decode('aMf+Tct/RLn2WQ==');
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->generator = new UriSafeTokenGenerator(self::ENTROPY);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->generator = null;
     }

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Csrf\Tests\TokenStorage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Csrf\TokenStorage\NativeSessionTokenStorage;
 
 /**
@@ -22,6 +23,8 @@ use Symfony\Component\Security\Csrf\TokenStorage\NativeSessionTokenStorage;
  */
 class NativeSessionTokenStorageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const SESSION_NAMESPACE = 'foobar';
 
     /**
@@ -29,7 +32,7 @@ class NativeSessionTokenStorageTest extends TestCase
      */
     private $storage;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $_SESSION = [];
 

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Csrf\Tests\TokenStorage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
@@ -21,6 +22,8 @@ use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
  */
 class SessionTokenStorageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const SESSION_NAMESPACE = 'foobar';
 
     /**
@@ -33,7 +36,7 @@ class SessionTokenStorageTest extends TestCase
      */
     private $storage;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->session = new Session(new MockArraySessionStorage());
         $this->storage = new SessionTokenStorage($this->session, self::SESSION_NAMESPACE);

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Guard\Tests\Authenticator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -23,6 +24,8 @@ use Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticato
  */
 class FormLoginAuthenticatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $requestWithoutSession;
     private $requestWithSession;
     private $authenticator;
@@ -127,7 +130,7 @@ class FormLoginAuthenticatorTest extends TestCase
         $this->assertEquals(self::LOGIN_URL, $failureResponse->getTargetUrl());
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->requestWithoutSession = new Request([], [], [], [], [], []);
         $this->requestWithSession = new Request([], [], [], [], [], []);

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Guard\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -28,6 +29,8 @@ use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
  */
 class GuardAuthenticationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $authenticationManager;
     private $guardAuthenticatorHandler;
     private $event;
@@ -420,7 +423,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $listener->handle($this->event);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager')
             ->disableOriginalConstructor()
@@ -445,7 +448,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $this->rememberMeServices = $this->getMockBuilder('Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface')->getMock();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->authenticationManager = null;
         $this->guardAuthenticatorHandler = null;

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Guard\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -22,6 +23,8 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 class GuardAuthenticatorHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $tokenStorage;
     private $dispatcher;
     private $token;
@@ -156,7 +159,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $handler->authenticateWithToken($this->token, $this->request, 'some_provider_key');
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
@@ -166,7 +169,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $this->guardAuthenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->tokenStorage = null;
         $this->dispatcher = null;

--- a/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Guard\Tests\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\AuthenticatorInterface;
@@ -24,6 +25,8 @@ use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
  */
 class GuardAuthenticationProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $userProvider;
     private $userChecker;
     private $preAuthenticationToken;
@@ -233,7 +236,7 @@ class GuardAuthenticationProviderTest extends TestCase
         $provider->authenticate($token);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();
         $this->userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
@@ -242,7 +245,7 @@ class GuardAuthenticationProviderTest extends TestCase
             ->getMock();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->userProvider = null;
         $this->userChecker = null;

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Authentication;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Security;
@@ -19,6 +20,8 @@ use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureH
 
 class DefaultAuthenticationFailureHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $httpKernel;
     private $httpUtils;
     private $logger;
@@ -26,7 +29,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     private $session;
     private $exception;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->httpKernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $this->httpUtils = $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -21,6 +22,8 @@ use Symfony\Component\Security\Http\Authentication\SimpleAuthenticationHandler;
 
 class SimpleAuthenticationHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $successHandler;
 
     private $failureHandler;
@@ -33,7 +36,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
 
     private $response;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->successHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface')->getMock();
         $this->failureHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/DigestDataTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/DigestDataTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Http\Firewall\DigestData;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\Security\Http\Firewall\DigestData;
  */
 class DigestDataTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetResponse()
     {
         $digestAuth = new DigestData(
@@ -163,7 +166,7 @@ class DigestDataTest extends TestCase
         $this->assertFalse($digestAuth->isNonceExpired());
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         class_exists('Symfony\Component\Security\Http\Firewall\DigestAuthenticationListener', true);
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
@@ -20,6 +21,8 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 class SimplePreAuthenticationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $authenticationManager;
     private $dispatcher;
     private $event;
@@ -93,7 +96,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $listener->handle($this->event);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager')
             ->disableOriginalConstructor()
@@ -116,7 +119,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $this->token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->authenticationManager = null;
         $this->dispatcher = null;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -25,6 +26,8 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 class SwitchUserListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $tokenStorage;
 
     private $userProvider;
@@ -37,7 +40,7 @@ class SwitchUserListenerTest extends TestCase
 
     private $event;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->tokenStorage = new TokenStorage();
         $this->userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Logout/CsrfTokenClearingLogoutHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/CsrfTokenClearingLogoutHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Logout;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -21,11 +22,13 @@ use Symfony\Component\Security\Http\Logout\CsrfTokenClearingLogoutHandler;
 
 class CsrfTokenClearingLogoutHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $session;
     private $csrfTokenStorage;
     private $csrfTokenClearingLogoutHandler;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->session = new Session(new MockArraySessionStorage());
         $this->csrfTokenStorage = new SessionTokenStorage($this->session, 'foo');

--- a/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Logout;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
@@ -25,12 +26,14 @@ use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
  */
 class LogoutUrlGeneratorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var TokenStorage */
     private $tokenStorage;
     /** @var LogoutUrlGenerator */
     private $generator;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $request = $this->getMockBuilder(Request::class)->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\RememberMe;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -24,7 +25,9 @@ use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
 class PersistentTokenBasedRememberMeServicesTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    use ForwardCompatTestTrait;
+
+    private static function doSetUpBeforeClass()
     {
         try {
             random_bytes(1);

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Encoder\ChainDecoder;
 
 class ChainDecoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const FORMAT_1 = 'format1';
     const FORMAT_2 = 'format2';
     const FORMAT_3 = 'format3';
@@ -24,7 +27,7 @@ class ChainDecoderTest extends TestCase
     private $decoder1;
     private $decoder2;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->decoder1 = $this
             ->getMockBuilder('Symfony\Component\Serializer\Encoder\DecoderInterface')

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Encoder\ChainEncoder;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Encoder\NormalizationAwareInterface;
 
 class ChainEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const FORMAT_1 = 'format1';
     const FORMAT_2 = 'format2';
     const FORMAT_3 = 'format3';
@@ -26,7 +29,7 @@ class ChainEncoderTest extends TestCase
     private $encoder1;
     private $encoder2;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->encoder1 = $this
             ->getMockBuilder('Symfony\Component\Serializer\Encoder\EncoderInterface')

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 
 /**
@@ -19,12 +20,14 @@ use Symfony\Component\Serializer\Encoder\CsvEncoder;
  */
 class CsvEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var CsvEncoder
      */
     private $encoder;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->encoder = new CsvEncoder();
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
@@ -12,15 +12,18 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 class JsonDecodeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var \Symfony\Component\Serializer\Encoder\JsonDecode */
     private $decode;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->decode = new JsonDecode();
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncodeTest.php
@@ -12,14 +12,17 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 class JsonEncodeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $encoder;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->encode = new JsonEncode();
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
 class JsonEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $encoder;
     private $serializer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->encoder = new JsonEncoder();
         $this->serializer = new Serializer([new CustomNormalizer()], ['json' => new JsonEncoder()]);

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -22,6 +23,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\ScalarDummy;
 
 class XmlEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var XmlEncoder
      */
@@ -29,7 +32,7 @@ class XmlEncoderTest extends TestCase
 
     private $exampleDateTimeString = '2017-02-19T15:16:08+0300';
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->encoder = new XmlEncoder();
         $serializer = new Serializer([new CustomNormalizer()], ['xml' => new XmlEncoder()]);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Mapping\Loader;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
@@ -22,12 +23,14 @@ use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
  */
 class AnnotationLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var AnnotationLoader
      */
     private $loader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->loader = new AnnotationLoader(new AnnotationReader());
     }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Mapping\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
@@ -21,6 +22,8 @@ use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
  */
 class XmlFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var XmlFileLoader
      */
@@ -30,7 +33,7 @@ class XmlFileLoaderTest extends TestCase
      */
     private $metadata;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->loader = new XmlFileLoader(__DIR__.'/../../Fixtures/serialization.xml');
         $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Mapping\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
@@ -21,6 +22,8 @@ use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
  */
 class YamlFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var YamlFileLoader
      */
@@ -30,7 +33,7 @@ class YamlFileLoaderTest extends TestCase
      */
     private $metadata;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->loader = new YamlFileLoader(__DIR__.'/../../Fixtures/serialization.yml');
         $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -25,6 +26,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\VariadicConstructorTypedArgsDumm
  */
 class AbstractNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var AbstractNormalizerDummy
      */
@@ -35,7 +38,7 @@ class AbstractNormalizerTest extends TestCase
      */
     private $classMetadata;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Serializer\Mapping\Loader\LoaderChain')->setConstructorArgs([[]])->getMock();
         $this->classMetadata = $this->getMockBuilder('Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory')->setConstructorArgs([$loader])->getMock();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class ArrayDenormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ArrayDenormalizer
      */
@@ -27,7 +30,7 @@ class ArrayDenormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->serializer = $this->getMockBuilder('Symfony\Component\Serializer\Serializer')->getMock();
         $this->denormalizer = new ArrayDenormalizer();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/CustomNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/CustomNormalizerTest.php
@@ -12,18 +12,21 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Fixtures\ScalarDummy;
 
 class CustomNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var CustomNormalizer
      */
     private $normalizer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->normalizer = new CustomNormalizer();
         $this->normalizer->setSerializer(new Serializer());

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
  */
 class DataUriNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const TEST_GIF_DATA = 'data:image/gif;base64,R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=';
     const TEST_TXT_DATA = 'data:text/plain,K%C3%A9vin%20Dunglas%0A';
     const TEST_TXT_CONTENT = "Kévin Dunglas\n";
@@ -29,7 +32,7 @@ class DataUriNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->normalizer = new DataUriNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
 
 /**
@@ -10,12 +11,14 @@ use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
  */
 class DateIntervalNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var DateIntervalNormalizer
      */
     private $normalizer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->normalizer = new DateIntervalNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 /**
@@ -19,12 +20,14 @@ use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
  */
 class DateTimeNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var DateTimeNormalizer
      */
     private $normalizer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->normalizer = new DateTimeNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
@@ -27,6 +28,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 
 class GetSetMethodNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var GetSetMethodNormalizer
      */
@@ -36,7 +39,7 @@ class GetSetMethodNormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->serializer = $this->getMockBuilder(__NAMESPACE__.'\SerializerNormalizer')->getMock();
         $this->normalizer = new GetSetMethodNormalizer();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -22,6 +23,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\JsonSerializableDummy;
  */
 class JsonSerializableNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var JsonSerializableNormalizer
      */
@@ -32,7 +35,7 @@ class JsonSerializableNormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->serializer = $this->getMockBuilder(JsonSerializerNormalizer::class)->getMock();
         $this->normalizer = new JsonSerializableNormalizer();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
@@ -35,6 +36,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
  */
 class ObjectNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ObjectNormalizer
      */
@@ -44,7 +47,7 @@ class ObjectNormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->serializer = $this->getMockBuilder(__NAMESPACE__.'\ObjectSerializerNormalizer')->getMock();
         $this->normalizer = new ObjectNormalizer();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
@@ -27,6 +28,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\PropertySiblingHolder;
 
 class PropertyNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var PropertyNormalizer
      */
@@ -36,7 +39,7 @@ class PropertyNormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->serializer = $this->getMockBuilder('Symfony\Component\Serializer\SerializerInterface')->getMock();
         $this->normalizer = new PropertyNormalizer();

--- a/src/Symfony/Component/Templating/Tests/Loader/ChainLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/ChainLoaderTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\Templating\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Templating\Loader\ChainLoader;
 use Symfony\Component\Templating\Loader\FilesystemLoader;
 use Symfony\Component\Templating\TemplateReference;
 
 class ChainLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $loader1;
     protected $loader2;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $fixturesPath = realpath(__DIR__.'/../Fixtures/');
         $this->loader1 = new FilesystemLoader($fixturesPath.'/null/%name%');

--- a/src/Symfony/Component/Templating/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/FilesystemLoaderTest.php
@@ -12,14 +12,17 @@
 namespace Symfony\Component\Templating\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Templating\Loader\FilesystemLoader;
 use Symfony\Component\Templating\TemplateReference;
 
 class FilesystemLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Templating\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Templating\Helper\SlotsHelper;
 use Symfony\Component\Templating\Loader\Loader;
 use Symfony\Component\Templating\PhpEngine;
@@ -22,14 +23,16 @@ use Symfony\Component\Templating\TemplateReferenceInterface;
 
 class PhpEngineTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $loader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->loader = new ProjectTemplateLoader();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->loader = null;
     }

--- a/src/Symfony/Component/Templating/Tests/TemplateNameParserTest.php
+++ b/src/Symfony/Component/Templating/Tests/TemplateNameParserTest.php
@@ -12,19 +12,22 @@
 namespace Symfony\Component\Templating\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Templating\TemplateNameParser;
 use Symfony\Component\Templating\TemplateReference;
 
 class TemplateNameParserTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $parser;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->parser = new TemplateNameParser();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->parser = null;
     }

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Translation\Tests\DataCollector;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Translation\DataCollector\TranslationDataCollector;
 use Symfony\Component\Translation\DataCollectorTranslator;
 
 class TranslationDataCollectorTest extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         if (!class_exists('Symfony\Component\HttpKernel\DataCollector\DataCollector')) {
             $this->markTestSkipped('The "DataCollector" is not available');

--- a/src/Symfony/Component/Translation/Tests/Loader/LocalizedTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/LocalizedTestCase.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 abstract class LocalizedTestCase extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         if (!\extension_loaded('intl')) {
             $this->markTestSkipped('Extension intl is required.');

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\LoaderInterface;
@@ -20,15 +21,17 @@ use Symfony\Component\Translation\Translator;
 
 class TranslatorCacheTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $tmpDir;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->tmpDir = sys_get_temp_dir().'/sf2_translation';
         $this->deleteTmpDir();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->deleteTmpDir();
     }

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Mapping\PropertyMetadata;
  */
 abstract class ConstraintValidatorTestCase extends TestCase
 {
-    use TestCaseSetUpTearDownTrait;
+    use ForwardCompatTestTrait;
 
     /**
      * @var ExecutionContextInterface

--- a/src/Symfony/Component/Validator/Test/ForwardCompatTestTrait.php
+++ b/src/Symfony/Component/Validator/Test/ForwardCompatTestTrait.php
@@ -22,7 +22,7 @@ if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \Reflection
     /**
      * @internal
      */
-    trait TestCaseSetUpTearDownTrait
+    trait ForwardCompatTestTrait
     {
         private function doSetUp(): void
         {
@@ -47,7 +47,7 @@ if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \Reflection
     /**
      * @internal
      */
-    trait TestCaseSetUpTearDownTrait
+    trait ForwardCompatTestTrait
     {
         /**
          * @return void

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -12,19 +12,22 @@
 namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
 class ConstraintViolationListTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $list;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->list = new ConstraintViolationList();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->list = null;
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\FileValidator;
@@ -18,6 +19,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 abstract class FileValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $path;
 
     protected $file;
@@ -27,7 +30,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         return new FileValidator();
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -36,7 +39,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         fwrite($this->file, ' ', 1);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Component\Validator\Constraints\ImageValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class ImageValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $context;
 
     /**
@@ -39,7 +42,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         return new ImageValidator();
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\TypeValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class TypeValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected static $file;
 
     protected function createValidator()
@@ -172,7 +175,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
         return static::$file;
     }
 
-    public static function tearDownAfterClass()
+    private static function doTearDownAfterClass()
     {
         if (static::$file) {
             fclose(static::$file);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Validator\Tests\Mapping\Cache;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
 
 class DoctrineCacheTest extends AbstractCacheTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         $this->cache = new DoctrineCache(new ArrayCache());
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/Psr6CacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/Psr6CacheTest.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\Validator\Tests\Mapping\Cache;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Validator\Mapping\Cache\Psr6Cache;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -11,7 +12,9 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
  */
 class Psr6CacheTest extends AbstractCacheTest
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         $this->cache = new Psr6Cache(new ArrayAdapter());
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Mapping;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -21,6 +22,8 @@ use Symfony\Component\Validator\Tests\Fixtures\PropertyConstraint;
 
 class ClassMetadataTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
     const PARENTCLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
     const PROVIDERCLASS = 'Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity';
@@ -28,12 +31,12 @@ class ClassMetadataTest extends TestCase
 
     protected $metadata;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->metadata = new ClassMetadata(self::CLASSNAME);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->metadata = null;
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -12,20 +12,23 @@
 namespace Symfony\Component\Validator\Tests\Mapping\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 
 class StaticMethodLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $errorLevel;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->errorLevel = error_reporting();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         error_reporting($this->errorLevel);
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/MemberMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/MemberMetadataTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Mapping;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\MemberMetadata;
 use Symfony\Component\Validator\Tests\Fixtures\ClassConstraint;
@@ -20,9 +21,11 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 
 class MemberMetadataTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $metadata;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->metadata = new TestMemberMetadata(
             'Symfony\Component\Validator\Tests\Fixtures\Entity',
@@ -31,7 +34,7 @@ class MemberMetadataTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->metadata = null;
     }

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Validator;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Expression;
@@ -33,6 +34,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 abstract class AbstractTest extends AbstractValidatorTest
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ValidatorInterface
      */
@@ -43,7 +46,7 @@ abstract class AbstractTest extends AbstractValidatorTest
      */
     abstract protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = []);
 
-    protected function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Valid;
@@ -28,6 +29,8 @@ use Symfony\Component\Validator\Tests\Fixtures\Reference;
  */
 abstract class AbstractValidatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const ENTITY_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
 
     const REFERENCE_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\Reference';
@@ -47,7 +50,7 @@ abstract class AbstractValidatorTest extends TestCase
      */
     public $referenceMetadata;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->metadataFactory = new FakeMetadataFactory();
         $this->metadata = new ClassMetadata(self::ENTITY_CLASS);
@@ -56,7 +59,7 @@ abstract class AbstractValidatorTest extends TestCase
         $this->metadataFactory->addMetadata($this->referenceMetadata);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->metadataFactory = null;
         $this->metadata = null;

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -12,22 +12,25 @@
 namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\ValidatorBuilder;
 use Symfony\Component\Validator\ValidatorBuilderInterface;
 
 class ValidatorBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var ValidatorBuilderInterface
      */
     protected $builder;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->builder = new ValidatorBuilder();
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->builder = null;
     }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Caster;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\ExceptionCaster;
 use Symfony\Component\VarDumper\Caster\FrameStub;
@@ -21,6 +22,7 @@ use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 
 class ExceptionCasterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
     use VarDumperTestTrait;
 
     private function getTestException($msg, &$ref = null)
@@ -28,7 +30,7 @@ class ExceptionCasterTest extends TestCase
         return new \Exception(''.$msg);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         ExceptionCaster::$srcContext = 1;
         ExceptionCaster::$traceArgs = true;
@@ -44,14 +46,14 @@ Exception {
   #message: "foo"
   #code: 0
   #file: "%sExceptionCasterTest.php"
-  #line: 28
+  #line: 30
   trace: {
-    %s%eTests%eCaster%eExceptionCasterTest.php:28 {
+    %s%eTests%eCaster%eExceptionCasterTest.php:30 {
       › {
       ›     return new \Exception(''.$msg);
       › }
     }
-    %s%eTests%eCaster%eExceptionCasterTest.php:40 { …}
+    %s%eTests%eCaster%eExceptionCasterTest.php:42 { …}
     Symfony\Component\VarDumper\Tests\Caster\ExceptionCasterTest->testDefaultSettings() {}
 %A
 EODUMP;
@@ -66,12 +68,12 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 {
-  %s%eTests%eCaster%eExceptionCasterTest.php:28 {
+  %s%eTests%eCaster%eExceptionCasterTest.php:30 {
     › {
     ›     return new \Exception(''.$msg);
     › }
   }
-  %s%eTests%eCaster%eExceptionCasterTest.php:65 { …}
+  %s%eTests%eCaster%eExceptionCasterTest.php:67 { …}
   Symfony\Component\VarDumper\Tests\Caster\ExceptionCasterTest->testSeek() {}
 %A
 EODUMP;
@@ -89,14 +91,14 @@ Exception {
   #message: "1"
   #code: 0
   #file: "%sExceptionCasterTest.php"
-  #line: 28
+  #line: 30
   trace: {
-    %sExceptionCasterTest.php:28 {
+    %sExceptionCasterTest.php:30 {
       › {
       ›     return new \Exception(''.$msg);
       › }
     }
-    %s%eTests%eCaster%eExceptionCasterTest.php:84 { …}
+    %s%eTests%eCaster%eExceptionCasterTest.php:86 { …}
     Symfony\Component\VarDumper\Tests\Caster\ExceptionCasterTest->testNoArgs() {}
 %A
 EODUMP;
@@ -114,9 +116,9 @@ Exception {
   #message: "1"
   #code: 0
   #file: "%sExceptionCasterTest.php"
-  #line: 28
+  #line: 30
   trace: {
-    %s%eTests%eCaster%eExceptionCasterTest.php:28
+    %s%eTests%eCaster%eExceptionCasterTest.php:30
     %s%eTests%eCaster%eExceptionCasterTest.php:%d
 %A
 EODUMP;
@@ -146,10 +148,10 @@ EODUMP;
   #<span class=sf-dump-protected title="Protected property">code</span>: <span class=sf-dump-num>0</span>
   #<span class=sf-dump-protected title="Protected property">file</span>: "<span class=sf-dump-str title="%sExceptionCasterTest.php
 %d characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class=sf-dump-ellipsis>%e</span>Tests%eCaster%eExceptionCasterTest.php</span>"
-  #<span class=sf-dump-protected title="Protected property">line</span>: <span class=sf-dump-num>28</span>
+  #<span class=sf-dump-protected title="Protected property">line</span>: <span class=sf-dump-num>30</span>
   <span class=sf-dump-meta>trace</span>: {<samp>
     <span class=sf-dump-meta title="%sExceptionCasterTest.php
-Stack level %d."><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class=sf-dump-ellipsis>%e</span>Tests%eCaster%eExceptionCasterTest.php</span>:<span class=sf-dump-num>28</span>
+Stack level %d."><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class=sf-dump-ellipsis>%e</span>Tests%eCaster%eExceptionCasterTest.php</span>:<span class=sf-dump-num>30</span>
      &hellip;%d
   </samp>}
 </samp>}
@@ -221,7 +223,7 @@ Exception {
   #message: "foo"
   #code: 0
   #file: "%sExceptionCasterTest.php"
-  #line: 28
+  #line: 30
 }
 EODUMP;
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Caster;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 
 /**
@@ -19,18 +20,19 @@ use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
  */
 class XmlReaderCasterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
     use VarDumperTestTrait;
 
     /** @var \XmlReader */
     private $reader;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->reader = new \XmlReader();
         $this->reader->open(__DIR__.'/../Fixtures/xml_reader.xml');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->reader->close();
     }

--- a/src/Symfony/Component/WebLink/Tests/HttpHeaderSerializerTest.php
+++ b/src/Symfony/Component/WebLink/Tests/HttpHeaderSerializerTest.php
@@ -13,16 +13,19 @@ namespace Symfony\Component\WebLink\Tests;
 
 use Fig\Link\Link;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 class HttpHeaderSerializerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var HttpHeaderSerializer
      */
     private $serializer;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->serializer = new HttpHeaderSerializer();
     }

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -3,17 +3,19 @@
 namespace Symfony\Component\Workflow\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Workflow\Dumper\GraphvizDumper;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Tests\WorkflowBuilderTrait;
 
 class GraphvizDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
     use WorkflowBuilderTrait;
 
     private $dumper;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dumper = new GraphvizDumper();
     }

--- a/src/Symfony/Component/Workflow/Tests/Dumper/StateMachineGraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/StateMachineGraphvizDumperTest.php
@@ -3,17 +3,19 @@
 namespace Symfony\Component\Workflow\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Workflow\Dumper\StateMachineGraphvizDumper;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Tests\WorkflowBuilderTrait;
 
 class StateMachineGraphvizDumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
     use WorkflowBuilderTrait;
 
     private $dumper;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->dumper = new StateMachineGraphvizDumper();
     }

--- a/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Workflow\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -18,12 +19,14 @@ use Symfony\Component\Workflow\Transition;
 
 class GuardListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $authenticationChecker;
     private $validator;
     private $listener;
     private $configuration;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->configuration = [
             'test_is_granted' => 'is_granted("something")',
@@ -44,7 +47,7 @@ class GuardListenerTest extends TestCase
         $this->listener = new GuardListener($this->configuration, $expressionLanguage, $tokenStorage, $this->authenticationChecker, $trustResolver, null, $this->validator);
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->authenticationChecker = null;
         $this->validator = null;

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Workflow\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
@@ -12,9 +13,11 @@ use Symfony\Component\Workflow\Workflow;
 
 class RegistryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $registry;
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->registry = new Registry();
 
@@ -23,7 +26,7 @@ class RegistryTest extends TestCase
         $this->registry->add(new Workflow(new Definition([], []), $this->getMockBuilder(MarkingStoreInterface::class)->getMock(), $this->getMockBuilder(EventDispatcherInterface::class)->getMock(), 'workflow3'), $this->createSupportStrategy(Subject2::class));
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->registry = null;
     }

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Yaml\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -24,6 +25,8 @@ use Symfony\Component\Yaml\Command\LintCommand;
  */
 class LintCommandTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $files;
 
     public function testLintCorrectFile()
@@ -115,13 +118,13 @@ YAML;
         return new CommandTester($command);
     }
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->files = [];
         @mkdir(sys_get_temp_dir().'/framework-yml-lint-test');
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Yaml\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Tag\TaggedValue;
@@ -19,6 +20,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class DumperTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $parser;
     protected $dumper;
     protected $path;
@@ -38,14 +41,14 @@ class DumperTest extends TestCase
         ],
     ];
 
-    protected function setUp()
+    private function doSetUp()
     {
         $this->parser = new Parser();
         $this->dumper = new Dumper();
         $this->path = __DIR__.'/Fixtures';
     }
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->parser = null;
         $this->dumper = null;

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -12,13 +12,16 @@
 namespace Symfony\Component\Yaml\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Inline;
 use Symfony\Component\Yaml\Yaml;
 
 class InlineTest extends TestCase
 {
-    protected function setUp()
+    use ForwardCompatTestTrait;
+
+    private function doSetUp()
     {
         Inline::initialize(0, 0);
     }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Yaml\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Tag\TaggedValue;
@@ -19,6 +20,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class ParserTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @var Parser */
     protected $parser;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Having `void` on setUp/tearDown is **really** painful /cc @sebastianbergmann FYI

This works around the issue by adding a new trait to the phpunit-bridge : `ForwardCompatTestTrait`.
Another reason why the bridge is so useful...

With this change, we should have the same codebase be able to run under phpunit 4.8 (used with PHP5.5) up to phpunit 8.2 (used with PHP7.4).

:crossed_fingers: :face_with_head_bandage: 

One more step towards PHP 7.4 support.