### PR TITLE
Ensure signatures for setUp|tearDown|setUpAfterClass|tearDownAfterClass methods in tests are compatible with phpunit 8.2

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
@@ -27,7 +27,7 @@ class DoctrineCloseConnectionMiddlewareTest extends MiddlewareTestCase
     private $middleware;
     private $entityManagerName = 'default';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -27,7 +27,7 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
     private $middleware;
     private $entityManagerName = 'default';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineTransactionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineTransactionMiddlewareTest.php
@@ -25,7 +25,7 @@ class DoctrineTransactionMiddlewareTest extends MiddlewareTestCase
     private $entityManager;
     private $middleware;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/ClassExistsMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClassExistsMockTest.php
@@ -16,12 +16,12 @@ use Symfony\Bridge\PhpUnit\ClassExistsMock;
 
 class ClassExistsMockTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         ClassExistsMock::register(__CLASS__);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         ClassExistsMock::withMockedClasses([
             ExistingClass::class => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
@@ -23,7 +23,7 @@ class CachePoolDeleteCommandTest extends TestCase
 {
     private $cachePool;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cachePool = $this->getMockBuilder(CacheItemPoolInterface::class)
             ->getMock();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
@@ -131,13 +131,13 @@ EOF;
         return $application;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         @mkdir(sys_get_temp_dir().'/xliff-lint-test');
         $this->files = [];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class CachePoolListCommandTest extends AbstractWebTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel(['test_case' => 'CachePools', 'root_config' => 'config.yml']);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -21,7 +21,7 @@ class RouterDebugCommandTest extends AbstractWebTestCase
 {
     private $application;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $kernel = static::createKernel(['test_case' => 'RouterDebug', 'root_config' => 'config.yml']);
         $this->application = new Application($kernel);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TranslationDebugCommandTest.php
@@ -21,7 +21,7 @@ class TranslationDebugCommandTest extends AbstractWebTestCase
 {
     private $application;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $kernel = static::createKernel(['test_case' => 'TransDebug', 'root_config' => 'config.yml']);
         $this->application = new Application($kernel);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
@@ -18,7 +18,7 @@ class PredisTagAwareAdapterTest extends PredisAdapterTest
 {
     use TagAwareTestTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
@@ -18,7 +18,7 @@ class PredisTagAwareClusterAdapterTest extends PredisClusterAdapterTest
 {
     use TagAwareTestTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareRedisClusterAdapterTest.php
@@ -18,7 +18,7 @@ class PredisTagAwareRedisClusterAdapterTest extends PredisRedisClusterAdapterTes
 {
     use TagAwareTestTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
@@ -19,7 +19,7 @@ class RedisTagAwareAdapterTest extends RedisAdapterTest
 {
     use TagAwareTestTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
@@ -18,7 +18,7 @@ class RedisTagAwareArrayAdapterTest extends RedisArrayAdapterTest
 {
     use TagAwareTestTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
@@ -19,7 +19,7 @@ class RedisTagAwareClusterAdapterTest extends RedisClusterAdapterTest
 {
     use TagAwareTestTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
@@ -24,7 +24,7 @@ class CachePoolPassTest extends TestCase
 {
     private $cachePoolPass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cachePoolPass = new CachePoolPass();
     }

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Cache\Psr16Cache;
  */
 class Psr16CacheTest extends SimpleCacheTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Console/Tests/Helper/DumperNativeFallbackTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DumperNativeFallbackTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
 
 class DumperNativeFallbackTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         ClassExistsMock::register(Dumper::class);
         ClassExistsMock::withMockedClasses([
@@ -27,7 +27,7 @@ class DumperNativeFallbackTest extends TestCase
         ]);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         ClassExistsMock::withMockedClasses([]);
     }

--- a/src/Symfony/Component/Console/Tests/Helper/DumperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DumperTest.php
@@ -20,13 +20,13 @@ class DumperTest extends TestCase
 {
     use VarDumperTestTrait;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         putenv('DUMP_LIGHT_ARRAY=1');
         putenv('DUMP_COMMA_SEPARATOR=1');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         putenv('DUMP_LIGHT_ARRAY');
         putenv('DUMP_COMMA_SEPARATOR');

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -24,12 +24,12 @@ class ConsoleSectionOutputTest extends TestCase
 {
     private $stream;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->stream = fopen('php://memory', 'r+b', false);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->stream = null;
     }

--- a/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
@@ -19,7 +19,7 @@ class QuestionTest extends TestCase
 {
     private $question;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->question = new Question('Test question');

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ContainerBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ContainerBagTest.php
@@ -26,7 +26,7 @@ class ContainerBagTest extends TestCase
     /** @var ContainerBag */
     private $containerBag;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parameterBag = new ParameterBag(['foo' => 'value']);
         $this->containerBag = new ContainerBag(new Container($this->parameterBag));

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -32,13 +32,13 @@ class EventDispatcherTest extends TestCase
 
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = $this->createEventDispatcher();
         $this->listener = new TestEventListener();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->dispatcher = null;
         $this->listener = null;

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/IntlCallbackChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/IntlCallbackChoiceLoaderTest.php
@@ -47,7 +47,7 @@ class IntlCallbackChoiceLoaderTest extends TestCase
      */
     private static $lazyChoiceList;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$loader = new IntlCallbackChoiceLoader(function () {
             return self::$choices;
@@ -98,7 +98,7 @@ class IntlCallbackChoiceLoaderTest extends TestCase
         );
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$loader = null;
         self::$value = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/StringToFloatTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/StringToFloatTransformerTest.php
@@ -18,12 +18,12 @@ class StringToFloatTransformerTest extends TestCase
 {
     private $transformer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->transformer = new StringToFloatTransformer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->transformer = null;
     }

--- a/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
@@ -23,7 +23,7 @@ class Psr18ClientTest extends TestCase
 {
     private static $server;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         TestHttpServer::start();
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MigratingSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MigratingSessionHandlerTest.php
@@ -20,7 +20,7 @@ class MigratingSessionHandlerTest extends TestCase
     private $currentHandler;
     private $writeOnlyHandler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->currentHandler = $this->createMock(\SessionHandlerInterface::class);
         $this->writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 class RedisClusterSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
-    public static function setupBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists('RedisCluster')) {
             self::markTestSkipped('The RedisCluster class is required.');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
@@ -26,7 +26,7 @@ class LocaleAwareListenerTest extends TestCase
     private $localeAwareService;
     private $requestStack;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->localeAwareService = $this->getMockBuilder(LocaleAwareInterface::class)->getMock();
         $this->requestStack = new RequestStack();

--- a/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
@@ -25,7 +25,7 @@ class PdoDbalStoreTest extends AbstractStoreTest
 
     protected static $dbFile;
 
-    public static function setupBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_lock');
 
@@ -33,7 +33,7 @@ class PdoDbalStoreTest extends AbstractStoreTest
         $store->createTable();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -24,7 +24,7 @@ class PdoStoreTest extends AbstractStoreTest
 
     protected static $dbFile;
 
-    public static function setupBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_lock');
 
@@ -32,7 +32,7 @@ class PdoStoreTest extends AbstractStoreTest
         $store->createTable();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -26,12 +26,12 @@ use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler;
  */
 class DebugCommandTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         putenv('COLUMNS='.(119 + \strlen(PHP_EOL)));
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv('COLUMNS=');
     }

--- a/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
@@ -28,7 +28,7 @@ class MessengerDataCollectorTest extends TestCase
     /** @var CliDumper */
     private $dumper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dumper = new CliDumper();
         $this->dumper->setColors(false);

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
@@ -36,7 +36,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
  */
 class AmqpExtIntegrationTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemoryTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemoryTransportFactoryTest.php
@@ -28,7 +28,7 @@ class InMemoryTransportFactoryTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new InMemoryTransportFactory();
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemoryTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemoryTransportTest.php
@@ -25,7 +25,7 @@ class InMemoryTransportTest extends TestCase
      */
     private $transport;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->transport = new InMemoryTransport();
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisExtIntegrationTest.php
@@ -23,7 +23,7 @@ class RedisExtIntegrationTest extends TestCase
     private $redis;
     private $connection;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!getenv('MESSENGER_REDIS_DSN')) {
             $this->markTestSkipped('The "MESSENGER_REDIS_DSN" environment variable is required.');

--- a/src/Symfony/Component/Mime/Tests/AbstractMimeTypeGuesserTest.php
+++ b/src/Symfony/Component/Mime/Tests/AbstractMimeTypeGuesserTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Mime\MimeTypeGuesserInterface;
 
 abstract class AbstractMimeTypeGuesserTest extends TestCase
 {
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         $path = __DIR__.'/Fixtures/mimetypes/to_delete';
         if (file_exists($path)) {

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
@@ -41,7 +41,7 @@ class CompiledUrlGeneratorDumperTest extends TestCase
      */
     private $largeTestTmpFilepath;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class CompiledUrlGeneratorDumperTest extends TestCase
         @unlink($this->largeTestTmpFilepath);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -26,14 +26,14 @@ class CompiledUrlMatcherDumperTest extends TestCase
      */
     private $dumpPath;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_matcher.'.uniqid('CompiledUrlMatcher').'.php';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
 
 class SodiumPasswordEncoderTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!SodiumPasswordEncoder::isSupported()) {
             $this->markTestSkipped('Libsodium is not available.');

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
@@ -25,7 +25,7 @@ class ConstraintViolationListNormalizerTest extends TestCase
 {
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->normalizer = new ConstraintViolationListNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeZoneNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeZoneNormalizerTest.php
@@ -24,7 +24,7 @@ class DateTimeZoneNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->normalizer = new DateTimeZoneNormalizer();
     }

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -188,13 +188,13 @@ XLIFF;
         return new CommandTester($command);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->files = [];
         @mkdir(sys_get_temp_dir().'/translation-xliff-lint-test');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
@@ -23,7 +23,7 @@ class CliDescriptorTest extends TestCase
     private static $timezone;
     private static $prevTerminalEmulator;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$timezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
@@ -32,7 +32,7 @@ class CliDescriptorTest extends TestCase
         putenv('TERMINAL_EMULATOR');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         date_default_timezone_set(self::$timezone);
         putenv('TERMINAL_EMULATOR'.(self::$prevTerminalEmulator ? '='.self::$prevTerminalEmulator : ''));

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
@@ -21,13 +21,13 @@ class HtmlDescriptorTest extends TestCase
 {
     private static $timezone;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$timezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         date_default_timezone_set(self::$timezone);
     }

--- a/src/Symfony/Component/Workflow/Tests/Metadata/InMemoryMetadataStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Metadata/InMemoryMetadataStoreTest.php
@@ -14,7 +14,7 @@ class InMemoryMetadataStoreTest extends TestCase
     private $store;
     private $transition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $workflowMetadata = [
             'title' => 'workflow title',

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -25,12 +25,12 @@ class ParserTest extends TestCase
     /** @var Parser */
     protected $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = new Parser();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->parser = null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | https://github.com/symfony/symfony/issues/32844
| License       | MIT
| Doc PR        | n/a

Please bear with me as this is my first pr to symfony. Branched off 4.3 as requested here: https://github.com/symfony/symfony/issues/32844

Tests currently do not pass due to:

```
PHP Fatal error:  Declaration of Symfony\Bridge\Monolog\Logger::reset() must be compatible with Monolog\Logger::reset(): void in /home/luis/Projects/symfony/src/Symfony/Bridge/Monolog/Logger.php on line 23
```
