### PR TITLE
[Yaml] PHP-8: Uncaught TypeError: abs() expects parameter 1 to be int or float, string given

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -668,7 +668,7 @@ class Parser
         }
 
         if (\in_array($value[0], ['!', '|', '>'], true) && self::preg_match('/^(?:'.self::TAG_PATTERN.' +)?'.self::BLOCK_SCALAR_HEADER_PATTERN.'$/', $value, $matches)) {
-            $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : '';
+            $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : 0;
 
             $data = $this->parseBlockScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs($modifiers));
 

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -668,9 +668,9 @@ class Parser
         }
 
         if (\in_array($value[0], ['!', '|', '>'], true) && self::preg_match('/^(?:'.self::TAG_PATTERN.' +)?'.self::BLOCK_SCALAR_HEADER_PATTERN.'$/', $value, $matches)) {
-            $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : 0;
+            $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : '';
 
-            $data = $this->parseBlockScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs($modifiers));
+            $data = $this->parseBlockScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs((int) $modifiers));
 
             if ('' !== $matches['tag'] && '!' !== $matches['tag']) {
                 if ('!!binary' === $matches['tag']) {

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2184,7 +2184,7 @@ YAML;
             [
                 'parameters' => [
                     'abc' => implode(PHP_EOL, ['one', 'two', 'three', 'four', 'five']),
-                ]
+                ],
             ],
             $this->parser->parse($yaml)
         );

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2183,7 +2183,7 @@ YAML;
         $this->assertSame(
             [
                 'parameters' => [
-                    'abc' => implode(PHP_EOL, ['one', 'two', 'three', 'four', 'five']),
+                    'abc' => implode("\n", ['one', 'two', 'three', 'four', 'five']),
                 ],
             ],
             $this->parser->parse($yaml)
@@ -2205,7 +2205,7 @@ YAML;
         $this->assertSame(
             [
                 'parameters' => [
-                    'abc' => implode(PHP_EOL, ['one', 'two', 'three', 'four', 'five']),
+                    'abc' => implode("\n", ['one', 'two', 'three', 'four', 'five']),
                 ],
             ],
             $this->parser->parse($yaml)

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2189,6 +2189,28 @@ YAML;
             $this->parser->parse($yaml)
         );
     }
+
+    public function testParseValueWithNegativeModifiers()
+    {
+        $yaml = <<<YAML
+parameters:
+    abc: |-3 # minus
+       one
+       two
+       three
+       four
+       five
+YAML;
+
+        $this->assertSame(
+            [
+                'parameters' => [
+                    'abc' => implode(PHP_EOL, ['one', 'two', 'three', 'four', 'five']),
+                ],
+            ],
+            $this->parser->parse($yaml)
+        );
+    }
 }
 
 class B

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2198,6 +2198,4 @@ class B
     const FOO = 'foo';
     const BAR = 'bar';
     const BAZ = 'baz';
-
-    const DELTA = 3;
 }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2167,6 +2167,28 @@ YAML;
 
         $this->assertSame(['parameters' => 'abc'], $this->parser->parse($yaml));
     }
+
+    public function testParseValueWithModifiers()
+    {
+        $yaml = <<<YAML
+parameters:
+    abc: |+5 # plus five spaces indent
+         one
+         two
+         three
+         four
+         five
+YAML;
+
+        $this->assertSame(
+            [
+                'parameters' => [
+                    'abc' => implode(PHP_EOL, ['one', 'two', 'three', 'four', 'five']),
+                ]
+            ],
+            $this->parser->parse($yaml)
+        );
+    }
 }
 
 class B
@@ -2176,4 +2198,6 @@ class B
     const FOO = 'foo';
     const BAR = 'bar';
     const BAZ = 'baz';
+
+    const DELTA = 3;
 }


### PR DESCRIPTION
PHP-8: Uncaught TypeError: abs() expects parameter 1 to be int or float, string given

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
