### PR TITLE
[ErrorRenderer] Add alias to FlattenException to avoid BC break

### DIFF
--- a/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
@@ -374,3 +374,18 @@ class FlattenException
         return rtrim($message);
     }
 }
+
+namespace Symfony\Component\Debug\Exception;
+
+if (!class_exists(FlattenException::class, false)) {
+    class_alias(\Symfony\Component\ErrorRenderer\Exception\FlattenException::class, FlattenException::class);
+}
+
+if (false) {
+    /**
+     * @deprecated since Symfony 4.4, use Symfony\Component\ErrorRenderer\Exception\FlattenException instead.
+     */
+    class FlattenException extends \Symfony\Component\ErrorRenderer\Exception\FlattenException
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/32473
| License       | MIT
| Doc PR        | -