### PR TITLE
[PhpUnitBridge] Fix deprecation assertInternalType - 4.4

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -11,10 +11,13 @@
 
 namespace Symfony\Component\HttpClient\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Contracts\HttpClient\Test\HttpClientTestCase as BaseHttpClientTestCase;
 
 abstract class HttpClientTestCase extends BaseHttpClientTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testToStream()
     {
         $client = $this->getHttpClient(__FUNCTION__);
@@ -28,7 +31,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertFalse(feof($stream));
         $this->assertTrue(rewind($stream));
 
-        $this->assertInternalType('array', json_decode(fread($stream, 1024), true));
+        $this->assertIsArray(json_decode(fread($stream, 1024), true));
         $this->assertSame('', fread($stream, 1));
         $this->assertTrue(feof($stream));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

This PR fixes PhpUnit deprecation :
> assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray(), assertIsBool(), assertIsFloat(), assertIsInt(), assertIsNumeric(), assertIsObject(), assertIsResource(), assertIsString(), assertIsScalar(), assertIsCallable(), or assertIsIterable() instead

follow #32846 for 4.4 branch