### PR TITLE
[PhpUnitBridge] Add assertIsX methods in ForwardCompatTestTrait

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV5.php
@@ -79,4 +79,114 @@ trait ForwardCompatTestTraitForV5
     {
         parent::tearDown();
     }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsArray($actual, $message = '')
+    {
+        static::assertInternalType('array', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsBool($actual, $message = '')
+    {
+        static::assertInternalType('bool', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsFloat($actual, $message = '')
+    {
+        static::assertInternalType('float', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsInt($actual, $message = '')
+    {
+        static::assertInternalType('int', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsNumeric($actual, $message = '')
+    {
+        static::assertInternalType('numeric', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsObject($actual, $message = '')
+    {
+        static::assertInternalType('object', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsResource($actual, $message = '')
+    {
+        static::assertInternalType('resource', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsString($actual, $message = '')
+    {
+        static::assertInternalType('string', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsScalar($actual, $message = '')
+    {
+        static::assertInternalType('scalar', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsCallable($actual, $message = '')
+    {
+        static::assertInternalType('callable', $actual, $message);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsIterable($actual, $message = '')
+    {
+        static::assertInternalType('iterable', $actual, $message);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | N/A

PhpUnit 8 deprecates the method `assertInternalType` in favor of `assertIsX`. This PR add the polyfill  methods `assertIsX` in the `ForwardCompatTestTraitForV5`. It'sq a requirement to update tests in order to be compatible with both PhpUnit 5 and 8

note: this PR split the PR #32846 to provides methods in the branch `master` in order to fix the test suite for #32846