### PR TITLE
[PhpUnitBridge] Fix deprecation assertInternalType

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1466,7 +1466,7 @@ class EntityTypeTest extends BaseTypeTest
         ]);
         $form->setData($emptyArray);
         $form->submit(null);
-        $this->assertInternalType('array', $form->getData());
+        $this->assertIsArray($form->getData());
         $this->assertEquals([], $form->getData());
         $this->assertEquals([], $form->getNormData());
         $this->assertSame([], $form->getViewData(), 'View data is always an array');
@@ -1484,7 +1484,7 @@ class EntityTypeTest extends BaseTypeTest
         $existing = [0 => $entity1];
         $form->setData($existing);
         $form->submit(null);
-        $this->assertInternalType('array', $form->getData());
+        $this->assertIsArray($form->getData());
         $this->assertEquals([], $form->getData());
         $this->assertEquals([], $form->getNormData());
         $this->assertSame([], $form->getViewData(), 'View data is always an array');

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV5.php
@@ -79,4 +79,114 @@ trait ForwardCompatTestTraitForV5
     {
         parent::tearDown();
     }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsArray($actual, $message = '')
+    {
+        static::assertInternalType('array', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsBool($actual, $message = '')
+    {
+        static::assertInternalType('bool', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsFloat($actual, $message = '')
+    {
+        static::assertInternalType('float', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsInt($actual, $message = '')
+    {
+        static::assertInternalType('int', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsNumeric($actual, $message = '')
+    {
+        static::assertInternalType('numeric', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsObject($actual, $message = '')
+    {
+        static::assertInternalType('object', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsResource($actual, $message = '')
+    {
+        static::assertInternalType('resource', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsString($actual, $message = '')
+    {
+        static::assertInternalType('string', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsScalar($actual, $message = '')
+    {
+        static::assertInternalType('scalar', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsCallable($actual, $message = '')
+    {
+        static::assertInternalType('callable', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsIterable($actual, $message = '')
+    {
+        static::assertInternalType('iterable', $actual, $message);
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
@@ -50,7 +50,7 @@ class SerializerCacheWarmerTest extends TestCase
 
         $values = $fallbackPool->getValues();
 
-        $this->assertInternalType('array', $values);
+        $this->assertIsArray($values);
         $this->assertCount(2, $values);
         $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person', $values);
         $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author', $values);
@@ -74,7 +74,7 @@ class SerializerCacheWarmerTest extends TestCase
 
         $values = $fallbackPool->getValues();
 
-        $this->assertInternalType('array', $values);
+        $this->assertIsArray($values);
         $this->assertCount(0, $values);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
@@ -46,7 +46,7 @@ class ValidatorCacheWarmerTest extends TestCase
 
         $values = $fallbackPool->getValues();
 
-        $this->assertInternalType('array', $values);
+        $this->assertIsArray($values);
         $this->assertCount(2, $values);
         $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Person', $values);
         $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Author', $values);
@@ -77,7 +77,7 @@ class ValidatorCacheWarmerTest extends TestCase
 
         $values = $fallbackPool->getValues();
 
-        $this->assertInternalType('array', $values);
+        $this->assertIsArray($values);
         $this->assertCount(2, $values);
         $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Category', $values);
         $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.SubCategory', $values);
@@ -99,7 +99,7 @@ class ValidatorCacheWarmerTest extends TestCase
 
         $values = $fallbackPool->getValues();
 
-        $this->assertInternalType('array', $values);
+        $this->assertIsArray($values);
         $this->assertCount(0, $values);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
@@ -30,7 +30,7 @@ class ProfilerTest extends AbstractWebTestCase
         $client->enableProfiler();
         $this->assertFalse($client->getProfile());
         $client->request('GET', '/profiler');
-        $this->assertInternalType('object', $client->getProfile());
+        $this->assertIsObject($client->getProfile());
 
         $client->request('GET', '/profiler');
         $this->assertFalse($client->getProfile());

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Tests\Fixtures\Builder\NodeBuilder as CustomNodeBuilder;
 
 class TreeBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testUsingACustomNodeBuilder()
     {
         $builder = new TreeBuilder();
@@ -128,7 +131,7 @@ class TreeBuilderTest extends TestCase
         $tree = $builder->buildTree();
         $children = $tree->getChildren();
 
-        $this->assertInternalType('array', $tree->getExample());
+        $this->assertIsArray($tree->getExample());
         $this->assertEquals('example', $children['child']->getExample());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -16,6 +16,7 @@ require_once __DIR__.'/Fixtures/includes/ProjectExtension.php';
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\ComposerResource;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileResource;
@@ -45,6 +46,8 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 class ContainerBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testDefaultRegisteredDefinitions()
     {
         $builder = new ContainerBuilder();
@@ -168,7 +171,7 @@ class ContainerBuilderTest extends TestCase
         $builder = new ContainerBuilder();
         $builder->register('foo', 'stdClass');
 
-        $this->assertInternalType('object', $builder->get('foo'), '->get() returns the service definition associated with the id');
+        $this->assertIsObject($builder->get('foo'), '->get() returns the service definition associated with the id');
     }
 
     public function testGetReturnsRegisteredService()
@@ -662,7 +665,7 @@ class ContainerBuilderTest extends TestCase
         $container->resolveEnvPlaceholders('%dummy%', true);
         $container->resolveEnvPlaceholders('%dummy2%', true);
 
-        $this->assertInternalType('array', $container->resolveEnvPlaceholders('%dummy2%', true));
+        $this->assertIsArray($container->resolveEnvPlaceholders('%dummy2%', true));
 
         foreach ($dummyArray as $key => $value) {
             $this->assertArrayHasKey($key, $container->resolveEnvPlaceholders('%dummy2%', true));

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -599,7 +599,7 @@ class YamlFileLoaderTest extends TestCase
 
         // Anonymous service in a callable
         $factory = $definition->getFactory();
-        $this->assertInternalType('array', $factory);
+        $this->assertIsArray($factory);
         $this->assertInstanceOf(Reference::class, $factory[0]);
         $this->assertTrue($container->has((string) $factory[0]));
         $this->assertRegExp('/^\d+_Quz~[._A-Za-z0-9]{7}$/', (string) $factory[0]);

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\DependencyInjection\Tests\ParameterBag;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 
 class EnvPlaceholderParameterBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */
@@ -42,7 +45,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $placeholder = array_values($placeholderForVariable)[0];
 
         $this->assertCount(1, $placeholderForVariable);
-        $this->assertInternalType('string', $placeholder);
+        $this->assertIsString($placeholder);
         $this->assertContains($envVariableName, $placeholder);
     }
 
@@ -65,7 +68,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $placeholder = array_values($placeholderForVariable)[0];
 
         $this->assertCount(1, $placeholderForVariable);
-        $this->assertInternalType('string', $placeholder);
+        $this->assertIsString($placeholder);
         $this->assertContains($envVariableName, $placeholder);
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\DomCrawler\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DomCrawler\Crawler;
 
 class CrawlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $crawler = new Crawler();
@@ -843,7 +846,7 @@ HTML;
     public function testLinks()
     {
         $crawler = $this->createTestCrawler('http://example.com/bar/')->selectLink('Foo');
-        $this->assertInternalType('array', $crawler->links(), '->links() returns an array');
+        $this->assertIsArray($crawler->links(), '->links() returns an array');
 
         $this->assertCount(4, $crawler->links(), '->links() returns an array');
         $links = $crawler->links();
@@ -855,7 +858,7 @@ HTML;
     public function testImages()
     {
         $crawler = $this->createTestCrawler('http://example.com/bar/')->selectImage('Bar');
-        $this->assertInternalType('array', $crawler->images(), '->images() returns an array');
+        $this->assertIsArray($crawler->images(), '->images() returns an array');
 
         $this->assertCount(4, $crawler->images(), '->images() returns an array');
         $images = $crawler->images();

--- a/src/Symfony/Component/DomCrawler/Tests/Field/FileFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/FileFormFieldTest.php
@@ -11,10 +11,13 @@
 
 namespace Symfony\Component\DomCrawler\Tests\Field;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DomCrawler\Field\FileFormField;
 
 class FileFormFieldTest extends FormFieldTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testInitialize()
     {
         $node = $this->createNode('input', '', ['type' => 'file']);
@@ -55,7 +58,7 @@ class FileFormFieldTest extends FormFieldTestCase
 
         $this->assertEquals(basename(__FILE__), $value['name'], "->$method() sets the name of the file field");
         $this->assertEquals('', $value['type'], "->$method() sets the type of the file field");
-        $this->assertInternalType('string', $value['tmp_name'], "->$method() sets the tmp_name of the file field");
+        $this->assertIsString($value['tmp_name'], "->$method() sets the tmp_name of the file field");
         $this->assertFileExists($value['tmp_name'], "->$method() creates a copy of the file at the tmp_name path");
         $this->assertEquals(0, $value['error'], "->$method() sets the error of the file field");
         $this->assertEquals(filesize(__FILE__), $value['size'], "->$method() sets the size of the file field");

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/DataCollectorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/DataCollectorExtensionTest.php
@@ -39,7 +39,7 @@ class DataCollectorExtensionTest extends TestCase
     {
         $typeExtensions = $this->extension->getTypeExtensions('Symfony\Component\Form\Extension\Core\Type\FormType');
 
-        $this->assertInternalType('array', $typeExtensions);
+        $this->assertIsArray($typeExtensions);
         $this->assertCount(1, $typeExtensions);
         $this->assertInstanceOf('Symfony\Component\Form\Extension\DataCollector\Type\DataCollectorTypeExtension', array_shift($typeExtensions));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Test\FormInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Constraints\GroupSequence;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
  */
 abstract class BaseValidatorExtensionTest extends TypeTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testValidationGroupNullByDefault()
     {
         $form = $this->createForm();
@@ -60,7 +63,7 @@ abstract class BaseValidatorExtensionTest extends TypeTestCase
             'validation_groups' => [$this, 'testValidationGroupsCanBeSetToCallback'],
         ]);
 
-        $this->assertInternalType('callable', $form->getConfig()->getOption('validation_groups'));
+        $this->assertIsCallable($form->getConfig()->getOption('validation_groups'));
     }
 
     public function testValidationGroupsCanBeSetToClosure()
@@ -69,7 +72,7 @@ abstract class BaseValidatorExtensionTest extends TypeTestCase
             'validation_groups' => function (FormInterface $form) { },
         ]);
 
-        $this->assertInternalType('callable', $form->getConfig()->getOption('validation_groups'));
+        $this->assertIsCallable($form->getConfig()->getOption('validation_groups'));
     }
 
     public function testValidationGroupsCanBeSetToGroupSequence()

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -56,7 +56,7 @@ class JsonResponseTest extends TestCase
 
         $response = new JsonResponse(0.1);
         $this->assertEquals('0.1', $response->getContent());
-        $this->assertInternalType('string', $response->getContent());
+        $this->assertIsString($response->getContent());
 
         $response = new JsonResponse(true);
         $this->assertSame('true', $response->getContent());
@@ -145,7 +145,7 @@ class JsonResponseTest extends TestCase
         $response = JsonResponse::create(0.1);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
         $this->assertEquals('0.1', $response->getContent());
-        $this->assertInternalType('string', $response->getContent());
+        $this->assertIsString($response->getContent());
 
         $response = JsonResponse::create(true);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1156,7 +1156,7 @@ class RequestTest extends TestCase
     {
         $req = new Request();
         $retval = $req->getContent(true);
-        $this->assertInternalType('resource', $retval);
+        $this->assertIsResource($retval);
         $this->assertEquals('', fread($retval, 1));
         $this->assertTrue(feof($retval));
     }
@@ -1166,7 +1166,7 @@ class RequestTest extends TestCase
         $req = new Request([], [], [], [], [], [], 'MyContent');
         $resource = $req->getContent(true);
 
-        $this->assertInternalType('resource', $resource);
+        $this->assertIsResource($resource);
         $this->assertEquals('MyContent', stream_get_contents($resource));
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -101,7 +101,7 @@ class NativeSessionStorageTest extends TestCase
 
         $storage->start();
         $id = $storage->getId();
-        $this->assertInternalType('string', $id);
+        $this->assertIsString($id);
         $this->assertNotSame('', $id);
 
         $storage->save();

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/MemoryDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/MemoryDataCollectorTest.php
@@ -12,19 +12,22 @@
 namespace Symfony\Component\HttpKernel\Tests\DataCollector;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector;
 
 class MemoryDataCollectorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCollect()
     {
         $collector = new MemoryDataCollector();
         $collector->collect(new Request(), new Response());
 
-        $this->assertInternalType('integer', $collector->getMemory());
-        $this->assertInternalType('integer', $collector->getMemoryLimit());
+        $this->assertIsInt($collector->getMemory());
+        $this->assertIsInt($collector->getMemoryLimit());
         $this->assertSame('memory', $collector->getName());
     }
 

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
@@ -36,7 +36,7 @@ class JsonBundleReaderTest extends TestCase
     {
         $data = $this->reader->read(__DIR__.'/Fixtures/json', 'en');
 
-        $this->assertInternalType('array', $data);
+        $this->assertIsArray($data);
         $this->assertSame('Bar', $data['Foo']);
         $this->assertArrayNotHasKey('ExistsNot', $data);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
@@ -36,7 +36,7 @@ class PhpBundleReaderTest extends TestCase
     {
         $data = $this->reader->read(__DIR__.'/Fixtures/php', 'en');
 
-        $this->assertInternalType('array', $data);
+        $this->assertIsArray($data);
         $this->assertSame('Bar', $data['Foo']);
         $this->assertArrayNotHasKey('ExistsNot', $data);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
@@ -709,7 +709,7 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
      */
     public function testGetFractionDigits($currency)
     {
-        $this->assertInternalType('numeric', $this->dataProvider->getFractionDigits($currency));
+        $this->assertIsNumeric($this->dataProvider->getFractionDigits($currency));
     }
 
     /**
@@ -717,7 +717,7 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
      */
     public function testGetRoundingIncrement($currency)
     {
-        $this->assertInternalType('numeric', $this->dataProvider->getRoundingIncrement($currency));
+        $this->assertIsNumeric($this->dataProvider->getRoundingIncrement($currency));
     }
 
     public function provideCurrenciesWithNumericEquivalent()

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -748,11 +748,11 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
 
         $parsedValue = $formatter->parse('2,147,483,647', NumberFormatter::TYPE_INT64);
-        $this->assertInternalType('integer', $parsedValue);
+        $this->assertIsInt($parsedValue);
         $this->assertEquals(2147483647, $parsedValue);
 
         $parsedValue = $formatter->parse('-2,147,483,648', NumberFormatter::TYPE_INT64);
-        $this->assertInternalType('int', $parsedValue);
+        $this->assertIsInt($parsedValue);
         $this->assertEquals(-2147483648, $parsedValue);
     }
 
@@ -763,11 +763,11 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
 
         $parsedValue = $formatter->parse('2,147,483,647', NumberFormatter::TYPE_INT64);
-        $this->assertInternalType('integer', $parsedValue);
+        $this->assertIsInt($parsedValue);
         $this->assertEquals(2147483647, $parsedValue);
 
         $parsedValue = $formatter->parse('-2,147,483,648', NumberFormatter::TYPE_INT64);
-        $this->assertInternalType('integer', $parsedValue);
+        $this->assertIsInt($parsedValue);
         $this->assertEquals(-2147483647 - 1, $parsedValue);
     }
 
@@ -782,11 +782,11 @@ abstract class AbstractNumberFormatterTest extends TestCase
 
         // int 64 using only 32 bit range strangeness
         $parsedValue = $formatter->parse('2,147,483,648', NumberFormatter::TYPE_INT64);
-        $this->assertInternalType('float', $parsedValue);
+        $this->assertIsFloat($parsedValue);
         $this->assertEquals(2147483648, $parsedValue, '->parse() TYPE_INT64 does not use true 64 bit integers, using only the 32 bit range.');
 
         $parsedValue = $formatter->parse('-2,147,483,649', NumberFormatter::TYPE_INT64);
-        $this->assertInternalType('float', $parsedValue);
+        $this->assertIsFloat($parsedValue);
         $this->assertEquals(-2147483649, $parsedValue, '->parse() TYPE_INT64 does not use true 64 bit integers, using only the 32 bit range.');
     }
 
@@ -800,12 +800,12 @@ abstract class AbstractNumberFormatterTest extends TestCase
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
 
         $parsedValue = $formatter->parse('2,147,483,648', NumberFormatter::TYPE_INT64);
-        $this->assertInternalType('integer', $parsedValue);
+        $this->assertIsInt($parsedValue);
 
         $this->assertEquals(2147483648, $parsedValue, '->parse() TYPE_INT64 uses true 64 bit integers (PHP >= 5.3.14 and PHP >= 5.4.4).');
 
         $parsedValue = $formatter->parse('-2,147,483,649', NumberFormatter::TYPE_INT64);
-        $this->assertInternalType('integer', $parsedValue);
+        $this->assertIsInt($parsedValue);
 
         $this->assertEquals(-2147483649, $parsedValue, '->parse() TYPE_INT64 uses true 64 bit integers (PHP >= 5.3.14 and PHP >= 5.4.4).');
     }

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\NumberFormatter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Globals\IntlGlobals;
 use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
  */
 class NumberFormatterTest extends AbstractNumberFormatterTest
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
      */

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -736,8 +736,8 @@ class ProcessTest extends TestCase
         // Ensure that both processed finished and the output is numeric
         $this->assertFalse($process1->isRunning());
         $this->assertFalse($process2->isRunning());
-        $this->assertInternalType('numeric', $process1->getOutput());
-        $this->assertInternalType('numeric', $process2->getOutput());
+        $this->assertIsNumeric($process1->getOutput());
+        $this->assertIsNumeric($process2->getOutput());
 
         // Ensure that restart returned a new process by check that the output is different
         $this->assertNotEquals($process1->getOutput(), $process2->getOutput());

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Tests\Matcher;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
@@ -21,13 +22,15 @@ use Symfony\Component\Routing\RouteCollection;
 
 class UrlMatcherTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testNoMethodSoAllowed()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertInternalType('array', $matcher->match('/foo'));
+        $this->assertIsArray($matcher->match('/foo'));
     }
 
     public function testMethodNotAllowed()
@@ -66,7 +69,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo', new Route('/foo', [], [], [], '', [], ['get']));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'head'));
-        $this->assertInternalType('array', $matcher->match('/foo'));
+        $this->assertIsArray($matcher->match('/foo'));
     }
 
     public function testMethodNotAllowedAggregatesAllowedMethods()
@@ -108,7 +111,7 @@ class UrlMatcherTest extends TestCase
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo', [], [], [], '', [], ['get', 'head']));
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertInternalType('array', $matcher->match('/foo'));
+        $this->assertIsArray($matcher->match('/foo'));
 
         // route does not match with POST method context
         $matcher = $this->getUrlMatcher($collection, new RequestContext('', 'post'));
@@ -120,9 +123,9 @@ class UrlMatcherTest extends TestCase
 
         // route does match with GET or HEAD method context
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertInternalType('array', $matcher->match('/foo'));
+        $this->assertIsArray($matcher->match('/foo'));
         $matcher = $this->getUrlMatcher($collection, new RequestContext('', 'head'));
-        $this->assertInternalType('array', $matcher->match('/foo'));
+        $this->assertIsArray($matcher->match('/foo'));
 
         // route with an optional variable as the first segment
         $collection = new RouteCollection();

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\RememberMe;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices;
@@ -19,6 +20,8 @@ use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
 class AbstractRememberMeServicesTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetRememberMeParameter()
     {
         $service = $this->getService(null, ['remember_me_parameter' => 'foo']);
@@ -261,7 +264,7 @@ class AbstractRememberMeServicesTest extends TestCase
         $service = $this->getService();
 
         $encoded = $this->callProtected($service, 'encodeCookie', [$cookieParts]);
-        $this->assertInternalType('string', $encoded);
+        $this->assertIsString($encoded);
 
         $decoded = $this->callProtected($service, 'decodeCookie', [$encoded]);
         $this->assertSame($cookieParts, $decoded);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -26,6 +27,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class AbstractObjectNormalizerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testDenormalize()
     {
         $normalizer = new AbstractObjectNormalizerDummy();
@@ -93,7 +96,7 @@ class AbstractObjectNormalizerTest extends TestCase
         );
 
         $this->assertInstanceOf(DummyCollection::class, $dummyCollection);
-        $this->assertInternalType('array', $dummyCollection->children);
+        $this->assertIsArray($dummyCollection->children);
         $this->assertCount(1, $dummyCollection->children);
         $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[0]);
     }
@@ -114,7 +117,7 @@ class AbstractObjectNormalizerTest extends TestCase
         );
 
         $this->assertInstanceOf(DummyCollection::class, $dummyCollection);
-        $this->assertInternalType('array', $dummyCollection->children);
+        $this->assertIsArray($dummyCollection->children);
         $this->assertCount(2, $dummyCollection->children);
         $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[0]);
         $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[1]);

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Stopwatch\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
@@ -23,6 +24,8 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 class StopwatchTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const DELTA = 20;
 
     public function testStart()
@@ -115,9 +118,9 @@ class StopwatchTest extends TestCase
         $stopwatch->start('foo');
         $event = $stopwatch->stop('foo');
 
-        $this->assertInternalType('float', $event->getStartTime());
-        $this->assertInternalType('float', $event->getEndTime());
-        $this->assertInternalType('float', $event->getDuration());
+        $this->assertIsFloat($event->getStartTime());
+        $this->assertIsFloat($event->getEndTime());
+        $this->assertIsFloat($event->getDuration());
     }
 
     public function testSection()

--- a/src/Symfony/Component/VarDumper/Tests/Cloner/DataTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Cloner/DataTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Cloner;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -19,6 +20,8 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 class DataTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testBasicData()
     {
         $values = [1 => 123, 4.5, 'abc', null, false];
@@ -69,7 +72,7 @@ class DataTest extends TestCase
 
         $children = $data->getValue();
 
-        $this->assertInternalType('array', $children);
+        $this->assertIsArray($children);
 
         $this->assertInstanceOf(Data::class, $children[0]);
         $this->assertInstanceOf(Data::class, $children[1]);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2080,7 +2080,7 @@ YAML;
 
     public function testParseFile()
     {
-        $this->assertInternalType('array', $this->parser->parseFile(__DIR__.'/Fixtures/index.yml'));
+        $this->assertIsArray($this->parser->parseFile(__DIR__.'/Fixtures/index.yml'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

This PR fixes PhpUnit deprecation :
> assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray(), assertIsBool(), assertIsFloat(), assertIsInt(), assertIsNumeric(), assertIsObject(), assertIsResource(), assertIsString(), assertIsScalar(), assertIsCallable(), or assertIsIterable() instead

- update all tests to use `assertIsX` instead of `assertInternalType('x'`
- adds methods `assertIsX` in `ForwardCompatTestTraitForV5`