### PR TITLE
[PhpUnitBridge] Fix deprecation assertInternalType - 4.3

### DIFF
--- a/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Currencies;
 
 /**
@@ -18,6 +19,8 @@ use Symfony\Component\Intl\Currencies;
  */
 class CurrenciesTest extends ResourceBundleTestCase
 {
+    use ForwardCompatTestTrait;
+
     // The below arrays document the state of the ICU data bundled with this package.
 
     private static $currencies = [
@@ -693,7 +696,7 @@ class CurrenciesTest extends ResourceBundleTestCase
      */
     public function testGetRoundingIncrement($currency)
     {
-        $this->assertInternalType('numeric', Currencies::getRoundingIncrement($currency));
+        $this->assertIsNumeric(Currencies::getRoundingIncrement($currency));
     }
 
     public function provideCurrenciesWithNumericEquivalent()

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -87,7 +87,7 @@ class RegistryTest extends TestCase
     public function testAllWithOneMatchWithSuccess()
     {
         $workflows = $this->registry->all(new Subject1());
-        $this->assertInternalType('array', $workflows);
+        $this->assertIsArray($workflows);
         $this->assertCount(1, $workflows);
         $this->assertInstanceOf(Workflow::class, $workflows[0]);
         $this->assertSame('workflow1', $workflows[0]->getName());
@@ -96,7 +96,7 @@ class RegistryTest extends TestCase
     public function testAllWithMultipleMatchWithSuccess()
     {
         $workflows = $this->registry->all(new Subject2());
-        $this->assertInternalType('array', $workflows);
+        $this->assertIsArray($workflows);
         $this->assertCount(2, $workflows);
         $this->assertInstanceOf(Workflow::class, $workflows[0]);
         $this->assertInstanceOf(Workflow::class, $workflows[1]);
@@ -107,7 +107,7 @@ class RegistryTest extends TestCase
     public function testAllWithNoMatch()
     {
         $workflows = $this->registry->all(new \stdClass());
-        $this->assertInternalType('array', $workflows);
+        $this->assertIsArray($workflows);
         $this->assertCount(0, $workflows);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

This PR fixes PhpUnit deprecation :
> assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray(), assertIsBool(), assertIsFloat(), assertIsInt(), assertIsNumeric(), assertIsObject(), assertIsResource(), assertIsString(), assertIsScalar(), assertIsCallable(), or assertIsIterable() instead

follow #32846 for 4.3 branch