### PR TITLE
[PhpUnitBridge] Remove @expectedException annotation

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -13,17 +13,18 @@ namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 class RegisterEventListenersAndSubscribersPassTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    use ForwardCompatTestTrait;
+
     public function testExceptionOnAbstractTaggedSubscriber()
     {
+        $this->expectException('InvalidArgumentException');
         $container = $this->createBuilder();
 
         $abstractDefinition = new Definition('stdClass');
@@ -35,11 +36,9 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
         $this->process($container);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testExceptionOnAbstractTaggedListener()
     {
+        $this->expectException('InvalidArgumentException');
         $container = $this->createBuilder();
 
         $abstractDefinition = new Definition('stdClass');

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterMappingsPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterMappingsPassTest.php
@@ -15,7 +15,7 @@ class RegisterMappingsPassTest extends TestCase
     public function testNoDriverParmeterException()
     {
         $this->expectException('InvalidArgumentException');
-        $this->getExpectedExceptionMessage('Could not find the manager name parameter in the container. Tried the following parameter names: "manager.param.one", "manager.param.two"');
+        $this->expectExceptionMessage('Could not find the manager name parameter in the container. Tried the following parameter names: "manager.param.one", "manager.param.two"');
         $container = $this->createBuilder();
         $this->process($container, [
             'manager.param.one',

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterMappingsPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterMappingsPassTest.php
@@ -4,17 +4,18 @@ namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPass;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 class RegisterMappingsPassTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageould Could not find the manager name parameter in the container. Tried the following parameter names: "manager.param.one", "manager.param.two"
-     */
+    use ForwardCompatTestTrait;
+
     public function testNoDriverParmeterException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->getExpectedExceptionMessage('Could not find the manager name parameter in the container. Tried the following parameter names: "manager.param.one", "manager.param.two"');
         $container = $this->createBuilder();
         $this->process($container, [
             'manager.param.one',

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -52,11 +52,9 @@ class DoctrineExtensionTest extends TestCase
             });
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testFixManagersAutoMappingsWithTwoAutomappings()
     {
+        $this->expectException('LogicException');
         $emConfigs = [
             'em1' => [
                 'auto_mapping' => true,
@@ -241,12 +239,10 @@ class DoctrineExtensionTest extends TestCase
         $this->assertTrue($container->hasAlias('doctrine.orm.default_metadata_cache'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage "unrecognized_type" is an unrecognized Doctrine cache driver.
-     */
     public function testUnrecognizedCacheDriverException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('"unrecognized_type" is an unrecognized Doctrine cache driver.');
         $cacheName = 'metadata_cache';
         $container = $this->createContainer();
         $objectManager = [

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
@@ -65,11 +65,9 @@ class CollectionToArrayTransformerTest extends TestCase
         $this->assertSame([], $this->transformer->transform(null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformExpectsArrayOrCollection()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->transform('Foo');
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -118,19 +118,15 @@ class EntityTypeTest extends BaseTypeTest
         // be managed!
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
-     */
     public function testClassOptionIsRequired()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
         $this->factory->createNamed('name', static::TESTED_TYPE);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     */
     public function testInvalidClassOption()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
         $this->factory->createNamed('name', static::TESTED_TYPE, null, [
             'class' => 'foo',
         ]);
@@ -190,11 +186,9 @@ class EntityTypeTest extends BaseTypeTest
         $this->assertEquals([1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')], $view->vars['choices']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testConfigureQueryBuilderWithNonQueryBuilderAndNonClosure()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
@@ -202,11 +196,9 @@ class EntityTypeTest extends BaseTypeTest
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
     public function testConfigureQueryBuilderWithClosureReturningNonQueryBuilder()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -83,12 +83,10 @@ class EntityUserProviderTest extends TestCase
         $this->assertSame($user, $provider->loadUserByUsername('user1'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You must either make the "Symfony\Bridge\Doctrine\Tests\Fixtures\User" entity Doctrine Repository ("Doctrine\ORM\EntityRepository") implement "Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.
-     */
     public function testLoadUserByUsernameWithNonUserLoaderRepositoryAndWithoutProperty()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('You must either make the "Symfony\Bridge\Doctrine\Tests\Fixtures\User" entity Doctrine Repository ("Doctrine\ORM\EntityRepository") implement "Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.');
         $em = DoctrineTestHelper::createTestEntityManager();
         $this->createSchema($em);
 
@@ -168,11 +166,9 @@ class EntityUserProviderTest extends TestCase
         $provider->loadUserByUsername('name');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLoadUserByUserNameShouldDeclineInvalidInterface()
     {
+        $this->expectException('InvalidArgumentException');
         $repository = $this->getMockBuilder('\Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
 
         $provider = new EntityUserProvider(

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -278,11 +278,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testAllConfiguredFieldsAreCheckedOfBeingMappedByDoctrineWithIgnoreNullEnabled()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name', 'name2'],
@@ -589,12 +587,10 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     * @expectedExceptionMessage Object manager "foo" does not exist.
-     */
     public function testDedicatedEntityManagerNullObject()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('Object manager "foo" does not exist.');
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
@@ -611,12 +607,10 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($entity, $constraint);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     * @expectedExceptionMessage Unable to find the object manager associated with an entity of class "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity"
-     */
     public function testEntityManagerNullObject()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('Unable to find the object manager associated with an entity of class "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity"');
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
@@ -695,12 +689,10 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     * @expectedExceptionMessage The "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity" entity repository does not support the "Symfony\Bridge\Doctrine\Tests\Fixtures\Person" entity. The entity should be an instance of or extend "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity".
-     */
     public function testInvalidateRepositoryForInheritance()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('The "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity" entity repository does not support the "Symfony\Bridge\Doctrine\Tests\Fixtures\Person" entity. The entity should be an instance of or extend "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity".');
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -117,51 +117,39 @@ class AppVariableTest extends TestCase
         $this->assertNull($this->appVariable->getUser());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testEnvironmentNotSet()
     {
+        $this->expectException('RuntimeException');
         $this->appVariable->getEnvironment();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testDebugNotSet()
     {
+        $this->expectException('RuntimeException');
         $this->appVariable->getDebug();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetTokenWithTokenStorageNotSet()
     {
+        $this->expectException('RuntimeException');
         $this->appVariable->getToken();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetUserWithTokenStorageNotSet()
     {
+        $this->expectException('RuntimeException');
         $this->appVariable->getUser();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetRequestWithRequestStackNotSet()
     {
+        $this->expectException('RuntimeException');
         $this->appVariable->getRequest();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetSessionWithRequestStackNotSet()
     {
+        $this->expectException('RuntimeException');
         $this->appVariable->getSession();
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -48,11 +48,9 @@ class LintCommandTest extends TestCase
         $this->assertRegExp('/ERROR  in \S+ \(line /', trim($tester->getDisplay()));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testLintFileNotReadable()
     {
+        $this->expectException('RuntimeException');
         $tester = $this->createCommandTester();
         $filename = $this->createFile('');
         unlink($filename);
@@ -74,11 +72,11 @@ class LintCommandTest extends TestCase
     /**
      * @group legacy
      * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bridge\Twig\Command\LintCommand::__construct()" is deprecated since Symfony 3.4 and support for it will be removed in 4.0. If the command was registered by convention, make it a service instead.
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The Twig environment needs to be set.
      */
     public function testLegacyLintCommand()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('The Twig environment needs to be set.');
         $command = new LintCommand();
 
         $application = new Application();

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -25,11 +25,9 @@ class HttpKernelExtensionTest extends TestCase
 {
     use ForwardCompatTestTrait;
 
-    /**
-     * @expectedException \Twig\Error\RuntimeError
-     */
     public function testFragmentWithError()
     {
+        $this->expectException('Twig\Error\RuntimeError');
         $renderer = $this->getFragmentHandler($this->throwException(new \Exception('foo')));
 
         $this->renderTemplate($renderer);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\StopwatchExtension;
 use Twig\Environment;
 use Twig\Error\RuntimeError;
@@ -19,11 +20,11 @@ use Twig\Loader\ArrayLoader;
 
 class StopwatchExtensionTest extends TestCase
 {
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     */
+    use ForwardCompatTestTrait;
+
     public function testFailIfStoppingWrongEvent()
     {
+        $this->expectException('Twig\Error\SyntaxError');
         $this->testTiming('{% stopwatch "foo" %}{% endstopwatch "bar" %}', []);
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Translator;
@@ -20,6 +21,8 @@ use Twig\Loader\ArrayLoader as TwigArrayLoader;
 
 class TranslationExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testEscaping()
     {
         $output = $this->getTemplate('{% trans %}Percent: %value%%% (%msg%){% endtrans %}')->render(['value' => 12, 'msg' => 'approx.']);
@@ -45,30 +48,24 @@ class TranslationExtensionTest extends TestCase
         $this->assertEquals($expected, $this->getTemplate($template)->render($variables));
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage Unexpected token. Twig was looking for the "with", "from", or "into" keyword in "index" at line 3.
-     */
     public function testTransUnknownKeyword()
     {
+        $this->expectException('Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('Unexpected token. Twig was looking for the "with", "from", or "into" keyword in "index" at line 3.');
         $output = $this->getTemplate("{% trans \n\nfoo %}{% endtrans %}")->render();
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage A message inside a trans tag must be a simple text in "index" at line 2.
-     */
     public function testTransComplexBody()
     {
+        $this->expectException('Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('A message inside a trans tag must be a simple text in "index" at line 2.');
         $output = $this->getTemplate("{% trans %}\n{{ 1 + 2 }}{% endtrans %}")->render();
     }
 
-    /**
-     * @expectedException        \Twig\Error\SyntaxError
-     * @expectedExceptionMessage A message inside a transchoice tag must be a simple text in "index" at line 2.
-     */
     public function testTransChoiceComplexBody()
     {
+        $this->expectException('Twig\Error\SyntaxError');
+        $this->expectExceptionMessage('A message inside a transchoice tag must be a simple text in "index" at line 2.');
         $output = $this->getTemplate("{% transchoice count %}\n{{ 1 + 2 }}{% endtranschoice %}")->render();
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\Translation;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Translation\TwigExtractor;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -21,6 +22,8 @@ use Twig\Loader\ArrayLoader;
 
 class TwigExtractorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getExtractData
      */
@@ -76,11 +79,11 @@ class TwigExtractorTest extends TestCase
     }
 
     /**
-     * @expectedException \Twig\Error\Error
      * @dataProvider resourcesWithSyntaxErrorsProvider
      */
     public function testExtractSyntaxError($resources)
     {
+        $this->expectException('Twig\Error\Error');
         $twig = new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock());
         $twig->addExtension(new TranslationExtension($this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock()));
 

--- a/src/Symfony/Bridge/Twig/Tests/TwigEngineTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/TwigEngineTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bridge\Twig\TwigEngine;
 use Symfony\Component\Templating\TemplateReference;
 use Twig\Environment;
@@ -19,6 +20,8 @@ use Twig\Loader\ArrayLoader;
 
 class TwigEngineTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testExistsWithTemplateInstances()
     {
         $engine = $this->getTwig();
@@ -58,11 +61,9 @@ class TwigEngineTest extends TestCase
         $this->assertSame('foo', $engine->render(new TemplateReference('index')));
     }
 
-    /**
-     * @expectedException \Twig\Error\SyntaxError
-     */
     public function testRenderWithError()
     {
+        $this->expectException('Twig\Error\SyntaxError');
         $engine = $this->getTwig();
 
         $engine->render(new TemplateReference('error'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -21,6 +22,8 @@ use Symfony\Component\Routing\RouteCollection;
 
 class RouterDebugCommandTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testDebugAllRoutes()
     {
         $tester = $this->createCommandTester();
@@ -39,11 +42,9 @@ class RouterDebugCommandTest extends TestCase
         $this->assertContains('Route Name   | foo', $tester->getDisplay());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDebugInvalidRoute()
     {
+        $this->expectException('InvalidArgumentException');
         $this->createCommandTester()->execute(['name' => 'test']);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -97,11 +97,9 @@ class TranslationDebugCommandTest extends TestCase
         $this->assertRegExp('/unused/', $tester->getDisplay());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDebugInvalidDirectory()
     {
+        $this->expectException('InvalidArgumentException');
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel->expects($this->once())
             ->method('getBundle')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -61,11 +61,9 @@ bar';
         $this->assertContains('Unable to parse at line 3 (near "bar").', trim($tester->getDisplay()));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testLintFileNotReadable()
     {
+        $this->expectException('RuntimeException');
         $tester = $this->createCommandTester();
         $filename = $this->createFile('');
         unlink($filename);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\Container;
@@ -31,6 +32,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 abstract class ControllerTraitTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     abstract protected function createController();
 
     public function testForward()
@@ -87,12 +90,10 @@ abstract class ControllerTraitTest extends TestCase
         $this->assertNull($controller->getUser());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The SecurityBundle is not registered in your application.
-     */
     public function testGetUserWithEmptyContainer()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('The SecurityBundle is not registered in your application.');
         $controller = $this->createController();
         $controller->setContainer(new Container());
 
@@ -274,11 +275,9 @@ abstract class ControllerTraitTest extends TestCase
         $this->assertContains('test.php', $response->headers->get('content-disposition'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException
-     */
     public function testFileWhichDoesNotExist()
     {
+        $this->expectException('Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException');
         $controller = $this->createController();
 
         /* @var BinaryFileResponse $response */
@@ -299,11 +298,9 @@ abstract class ControllerTraitTest extends TestCase
         $this->assertTrue($controller->isGranted('foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
-     */
     public function testdenyAccessUnlessGranted()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
         $authorizationChecker = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')->getMock();
         $authorizationChecker->expects($this->once())->method('isGranted')->willReturn(false);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
@@ -20,6 +21,8 @@ use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
  */
 class TemplateControllerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testTwig()
     {
         $twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
@@ -77,12 +80,10 @@ class TemplateControllerTest extends TestCase
         $this->assertEquals('bar', $controller->templateAction('mytemplate')->getContent());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage You can not use the TemplateController if the Templating Component or the Twig Bundle are not available.
-     */
     public function testNoTwigNorTemplating()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('You can not use the TemplateController if the Templating Component or the Twig Bundle are not available.');
         $controller = new TemplateController();
 
         $controller->templateAction('mytemplate')->getContent();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,6 +23,8 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class AddConsoleCommandPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider visibilityProvider
      */
@@ -63,12 +66,10 @@ class AddConsoleCommandPassTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "my-command" tagged "console.command" must not be abstract.
-     */
     public function testProcessThrowAnExceptionIfTheServiceIsAbstract()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must not be abstract.');
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddConsoleCommandPass());
 
@@ -80,12 +81,10 @@ class AddConsoleCommandPassTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "my-command" tagged "console.command" must be a subclass of "Symfony\Component\Console\Command\Command".
-     */
     public function testProcessThrowAnExceptionIfTheServiceIsNotASubclassOfCommand()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must be a subclass of "Symfony\Component\Console\Command\Command".');
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddConsoleCommandPass());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidatorsPass;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -24,6 +25,8 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class AddConstraintValidatorsPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testThatConstraintValidatorServicesAreProcessed()
     {
         $container = new ContainerBuilder();
@@ -46,12 +49,10 @@ class AddConstraintValidatorsPassTest extends TestCase
         $this->assertEquals($expected, $container->getDefinition((string) $validatorFactory->getArgument(0)));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "my_abstract_constraint_validator" tagged "validator.constraint_validator" must not be abstract.
-     */
     public function testAbstractConstraintValidator()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The service "my_abstract_constraint_validator" tagged "validator.constraint_validator" must not be abstract.');
         $container = new ContainerBuilder();
         $validatorFactory = $container->register('validator.validator_factory')
             ->addArgument([]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
@@ -96,12 +96,10 @@ class CachePoolPassTest extends TestCase
         $this->assertSame(3, $cachePool->getArgument(2));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid "cache.pool" tag for service "app.cache_pool": accepted attributes are
-     */
     public function testThrowsExceptionWhenCachePoolTagHasUnknownAttributes()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid "cache.pool" tag for service "app.cache_pool": accepted attributes are');
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', false);
         $container->setParameter('kernel.name', 'app');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPrunerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPrunerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPrunerPass;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
@@ -21,6 +22,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class CachePoolPrunerPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCompilerPassReplacesCommandArgument()
     {
         $container = new ContainerBuilder();
@@ -56,12 +59,10 @@ class CachePoolPrunerPassTest extends TestCase
         $this->assertCount($aliasesBefore, $container->getAliases());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Class "Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\NotFound" used for service "pool.not-found" cannot be found.
-     */
     public function testCompilerPassThrowsOnInvalidDefinitionClass()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Class "Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\NotFound" used for service "pool.not-found" cannot be found.');
         $container = new ContainerBuilder();
         $container->register('console.command.cache_pool_prune')->addArgument([]);
         $container->register('pool.not-found', NotFound::class)->addTag('cache.pool');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -24,6 +25,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class FormPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testDoNothingIfFormExtensionNotLoaded()
     {
         $container = new ContainerBuilder();
@@ -124,12 +127,10 @@ class FormPassTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage extended-type attribute, none was configured for the "my.type_extension" service
-     */
     public function testAddTaggedFormTypeExtensionWithoutExtendedTypeAttribute()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('extended-type attribute, none was configured for the "my.type_extension" service');
         $container = new ContainerBuilder();
         $container->addCompilerPass(new FormPass());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ProfilerPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * Tests that collectors that specify a template but no "id" will throw
      * an exception (both are needed if the template is specified).
@@ -24,11 +27,10 @@ class ProfilerPassTest extends TestCase
      * Thus, a fully-valid tag looks something like this:
      *
      *     <tag name="data_collector" template="YourBundle:Collector:templatename" id="your_collector_name" />
-     *
-     * @expectedException \InvalidArgumentException
      */
     public function testTemplateNoIdThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
         $builder = new ContainerBuilder();
         $builder->register('profiler', 'ProfilerClass');
         $builder->register('my_collector_service')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SerializerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -25,12 +26,12 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class SerializerPassTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage You must tag at least one service as "serializer.normalizer" to use the "serializer" service
-     */
+    use ForwardCompatTestTrait;
+
     public function testThrowExceptionWhenNoNormalizers()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('You must tag at least one service as "serializer.normalizer" to use the "serializer" service');
         $container = new ContainerBuilder();
         $container->register('serializer');
 
@@ -38,12 +39,10 @@ class SerializerPassTest extends TestCase
         $serializerPass->process($container);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage You must tag at least one service as "serializer.encoder" to use the "serializer" service
-     */
     public function testThrowExceptionWhenNoEncoders()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('You must tag at least one service as "serializer.encoder" to use the "serializer" service');
         $container = new ContainerBuilder();
         $container->register('serializer')
             ->addArgument([])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
@@ -55,12 +55,10 @@ class WorkflowGuardListenerPassTest extends TestCase
         $this->assertFalse($this->container->hasParameter('workflow.has_guard_listeners'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
-     * @expectedExceptionMessage The "security.token_storage" service is needed to be able to use the workflow guard listener.
-     */
     public function testExceptionIfTheTokenStorageServiceIsNotPresent()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\LogicException');
+        $this->expectExceptionMessage('The "security.token_storage" service is needed to be able to use the workflow guard listener.');
         $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);
@@ -69,12 +67,10 @@ class WorkflowGuardListenerPassTest extends TestCase
         $this->compilerPass->process($this->container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
-     * @expectedExceptionMessage The "security.authorization_checker" service is needed to be able to use the workflow guard listener.
-     */
     public function testExceptionIfTheAuthorizationCheckerServiceIsNotPresent()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\LogicException');
+        $this->expectExceptionMessage('The "security.authorization_checker" service is needed to be able to use the workflow guard listener.');
         $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);
@@ -83,12 +79,10 @@ class WorkflowGuardListenerPassTest extends TestCase
         $this->compilerPass->process($this->container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
-     * @expectedExceptionMessage The "security.authentication.trust_resolver" service is needed to be able to use the workflow guard listener.
-     */
     public function testExceptionIfTheAuthenticationTrustResolverServiceIsNotPresent()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\LogicException');
+        $this->expectExceptionMessage('The "security.authentication.trust_resolver" service is needed to be able to use the workflow guard listener.');
         $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
@@ -97,12 +91,10 @@ class WorkflowGuardListenerPassTest extends TestCase
         $this->compilerPass->process($this->container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
-     * @expectedExceptionMessage The "security.role_hierarchy" service is needed to be able to use the workflow guard listener.
-     */
     public function testExceptionIfTheRoleHierarchyServiceIsNotPresent()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\LogicException');
+        $this->expectExceptionMessage('The "security.role_hierarchy" service is needed to be able to use the workflow guard listener.');
         $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -107,10 +107,10 @@ class ConfigurationTest extends TestCase
 
     /**
      * @dataProvider getTestInvalidSessionName
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function testInvalidSessionName($sessionName)
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $processor = new Processor();
         $processor->processConfiguration(
             new Configuration(true),
@@ -163,10 +163,10 @@ class ConfigurationTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function testInvalidTypeTrustedProxies()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $processor = new Processor();
         $configuration = new Configuration(true);
         $processor->processConfiguration($configuration, [
@@ -179,10 +179,10 @@ class ConfigurationTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function testInvalidValueTrustedProxies()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $processor = new Processor();
         $configuration = new Configuration(true);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
 use Doctrine\Common\Annotations\Annotation;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAnnotationsCachedReaderPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
@@ -47,6 +48,8 @@ use Symfony\Component\Workflow\Registry;
 
 abstract class FrameworkExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private static $containerCache = [];
 
     abstract protected function loadFromFile(ContainerBuilder $container, $file);
@@ -106,12 +109,10 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(ArrayAdapter::class, $cache->getClass(), 'ArrayAdapter should be used in debug mode');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage CSRF protection needs sessions to be enabled.
-     */
     public function testCsrfProtectionNeedsSessionToBeEnabled()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('CSRF protection needs sessions to be enabled.');
         $this->createContainerFromFile('csrf_needs_session');
     }
 
@@ -252,39 +253,31 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('workflows_without_type');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage "type" and "service" cannot be used together.
-     */
     public function testWorkflowCannotHaveBothTypeAndService()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('"type" and "service" cannot be used together.');
         $this->createContainerFromFile('workflow_with_type_and_service');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage "supports" and "support_strategy" cannot be used together.
-     */
     public function testWorkflowCannotHaveBothSupportsAndSupportStrategy()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('"supports" and "support_strategy" cannot be used together.');
         $this->createContainerFromFile('workflow_with_support_and_support_strategy');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage "supports" or "support_strategy" should be configured.
-     */
     public function testWorkflowShouldHaveOneOfSupportsAndSupportStrategy()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('"supports" or "support_strategy" should be configured.');
         $this->createContainerFromFile('workflow_without_support_and_support_strategy');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage "arguments" and "service" cannot be used together.
-     */
     public function testWorkflowCannotHaveBothArgumentsAndService()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('"arguments" and "service" cannot be used together.');
         $this->createContainerFromFile('workflow_with_arguments_and_service');
     }
 
@@ -430,11 +423,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('xml', $arguments[2]['resource_type'], '->registerRouterConfiguration() sets routing resource type');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testRouterRequiresResourceOption()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $container = $this->createContainer();
         $loader = new FrameworkExtension();
         $loader->load([['router' => true]], $container);
@@ -473,11 +464,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('session.storage.php_bridge')->getArgument(0));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testNullSessionHandlerWithSavePath()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $this->createContainerFromFile('session_savepath');
     }
 
@@ -645,11 +634,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertFalse($container->has('templating.helper.translator'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testTemplatingRequiresAtLeastOneEngine()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $container = $this->createContainer();
         $loader = new FrameworkExtension();
         $loader->load([['templating' => null]], $container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -11,23 +11,24 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
 class PhpFrameworkExtensionTest extends FrameworkExtensionTest
 {
+    use ForwardCompatTestTrait;
+
     protected function loadFromFile(ContainerBuilder $container, $file)
     {
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/Fixtures/php'));
         $loader->load($file.'.php');
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testAssetsCannotHavePathAndUrl()
     {
+        $this->expectException('LogicException');
         $this->createContainerFromClosure(function ($container) {
             $container->loadFromExtension('framework', [
                 'assets' => [
@@ -38,11 +39,9 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTest
         });
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testAssetPackageCannotHavePathAndUrl()
     {
+        $this->expectException('LogicException');
         $this->createContainerFromClosure(function ($container) {
             $container->loadFromExtension('framework', [
                 'assets' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -68,12 +68,10 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $this->assertContains('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
 
-    /**
-     * @expectedException        \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage You have requested a non-existent service "unknown_pool"
-     */
     public function testClearUnexistingPool()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
+        $this->expectExceptionMessage('You have requested a non-existent service "unknown_pool"');
         $this->createCommandTester()
             ->execute(['pools' => ['unknown_pool']], ['decorated' => false]);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
 class CachePoolsTest extends AbstractWebTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCachePools()
     {
         $this->doTestCachePools([], AdapterInterface::class);
@@ -34,7 +37,7 @@ class CachePoolsTest extends AbstractWebTestCase
                 throw $e;
             }
             $this->markTestSkipped($e->getMessage());
-        } catch (\PHPUnit_Framework_Error_Warning $e) {
+        } catch (\PHPUnit\Framework\Error\Warning $e) {
             if (0 !== strpos($e->getMessage(), 'unable to connect to')) {
                 throw $e;
             }
@@ -59,7 +62,7 @@ class CachePoolsTest extends AbstractWebTestCase
                 throw $e;
             }
             $this->markTestSkipped($e->getMessage());
-        } catch (\PHPUnit_Framework_Error_Warning $e) {
+        } catch (\PHPUnit\Framework\Error\Warning $e) {
             if (0 !== strpos($e->getMessage(), 'unable to connect to')) {
                 throw $e;
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Routing;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
 use Symfony\Component\Routing\Route;
@@ -19,6 +20,8 @@ use Symfony\Component\Routing\RouteCollection;
 
 class RouterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGenerateWithServiceParam()
     {
         $routes = new RouteCollection();
@@ -133,12 +136,10 @@ class RouterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Using "%env(FOO)%" is not allowed in routing configuration.
-     */
     public function testEnvPlaceholders()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Using "%env(FOO)%" is not allowed in routing configuration.');
         $routes = new RouteCollection();
 
         $routes->add('foo', new Route('/%env(FOO)%'));
@@ -168,12 +169,10 @@ class RouterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException
-     * @expectedExceptionMessage You have requested a non-existent parameter "nope".
-     */
     public function testExceptionOnNonExistentParameter()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException');
+        $this->expectExceptionMessage('You have requested a non-existent parameter "nope".');
         $routes = new RouteCollection();
 
         $routes->add('foo', new Route('/%nope%'));
@@ -184,12 +183,10 @@ class RouterTest extends TestCase
         $router->getRouteCollection()->get('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The container parameter "object", used in the route configuration value "/%object%", must be a string or numeric, but it is of type object.
-     */
     public function testExceptionOnNonStringParameter()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The container parameter "object", used in the route configuration value "/%object%", must be a string or numeric, but it is of type object.');
         $routes = new RouteCollection();
 
         $routes->add('foo', new Route('/%object%'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/DelegatingEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/DelegatingEngineTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelegatingEngineTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSupportsRetrievesEngineFromTheContainer()
     {
         $container = $this->getContainerMock([
@@ -43,12 +46,10 @@ class DelegatingEngineTest extends TestCase
         $this->assertSame($secondEngine, $delegatingEngine->getEngine('template.php'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No engine is able to work with the template "template.php"
-     */
     public function testGetInvalidEngine()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('No engine is able to work with the template "template.php"');
         $firstEngine = $this->getEngineMock('template.php', false);
         $secondEngine = $this->getEngineMock('template.php', false);
         $container = $this->getContainerMock([

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Loader;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
 class TemplateLocatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLocateATemplate()
     {
         $template = new TemplateReference('bundle', 'controller', 'name', 'format', 'engine');
@@ -77,11 +80,9 @@ class TemplateLocatorTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testThrowsAnExceptionWhenTemplateIsNotATemplateReferenceInterface()
     {
+        $this->expectException('InvalidArgumentException');
         $locator = new TemplateLocator($this->getFileLocator());
         $locator->locate('template');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Templating\PhpEngine;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
@@ -23,6 +24,8 @@ use Symfony\Component\Templating\TemplateNameParser;
 
 class PhpEngineTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testEvaluateAddsAppGlobal()
     {
         $container = $this->getContainer();
@@ -43,11 +46,9 @@ class PhpEngineTest extends TestCase
         $this->assertEmpty($globals['app']->getRequest());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetInvalidHelper()
     {
+        $this->expectException('InvalidArgumentException');
         $container = $this->getContainer();
         $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
         $engine = new PhpEngine(new TemplateNameParser(), $container, $loader);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -77,11 +77,9 @@ class TemplateNameParserTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testParseValidNameWithNotFoundBundle()
     {
+        $this->expectException('InvalidArgumentException');
         $this->parser->parse('BarBundle:Post:index.html.php');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -110,10 +110,10 @@ class TranslatorTest extends TestCase
     /**
      * @group legacy
      * @expectedDeprecation The "Symfony\Bundle\FrameworkBundle\Translation\Translator::__construct()" method takes the default locale as the 3rd argument since Symfony 3.3. Not passing it is deprecated and will trigger an error in 4.0.
-     * @expectedException \InvalidArgumentException
      */
     public function testTransWithCachingWithInvalidLocaleOmittingLocale()
     {
+        $this->expectException('InvalidArgumentException');
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')->getMock();
         $translator = $this->getTranslator($loader, ['cache_dir' => $this->tmpDir], 'loader', '\Symfony\Bundle\FrameworkBundle\Tests\Translation\TranslatorWithInvalidLocale', null);
 
@@ -159,11 +159,11 @@ class TranslatorTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Missing third $defaultLocale argument.
      */
     public function testGetDefaultLocaleOmittingLocaleWithPsrContainer()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Missing third $defaultLocale argument.');
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $translator = new Translator($container, new MessageFormatter());
     }
@@ -250,12 +250,10 @@ class TranslatorTest extends TestCase
         $this->assertEquals('foobarbax (sr@latin)', $translator->trans('foobarbax'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid "invalid locale" locale.
-     */
     public function testTransWithCachingWithInvalidLocale()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid "invalid locale" locale.');
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')->getMock();
         $translator = $this->getTranslator($loader, ['cache_dir' => $this->tmpDir], 'loader', '\Symfony\Bundle\FrameworkBundle\Tests\Translation\TranslatorWithInvalidLocale');
 
@@ -285,12 +283,10 @@ class TranslatorTest extends TestCase
         $this->assertSame('en', $translator->getLocale());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The Translator does not support the following options: 'foo'
-     */
     public function testInvalidOptions()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The Translator does not support the following options: \'foo\'');
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
 
         (new Translator($container, new MessageFormatter(), 'en', [], ['foo' => 'bar']));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Validator\Constraint;
@@ -23,6 +24,8 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class ConstraintValidatorFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetInstanceCreatesValidator()
     {
         $factory = new ConstraintValidatorFactory(new Container());
@@ -59,11 +62,9 @@ class ConstraintValidatorFactoryTest extends TestCase
         $this->assertSame($validator, $factory->getInstance(new ConstraintAliasStub()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ValidatorException
-     */
     public function testGetInstanceInvalidValidatorClass()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ValidatorException');
         $constraint = $this->getMockBuilder('Symfony\\Component\\Validator\\Constraint')->getMock();
         $constraint
             ->expects($this->exactly(2))

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -24,11 +24,9 @@ class AddSecurityVotersPassTest extends TestCase
 {
     use ForwardCompatTestTrait;
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
-     */
     public function testNoVoters()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\LogicException');
         $container = new ContainerBuilder();
         $container
             ->register('security.access.decision_manager', AccessDecisionManager::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
@@ -22,6 +23,8 @@ use Symfony\Component\Security\Core\Encoder\Argon2iPasswordEncoder;
 
 abstract class CompleteConfigurationTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     abstract protected function getLoader(ContainerBuilder $container);
 
     abstract protected function getFileExtension();
@@ -553,12 +556,10 @@ abstract class CompleteConfigurationTest extends TestCase
         $this->assertSame('app.access_decision_manager', (string) $container->getAlias('security.access.decision_manager'), 'The custom access decision manager service is aliased');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "security.access_decision_manager": "strategy" and "service" cannot be used together.
-     */
     public function testAccessDecisionManagerServiceAndStrategyCannotBeUsedAtTheSameTime()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('Invalid configuration for path "security.access_decision_manager": "strategy" and "service" cannot be used together.');
         $this->getContainer('access_decision_manager_service_and_strategy');
     }
 
@@ -573,21 +574,17 @@ abstract class CompleteConfigurationTest extends TestCase
         $this->assertFalse($accessDecisionManagerDefinition->getArgument(3));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid firewall "main": user provider "undefined" not found.
-     */
     public function testFirewallUndefinedUserProvider()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('Invalid firewall "main": user provider "undefined" not found.');
         $this->getContainer('firewall_undefined_provider');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid firewall "main": user provider "undefined" not found.
-     */
     public function testFirewallListenerUndefinedProvider()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('Invalid firewall "main": user provider "undefined" not found.');
         $this->getContainer('listener_undefined_provider');
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration;
 use Symfony\Component\Config\Definition\Processor;
 
 class MainConfigurationTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * The minimal, required config needed to not have any required validation
      * issues.
@@ -33,11 +36,9 @@ class MainConfigurationTest extends TestCase
         ],
     ];
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testNoConfigForProvider()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $config = [
             'providers' => [
                 'stub' => [],
@@ -49,11 +50,9 @@ class MainConfigurationTest extends TestCase
         $processor->processConfiguration($configuration, [$config]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testManyConfigForProvider()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $config = [
             'providers' => [
                 'stub' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/GuardAuthenticationFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/GuardAuthenticationFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Factory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\GuardAuthenticationFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class GuardAuthenticationFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getValidConfigurationTests
      */
@@ -37,11 +40,11 @@ class GuardAuthenticationFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @dataProvider getInvalidConfigurationTests
      */
     public function testAddInvalidConfiguration(array $inputConfig)
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $factory = new GuardAuthenticationFactory();
         $nodeDefinition = new ArrayNodeDefinition('guard');
         $factory->addConfiguration($nodeDefinition);
@@ -130,11 +133,9 @@ class GuardAuthenticationFactoryTest extends TestCase
         $this->assertEquals('some_default_entry_point', $entryPointId);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testCannotOverrideDefaultEntryPoint()
     {
+        $this->expectException('LogicException');
         // any existing default entry point is used
         $config = [
             'authenticators' => ['authenticator123'],
@@ -143,11 +144,9 @@ class GuardAuthenticationFactoryTest extends TestCase
         $this->executeCreate($config, 'some_default_entry_point');
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testMultipleAuthenticatorsRequiresEntryPoint()
     {
+        $this->expectException('LogicException');
         // any existing default entry point is used
         $config = [
             'authenticators' => ['authenticator123', 'authenticatorABC'],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\DummyProvider;
@@ -19,12 +20,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SecurityExtensionTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The check_path "/some_area/login_check" for login method "form_login" is not matched by the firewall pattern "/secured_area/.*".
-     */
+    use ForwardCompatTestTrait;
+
     public function testInvalidCheckPath()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('The check_path "/some_area/login_check" for login method "form_login" is not matched by the firewall pattern "/secured_area/.*".');
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
@@ -46,12 +47,10 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage No authentication listener registered for firewall "some_firewall"
-     */
     public function testFirewallWithoutAuthenticationListener()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('No authentication listener registered for firewall "some_firewall"');
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
@@ -70,12 +69,10 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Unable to create definition for "security.user.provider.concrete.my_foo" user provider
-     */
     public function testFirewallWithInvalidUserProvider()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('Unable to create definition for "security.user.provider.concrete.my_foo" user provider');
         $container = $this->getRawContainer();
 
         $extension = $container->getExtension('security');
@@ -186,11 +183,11 @@ class SecurityExtensionTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Firewalls "some_firewall" and "some_other_firewall" need to have the same value for option "logout_on_user_change" as they are sharing the context "my_context"
      */
     public function testThrowsIfLogoutOnUserChangeDifferentForSharedContext()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('Firewalls "some_firewall" and "some_other_firewall" need to have the same value for option "logout_on_user_change" as they are sharing the context "my_context"');
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -208,12 +208,10 @@ EOTXT
         $this->assertContains('Encoder used       Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder', $this->passwordEncoderCommandTester->getDisplay());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage There are no configured encoders for the "security" extension.
-     */
     public function testThrowsExceptionOnNoConfiguredEncoders()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('There are no configured encoders for the "security" extension.');
         $application = new ConsoleApplication();
         $application->add(new UserPasswordEncoderCommand($this->getMockBuilder(EncoderFactoryInterface::class)->getMock(), []));
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -90,11 +90,9 @@ class TwigLoaderPassTest extends TestCase
         $this->assertEquals('test_loader_1', (string) $calls[1][1][0]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
-     */
     public function testMapperPassWithZeroTaggedLoaders()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\LogicException');
         $this->pass->process($this->builder);
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Bundle\TwigBundle\Tests\Loader;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 
 class FilesystemLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetSourceContext()
     {
         $parser = $this->getMockBuilder('Symfony\Component\Templating\TemplateNameParserInterface')->getMock();
@@ -51,11 +54,9 @@ class FilesystemLoaderTest extends TestCase
         $this->assertTrue($loader->exists($template));
     }
 
-    /**
-     * @expectedException \Twig\Error\LoaderError
-     */
     public function testTwigErrorIfLocatorThrowsInvalid()
     {
+        $this->expectException('Twig\Error\LoaderError');
         $parser = $this->getMockBuilder('Symfony\Component\Templating\TemplateNameParserInterface')->getMock();
         $parser
             ->expects($this->once())
@@ -75,11 +76,9 @@ class FilesystemLoaderTest extends TestCase
         $loader->getCacheKey('name.format.engine');
     }
 
-    /**
-     * @expectedException \Twig\Error\LoaderError
-     */
     public function testTwigErrorIfLocatorReturnsFalse()
     {
+        $this->expectException('Twig\Error\LoaderError');
         $parser = $this->getMockBuilder('Symfony\Component\Templating\TemplateNameParserInterface')->getMock();
         $parser
             ->expects($this->once())
@@ -99,12 +98,10 @@ class FilesystemLoaderTest extends TestCase
         $loader->getCacheKey('name.format.engine');
     }
 
-    /**
-     * @expectedException \Twig\Error\LoaderError
-     * @expectedExceptionMessageRegExp /Unable to find template "name\.format\.engine" \(looked into: .*Tests.Loader.\.\..DependencyInjection.Fixtures.Resources.views\)/
-     */
     public function testTwigErrorIfTemplateDoesNotExist()
     {
+        $this->expectException('Twig\Error\LoaderError');
+        $this->expectExceptionMessageRegExp('/Unable to find template "name\.format\.engine" \(looked into: .*Tests.Loader.\.\..DependencyInjection.Fixtures.Resources.views\)/');
         $parser = $this->getMockBuilder('Symfony\Component\Templating\TemplateNameParserInterface')->getMock();
         $locator = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -56,11 +56,9 @@ class TemplateManagerTest extends TestCase
         $this->templateManager = new TemplateManager($profiler, $twigEnvironment, $templates);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
     public function testGetNameOfInvalidTemplate()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         $this->templateManager->getName(new Profile('token'), 'notexistingpanel');
     }
 

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Asset\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 
 class PackagesTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetterSetters()
     {
         $packages = new Packages();
@@ -55,20 +58,16 @@ class PackagesTest extends TestCase
         $this->assertEquals('/foo?a', $packages->getUrl('/foo', 'a'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Asset\Exception\LogicException
-     */
     public function testNoDefaultPackage()
     {
+        $this->expectException('Symfony\Component\Asset\Exception\LogicException');
         $packages = new Packages();
         $packages->getPackage();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Asset\Exception\InvalidArgumentException
-     */
     public function testUndefinedPackage()
     {
+        $this->expectException('Symfony\Component\Asset\Exception\InvalidArgumentException');
         $packages = new Packages();
         $packages->getPackage('a');
     }

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Asset\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 
 class UrlPackageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getConfigs
      */
@@ -88,19 +91,15 @@ class UrlPackageTest extends TestCase
         $this->assertEquals('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Asset\Exception\LogicException
-     */
     public function testNoBaseUrls()
     {
+        $this->expectException('Symfony\Component\Asset\Exception\LogicException');
         new UrlPackage([], new EmptyVersionStrategy());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Asset\Exception\InvalidArgumentException
-     */
     public function testWrongBaseUrl()
     {
+        $this->expectException('Symfony\Component\Asset\Exception\InvalidArgumentException');
         new UrlPackage(['not-a-url'], new EmptyVersionStrategy());
     }
 

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Asset\Tests\VersionStrategy;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy;
 
 class JsonManifestVersionStrategyTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetVersion()
     {
         $strategy = $this->createStrategy('manifest-valid.json');
@@ -37,21 +40,17 @@ class JsonManifestVersionStrategyTest extends TestCase
         $this->assertEquals('css/other.css', $strategy->getVersion('css/other.css'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testMissingManifestFileThrowsException()
     {
+        $this->expectException('RuntimeException');
         $strategy = $this->createStrategy('non-existent-file.json');
         $strategy->getVersion('main.js');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Error parsing JSON
-     */
     public function testManifestFileWithBadJSONThrowsException()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Error parsing JSON');
         $strategy = $this->createStrategy('manifest-invalid.json');
         $strategy->getVersion('main.js');
     }

--- a/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
@@ -197,12 +197,10 @@ class CookieTest extends TestCase
         $this->assertFalse($cookie->isExpired());
     }
 
-    /**
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage The cookie expiration time "string" is not valid.
-     */
     public function testConstructException()
     {
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('The cookie expiration time "string" is not valid.');
         $cookie = new Cookie('foo', 'bar', 'string');
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
@@ -24,26 +25,24 @@ use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
  */
 class ChainAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function createCachePool($defaultLifetime = 0)
     {
         return new ChainAdapter([new ArrayAdapter($defaultLifetime), new ExternalAdapter(), new FilesystemAdapter('', $defaultLifetime)], $defaultLifetime);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage At least one adapter must be specified.
-     */
     public function testEmptyAdaptersException()
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('At least one adapter must be specified.');
         new ChainAdapter([]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The class "stdClass" does not implement
-     */
     public function testInvalidAdapterException()
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The class "stdClass" does not implement');
         new ChainAdapter([new \stdClass()]);
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 
 class MaxIdLengthAdapterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLongKey()
     {
         $cache = $this->getMockBuilder(MaxIdLengthAdapter::class)
@@ -62,12 +65,10 @@ class MaxIdLengthAdapterTest extends TestCase
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 40)])));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Namespace must be 26 chars max, 40 given ("----------------------------------------")
-     */
     public function testTooLongNamespace()
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Namespace must be 26 chars max, 40 given ("----------------------------------------")');
         $cache = $this->getMockBuilder(MaxIdLengthAdapter::class)
             ->setConstructorArgs([str_repeat('-', 40)])
             ->getMock();

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -66,11 +66,11 @@ class MemcachedAdapterTest extends AdapterTestCase
 
     /**
      * @dataProvider provideBadOptions
-     * @expectedException \ErrorException
-     * @expectedExceptionMessage constant(): Couldn't find constant Memcached::
      */
     public function testBadOptions($name, $value)
     {
+        $this->expectException('ErrorException');
+        $this->expectExceptionMessage('constant(): Couldn\'t find constant Memcached::');
         MemcachedAdapter::createConnection([], [$name => $value]);
     }
 
@@ -96,12 +96,10 @@ class MemcachedAdapterTest extends AdapterTestCase
         $this->assertSame(1, $client->getOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Cache\Exception\CacheException
-     * @expectedExceptionMessage MemcachedAdapter: "serializer" option must be "php" or "igbinary".
-     */
     public function testOptionSerializer()
     {
+        $this->expectException('Symfony\Component\Cache\Exception\CacheException');
+        $this->expectExceptionMessage('MemcachedAdapter: "serializer" option must be "php" or "igbinary".');
         if (!\Memcached::HAVE_JSON) {
             $this->markTestSkipped('Memcached::HAVE_JSON required');
         }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\CacheItem;
@@ -21,6 +22,8 @@ use Symfony\Component\Cache\CacheItem;
  */
 class ProxyAdapterTest extends AdapterTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected $skippedTests = [
         'testDeferredSaveWithoutCommit' => 'Assumes a shared cache which ArrayAdapter is not.',
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayAdapter is not.',
@@ -32,12 +35,10 @@ class ProxyAdapterTest extends AdapterTestCase
         return new ProxyAdapter(new ArrayAdapter(), '', $defaultLifetime);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage OK bar
-     */
     public function testProxyfiedItem()
     {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('OK bar');
         $item = new CacheItem();
         $pool = new ProxyAdapter(new TestingArrayAdapter($item));
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -58,11 +58,11 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
 
     /**
      * @dataProvider provideFailedCreateConnection
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Redis connection failed
      */
     public function testFailedCreateConnection($dsn)
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Redis connection failed');
         RedisAdapter::createConnection($dsn);
     }
 
@@ -77,11 +77,11 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
 
     /**
      * @dataProvider provideInvalidCreateConnection
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid Redis DSN
      */
     public function testInvalidCreateConnection($dsn)
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid Redis DSN');
         RedisAdapter::createConnection($dsn);
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -33,11 +33,9 @@ class TagAwareAdapterTest extends AdapterTestCase
         FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');
     }
 
-    /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
-     */
     public function testInvalidTag()
     {
+        $this->expectException('Psr\Cache\InvalidArgumentException');
         $pool = $this->createCachePool();
         $item = $pool->getItem('foo');
         $item->tag(':');

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Cache\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\CacheItem;
 
 class CacheItemTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testValidKey()
     {
         $this->assertSame('foo', CacheItem::validateKey('foo'));
@@ -23,11 +26,11 @@ class CacheItemTest extends TestCase
 
     /**
      * @dataProvider provideInvalidKey
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Cache key
      */
     public function testInvalidKey($key)
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Cache key');
         CacheItem::validateKey($key);
     }
 
@@ -66,11 +69,11 @@ class CacheItemTest extends TestCase
 
     /**
      * @dataProvider provideInvalidKey
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Cache tag
      */
     public function testInvalidTag($tag)
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Cache tag');
         $item = new CacheItem();
         $item->tag($tag);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Simple;
 
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\ChainCache;
@@ -22,26 +23,24 @@ use Symfony\Component\Cache\Simple\FilesystemCache;
  */
 class ChainCacheTest extends CacheTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function createSimpleCache($defaultLifetime = 0)
     {
         return new ChainCache([new ArrayCache($defaultLifetime), new FilesystemCache('', $defaultLifetime)], $defaultLifetime);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage At least one cache must be specified.
-     */
     public function testEmptyCachesException()
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('At least one cache must be specified.');
         new ChainCache([]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The class "stdClass" does not implement
-     */
     public function testInvalidCacheException()
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The class "stdClass" does not implement');
         new ChainCache([new \stdClass()]);
     }
 

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -76,11 +76,11 @@ class MemcachedCacheTest extends CacheTestCase
 
     /**
      * @dataProvider provideBadOptions
-     * @expectedException \ErrorException
-     * @expectedExceptionMessage constant(): Couldn't find constant Memcached::
      */
     public function testBadOptions($name, $value)
     {
+        $this->expectException('ErrorException');
+        $this->expectExceptionMessage('constant(): Couldn\'t find constant Memcached::');
         MemcachedCache::createConnection([], [$name => $value]);
     }
 
@@ -105,12 +105,10 @@ class MemcachedCacheTest extends CacheTestCase
         $this->assertSame(1, $client->getOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Cache\Exception\CacheException
-     * @expectedExceptionMessage MemcachedAdapter: "serializer" option must be "php" or "igbinary".
-     */
     public function testOptionSerializer()
     {
+        $this->expectException('Symfony\Component\Cache\Exception\CacheException');
+        $this->expectExceptionMessage('MemcachedAdapter: "serializer" option must be "php" or "igbinary".');
         if (!\Memcached::HAVE_JSON) {
             $this->markTestSkipped('Memcached::HAVE_JSON required');
         }

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
@@ -48,11 +48,11 @@ class RedisCacheTest extends AbstractRedisCacheTest
 
     /**
      * @dataProvider provideFailedCreateConnection
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Redis connection failed
      */
     public function testFailedCreateConnection($dsn)
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Redis connection failed');
         RedisCache::createConnection($dsn);
     }
 
@@ -67,11 +67,11 @@ class RedisCacheTest extends AbstractRedisCacheTest
 
     /**
      * @dataProvider provideInvalidCreateConnection
-     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid Redis DSN
      */
     public function testInvalidCreateConnection($dsn)
     {
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid Redis DSN');
         RedisCache::createConnection($dsn);
     }
 

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
 use Symfony\Component\ClassLoader\Tests\Fixtures\DeclaredClass;
 use Symfony\Component\ClassLoader\Tests\Fixtures\WarmedClass;
@@ -26,6 +27,8 @@ require_once __DIR__.'/Fixtures/ClassesWithParents/A.php';
  */
 class ClassCollectionLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testTraitDependencies()
     {
         require_once __DIR__.'/Fixtures/deps/traits.php';
@@ -208,11 +211,9 @@ class ClassCollectionLoaderTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUnableToLoadClassException()
     {
+        $this->expectException('InvalidArgumentException');
         if (is_file($file = sys_get_temp_dir().'/foo.php')) {
             unlink($file);
         }

--- a/src/Symfony/Component/Config/Tests/ConfigCacheFactoryTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheFactoryTest.php
@@ -12,16 +12,17 @@
 namespace Symfony\Component\Config\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\ConfigCacheFactory;
 
 class ConfigCacheFactoryTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid type for callback argument. Expected callable, but got "object".
-     */
+    use ForwardCompatTestTrait;
+
     public function testCacheWithInvalidCallback()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid type for callback argument. Expected callable, but got "object".');
         $cacheFactory = new ConfigCacheFactory(true);
 
         $cacheFactory->cache('file', new \stdClass());

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -21,21 +21,17 @@ class ArrayNodeTest extends TestCase
 {
     use ForwardCompatTestTrait;
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
-     */
     public function testNormalizeThrowsExceptionWhenFalseIsNotAllowed()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
         $node = new ArrayNode('root');
         $node->normalize(false);
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Unrecognized option "foo" under "root"
-     */
     public function testExceptionThrownOnUnrecognizedChild()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('Unrecognized option "foo" under "root"');
         $node = new ArrayNode('root');
         $node->normalize(['foo' => 'bar']);
     }
@@ -179,24 +175,20 @@ class ArrayNodeTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Child nodes must be named.
-     */
     public function testAddChildEmptyName()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Child nodes must be named.');
         $node = new ArrayNode('root');
 
         $childNode = new ArrayNode('');
         $node->addChild($childNode);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A child node named "foo" already exists.
-     */
     public function testAddChildNameAlreadyExists()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('A child node named "foo" already exists.');
         $node = new ArrayNode('root');
 
         $childNode = new ArrayNode('foo');
@@ -206,12 +198,10 @@ class ArrayNodeTest extends TestCase
         $node->addChild($childNodeWithSameName);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The node at path "foo" has no default value.
-     */
     public function testGetDefaultValueWithoutDefaultValue()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('The node at path "foo" has no default value.');
         $node = new ArrayNode('foo');
         $node->getDefaultValue();
     }

--- a/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\BooleanNode;
 
 class BooleanNodeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getValidValues
      */
@@ -48,10 +51,10 @@ class BooleanNodeTest extends TestCase
 
     /**
      * @dataProvider getInvalidValues
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
      */
     public function testNormalizeThrowsExceptionOnInvalidValues($value)
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
         $node = new BooleanNode('test');
         $node->normalize($value);
     }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
 use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
@@ -19,6 +20,8 @@ use Symfony\Component\Config\Definition\Processor;
 
 class ArrayNodeDefinitionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testAppendingSomeNode()
     {
         $parent = new ArrayNodeDefinition('root');
@@ -36,11 +39,11 @@ class ArrayNodeDefinitionTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
      * @dataProvider providePrototypeNodeSpecificCalls
      */
     public function testPrototypeNodeSpecificOption($method, $args)
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidDefinitionException');
         $node = new ArrayNodeDefinition('root');
 
         \call_user_func_array([$node, $method], $args);
@@ -58,11 +61,9 @@ class ArrayNodeDefinitionTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
-     */
     public function testConcreteNodeSpecificOption()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidDefinitionException');
         $node = new ArrayNodeDefinition('root');
         $node
             ->addDefaultsIfNotSet()
@@ -71,11 +72,9 @@ class ArrayNodeDefinitionTest extends TestCase
         $node->getNode();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
-     */
     public function testPrototypeNodesCantHaveADefaultValueWhenUsingDefaultChildren()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidDefinitionException');
         $node = new ArrayNodeDefinition('root');
         $node
             ->defaultValue([])

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
@@ -12,16 +12,17 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
 
 class BooleanNodeDefinitionTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
-     * @expectedExceptionMessage ->cannotBeEmpty() is not applicable to BooleanNodeDefinition.
-     */
+    use ForwardCompatTestTrait;
+
     public function testCannotBeEmptyThrowsAnException()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidDefinitionException');
+        $this->expectExceptionMessage('->cannotBeEmpty() is not applicable to BooleanNodeDefinition.');
         $def = new BooleanNodeDefinition('foo');
         $def->cannotBeEmpty();
     }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/EnumNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/EnumNodeDefinitionTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\EnumNodeDefinition;
 
 class EnumNodeDefinitionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testWithOneValue()
     {
         $def = new EnumNodeDefinition('foo');
@@ -34,22 +37,18 @@ class EnumNodeDefinitionTest extends TestCase
         $this->assertEquals(['foo'], $node->getValues());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage You must call ->values() on enum nodes.
-     */
     public function testNoValuesPassed()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('You must call ->values() on enum nodes.');
         $def = new EnumNodeDefinition('foo');
         $def->getNode();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage ->values() must be called with at least one value.
-     */
     public function testWithNoValues()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('->values() must be called with at least one value.');
         $def = new EnumNodeDefinition('foo');
         $def->values([]);
     }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class ExprBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testAlwaysExpression()
     {
         $test = $this->getTestBuilder()
@@ -164,11 +167,9 @@ class ExprBuilderTest extends TestCase
         yield [['value'], ['value']];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testThenInvalid()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $test = $this->getTestBuilder()
             ->ifString()
             ->thenInvalid('Invalid value')
@@ -185,21 +186,17 @@ class ExprBuilderTest extends TestCase
         $this->assertEquals([], $this->finalizeTestBuilder($test));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage You must specify an if part.
-     */
     public function testEndIfPartNotSpecified()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('You must specify an if part.');
         $this->getTestBuilder()->end();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage You must specify a then part.
-     */
     public function testEndThenPartNotSpecified()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('You must specify a then part.');
         $builder = $this->getTestBuilder();
         $builder->ifPart = 'test';
         $builder->end();

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
@@ -12,25 +12,24 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder as BaseNodeBuilder;
 use Symfony\Component\Config\Definition\Builder\VariableNodeDefinition as BaseVariableNodeDefinition;
 
 class NodeBuilderTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     */
+    use ForwardCompatTestTrait;
+
     public function testThrowsAnExceptionWhenTryingToCreateANonRegisteredNodeType()
     {
+        $this->expectException('RuntimeException');
         $builder = new BaseNodeBuilder();
         $builder->node('', 'foobar');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testThrowsAnExceptionWhenTheNodeClassIsNotFound()
     {
+        $this->expectException('RuntimeException');
         $builder = new BaseNodeBuilder();
         $builder
             ->setNodeClass('noclasstype', '\\foo\\bar\\noclass')

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
@@ -12,48 +12,43 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\FloatNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition as NumericNodeDefinition;
 
 class NumericNodeDefinitionTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You cannot define a min(4) as you already have a max(3)
-     */
+    use ForwardCompatTestTrait;
+
     public function testIncoherentMinAssertion()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('You cannot define a min(4) as you already have a max(3)');
         $def = new NumericNodeDefinition('foo');
         $def->max(3)->min(4);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You cannot define a max(2) as you already have a min(3)
-     */
     public function testIncoherentMaxAssertion()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('You cannot define a max(2) as you already have a min(3)');
         $node = new NumericNodeDefinition('foo');
         $node->min(3)->max(2);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value 4 is too small for path "foo". Should be greater than or equal to 5
-     */
     public function testIntegerMinAssertion()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('The value 4 is too small for path "foo". Should be greater than or equal to 5');
         $def = new IntegerNodeDefinition('foo');
         $def->min(5)->getNode()->finalize(4);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value 4 is too big for path "foo". Should be less than or equal to 3
-     */
     public function testIntegerMaxAssertion()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('The value 4 is too big for path "foo". Should be less than or equal to 3');
         $def = new IntegerNodeDefinition('foo');
         $def->max(3)->getNode()->finalize(4);
     }
@@ -65,22 +60,18 @@ class NumericNodeDefinitionTest extends TestCase
         $this->assertEquals(4, $node->finalize(4));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value 400 is too small for path "foo". Should be greater than or equal to 500
-     */
     public function testFloatMinAssertion()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('The value 400 is too small for path "foo". Should be greater than or equal to 500');
         $def = new FloatNodeDefinition('foo');
         $def->min(5E2)->getNode()->finalize(4e2);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value 4.3 is too big for path "foo". Should be less than or equal to 0.3
-     */
     public function testFloatMaxAssertion()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('The value 4.3 is too big for path "foo". Should be less than or equal to 0.3');
         $def = new FloatNodeDefinition('foo');
         $def->max(0.3)->getNode()->finalize(4.3);
     }
@@ -92,12 +83,10 @@ class NumericNodeDefinitionTest extends TestCase
         $this->assertEquals(4.5, $node->finalize(4.5));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
-     * @expectedExceptionMessage ->cannotBeEmpty() is not applicable to NumericNodeDefinition.
-     */
     public function testCannotBeEmptyThrowsAnException()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidDefinitionException');
+        $this->expectExceptionMessage('->cannotBeEmpty() is not applicable to NumericNodeDefinition.');
         $def = new NumericNodeDefinition('foo');
         $def->cannotBeEmpty();
     }

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -12,22 +12,23 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\EnumNode;
 
 class EnumNodeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testFinalizeValue()
     {
         $node = new EnumNode('foo', null, ['foo', 'bar']);
         $this->assertSame('foo', $node->finalize('foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $values must contain at least one element.
-     */
     public function testConstructionWithNoValues()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('$values must contain at least one element.');
         new EnumNode('foo', null, []);
     }
 
@@ -43,12 +44,10 @@ class EnumNodeTest extends TestCase
         $this->assertSame('foo', $node->finalize('foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value "foobar" is not allowed for path "foo". Permissible values: "foo", "bar"
-     */
     public function testFinalizeWithInvalidValue()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('The value "foobar" is not allowed for path "foo". Permissible values: "foo", "bar"');
         $node = new EnumNode('foo', null, ['foo', 'bar']);
         $node->finalize('foobar');
     }

--- a/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\FloatNode;
 
 class FloatNodeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getValidValues
      */
@@ -54,10 +57,10 @@ class FloatNodeTest extends TestCase
 
     /**
      * @dataProvider getInvalidValues
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
      */
     public function testNormalizeThrowsExceptionOnInvalidValues($value)
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
         $node = new FloatNode('test');
         $node->normalize($value);
     }

--- a/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\IntegerNode;
 
 class IntegerNodeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getValidValues
      */
@@ -49,10 +52,10 @@ class IntegerNodeTest extends TestCase
 
     /**
      * @dataProvider getInvalidValues
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
      */
     public function testNormalizeThrowsExceptionOnInvalidValues($value)
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
         $node = new IntegerNode('test');
         $node->normalize($value);
     }

--- a/src/Symfony/Component/Config/Tests/Definition/MergeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/MergeTest.php
@@ -12,15 +12,16 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class MergeTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\ForbiddenOverwriteException
-     */
+    use ForwardCompatTestTrait;
+
     public function testForbiddenOverwrite()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\ForbiddenOverwriteException');
         $tb = new TreeBuilder();
         $tree = $tb
             ->root('root', 'array')
@@ -92,11 +93,9 @@ class MergeTest extends TestCase
         ], $tree->merge($a, $b));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testDoesNotAllowNewKeysInSubsequentConfigs()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $tb = new TreeBuilder();
         $tree = $tb
             ->root('config', 'array')

--- a/src/Symfony/Component/Config/Tests/Definition/NormalizationTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/NormalizationTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Config\Tests\Definition;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\NodeInterface;
 
 class NormalizationTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getEncoderTests
      */
@@ -169,12 +172,10 @@ class NormalizationTest extends TestCase
         return array_map(function ($v) { return [$v]; }, $configs);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The attribute "id" must be set for path "root.thing".
-     */
     public function testNonAssociativeArrayThrowsExceptionIfAttributeNotSet()
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectExceptionMessage('The attribute "id" must be set for path "root.thing".');
         $denormalized = [
             'thing' => [
                 ['foo', 'bar'], ['baz', 'qux'],

--- a/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
@@ -77,10 +77,10 @@ class ScalarNodeTest extends TestCase
 
     /**
      * @dataProvider getInvalidValues
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
      */
     public function testNormalizeThrowsExceptionOnInvalidValues($value)
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
         $node = new ScalarNode('test');
         $node->normalize($value);
     }
@@ -143,12 +143,12 @@ class ScalarNodeTest extends TestCase
 
     /**
      * @dataProvider getEmptyValues
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      *
      * @param mixed $value
      */
     public function testNotAllowedEmptyValuesThrowException($value)
     {
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $node = new ScalarNode('test');
         $node->setAllowEmptyValue(false);
         $node->finalize($value);

--- a/src/Symfony/Component/Config/Tests/FileLocatorTest.php
+++ b/src/Symfony/Component/Config/Tests/FileLocatorTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Config\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 
 class FileLocatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getIsAbsolutePathTests
      */
@@ -86,33 +89,27 @@ class FileLocatorTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Exception\FileLocatorFileNotFoundException
-     * @expectedExceptionMessage The file "foobar.xml" does not exist
-     */
     public function testLocateThrowsAnExceptionIfTheFileDoesNotExists()
     {
+        $this->expectException('Symfony\Component\Config\Exception\FileLocatorFileNotFoundException');
+        $this->expectExceptionMessage('The file "foobar.xml" does not exist');
         $loader = new FileLocator([__DIR__.'/Fixtures']);
 
         $loader->locate('foobar.xml', __DIR__);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Exception\FileLocatorFileNotFoundException
-     */
     public function testLocateThrowsAnExceptionIfTheFileDoesNotExistsInAbsolutePath()
     {
+        $this->expectException('Symfony\Component\Config\Exception\FileLocatorFileNotFoundException');
         $loader = new FileLocator([__DIR__.'/Fixtures']);
 
         $loader->locate(__DIR__.'/Fixtures/foobar.xml', __DIR__);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage An empty file name is not valid to be located.
-     */
     public function testLocateEmpty()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('An empty file name is not valid to be located.');
         $loader = new FileLocator([__DIR__.'/Fixtures']);
 
         $loader->locate(null, __DIR__);

--- a/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Config\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 
 class DelegatingLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $loader = new DelegatingLoader($resolver = new LoaderResolver());
@@ -56,11 +59,9 @@ class DelegatingLoaderTest extends TestCase
         $loader->load('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Exception\FileLoaderLoadException
-     */
     public function testLoadThrowsAnExceptionIfTheResourceCannotBeLoaded()
     {
+        $this->expectException('Symfony\Component\Config\Exception\FileLoaderLoadException');
         $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
         $loader->expects($this->once())->method('supports')->willReturn(false);
         $resolver = new LoaderResolver([$loader]);

--- a/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Config\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Loader\Loader;
 
 class LoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetSetResolver()
     {
         $resolver = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderResolverInterface')->getMock();
@@ -43,11 +46,9 @@ class LoaderTest extends TestCase
         $this->assertSame($resolvedLoader, $loader->resolve('foo.xml'), '->resolve() finds a loader');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Exception\FileLoaderLoadException
-     */
     public function testResolveWhenResolverCannotFindLoader()
     {
+        $this->expectException('Symfony\Component\Config\Exception\FileLoaderLoadException');
         $resolver = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderResolverInterface')->getMock();
         $resolver->expects($this->once())
             ->method('resolve')

--- a/src/Symfony/Component/Config/Tests/Resource/ClassExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ClassExistenceResourceTest.php
@@ -13,12 +13,15 @@ namespace Symfony\Component\Config\Tests\Resource;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\Config\Tests\Fixtures\BadParent;
 use Symfony\Component\Config\Tests\Fixtures\Resource\ConditionalClass;
 
 class ClassExistenceResourceTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testToString()
     {
         $res = new ClassExistenceResource('BarClass');
@@ -86,12 +89,10 @@ EOF
         $this->assertTrue($res->isFresh(time()));
     }
 
-    /**
-     * @expectedException \ReflectionException
-     * @expectedExceptionMessage Class Symfony\Component\Config\Tests\Fixtures\MissingParent not found
-     */
     public function testBadParentWithNoTimestamp()
     {
+        $this->expectException('ReflectionException');
+        $this->expectExceptionMessage('Class Symfony\Component\Config\Tests\Fixtures\MissingParent not found');
         if (\PHP_VERSION_ID >= 70400) {
             throw new Warning('PHP 7.4 breaks this test, see https://bugs.php.net/78351.');
         }

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -66,12 +66,10 @@ class DirectoryResourceTest extends TestCase
         $this->assertEquals('bar', $resource->getPattern());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The directory ".*" does not exist./
-     */
     public function testResourceDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The directory ".*" does not exist./');
         $resource = new DirectoryResource('/____foo/foobar'.mt_rand(1, 999999));
     }
 

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -56,12 +56,10 @@ class FileResourceTest extends TestCase
         $this->assertSame(realpath($this->file), (string) $this->resource);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The file ".*" does not exist./
-     */
     public function testResourceDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The file ".*" does not exist./');
         $resource = new FileResource('/____foo/foobar'.mt_rand(1, 999999));
     }
 

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -65,12 +65,10 @@ class XmlUtilsTest extends TestCase
         $this->assertSame([], libxml_get_errors());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Util\Exception\InvalidXmlException
-     * @expectedExceptionMessage The XML is not valid
-     */
     public function testParseWithInvalidValidatorCallable()
     {
+        $this->expectException('Symfony\Component\Config\Util\Exception\InvalidXmlException');
+        $this->expectExceptionMessage('The XML is not valid');
         $fixtures = __DIR__.'/../Fixtures/Util/';
 
         $mock = $this->getMockBuilder(__NAMESPACE__.'\Validator')->getMock();

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -201,12 +201,10 @@ class ApplicationTest extends TestCase
         $this->assertEquals([$foo, $foo1], [$commands['foo:bar'], $commands['foo:bar1']], '->addCommands() registers an array of commands');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Command class "Foo5Command" is not correctly initialized. You probably forgot to call the parent constructor.
-     */
     public function testAddCommandWithEmptyConstructor()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Command class "Foo5Command" is not correctly initialized. You probably forgot to call the parent constructor.');
         $application = new Application();
         $application->add(new \Foo5Command());
     }
@@ -269,12 +267,10 @@ class ApplicationTest extends TestCase
         $this->assertEmpty($tester->getDisplay(true));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\CommandNotFoundException
-     * @expectedExceptionMessage The command "foofoo" does not exist.
-     */
     public function testGetInvalidCommand()
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
+        $this->expectExceptionMessage('The command "foofoo" does not exist.');
         $application = new Application();
         $application->get('foofoo');
     }
@@ -328,22 +324,18 @@ class ApplicationTest extends TestCase
         $this->assertEquals('test-ambiguous', $application->find('test')->getName());
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\CommandNotFoundException
-     * @expectedExceptionMessage There are no commands defined in the "bar" namespace.
-     */
     public function testFindInvalidNamespace()
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
+        $this->expectExceptionMessage('There are no commands defined in the "bar" namespace.');
         $application = new Application();
         $application->findNamespace('bar');
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\CommandNotFoundException
-     * @expectedExceptionMessage Command "foo1" is not defined
-     */
     public function testFindUniqueNameButNamespaceName()
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
+        $this->expectExceptionMessage('Command "foo1" is not defined');
         $application = new Application();
         $application->add(new \FooCommand());
         $application->add(new \Foo1Command());
@@ -386,12 +378,10 @@ class ApplicationTest extends TestCase
         $this->assertInstanceOf('FooSameCaseLowercaseCommand', $application->find('FoO:BaR'), '->find() will fallback to case insensitivity');
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\CommandNotFoundException
-     * @expectedExceptionMessage Command "FoO:BaR" is ambiguous
-     */
     public function testFindCaseInsensitiveSuggestions()
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
+        $this->expectExceptionMessage('Command "FoO:BaR" is ambiguous');
         $application = new Application();
         $application->add(new \FooSameCaseLowercaseCommand());
         $application->add(new \FooSameCaseUppercaseCommand());
@@ -479,12 +469,12 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider             provideInvalidCommandNamesSingle
-     * @expectedException        \Symfony\Component\Console\Exception\CommandNotFoundException
-     * @expectedExceptionMessage Did you mean this
+     * @dataProvider provideInvalidCommandNamesSingle
      */
     public function testFindAlternativeExceptionMessageSingle($name)
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
+        $this->expectExceptionMessage('Did you mean this');
         $application = new Application();
         $application->add(new \Foo3Command());
         $application->find($name);
@@ -660,12 +650,10 @@ class ApplicationTest extends TestCase
         $this->assertEquals('foo:sublong', $application->findNamespace('f:sub'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\CommandNotFoundException
-     * @expectedExceptionMessage Command "foo::bar" is not defined.
-     */
     public function testFindWithDoubleColonInNameThrowsException()
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
+        $this->expectExceptionMessage('Command "foo::bar" is not defined.');
         $application = new Application();
         $application->add(new \FooCommand());
         $application->add(new \Foo4Command());
@@ -1035,12 +1023,10 @@ class ApplicationTest extends TestCase
         $this->assertTrue($passedRightValue, '-> exit code 1 was passed in the console.terminate event');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage An option with shortcut "e" already exists.
-     */
     public function testAddingOptionWithDuplicateShortcut()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('An option with shortcut "e" already exists.');
         $dispatcher = new EventDispatcher();
         $application = new Application();
         $application->setAutoExit(false);
@@ -1063,11 +1049,11 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @expectedException \LogicException
      * @dataProvider getAddingAlreadySetDefinitionElementData
      */
     public function testAddingAlreadySetDefinitionElementData($def)
     {
+        $this->expectException('LogicException');
         $application = new Application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
@@ -1216,12 +1202,10 @@ class ApplicationTest extends TestCase
         $this->assertEquals('before.foo.after.'.PHP_EOL, $tester->getDisplay());
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage error
-     */
     public function testRunWithExceptionAndDispatcher()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('error');
         $application = new Application();
         $application->setDispatcher($this->getDispatcher());
         $application->setAutoExit(false);
@@ -1396,11 +1380,11 @@ class ApplicationTest extends TestCase
 
     /**
      * @requires PHP 7
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage error
      */
     public function testRunWithErrorAndDispatcher()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('error');
         $application = new Application();
         $application->setDispatcher($this->getDispatcher());
         $application->setAutoExit(false);
@@ -1650,11 +1634,9 @@ class ApplicationTest extends TestCase
         $this->assertSame(['lazy:alias', 'lazy:alias2'], $command->getAliases());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\CommandNotFoundException
-     */
     public function testGetDisabledLazyCommand()
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
         $application = new Application();
         $application->setCommandLoader(new FactoryCommandLoader(['disabled' => function () { return new DisabledCommand(); }]));
         $application->get('disabled');

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -43,12 +43,10 @@ class CommandTest extends TestCase
         $this->assertEquals('foo:bar', $command->getName(), '__construct() takes the command name as its first argument');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage The command defined in "Symfony\Component\Console\Command\Command" cannot have an empty name.
-     */
     public function testCommandNameCannotBeEmpty()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('The command defined in "Symfony\Component\Console\Command\Command" cannot have an empty name.');
         (new Application())->add(new Command());
     }
 
@@ -217,12 +215,10 @@ class CommandTest extends TestCase
         $this->assertEquals($formatterHelper->getName(), $command->getHelper('formatter')->getName(), '->getHelper() returns the correct helper');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage Cannot retrieve helper "formatter" because there is no HelperSet defined.
-     */
     public function testGetHelperWithoutHelperSet()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Cannot retrieve helper "formatter" because there is no HelperSet defined.');
         $command = new \TestCommand();
         $command->getHelper('formatter');
     }
@@ -290,22 +286,18 @@ class CommandTest extends TestCase
         $this->assertEquals('execute called'.PHP_EOL, $tester->getDisplay(), '->run() does not call the interact() method if the input is not interactive');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage You must override the execute() method in the concrete command class.
-     */
     public function testExecuteMethodNeedsToBeOverridden()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('You must override the execute() method in the concrete command class.');
         $command = new Command('foo');
         $command->run(new StringInput(''), new NullOutput());
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\InvalidOptionException
-     * @expectedExceptionMessage The "--bar" option does not exist.
-     */
     public function testRunWithInvalidOption()
     {
+        $this->expectException('Symfony\Component\Console\Exception\InvalidOptionException');
+        $this->expectExceptionMessage('The "--bar" option does not exist.');
         $command = new \TestCommand();
         $tester = new CommandTester($command);
         $tester->execute(['--bar' => true]);

--- a/src/Symfony/Component/Console/Tests/CommandLoader/ContainerCommandLoaderTest.php
+++ b/src/Symfony/Component/Console/Tests/CommandLoader/ContainerCommandLoaderTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Console\Tests\CommandLoader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class ContainerCommandLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testHas()
     {
         $loader = new ContainerCommandLoader(new ServiceLocator([
@@ -41,11 +44,9 @@ class ContainerCommandLoaderTest extends TestCase
         $this->assertInstanceOf(Command::class, $loader->get('bar'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\CommandNotFoundException
-     */
     public function testGetUnknownCommandThrows()
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
         (new ContainerCommandLoader(new ServiceLocator([]), []))->get('unknown');
     }
 

--- a/src/Symfony/Component/Console/Tests/CommandLoader/FactoryCommandLoaderTest.php
+++ b/src/Symfony/Component/Console/Tests/CommandLoader/FactoryCommandLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Console\Tests\CommandLoader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\FactoryCommandLoader;
 
 class FactoryCommandLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testHas()
     {
         $loader = new FactoryCommandLoader([
@@ -40,11 +43,9 @@ class FactoryCommandLoaderTest extends TestCase
         $this->assertInstanceOf(Command::class, $loader->get('bar'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\CommandNotFoundException
-     */
     public function testGetUnknownCommandThrows()
     {
+        $this->expectException('Symfony\Component\Console\Exception\CommandNotFoundException');
         (new FactoryCommandLoader([]))->get('unknown');
     }
 

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
@@ -24,6 +25,8 @@ use Symfony\Component\DependencyInjection\TypedReference;
 
 class AddConsoleCommandPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider visibilityProvider
      */
@@ -121,12 +124,10 @@ class AddConsoleCommandPassTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "my-command" tagged "console.command" must not be abstract.
-     */
     public function testProcessThrowAnExceptionIfTheServiceIsAbstract()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must not be abstract.');
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->addCompilerPass(new AddConsoleCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
@@ -139,12 +140,10 @@ class AddConsoleCommandPassTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "my-command" tagged "console.command" must be a subclass of "Symfony\Component\Console\Command\Command".
-     */
     public function testProcessThrowAnExceptionIfTheServiceIsNotASubclassOfCommand()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must be a subclass of "Symfony\Component\Console\Command\Command".');
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->addCompilerPass(new AddConsoleCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
@@ -227,12 +226,10 @@ class AddConsoleCommandPassTest extends TestCase
         $this->assertInstanceOf($className, $command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The definition for "my-child-command" has no class.
-     */
     public function testProcessOnChildDefinitionWithoutClass()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('The definition for "my-child-command" has no class.');
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddConsoleCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
 

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleStackTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleStackTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Console\Tests\Formatter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Formatter\OutputFormatterStyleStack;
 
 class OutputFormatterStyleStackTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testPush()
     {
         $stack = new OutputFormatterStyleStack();
@@ -59,11 +62,9 @@ class OutputFormatterStyleStackTest extends TestCase
         $this->assertEquals($s1, $stack->pop());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidPop()
     {
+        $this->expectException('InvalidArgumentException');
         $stack = new OutputFormatterStyleStack();
         $stack->push(new OutputFormatterStyle('white', 'black'));
         $stack->pop(new OutputFormatterStyle('yellow', 'blue'));

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Helper\ProgressIndicator;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -11,6 +12,8 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class ProgressIndicatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testDefaultIndicator()
     {
         $bar = new ProgressIndicator($output = $this->getOutputStream());
@@ -100,42 +103,34 @@ class ProgressIndicatorTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Must have at least 2 indicator value characters.
-     */
     public function testCannotSetInvalidIndicatorCharacters()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Must have at least 2 indicator value characters.');
         $bar = new ProgressIndicator($this->getOutputStream(), null, 100, ['1']);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Progress indicator already started.
-     */
     public function testCannotStartAlreadyStartedIndicator()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Progress indicator already started.');
         $bar = new ProgressIndicator($this->getOutputStream());
         $bar->start('Starting...');
         $bar->start('Starting Again.');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Progress indicator has not yet been started.
-     */
     public function testCannotAdvanceUnstartedIndicator()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Progress indicator has not yet been started.');
         $bar = new ProgressIndicator($this->getOutputStream());
         $bar->advance();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Progress indicator has not yet been started.
-     */
     public function testCannotFinishUnstartedIndicator()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Progress indicator has not yet been started.');
         $bar = new ProgressIndicator($this->getOutputStream());
         $bar->finish('Finished');
     }

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Tests\Helper;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -25,6 +26,8 @@ use Symfony\Component\Console\Question\Question;
  */
 class QuestionHelperTest extends AbstractQuestionHelperTest
 {
+    use ForwardCompatTestTrait;
+
     public function testAskChoice()
     {
         $questionHelper = new QuestionHelper();
@@ -518,12 +521,10 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $this->assertSame($expectedValue, $answer);
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The provided answer is ambiguous. Value should be one of env_2 or env_3.
-     */
     public function testAmbiguousChoiceFromChoicelist()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The provided answer is ambiguous. Value should be one of env_2 or env_3.');
         $possibleChoices = [
             'env_1' => 'My first environment',
             'env_2' => 'My environment',
@@ -748,7 +749,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     }
 
     /**
-     * @group        legacy
+     * @group legacy
      * @dataProvider getAskConfirmationData
      */
     public function testLegacyAskConfirmation($question, $expected, $default = true)
@@ -810,7 +811,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     }
 
     /**
-     * @group        legacy
+     * @group legacy
      * @dataProvider simpleAnswerProvider
      */
     public function testLegacySelectChoiceFromSimpleChoices($providedAnswer, $expectedValue)
@@ -834,7 +835,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     }
 
     /**
-     * @group        legacy
+     * @group legacy
      * @dataProvider mixedKeysChoiceListAnswerProvider
      */
     public function testLegacyChoiceFromChoicelistWithMixedKeys($providedAnswer, $expectedValue)
@@ -859,7 +860,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     }
 
     /**
-     * @group        legacy
+     * @group legacy
      * @dataProvider answerProvider
      */
     public function testLegacySelectChoiceFromChoiceList($providedAnswer, $expectedValue)
@@ -883,12 +884,12 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
     }
 
     /**
-     * @group                    legacy
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The provided answer is ambiguous. Value should be one of env_2 or env_3.
+     * @group legacy
      */
     public function testLegacyAmbiguousChoiceFromChoicelist()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The provided answer is ambiguous. Value should be one of env_2 or env_3.');
         $possibleChoices = [
             'env_1' => 'My first environment',
             'env_2' => 'My environment',
@@ -938,32 +939,26 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $dialog->ask($this->createInputInterfaceMock(), $output, $question);
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Aborted.
-     */
     public function testAskThrowsExceptionOnMissingInput()
     {
+        $this->expectException('Symfony\Component\Console\Exception\RuntimeException');
+        $this->expectExceptionMessage('Aborted.');
         $dialog = new QuestionHelper();
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new Question('What\'s your name?'));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Aborted.
-     */
     public function testAskThrowsExceptionOnMissingInputForChoiceQuestion()
     {
+        $this->expectException('Symfony\Component\Console\Exception\RuntimeException');
+        $this->expectExceptionMessage('Aborted.');
         $dialog = new QuestionHelper();
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new ChoiceQuestion('Choice', ['a', 'b']));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Aborted.
-     */
     public function testAskThrowsExceptionOnMissingInputWithValidator()
     {
+        $this->expectException('Symfony\Component\Console\Exception\RuntimeException');
+        $this->expectExceptionMessage('Aborted.');
         $dialog = new QuestionHelper();
 
         $question = new Question('What\'s your name?');
@@ -976,12 +971,10 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), $question);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Choice question must have at least 1 choice available.
-     */
     public function testEmptyChoices()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Choice question must have at least 1 choice available.');
         new ChoiceQuestion('Question', [], 'irrelevant');
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\Console\Tests\Helper;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
@@ -14,6 +15,8 @@ use Symfony\Component\Console\Question\Question;
  */
 class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
 {
+    use ForwardCompatTestTrait;
+
     public function testAskChoice()
     {
         $questionHelper = new SymfonyQuestionHelper();
@@ -122,12 +125,10 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
         $this->assertOutputContains('Question with a trailing \\', $output);
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Aborted.
-     */
     public function testAskThrowsExceptionOnMissingInput()
     {
+        $this->expectException('Symfony\Component\Console\Exception\RuntimeException');
+        $this->expectExceptionMessage('Aborted.');
         $dialog = new SymfonyQuestionHelper();
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new Question('What\'s your name?'));
     }

--- a/src/Symfony/Component/Console/Tests/Helper/TableStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableStyleTest.php
@@ -12,16 +12,17 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Helper\TableStyle;
 
 class TableStyleTest extends TestCase
 {
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage Invalid padding type. Expected one of (STR_PAD_LEFT, STR_PAD_RIGHT, STR_PAD_BOTH).
-     */
+    use ForwardCompatTestTrait;
+
     public function testSetPadTypeWithInvalidType()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid padding type. Expected one of (STR_PAD_LEFT, STR_PAD_RIGHT, STR_PAD_BOTH).');
         $style = new TableStyle();
         $style->setPadType('TEST');
     }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -729,12 +729,10 @@ TABLE;
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\InvalidArgumentException
-     * @expectedExceptionMessage A cell must be a TableCell, a scalar or an object implementing __toString, array given.
-     */
     public function testThrowsWhenTheCellInAnArray()
     {
+        $this->expectException('Symfony\Component\Console\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('A cell must be a TableCell, a scalar or an object implementing __toString, array given.');
         $table = new Table($output = $this->getOutputStream());
         $table
             ->setHeaders(['ISBN', 'Title', 'Author', 'Price'])
@@ -808,22 +806,18 @@ TABLE;
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Style "absent" is not defined.
-     */
     public function testIsNotDefinedStyleException()
     {
+        $this->expectException('Symfony\Component\Console\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Style "absent" is not defined.');
         $table = new Table($this->getOutputStream());
         $table->setStyle('absent');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Style "absent" is not defined.
-     */
     public function testGetStyleDefinition()
     {
+        $this->expectException('Symfony\Component\Console\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Style "absent" is not defined.');
         Table::getStyleDefinition('absent');
     }
 

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -94,22 +94,18 @@ class InputArgumentTest extends TestCase
         $this->assertEquals([1, 2], $argument->getDefault(), '->setDefault() changes the default value');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage Cannot set a default value except for InputArgument::OPTIONAL mode.
-     */
     public function testSetDefaultWithRequiredArgument()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Cannot set a default value except for InputArgument::OPTIONAL mode.');
         $argument = new InputArgument('foo', InputArgument::REQUIRED);
         $argument->setDefault('default');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage A default value for an array argument must be an array.
-     */
     public function testSetDefaultWithArrayArgument()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('A default value for an array argument must be an array.');
         $argument = new InputArgument('foo', InputArgument::IS_ARRAY);
         $argument->setDefault('default');
     }

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -89,12 +89,10 @@ class InputDefinitionTest extends TestCase
         $this->assertEquals(['foo' => $this->foo, 'bar' => $this->bar], $definition->getArguments(), '->addArgument() adds a InputArgument object');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage An argument with name "foo" already exists.
-     */
     public function testArgumentsMustHaveDifferentNames()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('An argument with name "foo" already exists.');
         $this->initializeArguments();
 
         $definition = new InputDefinition();
@@ -102,12 +100,10 @@ class InputDefinitionTest extends TestCase
         $definition->addArgument($this->foo1);
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage Cannot add an argument after an array argument.
-     */
     public function testArrayArgumentHasToBeLast()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Cannot add an argument after an array argument.');
         $this->initializeArguments();
 
         $definition = new InputDefinition();
@@ -115,12 +111,10 @@ class InputDefinitionTest extends TestCase
         $definition->addArgument(new InputArgument('anotherbar'));
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage Cannot add a required argument after an optional one.
-     */
     public function testRequiredArgumentCannotFollowAnOptionalOne()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Cannot add a required argument after an optional one.');
         $this->initializeArguments();
 
         $definition = new InputDefinition();
@@ -137,12 +131,10 @@ class InputDefinitionTest extends TestCase
         $this->assertEquals($this->foo, $definition->getArgument('foo'), '->getArgument() returns a InputArgument by its name');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The "bar" argument does not exist.
-     */
     public function testGetInvalidArgument()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The "bar" argument does not exist.');
         $this->initializeArguments();
 
         $definition = new InputDefinition();
@@ -209,12 +201,10 @@ class InputDefinitionTest extends TestCase
         $this->assertEquals(['bar' => $this->bar], $definition->getOptions(), '->setOptions() clears all InputOption objects');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The "-f" option does not exist.
-     */
     public function testSetOptionsClearsOptions()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The "-f" option does not exist.');
         $this->initializeOptions();
 
         $definition = new InputDefinition([$this->foo]);
@@ -243,12 +233,10 @@ class InputDefinitionTest extends TestCase
         $this->assertEquals(['foo' => $this->foo, 'bar' => $this->bar], $definition->getOptions(), '->addOption() adds a InputOption object');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage An option named "foo" already exists.
-     */
     public function testAddDuplicateOption()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('An option named "foo" already exists.');
         $this->initializeOptions();
 
         $definition = new InputDefinition();
@@ -256,12 +244,10 @@ class InputDefinitionTest extends TestCase
         $definition->addOption($this->foo2);
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage An option with shortcut "f" already exists.
-     */
     public function testAddDuplicateShortcutOption()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('An option with shortcut "f" already exists.');
         $this->initializeOptions();
 
         $definition = new InputDefinition();
@@ -277,12 +263,10 @@ class InputDefinitionTest extends TestCase
         $this->assertEquals($this->foo, $definition->getOption('foo'), '->getOption() returns a InputOption by its name');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The "--bar" option does not exist.
-     */
     public function testGetInvalidOption()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The "--bar" option does not exist.');
         $this->initializeOptions();
 
         $definition = new InputDefinition([$this->foo]);
@@ -324,12 +308,10 @@ class InputDefinitionTest extends TestCase
         $this->assertEquals($this->multi, $definition->getOptionForShortcut('mmm'), '->getOptionForShortcut() returns a InputOption by its shortcut');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The "-l" option does not exist.
-     */
     public function testGetOptionForInvalidShortcut()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The "-l" option does not exist.');
         $this->initializeOptions();
 
         $definition = new InputDefinition([$this->foo]);

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -27,12 +27,10 @@ class InputOptionTest extends TestCase
         $this->assertEquals('foo', $option->getName(), '__construct() removes the leading -- of the option name');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage Impossible to have an option mode VALUE_IS_ARRAY if the option does not accept a value.
-     */
     public function testArrayModeWithoutValue()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Impossible to have an option mode VALUE_IS_ARRAY if the option does not accept a value.');
         new InputOption('foo', 'f', InputOption::VALUE_IS_ARRAY);
     }
 
@@ -95,27 +93,21 @@ class InputOptionTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testEmptyNameIsInvalid()
     {
+        $this->expectException('InvalidArgumentException');
         new InputOption('');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDoubleDashNameIsInvalid()
     {
+        $this->expectException('InvalidArgumentException');
         new InputOption('--');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSingleDashOptionIsInvalid()
     {
+        $this->expectException('InvalidArgumentException');
         new InputOption('foo', '-');
     }
 
@@ -164,22 +156,18 @@ class InputOptionTest extends TestCase
         $this->assertEquals([1, 2], $option->getDefault(), '->setDefault() changes the default value');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage Cannot set a default value when using InputOption::VALUE_NONE mode.
-     */
     public function testDefaultValueWithValueNoneMode()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Cannot set a default value when using InputOption::VALUE_NONE mode.');
         $option = new InputOption('foo', 'f', InputOption::VALUE_NONE);
         $option->setDefault('default');
     }
 
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage A default value for an array option must be an array.
-     */
     public function testDefaultValueWithIsArrayMode()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('A default value for an array option must be an array.');
         $option = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY);
         $option->setDefault('default');
     }

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Input;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -19,6 +20,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 class InputTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name')]));
@@ -47,22 +50,18 @@ class InputTest extends TestCase
         $this->assertEquals(['name' => 'foo', 'bar' => null], $input->getOptions(), '->getOptions() returns all option values');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The "foo" option does not exist.
-     */
     public function testSetInvalidOption()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The "foo" option does not exist.');
         $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $input->setOption('foo', 'bar');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The "foo" option does not exist.
-     */
     public function testGetInvalidOption()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The "foo" option does not exist.');
         $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $input->getOption('foo');
     }
@@ -81,43 +80,35 @@ class InputTest extends TestCase
         $this->assertEquals(['name' => 'foo', 'bar' => 'default'], $input->getArguments(), '->getArguments() returns all argument values, even optional ones');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The "foo" argument does not exist.
-     */
     public function testSetInvalidArgument()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The "foo" argument does not exist.');
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
         $input->setArgument('foo', 'bar');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The "foo" argument does not exist.
-     */
     public function testGetInvalidArgument()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The "foo" argument does not exist.');
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
         $input->getArgument('foo');
     }
 
-    /**
-     * @expectedException        \RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "name").
-     */
     public function testValidateWithMissingArguments()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
         $input = new ArrayInput([]);
         $input->bind(new InputDefinition([new InputArgument('name', InputArgument::REQUIRED)]));
         $input->validate();
     }
 
-    /**
-     * @expectedException        \RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "name").
-     */
     public function testValidateWithMissingRequiredArguments()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
         $input = new ArrayInput(['bar' => 'baz']);
         $input->bind(new InputDefinition([new InputArgument('name', InputArgument::REQUIRED), new InputArgument('bar', InputArgument::OPTIONAL)]));
         $input->validate();

--- a/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
+++ b/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tests\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,6 +28,8 @@ use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
  */
 class ConsoleLoggerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var DummyOutput
      */
@@ -141,11 +144,9 @@ class ConsoleLoggerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Psr\Log\InvalidArgumentException
-     */
     public function testThrowsOnInvalidLevel()
     {
+        $this->expectException('Psr\Log\InvalidArgumentException');
         $logger = $this->getLogger();
         $logger->log('invalid level', 'Foo');
     }

--- a/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
@@ -39,12 +39,10 @@ class StreamOutputTest extends TestCase
         $this->assertTrue($output->isDecorated(), '__construct() takes the decorated flag as its second argument');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The StreamOutput class needs a stream as its first argument.
-     */
     public function testStreamIsRequired()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The StreamOutput class needs a stream as its first argument.');
         new StreamOutput('foo');
     }
 

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -141,12 +141,10 @@ class CommandTesterTest extends TestCase
         $this->assertEquals(implode('', $questions), $tester->getDisplay(true));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Aborted.
-     */
     public function testCommandWithWrongInputsNumber()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Aborted.');
         $questions = [
             'What\'s your name?',
             'How are you?',
@@ -168,12 +166,10 @@ class CommandTesterTest extends TestCase
         $tester->execute([]);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Aborted.
-     */
     public function testCommandWithQuestionsButNoInputs()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Aborted.');
         $questions = [
             'What\'s your name?',
             'How are you?',

--- a/src/Symfony/Component/CssSelector/Tests/CssSelectorConverterTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/CssSelectorConverterTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\CssSelector\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
 class CssSelectorConverterTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCssToXPath()
     {
         $converter = new CssSelectorConverter();
@@ -35,12 +38,10 @@ class CssSelectorConverterTest extends TestCase
         $this->assertEquals('descendant-or-self::H1', $converter->toXPath('H1'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\CssSelector\Exception\ParseException
-     * @expectedExceptionMessage Expected identifier, but <eof at 3> found.
-     */
     public function testParseExceptions()
     {
+        $this->expectException('Symfony\Component\CssSelector\Exception\ParseException');
+        $this->expectExceptionMessage('Expected identifier, but <eof at 3> found.');
         $converter = new CssSelectorConverter();
         $converter->toXPath('h1:');
     }

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\CssSelector\Tests\XPath;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\CssSelector\Node\ElementNode;
 use Symfony\Component\CssSelector\Node\FunctionNode;
 use Symfony\Component\CssSelector\Parser\Parser;
@@ -21,6 +22,8 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
 
 class TranslatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /** @dataProvider getXpathLiteralTestData */
     public function testXpathLiteral($value, $literal)
     {
@@ -35,31 +38,25 @@ class TranslatorTest extends TestCase
         $this->assertEquals($xpath, $translator->cssToXPath($css, ''));
     }
 
-    /**
-     * @expectedException \Symfony\Component\CssSelector\Exception\ExpressionErrorException
-     */
     public function testCssToXPathPseudoElement()
     {
+        $this->expectException('Symfony\Component\CssSelector\Exception\ExpressionErrorException');
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $translator->cssToXPath('e::first-line');
     }
 
-    /**
-     * @expectedException \Symfony\Component\CssSelector\Exception\ExpressionErrorException
-     */
     public function testGetExtensionNotExistsExtension()
     {
+        $this->expectException('Symfony\Component\CssSelector\Exception\ExpressionErrorException');
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $translator->getExtension('fake');
     }
 
-    /**
-     * @expectedException \Symfony\Component\CssSelector\Exception\ExpressionErrorException
-     */
     public function testAddCombinationNotExistsExtension()
     {
+        $this->expectException('Symfony\Component\CssSelector\Exception\ExpressionErrorException');
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $parser = new Parser();
@@ -68,11 +65,9 @@ class TranslatorTest extends TestCase
         $translator->addCombination('fake', $xpath, $combinedXpath);
     }
 
-    /**
-     * @expectedException \Symfony\Component\CssSelector\Exception\ExpressionErrorException
-     */
     public function testAddFunctionNotExistsFunction()
     {
+        $this->expectException('Symfony\Component\CssSelector\Exception\ExpressionErrorException');
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $xpath = new XPathExpr();
@@ -80,22 +75,18 @@ class TranslatorTest extends TestCase
         $translator->addFunction($xpath, $function);
     }
 
-    /**
-     * @expectedException \Symfony\Component\CssSelector\Exception\ExpressionErrorException
-     */
     public function testAddPseudoClassNotExistsClass()
     {
+        $this->expectException('Symfony\Component\CssSelector\Exception\ExpressionErrorException');
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $xpath = new XPathExpr();
         $translator->addPseudoClass($xpath, 'fake');
     }
 
-    /**
-     * @expectedException \Symfony\Component\CssSelector\Exception\ExpressionErrorException
-     */
     public function testAddAttributeMatchingClassNotExistsClass()
     {
+        $this->expectException('Symfony\Component\CssSelector\Exception\ExpressionErrorException');
         $translator = new Translator();
         $translator->registerExtension(new HtmlExtension($translator));
         $xpath = new XPathExpr();

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -62,12 +62,10 @@ class DebugClassLoaderTest extends TestCase
         $this->fail('DebugClassLoader did not register');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage boo
-     */
     public function testThrowingClass()
     {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('boo');
         try {
             class_exists(__NAMESPACE__.'\Fixtures\Throwing');
             $this->fail('Exception expected');
@@ -142,21 +140,17 @@ class DebugClassLoaderTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Case mismatch between loaded and declared class names
-     */
     public function testNameCaseMismatch()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Case mismatch between loaded and declared class names');
         class_exists(__NAMESPACE__.'\TestingCaseMismatch', true);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Case mismatch between class and real file names
-     */
     public function testFileCaseMismatch()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Case mismatch between class and real file names');
         if (!file_exists(__DIR__.'/Fixtures/CaseMismatch.php')) {
             $this->markTestSkipped('Can only be run on case insensitive filesystems');
         }
@@ -164,12 +158,10 @@ class DebugClassLoaderTest extends TestCase
         class_exists(__NAMESPACE__.'\Fixtures\CaseMismatch', true);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Case mismatch between loaded and declared class names
-     */
     public function testPsr4CaseMismatch()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Case mismatch between loaded and declared class names');
         class_exists(__NAMESPACE__.'\Fixtures\Psr4CaseMismatch', true);
     }
 

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Debug\Tests;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Debug\BufferingLogger;
 use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\Debug\Exception\SilencedErrorContext;
@@ -28,6 +29,8 @@ use Symfony\Component\Debug\Tests\Fixtures\LoggerThatSetAnErrorHandler;
  */
 class ErrorHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testRegister()
     {
         $handler = ErrorHandler::register();
@@ -573,11 +576,11 @@ class ErrorHandlerTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception
      * @group no-hhvm
      */
     public function testCustomExceptionHandler()
     {
+        $this->expectException('Exception');
         $handler = new ErrorHandler();
         $handler->setExceptionHandler(function ($e) use ($handler) {
             $handler->handleException($e);

--- a/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 class ChildDefinitionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $def = new ChildDefinition('foo');
@@ -90,11 +93,9 @@ class ChildDefinitionTest extends TestCase
         $this->assertSame(['index_0' => 'foo'], $def->getArguments());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testReplaceArgumentShouldRequireIntegerIndex()
     {
+        $this->expectException('InvalidArgumentException');
         $def = new ChildDefinition('foo');
 
         $def->replaceArgument('0', 'foo');
@@ -119,11 +120,9 @@ class ChildDefinitionTest extends TestCase
         $this->assertSame([0 => 'foo', 1 => 'bar', 'index_1' => 'baz', '$bar' => 'val'], $def->getArguments());
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testGetArgumentShouldCheckBounds()
     {
+        $this->expectException('OutOfBoundsException');
         $def = new ChildDefinition('foo');
 
         $def->setArguments([0 => 'foo']);
@@ -137,20 +136,16 @@ class ChildDefinitionTest extends TestCase
         $this->assertInstanceOf(ChildDefinition::class, new DefinitionDecorator('foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
-     */
     public function testCannotCallSetAutoconfigured()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\BadMethodCallException');
         $def = new ChildDefinition('foo');
         $def->setAutoconfigured(true);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
-     */
     public function testCannotCallSetInstanceofConditionals()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\BadMethodCallException');
         $def = new ChildDefinition('foo');
         $def->setInstanceofConditionals(['Foo' => new ChildDefinition('')]);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoAliasServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoAliasServicePassTest.php
@@ -12,16 +12,17 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\AutoAliasServicePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class AutoAliasServicePassTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException
-     */
+    use ForwardCompatTestTrait;
+
     public function testProcessWithMissingParameter()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException');
         $container = new ContainerBuilder();
 
         $container->register('example')
@@ -31,11 +32,9 @@ class AutoAliasServicePassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     */
     public function testProcessWithMissingFormat()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $container = new ContainerBuilder();
 
         $container->register('example')

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -186,12 +186,10 @@ class AutowirePassTest extends TestCase
         $this->assertCount(1, $pass->getAutowiringExceptions());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Invalid service "private_service": constructor of class "Symfony\Component\DependencyInjection\Tests\Compiler\PrivateConstructor" must be public.
-     */
     public function testPrivateConstructorThrowsAutowireException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Invalid service "private_service": constructor of class "Symfony\Component\DependencyInjection\Tests\Compiler\PrivateConstructor" must be public.');
         $container = new ContainerBuilder();
 
         $container->autowire('private_service', __NAMESPACE__.'\PrivateConstructor');
@@ -200,12 +198,10 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "a": argument "$collision" of method "Symfony\Component\DependencyInjection\Tests\Compiler\CannotBeAutowired::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" but no such service exists. You should maybe alias this interface to one of these existing services: "c1", "c2", "c3".
-     */
     public function testTypeCollision()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "a": argument "$collision" of method "Symfony\Component\DependencyInjection\Tests\Compiler\CannotBeAutowired::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" but no such service exists. You should maybe alias this interface to one of these existing services: "c1", "c2", "c3".');
         $container = new ContainerBuilder();
 
         $container->register('c1', __NAMESPACE__.'\CollisionA');
@@ -218,12 +214,10 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "a": argument "$k" of method "Symfony\Component\DependencyInjection\Tests\Compiler\NotGuessableArgument::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\Foo" but no such service exists. You should maybe alias this class to one of these existing services: "a1", "a2".
-     */
     public function testTypeNotGuessable()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "a": argument "$k" of method "Symfony\Component\DependencyInjection\Tests\Compiler\NotGuessableArgument::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\Foo" but no such service exists. You should maybe alias this class to one of these existing services: "a1", "a2".');
         $container = new ContainerBuilder();
 
         $container->register('a1', __NAMESPACE__.'\Foo');
@@ -235,12 +229,10 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "a": argument "$k" of method "Symfony\Component\DependencyInjection\Tests\Compiler\NotGuessableArgumentForSubclass::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\A" but no such service exists. You should maybe alias this class to one of these existing services: "a1", "a2".
-     */
     public function testTypeNotGuessableWithSubclass()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "a": argument "$k" of method "Symfony\Component\DependencyInjection\Tests\Compiler\NotGuessableArgumentForSubclass::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\A" but no such service exists. You should maybe alias this class to one of these existing services: "a1", "a2".');
         $container = new ContainerBuilder();
 
         $container->register('a1', __NAMESPACE__.'\B');
@@ -252,12 +244,10 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "a": argument "$collision" of method "Symfony\Component\DependencyInjection\Tests\Compiler\CannotBeAutowired::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" but no such service exists.
-     */
     public function testTypeNotGuessableNoServicesFound()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "a": argument "$collision" of method "Symfony\Component\DependencyInjection\Tests\Compiler\CannotBeAutowired::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" but no such service exists.');
         $container = new ContainerBuilder();
 
         $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
@@ -376,12 +366,10 @@ class AutowirePassTest extends TestCase
         $this->assertCount(0, $container->getDefinition('bar')->getArguments());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "a": argument "$r" of method "Symfony\Component\DependencyInjection\Tests\Compiler\BadTypeHintedArgument::__construct()" has type "Symfony\Component\DependencyInjection\Tests\Compiler\NotARealClass" but this class was not found.
-     */
     public function testClassNotFoundThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "a": argument "$r" of method "Symfony\Component\DependencyInjection\Tests\Compiler\BadTypeHintedArgument::__construct()" has type "Symfony\Component\DependencyInjection\Tests\Compiler\NotARealClass" but this class was not found.');
         $container = new ContainerBuilder();
 
         $aDefinition = $container->register('a', __NAMESPACE__.'\BadTypeHintedArgument');
@@ -393,12 +381,10 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "a": argument "$r" of method "Symfony\Component\DependencyInjection\Tests\Compiler\BadParentTypeHintedArgument::__construct()" has type "Symfony\Component\DependencyInjection\Tests\Compiler\OptionalServiceClass" but this class is missing a parent class (Class Symfony\Bug\NotExistClass not found).
-     */
     public function testParentClassNotFoundThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "a": argument "$r" of method "Symfony\Component\DependencyInjection\Tests\Compiler\BadParentTypeHintedArgument::__construct()" has type "Symfony\Component\DependencyInjection\Tests\Compiler\OptionalServiceClass" but this class is missing a parent class (Class Symfony\Bug\NotExistClass not found).');
         if (\PHP_VERSION_ID >= 70400) {
             throw new Warning('PHP 7.4 breaks this test, see https://bugs.php.net/78351.');
         }
@@ -463,12 +449,10 @@ class AutowirePassTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "arg_no_type_hint": argument "$bar" of method "Symfony\Component\DependencyInjection\Tests\Compiler\MultipleArguments::__construct()" is type-hinted "array", you should configure its value explicitly.
-     */
     public function testScalarArgsCannotBeAutowired()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "arg_no_type_hint": argument "$bar" of method "Symfony\Component\DependencyInjection\Tests\Compiler\MultipleArguments::__construct()" is type-hinted "array", you should configure its value explicitly.');
         $container = new ContainerBuilder();
 
         $container->register(A::class);
@@ -481,12 +465,10 @@ class AutowirePassTest extends TestCase
         (new AutowirePass())->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "arg_no_type_hint": argument "$foo" of method "Symfony\Component\DependencyInjection\Tests\Compiler\MultipleArguments::__construct()" has no type-hint, you should configure its value explicitly.
-     */
     public function testNoTypeArgsCannotBeAutowired()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "arg_no_type_hint": argument "$foo" of method "Symfony\Component\DependencyInjection\Tests\Compiler\MultipleArguments::__construct()" has no type-hint, you should configure its value explicitly.');
         $container = new ContainerBuilder();
 
         $container->register(A::class);
@@ -615,11 +597,11 @@ class AutowirePassTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @exceptedExceptionMessage Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy": method "setLogger()" does not exist.
      */
     public function testWithNonExistingSetterAndAutowiring()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
 
         $definition = $container->register(CaseSensitiveClass::class, CaseSensitiveClass::class)->setAutowired(true);
@@ -756,12 +738,10 @@ class AutowirePassTest extends TestCase
         $this->assertSame('Cannot autowire service "setter_injection_collision": argument "$collision" of method "Symfony\Component\DependencyInjection\Tests\Compiler\SetterInjectionCollision::setMultipleInstancesForOneArg()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" but no such service exists. You should maybe alias this interface to one of these existing services: "c1", "c2".', $e->getMessage());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "my_service": argument "$i" of method "Symfony\Component\DependencyInjection\Tests\Compiler\K::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\IInterface" but no such service exists. Did you create a class that implements this interface?
-     */
     public function testInterfaceWithNoImplementationSuggestToWriteOne()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "my_service": argument "$i" of method "Symfony\Component\DependencyInjection\Tests\Compiler\K::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\IInterface" but no such service exists. Did you create a class that implements this interface?');
         $container = new ContainerBuilder();
 
         $aDefinition = $container->register('my_service', K::class);
@@ -827,10 +807,10 @@ class AutowirePassTest extends TestCase
 
     /**
      * @dataProvider provideNotWireableCalls
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
      */
     public function testNotWireableCalls($method, $expectedMsg)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
         $container = new ContainerBuilder();
 
         $foo = $container->register('foo', NotWireable::class)->setAutowired(true)
@@ -899,12 +879,10 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "j": argument "$i" of method "Symfony\Component\DependencyInjection\Tests\Compiler\J::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\I" but no such service exists. Try changing the type-hint to "Symfony\Component\DependencyInjection\Tests\Compiler\IInterface" instead.
-     */
     public function testExceptionWhenAliasExists()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "j": argument "$i" of method "Symfony\Component\DependencyInjection\Tests\Compiler\J::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\I" but no such service exists. Try changing the type-hint to "Symfony\Component\DependencyInjection\Tests\Compiler\IInterface" instead.');
         $container = new ContainerBuilder();
 
         // multiple I services... but there *is* IInterface available
@@ -919,12 +897,10 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
-     * @expectedExceptionMessage Cannot autowire service "j": argument "$i" of method "Symfony\Component\DependencyInjection\Tests\Compiler\J::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\I" but no such service exists. You should maybe alias this class to one of these existing services: "i", "i2".
-     */
     public function testExceptionWhenAliasDoesNotExist()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\AutowiringFailedException');
+        $this->expectExceptionMessage('Cannot autowire service "j": argument "$i" of method "Symfony\Component\DependencyInjection\Tests\Compiler\J::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\I" but no such service exists. You should maybe alias this class to one of these existing services: "i", "i2".');
         if (\PHP_VERSION_ID >= 70400) {
             throw new Warning('PHP 7.4 breaks this test, see https://bugs.php.net/78351.');
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckArgumentsValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckArgumentsValidityPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\CheckArgumentsValidityPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class CheckArgumentsValidityPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -41,11 +44,11 @@ class CheckArgumentsValidityPassTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @dataProvider definitionProvider
      */
     public function testException(array $arguments, array $methodCalls)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
         $definition = $container->register('foo');
         $definition->setArguments($arguments);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\CheckCircularReferencesPass;
@@ -21,11 +22,11 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class CheckCircularReferencesPassTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     */
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
         $container = new ContainerBuilder();
         $container->register('a')->addArgument(new Reference('b'));
         $container->register('b')->addArgument(new Reference('a'));
@@ -33,11 +34,9 @@ class CheckCircularReferencesPassTest extends TestCase
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     */
     public function testProcessWithAliases()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
         $container = new ContainerBuilder();
         $container->register('a')->addArgument(new Reference('b'));
         $container->setAlias('b', 'c');
@@ -46,11 +45,9 @@ class CheckCircularReferencesPassTest extends TestCase
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     */
     public function testProcessWithFactory()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
         $container = new ContainerBuilder();
 
         $container
@@ -64,11 +61,9 @@ class CheckCircularReferencesPassTest extends TestCase
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     */
     public function testProcessDetectsIndirectCircularReference()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
         $container = new ContainerBuilder();
         $container->register('a')->addArgument(new Reference('b'));
         $container->register('b')->addArgument(new Reference('c'));
@@ -77,11 +72,9 @@ class CheckCircularReferencesPassTest extends TestCase
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     */
     public function testProcessDetectsIndirectCircularReferenceWithFactory()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
         $container = new ContainerBuilder();
 
         $container->register('a')->addArgument(new Reference('b'));
@@ -95,11 +88,9 @@ class CheckCircularReferencesPassTest extends TestCase
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     */
     public function testDeepCircularReference()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
         $container = new ContainerBuilder();
         $container->register('a')->addArgument(new Reference('b'));
         $container->register('b')->addArgument(new Reference('c'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -12,27 +12,26 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\CheckDefinitionValidityPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class CheckDefinitionValidityPassTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     */
+    use ForwardCompatTestTrait;
+
     public function testProcessDetectsSyntheticNonPublicDefinitions()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
         $container->register('a')->setSynthetic(true)->setPublic(false);
 
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     */
     public function testProcessDetectsNonSyntheticNonAbstractDefinitionWithoutClass()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
         $container->register('a')->setSynthetic(false)->setAbstract(false);
 
@@ -65,22 +64,18 @@ class CheckDefinitionValidityPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     */
     public function testInvalidTags()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
         $container->register('a', 'class')->addTag('foo', ['bar' => ['baz' => 'baz']]);
 
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvParameterException
-     */
     public function testDynamicPublicServiceName()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\EnvParameterException');
         $container = new ContainerBuilder();
         $env = $container->getParameterBag()->get('env(BAR)');
         $container->register("foo.$env", 'class')->setPublic(true);
@@ -88,11 +83,9 @@ class CheckDefinitionValidityPassTest extends TestCase
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvParameterException
-     */
     public function testDynamicPublicAliasName()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\EnvParameterException');
         $container = new ContainerBuilder();
         $env = $container->getParameterBag()->get('env(BAR)');
         $container->setAlias("foo.$env", 'class')->setPublic(true);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -35,11 +38,9 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     */
     public function testProcessThrowsExceptionOnInvalidReference()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
         $container = new ContainerBuilder();
 
         $container
@@ -50,11 +51,9 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
         $this->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     */
     public function testProcessThrowsExceptionOnInvalidReferenceFromInlinedDefinition()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
         $container = new ContainerBuilder();
 
         $def = new Definition();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckReferenceValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckReferenceValidityPassTest.php
@@ -12,17 +12,18 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\CheckReferenceValidityPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 class CheckReferenceValidityPassTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     */
+    use ForwardCompatTestTrait;
+
     public function testProcessDetectsReferenceToAbstractDefinition()
     {
+        $this->expectException('RuntimeException');
         $container = new ContainerBuilder();
 
         $container->register('a')->setAbstract(true);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DefinitionErrorExceptionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DefinitionErrorExceptionPassTest.php
@@ -12,18 +12,19 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\DefinitionErrorExceptionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 class DefinitionErrorExceptionPassTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Things went wrong!
-     */
+    use ForwardCompatTestTrait;
+
     public function testThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Things went wrong!');
         $container = new ContainerBuilder();
         $def = new Definition();
         $def->addError('Things went wrong!');

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
@@ -23,6 +24,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class InlineServiceDefinitionsPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -111,12 +114,10 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $this->assertEquals(new Reference('bar'), $container->getDefinition('foo')->getArgument(0));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     * @expectedExceptionMessage Circular reference detected for service "bar", path: "bar -> foo -> bar".
-     */
     public function testProcessThrowsOnNonSharedLoops()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
+        $this->expectExceptionMessage('Circular reference detected for service "bar", path: "bar -> foo -> bar".');
         $container = new ContainerBuilder();
         $container
             ->register('foo')

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Resource\FileResource;
@@ -23,6 +24,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class MergeExtensionConfigurationPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testExpressionLanguageProviderForwarding()
     {
         $tmpProviders = [];
@@ -102,12 +105,10 @@ class MergeExtensionConfigurationPassTest extends TestCase
         $this->assertSame(['BAZ' => 1, 'FOO' => 0], $container->getEnvCounters());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Using a cast in "env(int:FOO)" is incompatible with resolution at compile time in "Symfony\Component\DependencyInjection\Tests\Compiler\BarExtension". The logic in the extension should be moved to a compiler pass, or an env parameter with no cast should be used instead.
-     */
     public function testProcessedEnvsAreIncompatibleWithResolve()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Using a cast in "env(int:FOO)" is incompatible with resolution at compile time in "Symfony\Component\DependencyInjection\Tests\Compiler\BarExtension". The logic in the extension should be moved to a compiler pass, or an env parameter with no cast should be used instead.');
         $container = new ContainerBuilder();
         $container->registerExtension(new BarExtension());
         $container->prependExtensionConfig('bar', []);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\RegisterEnvVarProcessorsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 
 class RegisterEnvVarProcessorsPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSimpleProcessor()
     {
         $container = new ContainerBuilder();
@@ -53,12 +56,10 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
         $this->assertFalse($container->has('container.env_var_processors_locator'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid type "foo" returned by "Symfony\Component\DependencyInjection\Tests\Compiler\BadProcessor::getProvidedTypes()", expected one of "array", "bool", "float", "int", "string".
-     */
     public function testBadProcessor()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid type "foo" returned by "Symfony\Component\DependencyInjection\Tests\Compiler\BadProcessor::getProvidedTypes()", expected one of "array", "bool", "float", "int", "string".');
         $container = new ContainerBuilder();
         $container->register('foo', BadProcessor::class)->addTag('container.env_var_processor');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\RegisterServiceSubscribersPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveServiceSubscribersPass;
@@ -28,12 +29,12 @@ require_once __DIR__.'/../Fixtures/includes/classes.php';
 
 class RegisterServiceSubscribersPassTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Service "foo" must implement interface "Symfony\Component\DependencyInjection\ServiceSubscriberInterface".
-     */
+    use ForwardCompatTestTrait;
+
     public function testInvalidClass()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Service "foo" must implement interface "Symfony\Component\DependencyInjection\ServiceSubscriberInterface".');
         $container = new ContainerBuilder();
 
         $container->register('foo', CustomDefinition::class)
@@ -44,12 +45,10 @@ class RegisterServiceSubscribersPassTest extends TestCase
         (new ResolveServiceSubscribersPass())->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The "container.service_subscriber" tag accepts only the "key" and "id" attributes, "bar" given for service "foo".
-     */
     public function testInvalidAttributes()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The "container.service_subscriber" tag accepts only the "key" and "id" attributes, "bar" given for service "foo".');
         $container = new ContainerBuilder();
 
         $container->register('foo', TestServiceSubscriber::class)
@@ -118,12 +117,10 @@ class RegisterServiceSubscribersPassTest extends TestCase
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Service key "test" does not exist in the map returned by "Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber::getSubscribedServices()" for service "foo_service".
-     */
     public function testExtraServiceSubscriber()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Service key "test" does not exist in the map returned by "Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber::getSubscribedServices()" for service "foo_service".');
         $container = new ContainerBuilder();
         $container->register('foo_service', TestServiceSubscriber::class)
             ->setAutowired(true)

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\ReplaceAliasByActualDefinitionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -21,6 +22,8 @@ require_once __DIR__.'/../Fixtures/includes/foo.php';
 
 class ReplaceAliasByActualDefinitionPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -53,11 +56,9 @@ class ReplaceAliasByActualDefinitionPassTest extends TestCase
         $this->assertSame('b_alias', (string) $resolvedFactory[0]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testProcessWithInvalidAlias()
     {
+        $this->expectException('InvalidArgumentException');
         $container = new ContainerBuilder();
         $container->setAlias('a_alias', 'a');
         $this->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Compiler\AutowireRequiredMethodsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveBindingsPass;
@@ -28,6 +29,8 @@ require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
 
 class ResolveBindingsPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -49,12 +52,10 @@ class ResolveBindingsPassTest extends TestCase
         $this->assertEquals([['setSensitiveClass', [new Reference('foo')]]], $definition->getMethodCalls());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Unused binding "$quz" in service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy".
-     */
     public function testUnusedBinding()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Unused binding "$quz" in service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy".');
         $container = new ContainerBuilder();
 
         $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
@@ -64,12 +65,10 @@ class ResolveBindingsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegexp Unused binding "$quz" in service [\s\S]+ Invalid service ".*\\ParentNotExists": class NotExists not found\.
-     */
     public function testMissingParent()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('Unused binding "$quz" in service [\s\S]+ Invalid service ".*\\ParentNotExists": class NotExists not found\.');
         if (\PHP_VERSION_ID >= 70400) {
             throw new Warning('PHP 7.4 breaks this test, see https://bugs.php.net/78351.');
         }
@@ -119,11 +118,11 @@ class ResolveBindingsPassTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @exceptedExceptionMessage Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy": method "setLogger()" does not exist.
      */
     public function testWithNonExistingSetterAndBinding()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
 
         $bindings = [

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -68,7 +68,7 @@ class ResolveBindingsPassTest extends TestCase
     public function testMissingParent()
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
-        $this->expectExceptionMessageRegExp('Unused binding "$quz" in service [\s\S]+ Invalid service ".*\\ParentNotExists": class NotExists not found\.');
+        $this->expectExceptionMessageRegExp('/Unused binding "\$quz" in service [\s\S]+/');
         if (\PHP_VERSION_ID >= 70400) {
             throw new Warning('PHP 7.4 breaks this test, see https://bugs.php.net/78351.');
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
@@ -19,6 +20,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ResolveChildDefinitionsPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -432,12 +435,10 @@ class ResolveChildDefinitionsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     * @expectedExceptionMessageRegExp /^Circular reference detected for service "c", path: "c -> b -> a -> c"./
-     */
     public function testProcessDetectsChildDefinitionIndirectCircularReference()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
+        $this->expectExceptionMessageRegExp('/^Circular reference detected for service "c", path: "c -> b -> a -> c"./');
         $container = new ContainerBuilder();
 
         $container->register('a');

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -19,6 +20,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 
 class ResolveClassPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider provideValidClassId
      */
@@ -82,12 +85,10 @@ class ResolveClassPassTest extends TestCase
         $this->assertSame(self::class, $child->getClass());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Service definition "App\Foo\Child" has a parent but no class, and its name looks like a FQCN. Either the class is missing or you want to inherit it from the parent service. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.
-     */
     public function testAmbiguousChildDefinition()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Service definition "App\Foo\Child" has a parent but no class, and its name looks like a FQCN. Either the class is missing or you want to inherit it from the parent service. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.');
         $container = new ContainerBuilder();
         $parent = $container->register('App\Foo', null);
         $child = $container->setDefinition('App\Foo\Child', new ChildDefinition('App\Foo'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveFactoryClassPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveFactoryClassPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\ResolveFactoryClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -19,6 +20,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ResolveFactoryClassPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -71,12 +74,10 @@ class ResolveFactoryClassPassTest extends TestCase
         $this->assertSame($factory, $container->getDefinition('factory')->getFactory());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The "factory" service is defined to be created by a factory, but is missing the factory class. Did you forget to define the factory or service class?
-     */
     public function testNotAnyClassThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The "factory" service is defined to be created by a factory, but is missing the factory class. Did you forget to define the factory or service class?');
         $container = new ContainerBuilder();
 
         $factory = $container->register('factory');

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ResolveInstanceofConditionalsPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -172,12 +175,10 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $this->assertFalse($def->isAutowired());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage "App\FakeInterface" is set as an "instanceof" conditional, but it does not exist.
-     */
     public function testBadInterfaceThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('"App\FakeInterface" is set as an "instanceof" conditional, but it does not exist.');
         $container = new ContainerBuilder();
         $def = $container->register('normal_service', self::class);
         $def->setInstanceofConditionals([
@@ -200,12 +201,10 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $this->assertTrue($container->hasDefinition('normal_service'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Autoconfigured instanceof for type "PHPUnit\Framework\TestCase" defines method calls but these are not supported and should be removed.
-     */
     public function testProcessThrowsExceptionForAutoconfiguredCalls()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Autoconfigured instanceof for type "PHPUnit\Framework\TestCase" defines method calls but these are not supported and should be removed.');
         $container = new ContainerBuilder();
         $container->registerForAutoconfiguration(parent::class)
             ->addMethodCall('setFoo');
@@ -213,12 +212,10 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         (new ResolveInstanceofConditionalsPass())->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Autoconfigured instanceof for type "PHPUnit\Framework\TestCase" defines arguments but these are not supported and should be removed.
-     */
     public function testProcessThrowsExceptionForArguments()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Autoconfigured instanceof for type "PHPUnit\Framework\TestCase" defines arguments but these are not supported and should be removed.');
         $container = new ContainerBuilder();
         $container->registerForAutoconfiguration(parent::class)
             ->addArgument('bar');

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Compiler\ResolveNamedArgumentsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -26,6 +27,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1;
  */
 class ResolveNamedArgumentsPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -60,11 +63,9 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $this->assertSame([0 => '123'], $definition->getArguments());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     */
     public function testClassNull()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
 
         $definition = $container->register(NamedArgumentsDummy::class);
@@ -74,11 +75,9 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     */
     public function testClassNotExist()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
 
         $definition = $container->register(NotExist::class, NotExist::class);
@@ -88,11 +87,9 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     */
     public function testClassNoConstructor()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $container = new ContainerBuilder();
 
         $definition = $container->register(NoConstructor::class, NoConstructor::class);
@@ -102,12 +99,10 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy": method "__construct()" has no argument named "$notFound". Check your service definition.
-     */
     public function testArgumentNotFound()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy": method "__construct()" has no argument named "$notFound". Check your service definition.');
         $container = new ContainerBuilder();
 
         $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
@@ -117,12 +112,10 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1": method "Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummyWithoutReturnTypes::createTestDefinition1()" has no argument named "$notFound". Check your service definition.
-     */
     public function testCorrectMethodReportedInException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid service "Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1": method "Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummyWithoutReturnTypes::createTestDefinition1()" has no argument named "$notFound". Check your service definition.');
         $container = new ContainerBuilder();
 
         $container->register(FactoryDummyWithoutReturnTypes::class, FactoryDummyWithoutReturnTypes::class);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\ResolveReferencesToAliasesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ResolveReferencesToAliasesPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -51,11 +54,9 @@ class ResolveReferencesToAliasesPassTest extends TestCase
         $this->assertEquals('foo', (string) $arguments[0]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     */
     public function testAliasCircularReference()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
         $container = new ContainerBuilder();
         $container->setAlias('bar', 'foo');
         $container->setAlias('foo', 'bar');

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,12 +26,12 @@ require_once __DIR__.'/../Fixtures/includes/classes.php';
 
 class ServiceLocatorTagPassTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid definition for service "foo": an array of references is expected as first argument when the "container.service_locator" tag is set.
-     */
+    use ForwardCompatTestTrait;
+
     public function testNoServices()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid definition for service "foo": an array of references is expected as first argument when the "container.service_locator" tag is set.');
         $container = new ContainerBuilder();
 
         $container->register('foo', ServiceLocator::class)
@@ -40,12 +41,10 @@ class ServiceLocatorTagPassTest extends TestCase
         (new ServiceLocatorTagPass())->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid definition for service "foo": an array of references is expected as first argument when the "container.service_locator" tag is set, "string" found for key "0".
-     */
     public function testInvalidServices()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid definition for service "foo": an array of references is expected as first argument when the "container.service_locator" tag is set, "string" found for key "0".');
         $container = new ContainerBuilder();
 
         $container->register('foo', ServiceLocator::class)

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -131,12 +131,10 @@ class ContainerBuilderTest extends TestCase
         $this->assertTrue($builder->has('bar'), '->has() returns true if a service exists');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage You have requested a non-existent service "foo".
-     */
     public function testGetThrowsExceptionIfServiceDoesNotExist()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
+        $this->expectExceptionMessage('You have requested a non-existent service "foo".');
         $builder = new ContainerBuilder();
         $builder->get('foo');
     }
@@ -148,11 +146,9 @@ class ContainerBuilderTest extends TestCase
         $this->assertNull($builder->get('foo', ContainerInterface::NULL_ON_INVALID_REFERENCE), '->get() returns null if the service does not exist and NULL_ON_INVALID_REFERENCE is passed as a second argument');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     */
     public function testGetThrowsCircularReferenceExceptionIfServiceHasReferenceToItself()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
         $builder = new ContainerBuilder();
         $builder->register('baz', 'stdClass')->setArguments([new Reference('baz')]);
         $builder->get('baz');
@@ -200,21 +196,21 @@ class ContainerBuilderTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @dataProvider provideBadId
      */
     public function testBadAliasId($id)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $builder = new ContainerBuilder();
         $builder->setAlias($id, 'foo');
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @dataProvider provideBadId
      */
     public function testBadDefinitionId($id)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $builder = new ContainerBuilder();
         $builder->setDefinition($id, new Definition('Foo'));
     }
@@ -231,12 +227,10 @@ class ContainerBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException        \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage You have requested a synthetic service ("foo"). The DIC does not know how to construct this service.
-     */
     public function testGetUnsetLoadingServiceWhenCreateServiceThrowsAnException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('You have requested a synthetic service ("foo"). The DIC does not know how to construct this service.');
         $builder = new ContainerBuilder();
         $builder->register('foo', 'stdClass')->setSynthetic(true);
 
@@ -515,11 +509,9 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals(0, $i);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCreateSyntheticService()
     {
+        $this->expectException('RuntimeException');
         $builder = new ContainerBuilder();
         $builder->register('foo', 'Bar\FooClass')->setSynthetic(true);
         $builder->get('foo');
@@ -543,12 +535,10 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals($builder->get('foo'), $builder->resolveServices(new Expression('service("foo")')), '->resolveServices() resolves expressions');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Constructing service "foo" from a parent definition is not supported at build time.
-     */
     public function testResolveServicesWithDecoratedDefinition()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Constructing service "foo" from a parent definition is not supported at build time.');
         $builder = new ContainerBuilder();
         $builder->setDefinition('grandpa', new Definition('stdClass'));
         $builder->setDefinition('parent', new ChildDefinition('grandpa'));
@@ -624,12 +614,10 @@ class ContainerBuilderTest extends TestCase
         $this->assertSame(['AInterface' => $childDefA, 'BInterface' => $childDefB], $container->getAutoconfiguredInstanceof());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage "AInterface" has already been autoconfigured and merge() does not support merging autoconfiguration for the same class/interface.
-     */
     public function testMergeThrowsExceptionForDuplicateAutomaticInstanceofDefinitions()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('"AInterface" has already been autoconfigured and merge() does not support merging autoconfiguration for the same class/interface.');
         $container = new ContainerBuilder();
         $config = new ContainerBuilder();
         $container->registerForAutoconfiguration('AInterface');
@@ -731,12 +719,10 @@ class ContainerBuilderTest extends TestCase
         putenv('ARRAY');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage A string value must be composed of strings and/or numbers, but found parameter "env(json:ARRAY)" of type array inside string value "ABC %env(json:ARRAY)%".
-     */
     public function testCompileWithArrayInStringResolveEnv()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('A string value must be composed of strings and/or numbers, but found parameter "env(json:ARRAY)" of type array inside string value "ABC %env(json:ARRAY)%".');
         putenv('ARRAY={"foo":"bar"}');
 
         $container = new ContainerBuilder();
@@ -746,12 +732,10 @@ class ContainerBuilderTest extends TestCase
         putenv('ARRAY');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvNotFoundException
-     * @expectedExceptionMessage Environment variable not found: "FOO".
-     */
     public function testCompileWithResolveMissingEnv()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\EnvNotFoundException');
+        $this->expectExceptionMessage('Environment variable not found: "FOO".');
         $container = new ContainerBuilder();
         $container->setParameter('foo', '%env(FOO)%');
         $container->compile(true);
@@ -830,12 +814,10 @@ class ContainerBuilderTest extends TestCase
         $this->assertSame(['baz_bar'], array_keys($container->getDefinition('foo')->getArgument(1)));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException
-     * @expectedExceptionMessage Circular reference detected for parameter "env(resolve:DUMMY_ENV_VAR)" ("env(resolve:DUMMY_ENV_VAR)" > "env(resolve:DUMMY_ENV_VAR)").
-     */
     public function testCircularDynamicEnv()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException');
+        $this->expectExceptionMessage('Circular reference detected for parameter "env(resolve:DUMMY_ENV_VAR)" ("env(resolve:DUMMY_ENV_VAR)" > "env(resolve:DUMMY_ENV_VAR)").');
         putenv('DUMMY_ENV_VAR=some%foo%');
 
         $container = new ContainerBuilder();
@@ -849,11 +831,9 @@ class ContainerBuilderTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testMergeLogicException()
     {
+        $this->expectException('LogicException');
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->compile();
@@ -1103,11 +1083,9 @@ class ContainerBuilderTest extends TestCase
         $this->assertInstanceOf('BarClass', $container->get('bar_user')->bar);
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testThrowsExceptionWhenSetServiceOnACompiledContainer()
     {
+        $this->expectException('BadMethodCallException');
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->register('a', 'stdClass')->setPublic(true);
@@ -1134,11 +1112,9 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals($a, $container->get('a'));
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testThrowsExceptionWhenSetDefinitionOnACompiledContainer()
     {
+        $this->expectException('BadMethodCallException');
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
         $container->compile();
@@ -1230,12 +1206,10 @@ class ContainerBuilderTest extends TestCase
         $this->assertNotSame($bar->foo, $barUser->foo);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     * @expectedExceptionMessage Circular reference detected for service "app.test_class", path: "app.test_class -> App\TestClass -> app.test_class".
-     */
     public function testThrowsCircularExceptionForCircularAliases()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
+        $this->expectExceptionMessage('Circular reference detected for service "app.test_class", path: "app.test_class -> App\TestClass -> app.test_class".');
         $builder = new ContainerBuilder();
 
         $builder->setAliases([
@@ -1288,60 +1262,50 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals(CaseSensitiveClass::class, $autoloadClass->getClass());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The definition for "DateTime" has no class attribute, and appears to reference a class or interface in the global namespace.
-     */
     public function testNoClassFromGlobalNamespaceClassId()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The definition for "DateTime" has no class attribute, and appears to reference a class or interface in the global namespace.');
         $container = new ContainerBuilder();
 
         $definition = $container->register(\DateTime::class);
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The definition for "\DateTime" has no class attribute, and appears to reference a class or interface in the global namespace.
-     */
     public function testNoClassFromGlobalNamespaceClassIdWithLeadingSlash()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The definition for "\DateTime" has no class attribute, and appears to reference a class or interface in the global namespace.');
         $container = new ContainerBuilder();
 
         $container->register('\\'.\DateTime::class);
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The definition for "\Symfony\Component\DependencyInjection\Tests\FooClass" has no class attribute, and appears to reference a class or interface. Please specify the class attribute explicitly or remove the leading backslash by renaming the service to "Symfony\Component\DependencyInjection\Tests\FooClass" to get rid of this error.
-     */
     public function testNoClassFromNamespaceClassIdWithLeadingSlash()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The definition for "\Symfony\Component\DependencyInjection\Tests\FooClass" has no class attribute, and appears to reference a class or interface. Please specify the class attribute explicitly or remove the leading backslash by renaming the service to "Symfony\Component\DependencyInjection\Tests\FooClass" to get rid of this error.');
         $container = new ContainerBuilder();
 
         $container->register('\\'.FooClass::class);
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The definition for "123_abc" has no class.
-     */
     public function testNoClassFromNonClassId()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The definition for "123_abc" has no class.');
         $container = new ContainerBuilder();
 
         $definition = $container->register('123_abc');
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The definition for "\foo" has no class.
-     */
     public function testNoClassFromNsSeparatorId()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The definition for "\foo" has no class.');
         $container = new ContainerBuilder();
 
         $definition = $container->register('\\foo');

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class ContainerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $sc = new Container();
@@ -331,24 +334,20 @@ class ContainerTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage The "request" service is synthetic, it needs to be set at boot time before it can be used.
-     */
     public function testGetSyntheticServiceThrows()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
+        $this->expectExceptionMessage('The "request" service is synthetic, it needs to be set at boot time before it can be used.');
         require_once __DIR__.'/Fixtures/php/services9_compiled.php';
 
         $container = new \ProjectServiceContainer();
         $container->get('request');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage The "inlined" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.
-     */
     public function testGetRemovedServiceThrows()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
+        $this->expectExceptionMessage('The "inlined" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.');
         require_once __DIR__.'/Fixtures/php/services9_compiled.php';
 
         $container = new \ProjectServiceContainer();
@@ -430,12 +429,10 @@ class ContainerTest extends TestCase
         $this->assertNull($c->get('bar', ContainerInterface::NULL_ON_INVALID_REFERENCE));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Something went terribly wrong!
-     */
     public function testGetThrowsException()
     {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('Something went terribly wrong!');
         $c = new ProjectServiceContainer();
 
         try {

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionDecoratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionDecoratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
  */
 class DefinitionDecoratorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $def = new DefinitionDecorator('foo');
@@ -92,11 +95,9 @@ class DefinitionDecoratorTest extends TestCase
         $this->assertEquals(['index_0' => 'foo'], $def->getArguments());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testReplaceArgumentShouldRequireIntegerIndex()
     {
+        $this->expectException('InvalidArgumentException');
         $def = new DefinitionDecorator('foo');
 
         $def->replaceArgument('0', 'foo');
@@ -117,11 +118,9 @@ class DefinitionDecoratorTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar', 'index_1' => 'baz'], $def->getArguments());
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testGetArgumentShouldCheckBounds()
     {
+        $this->expectException('OutOfBoundsException');
         $def = new DefinitionDecorator('foo');
 
         $def->setArguments([0 => 'foo']);

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -100,12 +100,10 @@ class DefinitionTest extends TestCase
         $this->assertEquals([['foo', ['foo']]], $def->getMethodCalls(), '->removeMethodCall() removes a method to call');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Method name cannot be empty.
-     */
     public function testExceptionOnEmptyMethodCall()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Method name cannot be empty.');
         $def = new Definition('stdClass');
         $def->addMethodCall('');
     }
@@ -168,10 +166,10 @@ class DefinitionTest extends TestCase
 
     /**
      * @dataProvider invalidDeprecationMessageProvider
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */
     public function testSetDeprecatedWithInvalidDeprecationTemplate($message)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $def = new Definition('stdClass');
         $def->setDeprecated(false, $message);
     }
@@ -253,35 +251,29 @@ class DefinitionTest extends TestCase
         $this->assertSame(['foo', 'bar'], $def->getArguments());
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testGetArgumentShouldCheckBounds()
     {
+        $this->expectException('OutOfBoundsException');
         $def = new Definition('stdClass');
 
         $def->addArgument('foo');
         $def->getArgument(1);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     * @expectedExceptionMessage The index "1" is not in the range [0, 0].
-     */
     public function testReplaceArgumentShouldCheckBounds()
     {
+        $this->expectException('OutOfBoundsException');
+        $this->expectExceptionMessage('The index "1" is not in the range [0, 0].');
         $def = new Definition('stdClass');
 
         $def->addArgument('foo');
         $def->replaceArgument(1, 'bar');
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     * @expectedExceptionMessage Cannot replace arguments if none have been configured yet.
-     */
     public function testReplaceArgumentWithoutExistingArgumentsShouldCheckBounds()
     {
+        $this->expectException('OutOfBoundsException');
+        $this->expectExceptionMessage('Cannot replace arguments if none have been configured yet.');
         $def = new Definition('stdClass');
         $def->replaceArgument(0, 'bar');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -154,10 +154,10 @@ class PhpDumperTest extends TestCase
 
     /**
      * @dataProvider provideInvalidParameters
-     * @expectedException \InvalidArgumentException
      */
     public function testExportParameters($parameters)
     {
+        $this->expectException('InvalidArgumentException');
         $container = new ContainerBuilder(new ParameterBag($parameters));
         $container->compile();
         $dumper = new PhpDumper($container);
@@ -288,11 +288,11 @@ class PhpDumperTest extends TestCase
 
     /**
      * @dataProvider provideInvalidFactories
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Cannot dump definition
      */
     public function testInvalidFactories($factory)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Cannot dump definition');
         $container = new ContainerBuilder();
         $def = new Definition('stdClass');
         $def->setPublic(true);
@@ -452,12 +452,10 @@ class PhpDumperTest extends TestCase
         $this->assertStringEqualsFile(__FILE__, $container->getParameter('random'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvParameterException
-     * @expectedExceptionMessage Environment variables "FOO" are never used. Please, check your container's configuration.
-     */
     public function testUnusedEnvParameter()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\EnvParameterException');
+        $this->expectExceptionMessage('Environment variables "FOO" are never used. Please, check your container\'s configuration.');
         $container = new ContainerBuilder();
         $container->getParameter('env(FOO)');
         $container->compile();
@@ -465,12 +463,10 @@ class PhpDumperTest extends TestCase
         $dumper->dump();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException
-     * @expectedExceptionMessage Circular reference detected for parameter "env(resolve:DUMMY_ENV_VAR)" ("env(resolve:DUMMY_ENV_VAR)" > "env(resolve:DUMMY_ENV_VAR)").
-     */
     public function testCircularDynamicEnv()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException');
+        $this->expectExceptionMessage('Circular reference detected for parameter "env(resolve:DUMMY_ENV_VAR)" ("env(resolve:DUMMY_ENV_VAR)" > "env(resolve:DUMMY_ENV_VAR)").');
         $container = new ContainerBuilder();
         $container->setParameter('foo', '%bar%');
         $container->setParameter('bar', '%env(resolve:DUMMY_ENV_VAR)%');

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -3,12 +3,15 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\EnvVarProcessor;
 
 class EnvVarProcessorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const TEST_CONST = 'test';
 
     /**
@@ -98,12 +101,12 @@ class EnvVarProcessorTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Non-numeric env var
      * @dataProvider invalidInts
      */
     public function testGetEnvIntInvalid($value)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Non-numeric env var');
         $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('int', 'foo', function ($name) use ($value) {
@@ -148,12 +151,12 @@ class EnvVarProcessorTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Non-numeric env var
      * @dataProvider invalidFloats
      */
     public function testGetEnvFloatInvalid($value)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Non-numeric env var');
         $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('float', 'foo', function ($name) use ($value) {
@@ -197,12 +200,12 @@ class EnvVarProcessorTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage undefined constant
      * @dataProvider invalidConsts
      */
     public function testGetEnvConstInvalid($value)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('undefined constant');
         $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('const', 'foo', function ($name) use ($value) {
@@ -246,12 +249,10 @@ class EnvVarProcessorTest extends TestCase
         $this->assertSame([1], $result);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Syntax error
-     */
     public function testGetEnvInvalidJson()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Syntax error');
         $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('json', 'foo', function ($name) {
@@ -262,12 +263,12 @@ class EnvVarProcessorTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Invalid JSON env var
      * @dataProvider otherJsonValues
      */
     public function testGetEnvJsonOther($value)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Invalid JSON env var');
         $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('json', 'foo', function ($name) use ($value) {
@@ -287,12 +288,10 @@ class EnvVarProcessorTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Unsupported env var prefix
-     */
     public function testGetEnvUnknown()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Unsupported env var prefix');
         $processor = new EnvVarProcessor(new Container());
 
         $processor->getEnv('unknown', 'foo', function ($name) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Extension/ExtensionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Extension/ExtensionTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\DependencyInjection\Tests\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class ExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getResolvedEnabledFixtures
      */
@@ -34,12 +37,10 @@ class ExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The config array has no 'enabled' key.
-     */
     public function testIsConfigEnabledOnNonEnableableConfig()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The config array has no \'enabled\' key.');
         $extension = new EnableableExtension();
 
         $extension->isConfigEnabled(new ContainerBuilder(), []);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
@@ -61,12 +61,10 @@ class DirectoryLoaderTest extends TestCase
         $this->assertEquals(['ini' => 'ini', 'yaml' => 'yaml'], $this->container->getParameterBag()->all(), '->load() takes a single file that imports a directory');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The file "foo" does not exist (in:
-     */
     public function testExceptionIsRaisedWhenDirectoryDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The file "foo" does not exist (in:');
         $this->loader->load('foo/');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -200,12 +200,10 @@ class FileLoaderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Expected to find class "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\Prototype\\Bar" in file ".+" while importing services from resource "Prototype\/Sub\/\*", but it was not found\! Check the namespace prefix used with the resource/
-     */
     public function testRegisterClassesWithBadPrefix()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/Expected to find class "Symfony\\\Component\\\DependencyInjection\\\Tests\\\Fixtures\\\Prototype\\\Bar" in file ".+" while importing services from resource "Prototype\/Sub\/\*", but it was not found\! Check the namespace prefix used with the resource/');
         $container = new ContainerBuilder();
         $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
@@ -98,30 +98,24 @@ class IniFileLoaderTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The file "foo.ini" does not exist (in:
-     */
     public function testExceptionIsRaisedWhenIniFileDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The file "foo.ini" does not exist (in:');
         $this->loader->load('foo.ini');
     }
 
-    /**
-     * @expectedException        \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The "nonvalid.ini" file is not valid.
-     */
     public function testExceptionIsRaisedWhenIniFileCannotBeParsed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The "nonvalid.ini" file is not valid.');
         @$this->loader->load('nonvalid.ini');
     }
 
-    /**
-     * @expectedException        \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The "almostvalid.ini" file is not valid.
-     */
     public function testExceptionIsRaisedWhenIniFileIsAlmostValid()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The "almostvalid.ini" file is not valid.');
         @$this->loader->load('almostvalid.ini');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
 class PhpFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSupports()
     {
         $loader = new PhpFileLoader(new ContainerBuilder(), new FileLocator());
@@ -77,12 +80,10 @@ class PhpFileLoaderTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The service "child_service" cannot have a "parent" and also have "autoconfigure". Try disabling autoconfiguration for the service.
-     */
     public function testAutoConfigureAndChildDefinitionNotAllowed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The service "child_service" cannot have a "parent" and also have "autoconfigure". Try disabling autoconfiguration for the service.');
         $fixtures = realpath(__DIR__.'/../Fixtures');
         $container = new ContainerBuilder();
         $loader = new PhpFileLoader($container, new FileLocator());
@@ -90,12 +91,10 @@ class PhpFileLoaderTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid factory "factory:method": the `service:method` notation is not available when using PHP-based DI configuration. Use "[ref('factory'), 'method']" instead.
-     */
     public function testFactoryShortNotationNotAllowed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid factory "factory:method": the `service:method` notation is not available when using PHP-based DI configuration. Use "[ref(\'factory\'), \'method\']" instead.');
         $fixtures = realpath(__DIR__.'/../Fixtures');
         $container = new ContainerBuilder();
         $loader = new PhpFileLoader($container, new FileLocator());

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -328,22 +328,18 @@ class XmlFileLoaderTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     */
     public function testParseTagsWithoutNameThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $container = new ContainerBuilder();
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('tag_without_name.xml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The tag name for service ".+" in .* must be a non-empty string/
-     */
     public function testParseTagWithEmptyNameThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The tag name for service ".+" in .* must be a non-empty string/');
         $container = new ContainerBuilder();
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('tag_with_empty_name.xml');
@@ -733,36 +729,30 @@ class XmlFileLoaderTest extends TestCase
         $this->assertSame(['foo' => [[]], 'bar' => [[]]], $definition->getTags());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The service "child_service" cannot use the "parent" option in the same file where "instanceof" configuration is defined as using both is not supported. Move your child definitions to a separate file.
-     */
     public function testInstanceOfAndChildDefinitionNotAllowed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The service "child_service" cannot use the "parent" option in the same file where "instanceof" configuration is defined as using both is not supported. Move your child definitions to a separate file.');
         $container = new ContainerBuilder();
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('services_instanceof_with_parent.xml');
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The service "child_service" cannot have a "parent" and also have "autoconfigure". Try setting autoconfigure="false" for the service.
-     */
     public function testAutoConfigureAndChildDefinitionNotAllowed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The service "child_service" cannot have a "parent" and also have "autoconfigure". Try setting autoconfigure="false" for the service.');
         $container = new ContainerBuilder();
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('services_autoconfigure_with_parent.xml');
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute "autowire" on service "child_service" cannot be inherited from "defaults" when a "parent" is set. Move your child definitions to a separate file or define this attribute explicitly.
-     */
     public function testDefaultsAndChildDefinitionNotAllowed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Attribute "autowire" on service "child_service" cannot be inherited from "defaults" when a "parent" is set. Move your child definitions to a separate file or define this attribute explicitly.');
         $container = new ContainerBuilder();
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('services_defaults_with_parent.xml');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -311,7 +311,7 @@ class YamlFileLoaderTest extends TestCase
     public function testTagWithNonStringNameThrowsException()
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
-        $this->expectExceptionMessageRegExp('The tag name for service "\.+" must be a non-empty string');
+        $this->expectExceptionMessageRegExp('/The tag name for service ".+" in .+ must be a non-empty string/');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('tag_name_no_string.yml');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -45,12 +45,10 @@ class YamlFileLoaderTest extends TestCase
         require_once self::$fixturesPath.'/includes/ProjectExtension.php';
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The file ".+" does not exist./
-     */
     public function testLoadUnExistFile()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The file ".+" does not exist./');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/ini'));
         $r = new \ReflectionObject($loader);
         $m = $r->getMethod('loadFile');
@@ -59,12 +57,10 @@ class YamlFileLoaderTest extends TestCase
         $m->invoke($loader, 'foo.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The file ".+" does not contain valid YAML./
-     */
     public function testLoadInvalidYamlFile()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The file ".+" does not contain valid YAML./');
         $path = self::$fixturesPath.'/ini';
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator($path));
         $r = new \ReflectionObject($loader);
@@ -76,10 +72,10 @@ class YamlFileLoaderTest extends TestCase
 
     /**
      * @dataProvider provideInvalidFiles
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */
     public function testLoadInvalidFile($file)
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
 
         $loader->load($file.'.yml');
@@ -304,40 +300,32 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(['manager' => [['alias' => 'user']]], $definition->getTags());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The tag name for service ".+" in .+ must be a non-empty string/
-     */
     public function testTagWithEmptyNameThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The tag name for service ".+" in .+ must be a non-empty string/');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('tag_name_empty_string.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageREgExp /The tag name for service "\.+" must be a non-empty string/
-     */
     public function testTagWithNonStringNameThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('The tag name for service "\.+" must be a non-empty string');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('tag_name_no_string.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     */
     public function testTypesNotArray()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('bad_types1.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     */
     public function testTypeNotString()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('bad_types2.yml');
     }
@@ -433,12 +421,10 @@ class YamlFileLoaderTest extends TestCase
         $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component2\Dir2\Service5::class)->hasTag('foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /A "resource" attribute must be set when the "namespace" attribute is set for service ".+" in .+/
-     */
     public function testPrototypeWithNamespaceAndNoResource()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/A "resource" attribute must be set when the "namespace" attribute is set for service ".+" in .+/');
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services_prototype_namespace_without_resource.yml');
@@ -509,58 +495,48 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame(['foo' => [[]], 'bar' => [[]]], $definition->getTags());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The service "child_service" cannot use the "parent" option in the same file where "_instanceof" configuration is defined as using both is not supported. Move your child definitions to a separate file.
-     */
     public function testInstanceOfAndChildDefinitionNotAllowed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The service "child_service" cannot use the "parent" option in the same file where "_instanceof" configuration is defined as using both is not supported. Move your child definitions to a separate file.');
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services_instanceof_with_parent.yml');
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The service "child_service" cannot have a "parent" and also have "autoconfigure". Try setting "autoconfigure: false" for the service.
-     */
     public function testAutoConfigureAndChildDefinitionNotAllowed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The service "child_service" cannot have a "parent" and also have "autoconfigure". Try setting "autoconfigure: false" for the service.');
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services_autoconfigure_with_parent.yml');
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Attribute "autowire" on service "child_service" cannot be inherited from "_defaults" when a "parent" is set. Move your child definitions to a separate file or define this attribute explicitly.
-     */
     public function testDefaultsAndChildDefinitionNotAllowed()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Attribute "autowire" on service "child_service" cannot be inherited from "_defaults" when a "parent" is set. Move your child definitions to a separate file or define this attribute explicitly.');
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services_defaults_with_parent.yml');
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The value of the "decorates" option for the "bar" service must be the id of the service without the "@" prefix (replace "@foo" with "foo").
-     */
     public function testDecoratedServicesWithWrongSyntaxThrowsException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The value of the "decorates" option for the "bar" service must be the id of the service without the "@" prefix (replace "@foo" with "foo").');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('bad_decorates.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Parameter "tags" must be an array for service "Foo\\Bar" in .+services31_invalid_tags\.yml\. Check your YAML syntax./
-     */
     public function testInvalidTagsWithDefaults()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/Parameter "tags" must be an array for service "Foo\\\Bar" in .+services31_invalid_tags\.yml\. Check your YAML syntax./');
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services31_invalid_tags.yml');
     }
@@ -649,23 +625,19 @@ class YamlFileLoaderTest extends TestCase
         $this->assertFalse($container->has('Bar'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Creating an alias using the tag "!service" is not allowed in ".+anonymous_services_alias\.yml"\./
-     */
     public function testAnonymousServicesWithAliases()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/Creating an alias using the tag "!service" is not allowed in ".+anonymous_services_alias\.yml"\./');
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('anonymous_services_alias.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Using an anonymous service in a parameter is not allowed in ".+anonymous_services_in_parameters\.yml"\./
-     */
     public function testAnonymousServicesInParameters()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/Using an anonymous service in a parameter is not allowed in ".+anonymous_services_in_parameters\.yml"\./');
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('anonymous_services_in_parameters.yml');
@@ -681,23 +653,19 @@ class YamlFileLoaderTest extends TestCase
         $this->assertFalse($container->getDefinition('override_defaults_settings_to_false')->isAutoconfigured());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Service "_defaults" key must be an array, "NULL" given in ".+bad_empty_defaults\.yml"\./
-     */
     public function testEmptyDefaultsThrowsClearException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/Service "_defaults" key must be an array, "NULL" given in ".+bad_empty_defaults\.yml"\./');
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('bad_empty_defaults.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Service "_instanceof" key must be an array, "NULL" given in ".+bad_empty_instanceof\.yml"\./
-     */
     public function testEmptyInstanceofThrowsClearException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/Service "_instanceof" key must be an array, "NULL" given in ".+bad_empty_instanceof\.yml"\./');
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('bad_empty_instanceof.yml');

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -19,11 +19,9 @@ class EnvPlaceholderParameterBagTest extends TestCase
 {
     use ForwardCompatTestTrait;
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     */
     public function testGetThrowsInvalidArgumentExceptionIfEnvNameContainsNonWordCharacters()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
         $bag = new EnvPlaceholderParameterBag();
         $bag->get('env(%foo%)');
     }
@@ -132,12 +130,10 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $this->assertNull($bag->all()['env(NULL_VAR)']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The default value of env parameter "ARRAY_VAR" must be scalar or null, array given.
-     */
     public function testResolveThrowsOnBadDefaultValue()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The default value of env parameter "ARRAY_VAR" must be scalar or null, array given.');
         $bag = new EnvPlaceholderParameterBag();
         $bag->get('env(ARRAY_VAR)');
         $bag->set('env(ARRAY_VAR)', []);
@@ -154,12 +150,10 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $this->assertNull($bag->all()['env(NULL_VAR)']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The default value of an env() parameter must be scalar or null, but "array" given to "env(ARRAY_VAR)".
-     */
     public function testGetThrowsOnBadDefaultValue()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The default value of an env() parameter must be scalar or null, but "array" given to "env(ARRAY_VAR)".');
         $bag = new EnvPlaceholderParameterBag();
         $bag->set('env(ARRAY_VAR)', []);
         $bag->get('env(ARRAY_VAR)');

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\DependencyInjection\Tests\ParameterBag;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 class FrozenParameterBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $parameters = [
@@ -26,38 +29,30 @@ class FrozenParameterBagTest extends TestCase
         $this->assertEquals($parameters, $bag->all(), '__construct() takes an array of parameters as its first argument');
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testClear()
     {
+        $this->expectException('LogicException');
         $bag = new FrozenParameterBag([]);
         $bag->clear();
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testSet()
     {
+        $this->expectException('LogicException');
         $bag = new FrozenParameterBag([]);
         $bag->set('foo', 'bar');
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testAdd()
     {
+        $this->expectException('LogicException');
         $bag = new FrozenParameterBag([]);
         $bag->add([]);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRemove()
     {
+        $this->expectException('LogicException');
         $bag = new FrozenParameterBag(['foo' => 'bar']);
         $bag->remove('foo');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 
 class ServiceLocatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testHas()
     {
         $locator = new ServiceLocator([
@@ -58,12 +61,10 @@ class ServiceLocatorTest extends TestCase
         $this->assertSame(2, $i);
     }
 
-    /**
-     * @expectedException        \Psr\Container\NotFoundExceptionInterface
-     * @expectedExceptionMessage Service "dummy" not found: the container inside "Symfony\Component\DependencyInjection\Tests\ServiceLocatorTest" is a smaller service locator that only knows about the "foo" and "bar" services.
-     */
     public function testGetThrowsOnUndefinedService()
     {
+        $this->expectException('Psr\Container\NotFoundExceptionInterface');
+        $this->expectExceptionMessage('Service "dummy" not found: the container inside "Symfony\Component\DependencyInjection\Tests\ServiceLocatorTest" is a smaller service locator that only knows about the "foo" and "bar" services.');
         $locator = new ServiceLocator([
             'foo' => function () { return 'bar'; },
             'bar' => function () { return 'baz'; },
@@ -72,12 +73,10 @@ class ServiceLocatorTest extends TestCase
         $locator->get('dummy');
     }
 
-    /**
-     * @expectedException        \Psr\Container\NotFoundExceptionInterface
-     * @expectedExceptionMessage The service "foo" has a dependency on a non-existent service "bar". This locator only knows about the "foo" service.
-     */
     public function testThrowsOnUndefinedInternalService()
     {
+        $this->expectException('Psr\Container\NotFoundExceptionInterface');
+        $this->expectExceptionMessage('The service "foo" has a dependency on a non-existent service "bar". This locator only knows about the "foo" service.');
         $locator = new ServiceLocator([
             'foo' => function () use (&$locator) { return $locator->get('bar'); },
         ]);
@@ -85,12 +84,10 @@ class ServiceLocatorTest extends TestCase
         $locator->get('foo');
     }
 
-    /**
-     * @expectedException        \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
-     * @expectedExceptionMessage Circular reference detected for service "bar", path: "bar -> baz -> bar".
-     */
     public function testThrowsOnCircularReference()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
+        $this->expectExceptionMessage('Circular reference detected for service "bar", path: "bar -> baz -> bar".');
         $locator = new ServiceLocator([
             'foo' => function () use (&$locator) { return $locator->get('bar'); },
             'bar' => function () use (&$locator) { return $locator->get('baz'); },
@@ -100,12 +97,10 @@ class ServiceLocatorTest extends TestCase
         $locator->get('foo');
     }
 
-    /**
-     * @expectedException        \Psr\Container\NotFoundExceptionInterface
-     * @expectedExceptionMessage Service "foo" not found: even though it exists in the app's container, the container inside "caller" is a smaller service locator that only knows about the "bar" service. Unless you need extra laziness, try using dependency injection instead. Otherwise, you need to declare it using "SomeServiceSubscriber::getSubscribedServices()".
-     */
     public function testThrowsInServiceSubscriber()
     {
+        $this->expectException('Psr\Container\NotFoundExceptionInterface');
+        $this->expectExceptionMessage('Service "foo" not found: even though it exists in the app\'s container, the container inside "caller" is a smaller service locator that only knows about the "bar" service. Unless you need extra laziness, try using dependency injection instead. Otherwise, you need to declare it using "SomeServiceSubscriber::getSubscribedServices()".');
         $container = new Container();
         $container->set('foo', new \stdClass());
         $subscriber = new SomeServiceSubscriber();
@@ -115,12 +110,10 @@ class ServiceLocatorTest extends TestCase
         $subscriber->getFoo();
     }
 
-    /**
-     * @expectedException        \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage Service "foo" not found: even though it exists in the app's container, the container inside "foo" is a smaller service locator that is empty... Try using dependency injection instead.
-     */
     public function testGetThrowsServiceNotFoundException()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
+        $this->expectExceptionMessage('Service "foo" not found: even though it exists in the app\'s container, the container inside "foo" is a smaller service locator that is empty... Try using dependency injection instead.');
         $container = new Container();
         $container->set('foo', new \stdClass());
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -72,21 +72,17 @@ class CrawlerTest extends TestCase
         $this->assertEquals('Foo', $crawler->filterXPath('//body')->text(), '->add() adds nodes from a string');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAddInvalidType()
     {
+        $this->expectException('InvalidArgumentException');
         $crawler = new Crawler();
         $crawler->add(1);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Attaching DOM nodes from multiple documents in the same crawler is forbidden.
-     */
     public function testAddMultipleDocumentNode()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Attaching DOM nodes from multiple documents in the same crawler is forbidden.');
         $crawler = $this->createTestCrawler();
         $crawler->addHtmlContent('<html><div class="foo"></html>', 'UTF-8');
     }
@@ -772,22 +768,18 @@ HTML;
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The selected node should be instance of DOMElement
-     */
     public function testInvalidLink()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
         $crawler = $this->createTestCrawler('http://example.com/bar/');
         $crawler->filterXPath('//li/text()')->link();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The selected node should be instance of DOMElement
-     */
     public function testInvalidLinks()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
         $crawler = $this->createTestCrawler('http://example.com/bar/');
         $crawler->filterXPath('//li/text()')->link();
     }
@@ -889,12 +881,10 @@ HTML;
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The selected node should be instance of DOMElement
-     */
     public function testInvalidForm()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
         $crawler = $this->createTestCrawler('http://example.com/bar/');
         $crawler->filterXPath('//li/text()')->form();
     }
@@ -1002,7 +992,7 @@ HTML;
             $this->assertTrue(true, '->children() does not trigger a notice if the node has no children');
         } catch (\PHPUnit\Framework\Error\Notice $e) {
             $this->fail('->children() does not trigger a notice if the node has no children');
-        } catch (\PHPUnit_Framework_Error_Notice $e) {
+        } catch (\PHPUnit\Framework\Error\Notice $e) {
             $this->fail('->children() does not trigger a notice if the node has no children');
         }
     }
@@ -1112,11 +1102,9 @@ HTML;
         $this->assertSame('input', $crawler->first()->nodeName());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testEvaluateThrowsAnExceptionIfDocumentIsEmpty()
     {
+        $this->expectException('LogicException');
         (new Crawler())->evaluate('//form/input[1]');
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -67,11 +67,10 @@ class FormTest extends TestCase
 
     /**
      * __construct() should throw \\LogicException if the form attribute is invalid.
-     *
-     * @expectedException \LogicException
      */
     public function testConstructorThrowsExceptionIfNoRelatedForm()
     {
+        $this->expectException('LogicException');
         $dom = new \DOMDocument();
         $dom->loadHTML('
             <html>
@@ -717,20 +716,16 @@ class FormTest extends TestCase
         $registry->remove('[t:dbt%3adate;]data_daterange_enddate_value');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testFormFieldRegistryGetThrowAnExceptionWhenTheFieldDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
         $registry = new FormFieldRegistry();
         $registry->get('foo');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testFormFieldRegistrySetThrowAnExceptionWhenTheFieldDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
         $registry = new FormFieldRegistry();
         $registry->set('foo', null);
     }
@@ -807,24 +802,20 @@ class FormTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot set value on a compound field "foo[bar]".
-     */
     public function testFormRegistrySetValueOnCompoundField()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Cannot set value on a compound field "foo[bar]".');
         $registry = new FormFieldRegistry();
         $registry->add($this->getFormFieldMock('foo[bar][baz]'));
 
         $registry->set('foo[bar]', 'fbb');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unreachable field "0"
-     */
     public function testFormRegistrySetArrayOnNotCompoundField()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Unreachable field "0"');
         $registry = new FormFieldRegistry();
         $registry->add($this->getFormFieldMock('bar'));
 

--- a/src/Symfony/Component/DomCrawler/Tests/ImageTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/ImageTest.php
@@ -12,15 +12,16 @@
 namespace Symfony\Component\DomCrawler\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DomCrawler\Image;
 
 class ImageTest extends TestCase
 {
-    /**
-     * @expectedException \LogicException
-     */
+    use ForwardCompatTestTrait;
+
     public function testConstructorWithANonImgTag()
     {
+        $this->expectException('LogicException');
         $dom = new \DOMDocument();
         $dom->loadHTML('<html><div><div></html>');
 

--- a/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
@@ -12,26 +12,25 @@
 namespace Symfony\Component\DomCrawler\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DomCrawler\Link;
 
 class LinkTest extends TestCase
 {
-    /**
-     * @expectedException \LogicException
-     */
+    use ForwardCompatTestTrait;
+
     public function testConstructorWithANonATag()
     {
+        $this->expectException('LogicException');
         $dom = new \DOMDocument();
         $dom->loadHTML('<html><div><div></html>');
 
         new Link($dom->getElementsByTagName('div')->item(0), 'http://www.example.com/');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorWithAnInvalidCurrentUri()
     {
+        $this->expectException('InvalidArgumentException');
         $dom = new \DOMDocument();
         $dom->loadHTML('<html><a href="/foo">foo</a></html>');
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Dotenv\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Dotenv\Exception\FormatException;
 
 class DotenvTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getEnvDataWithFormatErrors
      */
@@ -200,11 +203,9 @@ class DotenvTest extends TestCase
         $this->assertSame('BAZ', $bar);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Dotenv\Exception\PathException
-     */
     public function testLoadDirectory()
     {
+        $this->expectException('Symfony\Component\Dotenv\Exception\PathException');
         $dotenv = new Dotenv();
         $dotenv->load(__DIR__);
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\EventDispatcher\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -19,14 +20,15 @@ use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 
 class RegisterListenersPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * Tests that event subscribers not implementing EventSubscriberInterface
      * trigger an exception.
-     *
-     * @expectedException \InvalidArgumentException
      */
     public function testEventSubscriberWithoutInterface()
     {
+        $this->expectException('InvalidArgumentException');
         $builder = new ContainerBuilder();
         $builder->register('event_dispatcher');
         $builder->register('my_event_subscriber', 'stdClass')
@@ -63,12 +65,10 @@ class RegisterListenersPassTest extends TestCase
         $this->assertEquals($expectedCalls, $eventDispatcherDefinition->getMethodCalls());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "foo" tagged "kernel.event_listener" must not be abstract.
-     */
     public function testAbstractEventListener()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The service "foo" tagged "kernel.event_listener" must not be abstract.');
         $container = new ContainerBuilder();
         $container->register('foo', 'stdClass')->setAbstract(true)->addTag('kernel.event_listener', []);
         $container->register('event_dispatcher', 'stdClass');
@@ -77,12 +77,10 @@ class RegisterListenersPassTest extends TestCase
         $registerListenersPass->process($container);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "foo" tagged "kernel.event_subscriber" must not be abstract.
-     */
     public function testAbstractEventSubscriber()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The service "foo" tagged "kernel.event_subscriber" must not be abstract.');
         $container = new ContainerBuilder();
         $container->register('foo', 'stdClass')->setAbstract(true)->addTag('kernel.event_subscriber', []);
         $container->register('event_dispatcher', 'stdClass');
@@ -128,12 +126,10 @@ class RegisterListenersPassTest extends TestCase
         $this->assertTrue($container->getDefinition('foo')->hasTag('container.hot_path'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You have requested a non-existent parameter "subscriber.class"
-     */
     public function testEventSubscriberUnresolvableClassName()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('You have requested a non-existent parameter "subscriber.class"');
         $container = new ContainerBuilder();
         $container->register('foo', '%subscriber.class%')->addTag('kernel.event_subscriber', []);
         $container->register('event_dispatcher', 'stdClass');

--- a/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -81,11 +81,9 @@ class GenericEventTest extends TestCase
         $this->assertEquals('Event', $this->event->getArgument('name'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetArgException()
     {
+        $this->expectException('\InvalidArgumentException');
         $this->event->getArgument('nameNotExist');
     }
 

--- a/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
@@ -71,37 +71,29 @@ class ImmutableEventDispatcherTest extends TestCase
         $this->assertSame('result', $this->dispatcher->hasListeners('event'));
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testAddListenerDisallowed()
     {
+        $this->expectException('\BadMethodCallException');
         $this->dispatcher->addListener('event', function () { return 'foo'; });
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testAddSubscriberDisallowed()
     {
+        $this->expectException('\BadMethodCallException');
         $subscriber = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')->getMock();
 
         $this->dispatcher->addSubscriber($subscriber);
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testRemoveListenerDisallowed()
     {
+        $this->expectException('\BadMethodCallException');
         $this->dispatcher->removeListener('event', function () { return 'foo'; });
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testRemoveSubscriberDisallowed()
     {
+        $this->expectException('\BadMethodCallException');
         $subscriber = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventSubscriberInterface')->getMock();
 
         $this->dispatcher->removeSubscriber($subscriber);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionFunctionTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionFunctionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ExpressionLanguage\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 
 /**
@@ -21,21 +22,19 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunction;
  */
 class ExpressionFunctionTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage PHP function "fn_does_not_exist" does not exist.
-     */
+    use ForwardCompatTestTrait;
+
     public function testFunctionDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('PHP function "fn_does_not_exist" does not exist.');
         ExpressionFunction::fromPhp('fn_does_not_exist');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage An expression function name must be defined when PHP function "Symfony\Component\ExpressionLanguage\Tests\fn_namespaced" is namespaced.
-     */
     public function testFunctionNamespaced()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('An expression function name must be defined when PHP function "Symfony\Component\ExpressionLanguage\Tests\fn_namespaced" is namespaced.');
         ExpressionFunction::fromPhp('Symfony\Component\ExpressionLanguage\Tests\fn_namespaced');
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ExpressionLanguage\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\ParsedExpression;
@@ -19,6 +20,8 @@ use Symfony\Component\ExpressionLanguage\Tests\Fixtures\TestProvider;
 
 class ExpressionLanguageTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCachedParse()
     {
         $cacheMock = $this->getMockBuilder('Psr\Cache\CacheItemPoolInterface')->getMock();
@@ -94,12 +97,10 @@ class ExpressionLanguageTest extends TestCase
         $this->assertSame($savedParsedExpression, $parsedExpression);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cache argument has to implement Psr\Cache\CacheItemPoolInterface.
-     */
     public function testWrongCacheImplementation()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Cache argument has to implement Psr\Cache\CacheItemPoolInterface.');
         $cacheMock = $this->getMockBuilder('Psr\Cache\CacheItemSpoolInterface')->getMock();
         $expressionLanguage = new ExpressionLanguage($cacheMock);
     }
@@ -146,12 +147,10 @@ class ExpressionLanguageTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @expectedException \Symfony\Component\ExpressionLanguage\SyntaxError
-     * @expectedExceptionMessage Unexpected end of expression around position 6 for expression `node.`.
-     */
     public function testParseThrowsInsteadOfNotice()
     {
+        $this->expectException('Symfony\Component\ExpressionLanguage\SyntaxError');
+        $this->expectExceptionMessage('Unexpected end of expression around position 6 for expression `node.`.');
         $expressionLanguage = new ExpressionLanguage();
         $expressionLanguage->parse('node.', ['node']);
     }
@@ -240,10 +239,10 @@ class ExpressionLanguageTest extends TestCase
 
     /**
      * @dataProvider getRegisterCallbacks
-     * @expectedException \LogicException
      */
     public function testRegisterAfterParse($registerCallback)
     {
+        $this->expectException('LogicException');
         $el = new ExpressionLanguage();
         $el->parse('1 + 1', []);
         $registerCallback($el);
@@ -251,31 +250,29 @@ class ExpressionLanguageTest extends TestCase
 
     /**
      * @dataProvider getRegisterCallbacks
-     * @expectedException \LogicException
      */
     public function testRegisterAfterEval($registerCallback)
     {
+        $this->expectException('LogicException');
         $el = new ExpressionLanguage();
         $el->evaluate('1 + 1');
         $registerCallback($el);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessageRegExp  /Unable to call method "\w+" of object "\w+"./
-     */
     public function testCallBadCallable()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessageRegExp('/Unable to call method "\w+" of object "\w+"./');
         $el = new ExpressionLanguage();
         $el->evaluate('foo.myfunction()', ['foo' => new \stdClass()]);
     }
 
     /**
      * @dataProvider getRegisterCallbacks
-     * @expectedException \LogicException
      */
     public function testRegisterAfterCompile($registerCallback)
     {
+        $this->expectException('LogicException');
         $el = new ExpressionLanguage();
         $el->compile('1 + 1');
         $registerCallback($el);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -40,22 +40,18 @@ class LexerTest extends TestCase
         $this->assertEquals(new TokenStream($tokens, $expression), $this->lexer->tokenize($expression));
     }
 
-    /**
-     * @expectedException \Symfony\Component\ExpressionLanguage\SyntaxError
-     * @expectedExceptionMessage Unexpected character "'" around position 33 for expression `service(faulty.expression.example').dummyMethod()`.
-     */
     public function testTokenizeThrowsErrorWithMessage()
     {
+        $this->expectException('Symfony\Component\ExpressionLanguage\SyntaxError');
+        $this->expectExceptionMessage('Unexpected character "\'" around position 33 for expression `service(faulty.expression.example\').dummyMethod()`.');
         $expression = "service(faulty.expression.example').dummyMethod()";
         $this->lexer->tokenize($expression);
     }
 
-    /**
-     * @expectedException \Symfony\Component\ExpressionLanguage\SyntaxError
-     * @expectedExceptionMessage Unclosed "(" around position 7 for expression `service(unclosed.expression.dummyMethod()`.
-     */
     public function testTokenizeThrowsErrorOnUnclosedBrace()
     {
+        $this->expectException('Symfony\Component\ExpressionLanguage\SyntaxError');
+        $this->expectExceptionMessage('Unclosed "(" around position 7 for expression `service(unclosed.expression.dummyMethod()`.');
         $expression = 'service(unclosed.expression.dummyMethod()';
         $this->lexer->tokenize($expression);
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -12,29 +12,28 @@
 namespace Symfony\Component\ExpressionLanguage\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\ExpressionLanguage\Lexer;
 use Symfony\Component\ExpressionLanguage\Node;
 use Symfony\Component\ExpressionLanguage\Parser;
 
 class ParserTest extends TestCase
 {
-    /**
-     * @expectedException        \Symfony\Component\ExpressionLanguage\SyntaxError
-     * @expectedExceptionMessage Variable "foo" is not valid around position 1 for expression `foo`.
-     */
+    use ForwardCompatTestTrait;
+
     public function testParseWithInvalidName()
     {
+        $this->expectException('Symfony\Component\ExpressionLanguage\SyntaxError');
+        $this->expectExceptionMessage('Variable "foo" is not valid around position 1 for expression `foo`.');
         $lexer = new Lexer();
         $parser = new Parser([]);
         $parser->parse($lexer->tokenize('foo'));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\ExpressionLanguage\SyntaxError
-     * @expectedExceptionMessage Variable "foo" is not valid around position 1 for expression `foo`.
-     */
     public function testParseWithZeroInNames()
     {
+        $this->expectException('Symfony\Component\ExpressionLanguage\SyntaxError');
+        $this->expectExceptionMessage('Variable "foo" is not valid around position 1 for expression `foo`.');
         $lexer = new Lexer();
         $parser = new Parser([]);
         $parser->parse($lexer->tokenize('foo'), [0]);
@@ -165,10 +164,10 @@ class ParserTest extends TestCase
 
     /**
      * @dataProvider getInvalidPostfixData
-     * @expectedException \Symfony\Component\ExpressionLanguage\SyntaxError
      */
     public function testParseWithInvalidPostfixData($expr, $names = [])
     {
+        $this->expectException('Symfony\Component\ExpressionLanguage\SyntaxError');
         $lexer = new Lexer();
         $parser = new Parser([]);
         $parser->parse($lexer->tokenize($expr), $names);
@@ -196,12 +195,10 @@ class ParserTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\ExpressionLanguage\SyntaxError
-     * @expectedExceptionMessage Did you mean "baz"?
-     */
     public function testNameProposal()
     {
+        $this->expectException('Symfony\Component\ExpressionLanguage\SyntaxError');
+        $this->expectExceptionMessage('Did you mean "baz"?');
         $lexer = new Lexer();
         $parser = new Parser([]);
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\Filesystem\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 /**
  * Test class for Filesystem.
  */
 class FilesystemTest extends FilesystemTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCopyCreatesNewFile()
     {
         $sourceFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_source_file';
@@ -29,22 +33,18 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertStringEqualsFile($targetFilePath, 'SOURCE FILE');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testCopyFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $sourceFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_source_file';
         $targetFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_target_file';
 
         $this->filesystem->copy($sourceFilePath, $targetFilePath);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testCopyUnreadableFileFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         // skip test on Windows; PHP can't easily set file as unreadable on Windows
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('This test cannot run on Windows.');
@@ -118,11 +118,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertStringEqualsFile($targetFilePath, 'SOURCE FILE');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testCopyWithOverrideWithReadOnlyTargetFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         // skip test on Windows; PHP can't easily set file as unwritable on Windows
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('This test cannot run on Windows.');
@@ -222,11 +220,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertTrue(is_dir($basePath.'3'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testMkdirCreatesDirectoriesFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $basePath = $this->workspace.\DIRECTORY_SEPARATOR;
         $dir = $basePath.'2';
 
@@ -244,11 +240,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($file);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testTouchFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $file = $this->workspace.\DIRECTORY_SEPARATOR.'1'.\DIRECTORY_SEPARATOR.'2';
 
         $this->filesystem->touch($file);
@@ -380,11 +374,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertTrue($this->filesystem->exists($basePath.'folder'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testFilesExistsFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         if ('\\' !== \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('Long file names are an issue on Windows');
         }
@@ -613,11 +605,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertSame($owner, $this->getFileOwner($link));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testChownSymlinkFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $this->markAsSkippedIfSymlinkIsMissing();
 
         $file = $this->workspace.\DIRECTORY_SEPARATOR.'file';
@@ -630,11 +620,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chown($link, 'user'.time().mt_rand(1000, 9999));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testChownLinkFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $this->markAsSkippedIfLinkIsMissing();
 
         $file = $this->workspace.\DIRECTORY_SEPARATOR.'file';
@@ -647,11 +635,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chown($link, 'user'.time().mt_rand(1000, 9999));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testChownFail()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $this->markAsSkippedIfPosixIsMissing();
 
         $dir = $this->workspace.\DIRECTORY_SEPARATOR.'dir';
@@ -722,11 +708,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertSame($group, $this->getFileGroup($link));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testChgrpSymlinkFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $this->markAsSkippedIfSymlinkIsMissing();
 
         $file = $this->workspace.\DIRECTORY_SEPARATOR.'file';
@@ -739,11 +723,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chgrp($link, 'user'.time().mt_rand(1000, 9999));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testChgrpLinkFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $this->markAsSkippedIfLinkIsMissing();
 
         $file = $this->workspace.\DIRECTORY_SEPARATOR.'file';
@@ -756,11 +738,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chgrp($link, 'user'.time().mt_rand(1000, 9999));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testChgrpFail()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $this->markAsSkippedIfPosixIsMissing();
 
         $dir = $this->workspace.\DIRECTORY_SEPARATOR.'dir';
@@ -781,11 +761,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($newPath);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testRenameThrowsExceptionIfTargetAlreadyExists()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $file = $this->workspace.\DIRECTORY_SEPARATOR.'file';
         $newPath = $this->workspace.\DIRECTORY_SEPARATOR.'new_file';
 
@@ -809,11 +787,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($newPath);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testRenameThrowsExceptionOnError()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $file = $this->workspace.\DIRECTORY_SEPARATOR.uniqid('fs_test_', true);
         $newPath = $this->workspace.\DIRECTORY_SEPARATOR.'new_file';
 
@@ -1420,11 +1396,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($filename);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testTempnamWithZlibSchemeFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $scheme = 'compress.zlib://';
         $dirname = $scheme.$this->workspace;
 
@@ -1445,11 +1419,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileNotExists($filename);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testTempnamWithPharSchemeFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         // Skip test if Phar disabled phar.readonly must be 0 in php.ini
         if (!\Phar::canWrite()) {
             $this->markTestSkipped('This test cannot run when phar.readonly is 1.');
@@ -1464,11 +1436,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->tempnam($dirname, $pharname.'/bar');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     */
     public function testTempnamWithHTTPSchemeFails()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $scheme = 'http://';
         $dirname = $scheme.$this->workspace;
 

--- a/src/Symfony/Component/Filesystem/Tests/LockHandlerTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/LockHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Filesystem\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\LockHandler;
@@ -21,24 +22,22 @@ use Symfony\Component\Filesystem\LockHandler;
  */
 class LockHandlerTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     * @expectedExceptionMessage Failed to create "/a/b/c/d/e": mkdir(): Permission denied.
-     */
+    use ForwardCompatTestTrait;
+
     public function testConstructWhenRepositoryDoesNotExist()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
+        $this->expectExceptionMessage('Failed to create "/a/b/c/d/e": mkdir(): Permission denied.');
         if (!getenv('USER') || 'root' === getenv('USER')) {
             $this->markTestSkipped('This test will fail if run under superuser');
         }
         new LockHandler('lock', '/a/b/c/d/e');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
-     * @expectedExceptionMessage The directory "/" is not writable.
-     */
     public function testConstructWhenRepositoryIsNotWriteable()
     {
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
+        $this->expectExceptionMessage('The directory "/" is not writable.');
         if (!getenv('USER') || 'root' === getenv('USER')) {
             $this->markTestSkipped('This test will fail if run under superuser');
         }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -11,10 +11,13 @@
 
 namespace Symfony\Component\Finder\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Finder\Finder;
 
 class FinderTest extends Iterator\RealIteratorTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCreate()
     {
         $this->assertInstanceOf('Symfony\Component\Finder\Finder', Finder::create());
@@ -311,11 +314,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($expected, $iterator);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInWithNonExistentDirectory()
     {
+        $this->expectException('InvalidArgumentException');
         $finder = new Finder();
         $finder->in('foobar');
     }
@@ -328,11 +329,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsoluteFixtures(['A/B/C/abc.dat', 'copy/A/B/C/abc.dat.copy']), $finder);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInWithNonDirectoryGlob()
     {
+        $this->expectException('InvalidArgumentException');
         $finder = new Finder();
         $finder->in(__DIR__.'/Fixtures/A/a*');
     }
@@ -349,11 +348,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsoluteFixtures(['A/B/C/abc.dat', 'copy/A/B/C/abc.dat.copy']), $finder);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testGetIteratorWithoutIn()
     {
+        $this->expectException('LogicException');
         $finder = Finder::create();
         $finder->getIterator();
     }
@@ -481,11 +478,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertCount($i, $files);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testCountWithoutIn()
     {
+        $this->expectException('LogicException');
         $finder = Finder::create()->files();
         \count($finder);
     }
@@ -710,7 +705,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
                 $this->fail('Finder should throw an exception when opening a non-readable directory.');
             } catch (\Exception $e) {
                 $expectedExceptionClass = 'Symfony\\Component\\Finder\\Exception\\AccessDeniedException';
-                if ($e instanceof \PHPUnit_Framework_ExpectationFailedException) {
+                if ($e instanceof \PHPUnit\Framework\ExpectationFailedException) {
                     $this->fail(sprintf("Expected exception:\n%s\nGot:\n%s\nWith comparison failure:\n%s", $expectedExceptionClass, 'PHPUnit_Framework_ExpectationFailedException', $e->getComparisonFailure()->getExpectedAsString()));
                 }
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/CustomFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/CustomFilterIteratorTest.php
@@ -11,15 +11,16 @@
 
 namespace Symfony\Component\Finder\Tests\Iterator;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Finder\Iterator\CustomFilterIterator;
 
 class CustomFilterIteratorTest extends IteratorTestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    use ForwardCompatTestTrait;
+
     public function testWithInvalidFilter()
     {
+        $this->expectException('InvalidArgumentException');
         new CustomFilterIterator(new Iterator(), ['foo']);
     }
 

--- a/src/Symfony/Component/Form/Tests/ButtonTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonTest.php
@@ -33,11 +33,9 @@ class ButtonTest extends TestCase
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
-     */
     public function testSetParentOnSubmittedButton()
     {
+        $this->expectException('Symfony\Component\Form\Exception\AlreadySubmittedException');
         $button = $this->getButtonBuilder('button')
             ->getForm()
         ;

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -51,12 +51,10 @@ class DebugCommandTest extends TestCase
         $this->assertContains('Symfony\Component\Form\Extension\Core\Type\FormType (method)', $tester->getDisplay());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Could not find type "NonExistentType"
-     */
     public function testDebugSingleFormTypeNotFound()
     {
+        $this->expectException('Symfony\Component\Console\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Could not find type "NonExistentType"');
         $tester = $this->createCommandTester();
         $tester->execute(['class' => 'NonExistentType'], ['decorated' => false, 'interactive' => false]);
     }
@@ -108,11 +106,9 @@ TXT
         , $output);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDebugInvalidFormType()
     {
+        $this->expectException('InvalidArgumentException');
         $this->createCommandTester()->execute(['class' => 'test']);
     }
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
@@ -26,6 +27,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CompoundFormTest extends AbstractFormTest
 {
+    use ForwardCompatTestTrait;
+
     public function testValidIfAllChildrenAreValid()
     {
         $this->form->add($this->getBuilder('firstName')->getForm());
@@ -269,11 +272,9 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertSame(['foo' => $child], $this->form->all());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
-     */
     public function testAddThrowsExceptionIfAlreadySubmitted()
     {
+        $this->expectException('Symfony\Component\Form\Exception\AlreadySubmittedException');
         $this->form->submit([]);
         $this->form->add($this->getBuilder('foo')->getForm());
     }
@@ -288,11 +289,9 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertCount(0, $this->form);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
-     */
     public function testRemoveThrowsExceptionIfAlreadySubmitted()
     {
+        $this->expectException('Symfony\Component\Form\Exception\AlreadySubmittedException');
         $this->form->add($this->getBuilder('foo')->setCompound(false)->getForm());
         $this->form->submit(['foo' => 'bar']);
         $this->form->remove('foo');

--- a/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
+++ b/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -27,6 +28,8 @@ use Symfony\Component\Form\FormRegistry;
  */
 class FormPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testDoNothingIfFormExtensionNotLoaded()
     {
         $container = $this->createContainerBuilder();
@@ -156,12 +159,10 @@ class FormPassTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage extended-type attribute, none was configured for the "my.type_extension" service
-     */
     public function testAddTaggedFormTypeExtensionWithoutExtendedTypeAttribute()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('extended-type attribute, none was configured for the "my.type_extension" service');
         $container = $this->createContainerBuilder();
 
         $container->setDefinition('form.extension', $this->createExtensionDefinition());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
@@ -71,11 +71,9 @@ class ArrayToPartsTransformerTest extends TestCase
         $this->assertSame($output, $this->transformer->transform(null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformRequiresArray()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->transform('12345');
     }
 
@@ -126,11 +124,9 @@ class ArrayToPartsTransformerTest extends TestCase
         $this->assertNull($this->transformer->reverseTransform($input));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformPartiallyNull()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $input = [
             'first' => [
                 'a' => '1',
@@ -143,11 +139,9 @@ class ArrayToPartsTransformerTest extends TestCase
         $this->transformer->reverseTransform($input);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformRequiresArray()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->reverseTransform('12345');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BaseDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BaseDateTimeTransformerTest.php
@@ -12,24 +12,23 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 class BaseDateTimeTransformerTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     * @expectedExceptionMessage this_timezone_does_not_exist
-     */
+    use ForwardCompatTestTrait;
+
     public function testConstructFailsIfInputTimezoneIsInvalid()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('this_timezone_does_not_exist');
         $this->getMockBuilder('Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer')->setConstructorArgs(['this_timezone_does_not_exist'])->getMock();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     * @expectedExceptionMessage that_timezone_does_not_exist
-     */
     public function testConstructFailsIfOutputTimezoneIsInvalid()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('that_timezone_does_not_exist');
         $this->getMockBuilder('Symfony\Component\Form\Extension\Core\DataTransformer\BaseDateTimeTransformer')->setConstructorArgs([null, 'that_timezone_does_not_exist'])->getMock();
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -48,19 +48,15 @@ class BooleanToStringTransformerTest extends TestCase
         $this->assertNull($this->transformer->transform(null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformFailsIfString()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->transform('1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformFailsIfInteger()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->reverseTransform(1);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
@@ -91,10 +91,10 @@ class ChoiceToValueTransformerTest extends TestCase
 
     /**
      * @dataProvider reverseTransformExpectsStringOrNullProvider
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
     public function testReverseTransformExpectsStringOrNull($value)
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->reverseTransform($value);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoicesToValuesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoicesToValuesTransformerTest.php
@@ -56,11 +56,9 @@ class ChoicesToValuesTransformerTest extends TestCase
         $this->assertSame([], $this->transformer->transform(null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformExpectsArray()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->transform('foobar');
     }
 
@@ -84,11 +82,9 @@ class ChoicesToValuesTransformerTest extends TestCase
         $this->assertSame([], $this->transformerWithNull->reverseTransform(null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformExpectsArray()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->reverseTransform('foobar');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToArrayTransformer;
 
 class DateTimeToArrayTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testTransform()
     {
         $transformer = new DateTimeToArrayTransformer('UTC', 'UTC');
@@ -137,11 +140,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         $this->assertSame($output, $transformer->transform($input));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformRequiresDateTime()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform('12345');
     }
@@ -211,11 +212,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         $this->assertNull($transformer->reverseTransform($input));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformPartiallyEmptyYear()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'month' => '2',
@@ -226,11 +225,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformPartiallyEmptyMonth()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -241,11 +238,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformPartiallyEmptyDay()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -256,11 +251,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformPartiallyEmptyHour()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -271,11 +264,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformPartiallyEmptyMinute()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -286,11 +277,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformPartiallyEmptySecond()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -346,20 +335,16 @@ class DateTimeToArrayTransformerTest extends TestCase
         $this->assertEquals($output, $transformer->reverseTransform($input));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformRequiresArray()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform('12345');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNegativeYear()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '-1',
@@ -371,11 +356,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNegativeMonth()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -387,11 +370,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNegativeDay()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -403,11 +384,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNegativeHour()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -419,11 +398,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNegativeMinute()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -435,11 +412,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNegativeSecond()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -451,11 +426,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithInvalidMonth()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -467,11 +440,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithInvalidDay()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -483,11 +454,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithStringDay()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -499,11 +468,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithStringMonth()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -515,11 +482,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithStringYear()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => 'bazinga',
@@ -531,11 +496,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithEmptyStringHour()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -547,11 +510,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithEmptyStringMinute()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',
@@ -563,11 +524,9 @@ class DateTimeToArrayTransformerTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithEmptyStringSecond()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform([
             'year' => '2010',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
@@ -12,11 +12,13 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToHtml5LocalDateTimeTransformer;
 use Symfony\Component\Form\Tests\Extension\Core\DataTransformer\Traits\DateTimeEqualsTrait;
 
 class DateTimeToHtml5LocalDateTimeTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
     use DateTimeEqualsTrait;
 
     public function transformProvider()
@@ -72,11 +74,9 @@ class DateTimeToHtml5LocalDateTimeTransformerTest extends TestCase
         $this->assertSame($to, $transformer->transform(null !== $from ? new \DateTimeImmutable($from) : null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformRequiresValidDateTime()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToHtml5LocalDateTimeTransformer();
         $transformer->transform('2010-01-01');
     }
@@ -95,30 +95,24 @@ class DateTimeToHtml5LocalDateTimeTransformerTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformRequiresString()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToHtml5LocalDateTimeTransformer();
         $transformer->reverseTransform(12345);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNonExistingDate()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToHtml5LocalDateTimeTransformer('UTC', 'UTC');
 
         $transformer->reverseTransform('2010-04-31T04:05');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformExpectsValidDateString()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToHtml5LocalDateTimeTransformer('UTC', 'UTC');
 
         $transformer->reverseTransform('2010-2010-2010');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -175,11 +175,9 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals($dateTime->format('d.m.Y, H:i'), $transformer->transform($input));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformRequiresValidDateTime()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToLocalizedStringTransformer();
         $transformer->transform('2010-01-01');
     }
@@ -285,73 +283,57 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
         $this->assertNull($transformer->reverseTransform(''));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformRequiresString()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToLocalizedStringTransformer();
         $transformer->reverseTransform(12345);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWrapsIntlErrors()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToLocalizedStringTransformer();
         $transformer->reverseTransform('12345');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
     public function testValidateDateFormatOption()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         new DateTimeToLocalizedStringTransformer(null, null, 'foobar');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
     public function testValidateTimeFormatOption()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         new DateTimeToLocalizedStringTransformer(null, null, null, 'foobar');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNonExistingDate()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::SHORT);
 
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('31.04.10 04:05'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformOutOfTimestampRange()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC');
         $transformer->reverseTransform('1789-07-14');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformFiveDigitYears()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::GREGORIAN, 'yyyy-MM-dd');
         $transformer->reverseTransform('20107-03-21');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformFiveDigitYearsWithTimestamp()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::GREGORIAN, 'yyyy-MM-dd HH:mm:ss');
         $transformer->reverseTransform('20107-03-21 12:34:56');
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -87,11 +87,9 @@ class DateTimeToRfc3339TransformerTest extends TestCase
         $this->assertSame($to, $transformer->transform(null !== $from ? new \DateTimeImmutable($from) : null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformRequiresValidDateTime()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToRfc3339Transformer();
         $transformer->transform('2010-01-01');
     }
@@ -110,20 +108,16 @@ class DateTimeToRfc3339TransformerTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformRequiresString()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToRfc3339Transformer();
         $transformer->reverseTransform(12345);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformWithNonExistingDate()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToRfc3339Transformer('UTC', 'UTC');
 
         $transformer->reverseTransform('2010-04-31T04:05Z');
@@ -131,10 +125,10 @@ class DateTimeToRfc3339TransformerTest extends TestCase
 
     /**
      * @dataProvider invalidDateStringProvider
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
     public function testReverseTransformExpectsValidDateString($date)
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new DateTimeToRfc3339Transformer('UTC', 'UTC');
 
         $transformer->reverseTransform($date);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeZoneToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeZoneToStringTransformerTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeZoneToStringTransformer;
 
 class DateTimeZoneToStringTransformerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSingle()
     {
         $transformer = new DateTimeZoneToStringTransformer();
@@ -38,19 +41,15 @@ class DateTimeZoneToStringTransformerTest extends TestCase
         $this->assertEquals([new \DateTimeZone('Europe/Amsterdam')], $transformer->reverseTransform(['Europe/Amsterdam']));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testInvalidTimezone()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         (new DateTimeZoneToStringTransformer())->transform(1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testUnknownTimezone()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         (new DateTimeZoneToStringTransformer(true))->reverseTransform(['Foo/Bar']);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -190,21 +190,17 @@ class IntegerToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals($output, $transformer->reverseTransform($input));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformExpectsString()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new IntegerToLocalizedStringTransformer();
 
         $transformer->reverseTransform(1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformExpectsValidNumber()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new IntegerToLocalizedStringTransformer();
 
         $transformer->reverseTransform('foo');
@@ -212,10 +208,10 @@ class IntegerToLocalizedStringTransformerTest extends TestCase
 
     /**
      * @dataProvider floatNumberProvider
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
     public function testReverseTransformExpectsInteger($number, $locale)
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         IntlTestHelper::requireFullIntl($this, false);
 
         \Locale::setDefault($locale);
@@ -233,41 +229,33 @@ class IntegerToLocalizedStringTransformerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsNaN()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new IntegerToLocalizedStringTransformer();
 
         $transformer->reverseTransform('NaN');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsNaN2()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new IntegerToLocalizedStringTransformer();
 
         $transformer->reverseTransform('nan');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsInfinity()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new IntegerToLocalizedStringTransformer();
 
         $transformer->reverseTransform('∞');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsNegativeInfinity()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new IntegerToLocalizedStringTransformer();
 
         $transformer->reverseTransform('-∞');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -400,11 +400,9 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         // Since we test against "de_DE", we need the full implementation
         IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
@@ -415,11 +413,9 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $transformer->reverseTransform('1.234.5');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         // Since we test against "de_DE", we need the full implementation
         IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
@@ -459,11 +455,9 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
         $transformer = new NumberToLocalizedStringTransformer(null, true);
@@ -471,11 +465,9 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $transformer->reverseTransform('1,234,5');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
         $transformer = new NumberToLocalizedStringTransformer(null, true);
@@ -491,44 +483,37 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testTransformExpectsNumeric()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->transform('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformExpectsString()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform(1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformExpectsValidNumber()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform('foo');
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      * @dataProvider nanRepresentationProvider
-     *
      * @see https://github.com/symfony/symfony/issues/3161
      */
     public function testReverseTransformDisallowsNaN($nan)
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform($nan);
@@ -543,63 +528,51 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsInfinity()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform('∞');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsInfinity2()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform('∞,123');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsNegativeInfinity()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform('-∞');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsLeadingExtraCharacters()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform('foo123');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo3"
-     */
     public function testReverseTransformDisallowsCenteredExtraCharacters()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo3"');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform('12foo3');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo8"
-     */
     public function testReverseTransformDisallowsCenteredExtraCharactersMultibyte()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
         // Since we test against other locales, we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
@@ -610,12 +583,10 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $transformer->reverseTransform("12\xc2\xa0345,67foo8");
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo8"
-     */
     public function testReverseTransformIgnoresTrailingSpacesInExceptionMessage()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
         // Since we test against other locales, we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
@@ -626,23 +597,19 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $transformer->reverseTransform("12\xc2\xa0345,67foo8  \xc2\xa0\t");
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo"
-     */
     public function testReverseTransformDisallowsTrailingExtraCharacters()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform('123foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo"
-     */
     public function testReverseTransformDisallowsTrailingExtraCharactersMultibyte()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
         // Since we test against other locales, we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -145,11 +145,9 @@ class PercentToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         // Since we test against "de_DE", we need the full implementation
         IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
@@ -160,11 +158,9 @@ class PercentToLocalizedStringTransformerTest extends TestCase
         $transformer->reverseTransform('1.234.5');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         // Since we test against "de_DE", we need the full implementation
         IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
@@ -204,11 +200,9 @@ class PercentToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
         $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
@@ -216,11 +210,9 @@ class PercentToLocalizedStringTransformerTest extends TestCase
         $transformer->reverseTransform('1,234,5');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
         $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
@@ -246,34 +238,30 @@ class PercentToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDisallowsLeadingExtraCharacters()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new PercentToLocalizedStringTransformer();
 
         $transformer->reverseTransform('foo123');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo3"
-     */
     public function testReverseTransformDisallowsCenteredExtraCharacters()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo3"');
         $transformer = new PercentToLocalizedStringTransformer();
 
         $transformer->reverseTransform('12foo3');
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo8"
      * @requires extension mbstring
      */
     public function testReverseTransformDisallowsCenteredExtraCharactersMultibyte()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
         // Since we test against other locales, we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
@@ -284,24 +272,22 @@ class PercentToLocalizedStringTransformerTest extends TestCase
         $transformer->reverseTransform("12\xc2\xa0345,67foo8");
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo"
-     */
     public function testReverseTransformDisallowsTrailingExtraCharacters()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
         $transformer = new PercentToLocalizedStringTransformer();
 
         $transformer->reverseTransform('123foo');
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage The number contains unrecognized characters: "foo"
      * @requires extension mbstring
      */
     public function testReverseTransformDisallowsTrailingExtraCharactersMultibyte()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
         // Since we test against other locales, we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -108,11 +108,9 @@ class ValueToDuplicatesTransformerTest extends TestCase
         $this->assertSame('0', $this->transformer->reverseTransform($input));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformPartiallyNull()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $input = [
             'a' => 'Foo',
             'b' => 'Foo',
@@ -122,11 +120,9 @@ class ValueToDuplicatesTransformerTest extends TestCase
         $this->transformer->reverseTransform($input);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformDifferences()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $input = [
             'a' => 'Foo',
             'b' => 'Bar',
@@ -136,11 +132,9 @@ class ValueToDuplicatesTransformerTest extends TestCase
         $this->transformer->reverseTransform($input);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformRequiresArray()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $this->transformer->reverseTransform('12345');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
@@ -185,10 +185,10 @@ abstract class MergeCollectionListenerTest extends TestCase
 
     /**
      * @dataProvider getBooleanMatrix2
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
      */
     public function testRequireArrayOrTraversable($allowAdd, $allowDelete)
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $newData = 'no array or traversable';
         $event = new FormEvent($this->form, $newData);
         $listener = new MergeCollectionListener($allowAdd, $allowDelete);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -69,11 +69,9 @@ class ResizeFormListenerTest extends TestCase
         $this->assertTrue($this->form->has('2'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
     public function testPreSetDataRequiresArrayOrTraversable()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', [], false, false);
@@ -204,11 +202,9 @@ class ResizeFormListenerTest extends TestCase
         $this->assertEquals($data, $event->getData());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
     public function testOnSubmitNormDataRequiresArrayOrTraversable()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', [], false, false);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -11,18 +11,20 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 /**
  * @author Stepan Anchugov <kixxx1@gmail.com>
  */
 class BirthdayTypeTest extends DateTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\BirthdayType';
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testSetInvalidYearsOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'years' => 'bad value',
         ]);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class ButtonTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\ButtonType';
 
     public function testCreateButtonInstances()
@@ -24,14 +28,14 @@ class ButtonTypeTest extends BaseTypeTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\BadMethodCallException
-     * @expectedExceptionMessage Buttons do not support empty data.
      *
      * @param string $emptyData
      * @param null   $expectedData
      */
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = null)
     {
+        $this->expectException('Symfony\Component\Form\Exception\BadMethodCallException');
+        $this->expectExceptionMessage('Buttons do not support empty data.');
         parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -83,21 +83,17 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->objectChoices = null;
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testChoicesOptionExpectsArrayOrTraversable()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'choices' => new \stdClass(),
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testChoiceLoaderOptionExpectsChoiceLoaderInterface()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'choice_loader' => new \stdClass(),
         ]);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -38,21 +38,17 @@ class DateTypeTest extends BaseTypeTest
         \Locale::setDefault($this->defaultLocale);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testInvalidWidgetOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'widget' => 'fake_widget',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testInvalidInputOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'input' => 'fake_input',
         ]);
@@ -344,11 +340,10 @@ class DateTypeTest extends BaseTypeTest
     /**
      * This test is to check that the strings '0', '1', '2', '3' are not accepted
      * as valid IntlDateFormatter constants for FULL, LONG, MEDIUM or SHORT respectively.
-     *
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testThrowExceptionIfFormatIsNoPattern()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'format' => '0',
             'widget' => 'single_text',
@@ -356,75 +351,61 @@ class DateTypeTest extends BaseTypeTest
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The "format" option should contain the letters "y", "M" and "d". Its current value is "yy".
-     */
     public function testThrowExceptionIfFormatDoesNotContainYearMonthAndDay()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The "format" option should contain the letters "y", "M" and "d". Its current value is "yy".');
         $this->factory->create(static::TESTED_TYPE, null, [
             'months' => [6, 7],
             'format' => 'yy',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The "format" option should contain the letters "y", "M" or "d". Its current value is "wrong".
-     */
     public function testThrowExceptionIfFormatMissesYearMonthAndDayWithSingleTextWidget()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The "format" option should contain the letters "y", "M" or "d". Its current value is "wrong".');
         $this->factory->create(static::TESTED_TYPE, null, [
             'widget' => 'single_text',
             'format' => 'wrong',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfFormatIsNoConstant()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'format' => 105,
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfFormatIsInvalid()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'format' => [],
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfYearsIsInvalid()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'years' => 'bad value',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfMonthsIsInvalid()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'months' => 'bad value',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfDaysIsInvalid()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'days' => 'bad value',
         ]);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -20,8 +20,6 @@ use Symfony\Component\PropertyAccess\PropertyPath;
 
 class FormTest_AuthorWithoutRefSetter
 {
-    use ForwardCompatTestTrait;
-
     protected $reference;
 
     protected $referenceCopy;
@@ -54,6 +52,8 @@ class FormTest_AuthorWithoutRefSetter
 
 class FormTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\FormType';
 
     public function testCreateFormInstances()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Tests\Fixtures\Author;
@@ -19,6 +20,8 @@ use Symfony\Component\PropertyAccess\PropertyPath;
 
 class FormTest_AuthorWithoutRefSetter
 {
+    use ForwardCompatTestTrait;
+
     protected $reference;
 
     protected $referenceCopy;
@@ -160,11 +163,9 @@ class FormTypeTest extends BaseTypeTest
         ]));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
     public function testDataClassMustBeValidClassOrInterface()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
         $this->factory->createBuilder(static::TESTED_TYPE, null, [
             'data_class' => 'foobar',
         ]);
@@ -329,11 +330,9 @@ class FormTypeTest extends BaseTypeTest
         $this->assertEquals('Bernhard', $author->firstName);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testAttributesException()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, ['attr' => '']);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -81,33 +81,27 @@ class RepeatedTypeTest extends BaseTypeTest
         $this->assertFalse($form['second']->isRequired());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testSetInvalidOptions()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'type' => TextTypeTest::TESTED_TYPE,
             'options' => 'bad value',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testSetInvalidFirstOptions()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'type' => TextTypeTest::TESTED_TYPE,
             'first_options' => 'bad value',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testSetInvalidSecondOptions()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'type' => TextTypeTest::TESTED_TYPE,
             'second_options' => 'bad value',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormError;
 
 class TimeTypeTest extends BaseTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\TimeType';
 
     public function testSubmitDateTime()
@@ -683,42 +686,34 @@ class TimeTypeTest extends BaseTypeTest
         $this->assertSame([$error], iterator_to_array($form->getErrors()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidConfigurationException
-     */
     public function testInitializeWithSecondsAndWithoutMinutes()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidConfigurationException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'with_minutes' => false,
             'with_seconds' => true,
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfHoursIsInvalid()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'hours' => 'bad value',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfMinutesIsInvalid()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'minutes' => 'bad value',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfSecondsIsInvalid()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'seconds' => 'bad value',
         ]);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class UrlTypeTest extends TextTypeTest
 {
+    use ForwardCompatTestTrait;
+
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\UrlType';
 
     public function testSubmitAddsDefaultProtocolIfNoneIsIncluded()
@@ -73,11 +77,9 @@ class UrlTypeTest extends TextTypeTest
         $this->assertSame('www.domain.com', $form->getViewData());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testThrowExceptionIfDefaultProtocolIsInvalid()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->factory->create(static::TESTED_TYPE, null, [
             'default_protocol' => [],
         ]);

--- a/src/Symfony/Component/Form/Tests/Extension/DependencyInjection/DependencyInjectionExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DependencyInjection/DependencyInjectionExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension;
@@ -20,6 +21,8 @@ use Symfony\Component\Form\FormTypeGuesserInterface;
 
 class DependencyInjectionExtensionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetTypeExtensions()
     {
         $typeExtension1 = new DummyExtension('test');
@@ -40,11 +43,9 @@ class DependencyInjectionExtensionTest extends TestCase
         $this->assertSame([$typeExtension3], $extension->getTypeExtensions('other'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
     public function testThrowExceptionForInvalidExtendedType()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
         $extensions = [
             'test' => new \ArrayIterator([new DummyExtension('unmatched')]),
         ];
@@ -79,11 +80,11 @@ class DependencyInjectionExtensionTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
      * @expectedDeprecation Passing four arguments to the Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension::__construct() method is deprecated since Symfony 3.3 and will be disallowed in Symfony 4.0. The new constructor only accepts three arguments.
      */
     public function testLegacyThrowExceptionForInvalidExtendedType()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
         $formTypeExtension = new DummyExtension('unmatched');
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\HttpFoundation;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
 use Symfony\Component\Form\Tests\AbstractRequestHandlerTest;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -21,19 +22,17 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTest
 {
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
+    use ForwardCompatTestTrait;
+
     public function testRequestShouldNotBeNull()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $this->requestHandler->handleRequest($this->createForm('name', 'GET'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
     public function testRequestShouldBeInstanceOfRequest()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $this->requestHandler->handleRequest($this->createForm('name', 'GET'), new \stdClass());
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationPathTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\ViolationMapper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationPath;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationPath;
  */
 class ViolationPathTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function providePaths()
     {
         return [
@@ -140,21 +143,17 @@ class ViolationPathTest extends TestCase
         $this->assertEquals('street', $path->getElement(1));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testGetElementDoesNotAcceptInvalidIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $path = new ViolationPath('children[address].data[street].name');
 
         $path->getElement(3);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testGetElementDoesNotAcceptNegativeIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $path = new ViolationPath('children[address].data[street].name');
 
         $path->getElement(-1);
@@ -168,21 +167,17 @@ class ViolationPathTest extends TestCase
         $this->assertTrue($path->isProperty(2));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testIsPropertyDoesNotAcceptInvalidIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $path = new ViolationPath('children[address].data[street].name');
 
         $path->isProperty(3);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testIsPropertyDoesNotAcceptNegativeIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $path = new ViolationPath('children[address].data[street].name');
 
         $path->isProperty(-1);
@@ -196,21 +191,17 @@ class ViolationPathTest extends TestCase
         $this->assertFalse($path->isIndex(2));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testIsIndexDoesNotAcceptInvalidIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $path = new ViolationPath('children[address].data[street].name');
 
         $path->isIndex(3);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testIsIndexDoesNotAcceptNegativeIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $path = new ViolationPath('children[address].data[street].name');
 
         $path->isIndex(-1);
@@ -225,21 +216,17 @@ class ViolationPathTest extends TestCase
         $this->assertFalse($path->mapsForm(2));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testMapsFormDoesNotAcceptInvalidIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $path = new ViolationPath('children[address].data[street].name');
 
         $path->mapsForm(3);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testMapsFormDoesNotAcceptNegativeIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $path = new ViolationPath('children[address].data[street].name');
 
         $path->mapsForm(-1);

--- a/src/Symfony/Component/Form/Tests/FormConfigTest.php
+++ b/src/Symfony/Component/Form/Tests/FormConfigTest.php
@@ -139,11 +139,9 @@ class FormConfigTest extends TestCase
         self::assertSame('PATCH', $formConfigBuilder->getMethod());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
     public function testSetMethodDoesNotAllowOtherValues()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
         $this->getConfigBuilder()->setMethod('foo');
     }
 

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -149,21 +149,17 @@ class FormFactoryTest extends TestCase
         $this->assertSame($this->builder, $this->factory->createNamedBuilder('name', 'type', 'DATA', $options));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Form\Exception\UnexpectedTypeException
-     * @expectedExceptionMessage Expected argument of type "string", "stdClass" given
-     */
     public function testCreateNamedBuilderThrowsUnderstandableException()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
+        $this->expectExceptionMessage('Expected argument of type "string", "stdClass" given');
         $this->factory->createNamedBuilder('name', new \stdClass());
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Form\Exception\UnexpectedTypeException
-     * @expectedExceptionMessage Expected argument of type "string", "stdClass" given
-     */
     public function testCreateThrowsUnderstandableException()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
+        $this->expectExceptionMessage('Expected argument of type "string", "stdClass" given');
         $this->factory->create(new \stdClass());
     }
 

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -105,19 +105,15 @@ class FormRegistryTest extends TestCase
         $this->assertSame($resolvedType, $this->registry->getType('Symfony\Component\Form\Tests\Fixtures\FooType'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
     public function testFailIfUnregisteredTypeNoClass()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
         $this->registry->getType('Symfony\Blubb');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
     public function testFailIfUnregisteredTypeNoFormType()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
         $this->registry->getType('stdClass');
     }
 
@@ -163,12 +159,10 @@ class FormRegistryTest extends TestCase
         $this->assertSame($resolvedType, $this->registry->getType(\get_class($type)));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\LogicException
-     * @expectedExceptionMessage Circular reference detected for form type "Symfony\Component\Form\Tests\Fixtures\FormWithSameParentType" (Symfony\Component\Form\Tests\Fixtures\FormWithSameParentType > Symfony\Component\Form\Tests\Fixtures\FormWithSameParentType).
-     */
     public function testFormCannotHaveItselfAsAParent()
     {
+        $this->expectException('Symfony\Component\Form\Exception\LogicException');
+        $this->expectExceptionMessage('Circular reference detected for form type "Symfony\Component\Form\Tests\Fixtures\FormWithSameParentType" (Symfony\Component\Form\Tests\Fixtures\FormWithSameParentType > Symfony\Component\Form\Tests\Fixtures\FormWithSameParentType).');
         $type = new FormWithSameParentType();
 
         $this->extension2->addType($type);
@@ -176,12 +170,10 @@ class FormRegistryTest extends TestCase
         $this->registry->getType(FormWithSameParentType::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\LogicException
-     * @expectedExceptionMessage Circular reference detected for form type "Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeFoo" (Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeFoo > Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeBar > Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeBaz > Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeFoo).
-     */
     public function testRecursiveFormDependencies()
     {
+        $this->expectException('Symfony\Component\Form\Exception\LogicException');
+        $this->expectExceptionMessage('Circular reference detected for form type "Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeFoo" (Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeFoo > Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeBar > Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeBaz > Symfony\Component\Form\Tests\Fixtures\RecursiveFormTypeFoo).');
         $foo = new RecursiveFormTypeFoo();
         $bar = new RecursiveFormTypeBar();
         $baz = new RecursiveFormTypeBaz();
@@ -193,11 +185,9 @@ class FormRegistryTest extends TestCase
         $this->registry->getType(RecursiveFormTypeFoo::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
     public function testGetTypeThrowsExceptionIfTypeNotFound()
     {
+        $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
         $this->registry->getType('bar');
     }
 

--- a/src/Symfony/Component/Form/Tests/Guess/GuessTest.php
+++ b/src/Symfony/Component/Form/Tests/Guess/GuessTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Guess;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Guess\Guess;
 
 class TestGuess extends Guess
@@ -20,6 +21,8 @@ class TestGuess extends Guess
 
 class GuessTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetBestGuessReturnsGuessWithHighestConfidence()
     {
         $guess1 = new TestGuess(Guess::MEDIUM_CONFIDENCE);
@@ -29,11 +32,9 @@ class GuessTest extends TestCase
         $this->assertSame($guess3, Guess::getBestGuess([$guess1, $guess2, $guess3]));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGuessExpectsValidConfidence()
     {
+        $this->expectException('\InvalidArgumentException');
         new TestGuess(5);
     }
 }

--- a/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
@@ -51,11 +51,9 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
         $_SERVER = self::$serverBackup;
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
     public function testRequestShouldBeNull()
     {
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $this->requestHandler->handleRequest($this->createForm('name', 'GET'), 'request');
     }
 

--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -12,19 +12,16 @@
 namespace Symfony\Component\Form\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 class TranslationFilesTest extends TestCase
 {
-    use ForwardCompatTestTrait;
-
     /**
      * @dataProvider provideTranslationFiles
      */
     public function testTranslationFileIsValid($filePath)
     {
         if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
+            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }

--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\Form\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 class TranslationFilesTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider provideTranslationFiles
      */
     public function testTranslationFileIsValid($filePath)
     {
         if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
+            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Form;
@@ -54,6 +55,8 @@ class SimpleFormTest_Traversable implements \IteratorAggregate
 
 class SimpleFormTest extends AbstractFormTest
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider provideFormNames
      */
@@ -94,12 +97,10 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame('bar', $form->getViewData());
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Form\Exception\TransformationFailedException
-     * @expectedExceptionMessage Unable to transform data for property path "name": No mapping for value "arg"
-     */
     public function testDataTransformationFailure()
     {
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
+        $this->expectExceptionMessage('Unable to transform data for property path "name": No mapping for value "arg"');
         $model = new FixedDataTransformer([
             'default' => 'foo',
         ]);
@@ -160,11 +161,9 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertNull($form->getData());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
-     */
     public function testSubmitThrowsExceptionIfAlreadySubmitted()
     {
+        $this->expectException('Symfony\Component\Form\Exception\AlreadySubmittedException');
         $this->form->submit([]);
         $this->form->submit([]);
     }
@@ -363,11 +362,9 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertCount(0, $this->form->getErrors());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
-     */
     public function testSetParentThrowsExceptionIfAlreadySubmitted()
     {
+        $this->expectException('Symfony\Component\Form\Exception\AlreadySubmittedException');
         $this->form->submit([]);
         $this->form->setParent($this->getBuilder('parent')->getForm());
     }
@@ -385,11 +382,9 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertFalse($this->form->isSubmitted());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
-     */
     public function testSetDataThrowsExceptionIfAlreadySubmitted()
     {
+        $this->expectException('Symfony\Component\Form\Exception\AlreadySubmittedException');
         $this->form->submit([]);
         $this->form->setData(null);
     }
@@ -788,12 +783,10 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertNull($form->getParent());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\LogicException
-     * @expectedExceptionMessage A form with an empty name cannot have a parent form.
-     */
     public function testFormCannotHaveEmptyNameNotInRootLevel()
     {
+        $this->expectException('Symfony\Component\Form\Exception\LogicException');
+        $this->expectExceptionMessage('A form with an empty name cannot have a parent form.');
         $this->getBuilder()
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
@@ -900,11 +893,9 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame($arrayAccess, $form->getViewData());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\LogicException
-     */
     public function testViewDataMustBeObjectIfDataClassIsSet()
     {
+        $this->expectException('Symfony\Component\Form\Exception\LogicException');
         $config = new FormConfigBuilder('name', 'stdClass', $this->dispatcher);
         $config->addViewTransformer(new FixedDataTransformer([
             '' => '',
@@ -915,12 +906,10 @@ class SimpleFormTest extends AbstractFormTest
         $form->setData('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     * @expectedExceptionMessage A cycle was detected. Listeners to the PRE_SET_DATA event must not call setData(). You should call setData() on the FormEvent object instead.
-     */
     public function testSetDataCannotInvokeItself()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
+        $this->expectExceptionMessage('A cycle was detected. Listeners to the PRE_SET_DATA event must not call setData(). You should call setData() on the FormEvent object instead.');
         // Cycle detection to prevent endless loops
         $config = new FormConfigBuilder('name', 'stdClass', $this->dispatcher);
         $config->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
@@ -989,11 +978,9 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame('view[foo]', $parent->get('child')->getViewData());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     */
     public function testInheritDataDisallowsSetData()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
         $form = $this->getBuilder()
             ->setInheritData(true)
             ->getForm();
@@ -1001,11 +988,9 @@ class SimpleFormTest extends AbstractFormTest
         $form->setData('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     */
     public function testGetDataRequiresParentToBeSetIfInheritData()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
         $form = $this->getBuilder()
             ->setInheritData(true)
             ->getForm();
@@ -1013,11 +998,9 @@ class SimpleFormTest extends AbstractFormTest
         $form->getData();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     */
     public function testGetNormDataRequiresParentToBeSetIfInheritData()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
         $form = $this->getBuilder()
             ->setInheritData(true)
             ->getForm();
@@ -1025,11 +1008,9 @@ class SimpleFormTest extends AbstractFormTest
         $form->getNormData();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     */
     public function testGetViewDataRequiresParentToBeSetIfInheritData()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
         $form = $this->getBuilder()
             ->setInheritData(true)
             ->getForm();
@@ -1077,11 +1058,9 @@ class SimpleFormTest extends AbstractFormTest
         $form->initialize();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     */
     public function testInitializeFailsIfParent()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
         $parent = $this->getBuilder()->setRequired(false)->getForm();
         $child = $this->getBuilder()->setRequired(true)->getForm();
 
@@ -1090,12 +1069,10 @@ class SimpleFormTest extends AbstractFormTest
         $child->initialize();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     * @expectedExceptionMessage A cycle was detected. Listeners to the PRE_SET_DATA event must not call getData() if the form data has not already been set. You should call getData() on the FormEvent object instead.
-     */
     public function testCannotCallGetDataInPreSetDataListenerIfDataHasNotAlreadyBeenSet()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
+        $this->expectExceptionMessage('A cycle was detected. Listeners to the PRE_SET_DATA event must not call getData() if the form data has not already been set. You should call getData() on the FormEvent object instead.');
         $config = new FormConfigBuilder('name', 'stdClass', $this->dispatcher);
         $config->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             $event->getForm()->getData();
@@ -1105,12 +1082,10 @@ class SimpleFormTest extends AbstractFormTest
         $form->setData('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     * @expectedExceptionMessage A cycle was detected. Listeners to the PRE_SET_DATA event must not call getNormData() if the form data has not already been set.
-     */
     public function testCannotCallGetNormDataInPreSetDataListener()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
+        $this->expectExceptionMessage('A cycle was detected. Listeners to the PRE_SET_DATA event must not call getNormData() if the form data has not already been set.');
         $config = new FormConfigBuilder('name', 'stdClass', $this->dispatcher);
         $config->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             $event->getForm()->getNormData();
@@ -1120,12 +1095,10 @@ class SimpleFormTest extends AbstractFormTest
         $form->setData('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\RuntimeException
-     * @expectedExceptionMessage A cycle was detected. Listeners to the PRE_SET_DATA event must not call getViewData() if the form data has not already been set.
-     */
     public function testCannotCallGetViewDataInPreSetDataListener()
     {
+        $this->expectException('Symfony\Component\Form\Exception\RuntimeException');
+        $this->expectExceptionMessage('A cycle was detected. Listeners to the PRE_SET_DATA event must not call getViewData() if the form data has not already been set.');
         $config = new FormConfigBuilder('name', 'stdClass', $this->dispatcher);
         $config->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             $event->getForm()->getViewData();

--- a/src/Symfony/Component/Form/Tests/Util/OrderedHashMapTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/OrderedHashMapTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Form\Util\OrderedHashMap;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\Form\Util\OrderedHashMap;
  */
 class OrderedHashMapTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGet()
     {
         $map = new OrderedHashMap();
@@ -27,11 +30,9 @@ class OrderedHashMapTest extends TestCase
         $this->assertSame(1, $map['first']);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testGetNonExistingFails()
     {
+        $this->expectException('OutOfBoundsException');
         $map = new OrderedHashMap();
 
         $map['first'];

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -49,11 +49,9 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertSame('fööö.html', $response->getFile()->getFilename());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testSetContent()
     {
+        $this->expectException('LogicException');
         $response = new BinaryFileResponse(__FILE__);
         $response->setContent('foo');
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Cookie;
 
 /**
@@ -24,6 +25,8 @@ use Symfony\Component\HttpFoundation\Cookie;
  */
 class CookieTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function invalidNames()
     {
         return [
@@ -41,18 +44,16 @@ class CookieTest extends TestCase
 
     /**
      * @dataProvider invalidNames
-     * @expectedException \InvalidArgumentException
      */
     public function testInstantiationThrowsExceptionIfCookieNameContainsInvalidCharacters($name)
     {
+        $this->expectException('InvalidArgumentException');
         new Cookie($name);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidExpiration()
     {
+        $this->expectException('InvalidArgumentException');
         new Cookie('MyCookie', 'foo', 'bar');
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ExpressionRequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ExpressionRequestMatcherTest.php
@@ -12,17 +12,18 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\ExpressionRequestMatcher;
 use Symfony\Component\HttpFoundation\Request;
 
 class ExpressionRequestMatcherTest extends TestCase
 {
-    /**
-     * @expectedException \LogicException
-     */
+    use ForwardCompatTestTrait;
+
     public function testWhenNoExpressionIsSet()
     {
+        $this->expectException('LogicException');
         $expressionRequestMatcher = new ExpressionRequestMatcher();
         $expressionRequestMatcher->matches(new Request());
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -145,11 +145,9 @@ class UploadedFileTest extends TestCase
         $this->assertEquals('gif', $file->getClientOriginalExtension());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpFoundation\File\Exception\FileException
-     */
     public function testMoveLocalFileIsNotAllowed()
     {
+        $this->expectException('Symfony\Component\HttpFoundation\File\Exception\FileException');
         $file = new UploadedFile(
             __DIR__.'/Fixtures/test.gif',
             'original.gif',

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -26,11 +26,9 @@ class FileBagTest extends TestCase
 {
     use ForwardCompatTestTrait;
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testFileMustBeAnArrayOrUploadedFile()
     {
+        $this->expectException('InvalidArgumentException');
         new FileBag(['file' => 'foo']);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\HeaderBag;
 
 class HeaderBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $bag = new HeaderBag(['foo' => 'bar']);
@@ -48,11 +51,9 @@ class HeaderBagTest extends TestCase
         $this->assertInstanceOf('DateTime', $headerDate);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetDateException()
     {
+        $this->expectException('RuntimeException');
         $bag = new HeaderBag(['foo' => 'Tue']);
         $headerDate = $bag->getDate('foo');
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\IpUtils;
 
 class IpUtilsTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getIpv4Data
      */
@@ -73,11 +76,11 @@ class IpUtilsTest extends TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
      * @requires extension sockets
      */
     public function testAnIpv6WithOptionDisabledIpv6()
     {
+        $this->expectException('RuntimeException');
         if (\defined('AF_INET6')) {
             $this->markTestSkipped('Only works when PHP is compiled with the option "disable-ipv6".');
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -219,29 +219,23 @@ class JsonResponseTest extends TestCase
         $this->assertSame('{"foo":"bar"}', $response->getContent());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetCallbackInvalidIdentifier()
     {
+        $this->expectException('InvalidArgumentException');
         $response = new JsonResponse('foo');
         $response->setCallback('+invalid');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetContent()
     {
+        $this->expectException('InvalidArgumentException');
         JsonResponse::create("\xB1\x31");
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage This error is expected
-     */
     public function testSetContentJsonSerializeError()
     {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('This error is expected');
         if (!interface_exists('JsonSerializable', false)) {
             $this->markTestSkipped('JsonSerializable is required.');
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class RedirectResponseTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGenerateMetaRedirect()
     {
         $response = new RedirectResponse('foo.bar');
@@ -26,19 +29,15 @@ class RedirectResponseTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRedirectResponseConstructorNullUrl()
     {
+        $this->expectException('InvalidArgumentException');
         $response = new RedirectResponse(null);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRedirectResponseConstructorWrongStatusCode()
     {
+        $this->expectException('InvalidArgumentException');
         $response = new RedirectResponse('foo.bar', 404);
     }
 
@@ -65,11 +64,9 @@ class RedirectResponseTest extends TestCase
         $this->assertEquals('baz.beep', $response->getTargetUrl());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetTargetUrlNull()
     {
+        $this->expectException('InvalidArgumentException');
         $response = new RedirectResponse('foo.bar');
         $response->setTargetUrl(null);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -889,11 +889,9 @@ class RequestTest extends TestCase
         $this->assertEquals(80, $port, 'With only PROTO set and value is not recognized, getPort() defaults to 80.');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetHostWithFakeHttpHostValue()
     {
+        $this->expectException('RuntimeException');
         $request = new Request();
         $request->initialize([], [], [], [], [], ['HTTP_HOST' => 'www.host.com?query=string']);
         $request->getHost();
@@ -1058,11 +1056,11 @@ class RequestTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException
      * @dataProvider getClientIpsWithConflictingHeadersProvider
      */
     public function testGetClientIpsWithConflictingHeaders($httpForwarded, $httpXForwardedFor)
     {
+        $this->expectException('Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException');
         $request = new Request();
 
         $server = [
@@ -1182,11 +1180,11 @@ class RequestTest extends TestCase
     }
 
     /**
-     * @expectedException \LogicException
      * @dataProvider getContentCantBeCalledTwiceWithResourcesProvider
      */
     public function testGetContentCantBeCalledTwiceWithResources($first, $second)
     {
+        $this->expectException('LogicException');
         if (\PHP_VERSION_ID >= 50600) {
             $this->markTestSkipped('PHP >= 5.6 allows to open php://input several times.');
         }
@@ -1971,20 +1969,20 @@ class RequestTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedException \InvalidArgumentException
      */
     public function testSetTrustedProxiesInvalidHeaderName()
     {
+        $this->expectException('InvalidArgumentException');
         Request::create('http://example.com/');
         Request::setTrustedHeaderName('bogus name', 'X_MY_FOR');
     }
 
     /**
      * @group legacy
-     * @expectedException \InvalidArgumentException
      */
     public function testGetTrustedProxiesInvalidHeaderName()
     {
+        $this->expectException('InvalidArgumentException');
         Request::create('http://example.com/');
         Request::getTrustedHeaderName('bogus name');
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
@@ -20,6 +21,8 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
  */
 class ResponseHeaderBagTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testAllPreserveCase()
     {
         $headers = [
@@ -240,21 +243,17 @@ class ResponseHeaderBagTest extends TestCase
         $this->assertEquals([], $bag->getCookies());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetCookiesWithInvalidArgument()
     {
+        $this->expectException('InvalidArgumentException');
         $bag = new ResponseHeaderBag();
 
         $bag->getCookies('invalid_argument');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMakeDispositionInvalidDisposition()
     {
+        $this->expectException('InvalidArgumentException');
         $headers = new ResponseHeaderBag();
 
         $headers->makeDisposition('invalid', 'foo.html');
@@ -298,10 +297,10 @@ class ResponseHeaderBagTest extends TestCase
 
     /**
      * @dataProvider provideMakeDispositionFail
-     * @expectedException \InvalidArgumentException
      */
     public function testMakeDispositionFail($disposition, $filename)
     {
+        $this->expectException('InvalidArgumentException');
         $headers = new ResponseHeaderBag();
 
         $headers->makeDisposition($disposition, $filename);

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,6 +20,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ResponseTest extends ResponseTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCreate()
     {
         $response = Response::create('foo', 301, ['Foo' => 'bar']);
@@ -846,11 +849,11 @@ class ResponseTest extends ResponseTestCase
     }
 
     /**
-     * @expectedException \UnexpectedValueException
      * @dataProvider invalidContentProvider
      */
     public function testSetContentInvalid($content)
     {
+        $this->expectException('UnexpectedValueException');
         $response = new Response();
         $response->setContent($content);
     }
@@ -928,11 +931,11 @@ class ResponseTest extends ResponseTestCase
     }
 
     /**
-     * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+     * @see http://github.com/zendframework/zend-diactoros for the canonical source repository
      *
-     * @author    Fábio Pacheco
+     * @author Fábio Pacheco
      * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
-     * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+     * @license https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
      */
     public function ianaCodesReasonPhrasesProvider()
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -65,19 +65,15 @@ class MongoDbSessionHandlerTest extends TestCase
         $this->storage = new MongoDbSessionHandler($this->mongo, $this->options);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorShouldThrowExceptionForInvalidMongo()
     {
+        $this->expectException('InvalidArgumentException');
         new MongoDbSessionHandler(new \stdClass(), $this->options);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorShouldThrowExceptionForMissingOptions()
     {
+        $this->expectException('InvalidArgumentException');
         new MongoDbSessionHandler($this->mongo, []);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 
@@ -25,6 +26,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
  */
 class NativeFileSessionHandlerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstruct()
     {
         $storage = new NativeSessionStorage(['name' => 'TESTING'], new NativeFileSessionHandler(sys_get_temp_dir()));
@@ -59,11 +62,9 @@ class NativeFileSessionHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructException()
     {
+        $this->expectException('InvalidArgumentException');
         $handler = new NativeFileSessionHandler('something;invalid;with;too-many-args');
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -51,22 +51,18 @@ class PdoSessionHandlerTest extends TestCase
         return $pdo;
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testWrongPdoErrMode()
     {
+        $this->expectException('InvalidArgumentException');
         $pdo = $this->getMemorySqlitePdo();
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_SILENT);
 
         $storage = new PdoSessionHandler($pdo);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testInexistentTable()
     {
+        $this->expectException('RuntimeException');
         $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), ['db_table' => 'inexistent_table']);
         $storage->open('', 'sid');
         $storage->read('id');
@@ -74,11 +70,9 @@ class PdoSessionHandlerTest extends TestCase
         $storage->close();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCreateTableTwice()
     {
+        $this->expectException('RuntimeException');
         $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
         $storage->createTable();
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
@@ -124,11 +124,9 @@ class MockArraySessionStorageTest extends TestCase
         $this->assertTrue($storage->isStarted());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testUnstartedSave()
     {
+        $this->expectException('RuntimeException');
         $this->storage->save();
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -110,11 +110,9 @@ class MockFileSessionStorageTest extends TestCase
         $this->assertEquals('bar', $storage2->getBag('attributes')->get('foo'), 'values persist between instances');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testSaveWithoutStart()
     {
+        $this->expectException('RuntimeException');
         $storage1 = $this->getStorage();
         $storage1->save();
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -75,20 +75,16 @@ class NativeSessionStorageTest extends TestCase
         $this->assertSame($bag, $storage->getBag($bag->getName()));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRegisterBagException()
     {
+        $this->expectException('InvalidArgumentException');
         $storage = $this->getStorage();
         $storage->getBag('non_existing');
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRegisterBagForAStartedSessionThrowsException()
     {
+        $this->expectException('LogicException');
         $storage = $this->getStorage();
         $storage->start();
         $storage->registerBag(new AttributeBag());
@@ -204,11 +200,9 @@ class NativeSessionStorageTest extends TestCase
         $this->assertSame('200', ini_get('session.cache_expire'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetSaveHandlerException()
     {
+        $this->expectException('InvalidArgumentException');
         $storage = $this->getStorage();
         $storage->setSaveHandler(new \stdClass());
     }
@@ -231,11 +225,9 @@ class NativeSessionStorageTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testStarted()
     {
+        $this->expectException('RuntimeException');
         $storage = $this->getStorage();
 
         $this->assertFalse($storage->getSaveHandler()->isActive());

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -83,10 +83,10 @@ class AbstractProxyTest extends TestCase
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     * @expectedException \LogicException
      */
     public function testNameException()
     {
+        $this->expectException('LogicException');
         session_start();
         $this->proxy->setName('foo');
     }
@@ -106,10 +106,10 @@ class AbstractProxyTest extends TestCase
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     * @expectedException \LogicException
      */
     public function testIdException()
     {
+        $this->expectException('LogicException');
         session_start();
         $this->proxy->setId('foo');
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -28,7 +28,7 @@ class SessionHandlerProxyTest extends TestCase
     use ForwardCompatTestTrait;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_Matcher
+     * @var \PHPUnit\Framework\MockObject\Matcher
      */
     private $mock;
 

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class StreamedResponseTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $response = new StreamedResponse(function () { echo 'foo'; }, 404, ['Content-Type' => 'text/plain']);
@@ -81,20 +84,16 @@ class StreamedResponseTest extends TestCase
         $this->assertEquals(1, $called);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testSendContentWithNonCallable()
     {
+        $this->expectException('LogicException');
         $response = new StreamedResponse(null);
         $response->sendContent();
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testSetContent()
     {
+        $this->expectException('LogicException');
         $response = new StreamedResponse(function () { echo 'foo'; });
         $response->setContent('foo');
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Bundle;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionAbsentBundle\ExtensionAbsentBundle;
@@ -21,6 +22,8 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Extension
 
 class BundleTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetContainerExtension()
     {
         $bundle = new ExtensionPresentBundle();
@@ -49,12 +52,10 @@ class BundleTest extends TestCase
         $this->assertNull($bundle2->registerCommands($app));
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface
-     */
     public function testGetContainerExtensionWithInvalidClass()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface');
         $bundle = new ExtensionNotValidBundle();
         $bundle->getContainerExtension();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/CacheClearer/Psr6CacheClearerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheClearer/Psr6CacheClearerTest.php
@@ -13,10 +13,13 @@ namespace Symfony\Component\HttpKernel\Tests\CacheClearer;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
 
 class Psr6CacheClearerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testClearPoolsInjectedInConstructor()
     {
         $pool = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
@@ -37,12 +40,10 @@ class Psr6CacheClearerTest extends TestCase
         (new Psr6CacheClearer(['pool' => $pool]))->clearPool('pool');
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage Cache pool not found: unknown
-     */
     public function testClearPoolThrowsExceptionOnUnreferencedPool()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Cache pool not found: unknown');
         (new Psr6CacheClearer())->clearPool('unknown');
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
@@ -39,11 +39,9 @@ class CacheWarmerTest extends TestCase
         $this->assertFileExists(self::$cacheFile);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testWriteNonWritableCacheFileThrowsARuntimeException()
     {
+        $this->expectException('RuntimeException');
         $nonWritableFile = '/this/file/is/very/probably/not/writable';
         $warmer = new TestCacheWarmer($nonWritableFile);
         $warmer->warmUp(\dirname($nonWritableFile));

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -170,10 +170,10 @@ class ArgumentResolverTest extends TestCase
 
     /**
      * @requires PHP 5.6
-     * @expectedException \InvalidArgumentException
      */
     public function testGetVariadicArgumentsWithoutArrayInRequest()
     {
+        $this->expectException('InvalidArgumentException');
         $request = Request::create('/');
         $request->attributes->set('foo', 'foo');
         $request->attributes->set('bar', 'foo');
@@ -184,10 +184,10 @@ class ArgumentResolverTest extends TestCase
 
     /**
      * @requires PHP 5.6
-     * @expectedException \InvalidArgumentException
      */
     public function testGetArgumentWithoutArray()
     {
+        $this->expectException('InvalidArgumentException');
         $factory = new ArgumentMetadataFactory();
         $valueResolver = $this->getMockBuilder(ArgumentValueResolverInterface::class)->getMock();
         $resolver = new ArgumentResolver($factory, [$valueResolver]);
@@ -202,11 +202,9 @@ class ArgumentResolverTest extends TestCase
         $resolver->getArguments($request, $controller);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testIfExceptionIsThrownWhenMissingAnArgument()
     {
+        $this->expectException('RuntimeException');
         $request = Request::create('/');
         $controller = [$this, 'controllerWithFoo'];
 
@@ -269,11 +267,9 @@ class ArgumentResolverTest extends TestCase
         $this->assertEquals([$session], self::$resolver->getArguments($request, $controller));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetSessionMissMatchWithInterface()
     {
+        $this->expectException('RuntimeException');
         $session = $this->getMockBuilder(SessionInterface::class)->getMock();
         $request = Request::create('/');
         $request->setSession($session);
@@ -282,11 +278,9 @@ class ArgumentResolverTest extends TestCase
         self::$resolver->getArguments($request, $controller);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetSessionMissMatchWithImplementation()
     {
+        $this->expectException('RuntimeException');
         $session = new Session(new MockArraySessionStorage());
         $request = Request::create('/');
         $request->setSession($session);
@@ -295,11 +289,9 @@ class ArgumentResolverTest extends TestCase
         self::$resolver->getArguments($request, $controller);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetSessionMissMatchOnNull()
     {
+        $this->expectException('RuntimeException');
         $request = Request::create('/');
         $controller = [$this, 'controllerWithExtendingSession'];
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
@@ -115,12 +115,10 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $this->assertSame([NonInstantiableController::class, 'action'], $controller);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Controller "Symfony\Component\HttpKernel\Tests\Controller\ImpossibleConstructController" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?
-     */
     public function testNonConstructController()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Controller "Symfony\Component\HttpKernel\Tests\Controller\ImpossibleConstructController" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?');
         $container = $this->getMockBuilder(Container::class)->getMock();
         $container->expects($this->at(0))
             ->method('has')
@@ -182,12 +180,10 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $this->assertSame([$service, 'action'], $controller);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Controller "app.my_controller" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?
-     */
     public function testExceptionWhenUsingRemovedControllerService()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Controller "app.my_controller" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?');
         $container = $this->getMockBuilder(Container::class)->getMock();
         $container->expects($this->at(0))
             ->method('has')
@@ -208,12 +204,10 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $resolver->getController($request);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Controller "app.my_controller" cannot be called without a method name. Did you forget an "__invoke" method?
-     */
     public function testExceptionWhenUsingControllerWithoutAnInvokeMethod()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Controller "app.my_controller" cannot be called without a method name. Did you forget an "__invoke" method?');
         $container = $this->getMockBuilder(Container::class)->getMock();
         $container->expects($this->once())
             ->method('has')

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -93,11 +93,9 @@ class ControllerResolverTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest', $controller);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetControllerOnObjectWithoutInvokeMethod()
     {
+        $this->expectException('InvalidArgumentException');
         $resolver = $this->createControllerResolver();
 
         $request = Request::create('/');
@@ -233,11 +231,11 @@ class ControllerResolverTest extends TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
      * @group legacy
      */
     public function testIfExceptionIsThrownWhenMissingAnArgument()
     {
+        $this->expectException('RuntimeException');
         $resolver = new ControllerResolver();
         $request = Request::create('/');
 

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\HttpKernel\Tests\ControllerMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 class ArgumentMetadataTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testWithBcLayerWithDefault()
     {
         $argument = new ArgumentMetadata('foo', 'string', false, true, 'default value');
@@ -32,11 +35,9 @@ class ArgumentMetadataTest extends TestCase
         $this->assertSame('default value', $argument->getDefaultValue());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testDefaultValueUnavailable()
     {
+        $this->expectException('LogicException');
         $argument = new ArgumentMetadata('foo', 'string', false, false, null, false);
 
         $this->assertFalse($argument->isNullable());

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -22,14 +23,15 @@ use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
 class FragmentRendererPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * Tests that content rendering not implementing FragmentRendererInterface
      * triggers an exception.
-     *
-     * @expectedException \InvalidArgumentException
      */
     public function testContentRendererWithoutInterface()
     {
+        $this->expectException('InvalidArgumentException');
         $builder = new ContainerBuilder();
         $fragmentHandlerDefinition = $builder->register('fragment.handler');
         $builder->register('my_content_renderer', 'Symfony\Component\DependencyInjection\Definition')

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -25,12 +26,12 @@ use Symfony\Component\HttpKernel\DependencyInjection\RegisterControllerArgumentL
 
 class RegisterControllerArgumentLocatorsPassTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Class "Symfony\Component\HttpKernel\Tests\DependencyInjection\NotFound" used for service "foo" cannot be found.
-     */
+    use ForwardCompatTestTrait;
+
     public function testInvalidClass()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Class "Symfony\Component\HttpKernel\Tests\DependencyInjection\NotFound" used for service "foo" cannot be found.');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
 
@@ -42,12 +43,10 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Missing "action" attribute on tag "controller.service_arguments" {"argument":"bar"} for service "foo".
-     */
     public function testNoAction()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Missing "action" attribute on tag "controller.service_arguments" {"argument":"bar"} for service "foo".');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
 
@@ -59,12 +58,10 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Missing "argument" attribute on tag "controller.service_arguments" {"action":"fooAction"} for service "foo".
-     */
     public function testNoArgument()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Missing "argument" attribute on tag "controller.service_arguments" {"action":"fooAction"} for service "foo".');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
 
@@ -76,12 +73,10 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Missing "id" attribute on tag "controller.service_arguments" {"action":"fooAction","argument":"bar"} for service "foo".
-     */
     public function testNoService()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Missing "id" attribute on tag "controller.service_arguments" {"action":"fooAction","argument":"bar"} for service "foo".');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
 
@@ -93,12 +88,10 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid "action" attribute on tag "controller.service_arguments" for service "foo": no public "barAction()" method found on class "Symfony\Component\HttpKernel\Tests\DependencyInjection\RegisterTestController".
-     */
     public function testInvalidMethod()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid "action" attribute on tag "controller.service_arguments" for service "foo": no public "barAction()" method found on class "Symfony\Component\HttpKernel\Tests\DependencyInjection\RegisterTestController".');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
 
@@ -110,12 +103,10 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid "controller.service_arguments" tag for service "foo": method "fooAction()" has no "baz" argument on class "Symfony\Component\HttpKernel\Tests\DependencyInjection\RegisterTestController".
-     */
     public function testInvalidArgument()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid "controller.service_arguments" tag for service "foo": method "fooAction()" has no "baz" argument on class "Symfony\Component\HttpKernel\Tests\DependencyInjection\RegisterTestController".');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
 
@@ -207,12 +198,10 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $this->assertSame(['foo:fooAction'], array_keys($locator));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Cannot determine controller argument for "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClassController::fooAction()": the $nonExistent argument is type-hinted with the non-existent class or interface: "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClass". Did you forget to add a use statement?
-     */
     public function testExceptionOnNonExistentTypeHint()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Cannot determine controller argument for "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClassController::fooAction()": the $nonExistent argument is type-hinted with the non-existent class or interface: "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClass". Did you forget to add a use statement?');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
 
@@ -223,12 +212,10 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Cannot determine controller argument for "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClassDifferentNamespaceController::fooAction()": the $nonExistent argument is type-hinted with the non-existent class or interface: "Acme\NonExistentClass".
-     */
     public function testExceptionOnNonExistentTypeHintDifferentNamespace()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Cannot determine controller argument for "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClassDifferentNamespaceController::fooAction()": the $nonExistent argument is type-hinted with the non-existent class or interface: "Acme\NonExistentClass".');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
 

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ResettableServicePassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ResettableServicePassTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -14,6 +15,8 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\ResettableService;
 
 class ResettableServicePassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCompilerPass()
     {
         $container = new ContainerBuilder();
@@ -48,12 +51,10 @@ class ResettableServicePassTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Tag kernel.reset requires the "method" attribute to be set.
-     */
     public function testMissingMethod()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Tag kernel.reset requires the "method" attribute to be set.');
         $container = new ContainerBuilder();
         $container->register(ResettableService::class)
             ->addTag('kernel.reset');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\FragmentListener;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpKernel\UriSigner;
 
 class FragmentListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testOnlyTriggeredOnFragmentRoute()
     {
         $request = Request::create('http://example.com/foo?_path=foo%3Dbar%26_controller%3Dfoo');
@@ -50,11 +53,9 @@ class FragmentListenerTest extends TestCase
         $this->assertEquals($expected, $request->attributes->all());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAccessDeniedWithNonSafeMethods()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
         $request = Request::create('http://example.com/_fragment', 'POST');
 
         $listener = new FragmentListener(new UriSigner('foo'));
@@ -63,11 +64,9 @@ class FragmentListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
     public function testAccessDeniedWithWrongSignature()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException');
         $request = Request::create('http://example.com/_fragment', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.1']);
 
         $listener = new FragmentListener(new UriSigner('foo'));

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -87,11 +87,9 @@ class RouterListenerTest extends TestCase
         return new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidMatcher()
     {
+        $this->expectException('InvalidArgumentException');
         new RouterListener(new \stdClass(), $this->requestStack);
     }
 
@@ -212,11 +210,9 @@ class RouterListenerTest extends TestCase
         $this->assertContains('Welcome', $response->getContent());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     */
     public function testRequestWithBadHost()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $request = Request::create('http://bad host %22/');
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ValidateRequestListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ValidateRequestListenerTest.php
@@ -29,11 +29,9 @@ class ValidateRequestListenerTest extends TestCase
         Request::setTrustedProxies([], -1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException
-     */
     public function testListenerThrowsWhenMasterRequestHasInconsistentClientIps()
     {
+        $this->expectException('Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException');
         $dispatcher = new EventDispatcher();
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Fragment;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpKernel\UriSigner;
 
 class EsiFragmentRendererTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testRenderFallbackToInlineStrategyIfEsiNotSupported()
     {
         $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true));
@@ -77,11 +80,9 @@ class EsiFragmentRendererTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRenderControllerReferenceWithoutSignerThrowsException()
     {
+        $this->expectException('LogicException');
         $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy());
 
         $request = Request::create('/');
@@ -91,11 +92,9 @@ class EsiFragmentRendererTest extends TestCase
         $strategy->render(new ControllerReference('main_controller'), $request);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRenderAltControllerReferenceWithoutSignerThrowsException()
     {
+        $this->expectException('LogicException');
         $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy());
 
         $request = Request::create('/');

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -39,31 +39,25 @@ class FragmentHandlerTest extends TestCase
         ;
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWhenRendererDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
         $handler = new FragmentHandler($this->requestStack);
         $handler->render('/', 'foo');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithUnknownRenderer()
     {
+        $this->expectException('InvalidArgumentException');
         $handler = $this->getHandler($this->returnValue(new Response('foo')));
 
         $handler->render('/', 'bar');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Error when rendering "http://localhost/" (Status code is 404).
-     */
     public function testDeliverWithUnsuccessfulResponse()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Error when rendering "http://localhost/" (Status code is 404).');
         $handler = $this->getHandler($this->returnValue(new Response('foo', 404)));
 
         $handler->render('/', 'foo');

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Fragment;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\HIncludeFragmentRenderer;
@@ -19,11 +20,11 @@ use Symfony\Component\HttpKernel\UriSigner;
 
 class HIncludeFragmentRendererTest extends TestCase
 {
-    /**
-     * @expectedException \LogicException
-     */
+    use ForwardCompatTestTrait;
+
     public function testRenderExceptionWhenControllerAndNoSigner()
     {
+        $this->expectException('LogicException');
         $strategy = new HIncludeFragmentRenderer();
         $strategy->render(new ControllerReference('main_controller', [], []), Request::create('/'));
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Fragment;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -25,6 +26,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class InlineFragmentRendererTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testRender()
     {
         $strategy = new InlineFragmentRenderer($this->getKernel($this->returnValue(new Response('foo'))));
@@ -111,11 +114,9 @@ class InlineFragmentRendererTest extends TestCase
         Request::setTrustedProxies([], -1);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testRenderExceptionNoIgnoreErrors()
     {
+        $this->expectException('RuntimeException');
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $dispatcher->expects($this->never())->method('dispatch');
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\HttpKernel\Tests\Fragment;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 class RoutableFragmentRendererTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getGenerateFragmentUriData
      */
@@ -56,11 +59,11 @@ class RoutableFragmentRendererTest extends TestCase
     }
 
     /**
-     * @expectedException \LogicException
-     * @dataProvider      getGenerateFragmentUriDataWithNonScalar
+     * @dataProvider getGenerateFragmentUriDataWithNonScalar
      */
     public function testGenerateFragmentUriWithNonScalar($controller)
     {
+        $this->expectException('LogicException');
         $this->callGenerateFragmentUriMethod($controller, Request::create('/'));
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/SsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/SsiFragmentRendererTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Fragment;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\SsiFragmentRenderer;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpKernel\UriSigner;
 
 class SsiFragmentRendererTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testRenderFallbackToInlineStrategyIfSsiNotSupported()
     {
         $strategy = new SsiFragmentRenderer(new Ssi(), $this->getInlineStrategy(true));
@@ -56,11 +59,9 @@ class SsiFragmentRendererTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRenderControllerReferenceWithoutSignerThrowsException()
     {
+        $this->expectException('LogicException');
         $strategy = new SsiFragmentRenderer(new Ssi(), $this->getInlineStrategy());
 
         $request = Request::create('/');
@@ -70,11 +71,9 @@ class SsiFragmentRendererTest extends TestCase
         $strategy->render(new ControllerReference('main_controller'), $request);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRenderAltControllerReferenceWithoutSignerThrowsException()
     {
+        $this->expectException('LogicException');
         $strategy = new SsiFragmentRenderer(new Ssi(), $this->getInlineStrategy());
 
         $request = Request::create('/');

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
 
 class EsiTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testHasSurrogateEsiCapability()
     {
         $esi = new Esi();
@@ -153,11 +156,9 @@ class EsiTest extends TestCase
         $this->assertEquals('<?php echo "<?"; ?>php <?php echo "<?"; ?> <?php echo "<%"; ?> <?php echo "<s"; ?>cript language=php>', $response->getContent());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testProcessWhenNoSrcInAnEsi()
     {
+        $this->expectException('RuntimeException');
         $esi = new Esi();
 
         $request = Request::create('/');
@@ -193,11 +194,9 @@ class EsiTest extends TestCase
         $this->assertEquals('foo', $esi->handle($cache, '/', '/alt', true));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testHandleWhenResponseIsNot200()
     {
+        $this->expectException('RuntimeException');
         $esi = new Esi();
         $response = new Response('foo');
         $response->setStatusCode(404);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\Ssi;
 
 class SsiTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testHasSurrogateSsiCapability()
     {
         $ssi = new Ssi();
@@ -120,11 +123,9 @@ class SsiTest extends TestCase
         $this->assertEquals('<?php echo "<?"; ?>php <?php echo "<?"; ?> <?php echo "<%"; ?> <?php echo "<s"; ?>cript language=php>', $response->getContent());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testProcessWhenNoSrcInAnSsi()
     {
+        $this->expectException('RuntimeException');
         $ssi = new Ssi();
 
         $request = Request::create('/');
@@ -160,11 +161,9 @@ class SsiTest extends TestCase
         $this->assertEquals('foo', $ssi->handle($cache, '/', '/alt', true));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testHandleWhenResponseIsNot200()
     {
+        $this->expectException('RuntimeException');
         $ssi = new Ssi();
         $response = new Response('foo');
         $response->setStatusCode(404);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -30,21 +31,19 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class HttpKernelTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     */
+    use ForwardCompatTestTrait;
+
     public function testHandleWhenControllerThrowsAnExceptionAndCatchIsTrue()
     {
+        $this->expectException('RuntimeException');
         $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \RuntimeException(); });
 
         $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testHandleWhenControllerThrowsAnExceptionAndCatchIsFalseAndNoListenerIsRegistered()
     {
+        $this->expectException('RuntimeException');
         $kernel = $this->getHttpKernel(new EventDispatcher(), function () { throw new \RuntimeException(); });
 
         $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, false);
@@ -177,11 +176,9 @@ class HttpKernelTest extends TestCase
         $this->assertEquals('hello', $kernel->handle(new Request())->getContent());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
     public function testHandleWhenNoControllerIsFound()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
         $dispatcher = new EventDispatcher();
         $kernel = $this->getHttpKernel($dispatcher, false);
 
@@ -229,11 +226,9 @@ class HttpKernelTest extends TestCase
         $this->assertResponseEquals(new Response('foo'), $kernel->handle(new Request()));
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testHandleWhenTheControllerDoesNotReturnAResponse()
     {
+        $this->expectException('LogicException');
         $dispatcher = new EventDispatcher();
         $kernel = $this->getHttpKernel($dispatcher, function () { return 'foo'; });
 
@@ -331,11 +326,9 @@ class HttpKernelTest extends TestCase
         $kernel->handle($request, HttpKernelInterface::MASTER_REQUEST);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     */
     public function testInconsistentClientIpsOnMasterRequests()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
         $request = new Request();
         $request->setTrustedProxies(['1.1.1.1'], Request::HEADER_X_FORWARDED_FOR | Request::HEADER_FORWARDED);
         $request->server->set('REMOTE_ADDR', '1.1.1.1');

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -391,35 +391,27 @@ EOF;
         $this->assertEquals($expected, $kernel->serialize());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLocateResourceThrowsExceptionWhenNameIsNotValid()
     {
+        $this->expectException('InvalidArgumentException');
         $this->getKernel()->locateResource('Foo');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testLocateResourceThrowsExceptionWhenNameIsUnsafe()
     {
+        $this->expectException('RuntimeException');
         $this->getKernel()->locateResource('@FooBundle/../bar');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLocateResourceThrowsExceptionWhenBundleDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
         $this->getKernel()->locateResource('@FooBundle/config/routing.xml');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLocateResourceThrowsExceptionWhenResourceDoesNotExist()
     {
+        $this->expectException('InvalidArgumentException');
         $kernel = $this->getKernel(['getBundle']);
         $kernel
             ->expects($this->once())
@@ -675,11 +667,11 @@ EOF;
 
     /**
      * @group legacy
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Bundle "ChildCBundle" extends bundle "FooBar", which is not registered.
      */
     public function testInitializeBundlesThrowsExceptionWhenAParentDoesNotExists()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Bundle "ChildCBundle" extends bundle "FooBar", which is not registered.');
         $child = $this->getBundle(null, 'FooBar', 'ChildCBundle');
         $kernel = $this->getKernel([], [$child]);
         $kernel->boot();
@@ -711,11 +703,11 @@ EOF;
 
     /**
      * @group legacy
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Bundle "ParentCBundle" is directly extended by two bundles "ChildC2Bundle" and "ChildC1Bundle".
      */
     public function testInitializeBundlesThrowsExceptionWhenABundleIsDirectlyExtendedByTwoBundles()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Bundle "ParentCBundle" is directly extended by two bundles "ChildC2Bundle" and "ChildC1Bundle".');
         $parent = $this->getBundle(null, null, 'ParentCBundle');
         $child1 = $this->getBundle(null, 'ParentCBundle', 'ChildC1Bundle');
         $child2 = $this->getBundle(null, 'ParentCBundle', 'ChildC2Bundle');
@@ -726,11 +718,11 @@ EOF;
 
     /**
      * @group legacy
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Trying to register two bundles with the same name "DuplicateName"
      */
     public function testInitializeBundleThrowsExceptionWhenRegisteringTwoBundlesWithTheSameName()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Trying to register two bundles with the same name "DuplicateName"');
         $fooBundle = $this->getBundle(null, null, 'FooBundle', 'DuplicateName');
         $barBundle = $this->getBundle(null, null, 'BarBundle', 'DuplicateName');
 
@@ -740,11 +732,11 @@ EOF;
 
     /**
      * @group legacy
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Bundle "CircularRefBundle" can not extend itself.
      */
     public function testInitializeBundleThrowsExceptionWhenABundleExtendsItself()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Bundle "CircularRefBundle" can not extend itself.');
         $circularRef = $this->getBundle(null, 'CircularRefBundle', 'CircularRefBundle');
 
         $kernel = $this->getKernel([], [$circularRef]);

--- a/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
@@ -110,27 +110,21 @@ class LoggerTest extends TestCase
         $this->assertSame([], $this->getLogs());
     }
 
-    /**
-     * @expectedException \Psr\Log\InvalidArgumentException
-     */
     public function testThrowsOnInvalidLevel()
     {
+        $this->expectException('Psr\Log\InvalidArgumentException');
         $this->logger->log('invalid level', 'Foo');
     }
 
-    /**
-     * @expectedException \Psr\Log\InvalidArgumentException
-     */
     public function testThrowsOnInvalidMinLevel()
     {
+        $this->expectException('Psr\Log\InvalidArgumentException');
         new Logger('invalid');
     }
 
-    /**
-     * @expectedException \Psr\Log\InvalidArgumentException
-     */
     public function testInvalidOutput()
     {
+        $this->expectException('Psr\Log\InvalidArgumentException');
         new Logger(LogLevel::DEBUG, '/');
     }
 

--- a/src/Symfony/Component/Intl/Tests/Collator/CollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/CollatorTest.php
@@ -11,33 +11,30 @@
 
 namespace Symfony\Component\Intl\Tests\Collator;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Collator\Collator;
 use Symfony\Component\Intl\Globals\IntlGlobals;
 
 class CollatorTest extends AbstractCollatorTest
 {
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
-     */
+    use ForwardCompatTestTrait;
+
     public function testConstructorWithUnsupportedLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         new Collator('pt_BR');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testCompare()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $collator = $this->getCollator('en');
         $collator->compare('a', 'b');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetAttribute()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $collator = $this->getCollator('en');
         $collator->getAttribute(Collator::NUMERIC_COLLATION);
     }
@@ -66,38 +63,30 @@ class CollatorTest extends AbstractCollatorTest
         $this->assertInstanceOf('\Symfony\Component\Intl\Collator\Collator', $collator);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetSortKey()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $collator = $this->getCollator('en');
         $collator->getSortKey('Hello');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetStrength()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $collator = $this->getCollator('en');
         $collator->getStrength();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testSetAttribute()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $collator = $this->getCollator('en');
         $collator->setAttribute(Collator::NUMERIC_COLLATION, Collator::ON);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testSetStrength()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $collator = $this->getCollator('en');
         $collator->setStrength(Collator::PRIMARY);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -105,11 +105,9 @@ class BundleEntryReaderTest extends TestCase
         $this->assertSame('Bar', $this->reader->readEntry(self::RES_DIR, 'root', ['Entries', 'Foo']));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
-     */
     public function testReadNonExistingEntry()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MissingResourceException');
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
@@ -133,11 +131,9 @@ class BundleEntryReaderTest extends TestCase
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
-     */
     public function testDontFallbackIfEntryDoesNotExistAndFallbackDisabled()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MissingResourceException');
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
@@ -161,11 +157,9 @@ class BundleEntryReaderTest extends TestCase
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
-     */
     public function testDontFallbackIfLocaleDoesNotExistAndFallbackDisabled()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MissingResourceException');
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
@@ -293,11 +287,9 @@ class BundleEntryReaderTest extends TestCase
         $this->assertSame($childData, $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
-     */
     public function testFailIfEntryFoundNeitherInParentNorChild()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MissingResourceException');
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
@@ -84,27 +84,21 @@ class IntlBundleReaderTest extends TestCase
         $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\ResourceBundleNotFoundException
-     */
     public function testReadFailsIfNonExistingLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\ResourceBundleNotFoundException');
         $this->reader->read(__DIR__.'/Fixtures/res', 'foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\ResourceBundleNotFoundException
-     */
     public function testReadFailsIfNonExistingFallbackLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\ResourceBundleNotFoundException');
         $this->reader->read(__DIR__.'/Fixtures/res', 'ro_AT');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\RuntimeException
-     */
     public function testReadFailsIfNonExistingDirectory()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\RuntimeException');
         $this->reader->read(__DIR__.'/foo', 'ro');
     }
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
@@ -41,43 +41,33 @@ class JsonBundleReaderTest extends TestCase
         $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\ResourceBundleNotFoundException
-     */
     public function testReadFailsIfNonExistingLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\ResourceBundleNotFoundException');
         $this->reader->read(__DIR__.'/Fixtures/json', 'foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\RuntimeException
-     */
     public function testReadFailsIfNonExistingDirectory()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\RuntimeException');
         $this->reader->read(__DIR__.'/foo', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\RuntimeException
-     */
     public function testReadFailsIfNotAFile()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\RuntimeException');
         $this->reader->read(__DIR__.'/Fixtures/NotAFile', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\RuntimeException
-     */
     public function testReadFailsIfInvalidJson()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\RuntimeException');
         $this->reader->read(__DIR__.'/Fixtures/json', 'en_Invalid');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\ResourceBundleNotFoundException
-     */
     public function testReaderDoesNotBreakOutOfGivenPath()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\ResourceBundleNotFoundException');
         $this->reader->read(__DIR__.'/Fixtures/json', '../invalid_directory/en');
     }
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
@@ -41,35 +41,27 @@ class PhpBundleReaderTest extends TestCase
         $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\ResourceBundleNotFoundException
-     */
     public function testReadFailsIfNonExistingLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\ResourceBundleNotFoundException');
         $this->reader->read(__DIR__.'/Fixtures/php', 'foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\RuntimeException
-     */
     public function testReadFailsIfNonExistingDirectory()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\RuntimeException');
         $this->reader->read(__DIR__.'/foo', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\RuntimeException
-     */
     public function testReadFailsIfNotAFile()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\RuntimeException');
         $this->reader->read(__DIR__.'/Fixtures/NotAFile', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\ResourceBundleNotFoundException
-     */
     public function testReaderDoesNotBreakOutOfGivenPath()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\ResourceBundleNotFoundException');
         $this->reader->read(__DIR__.'/Fixtures/php', '../invalid_directory/en');
     }
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
@@ -746,10 +746,10 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
 
     /**
      * @dataProvider provideCurrenciesWithoutNumericEquivalent
-     * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
      */
     public function testGetNumericCodeFailsIfNoNumericEquivalent($currency)
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MissingResourceException');
         $this->dataProvider->getNumericCode($currency);
     }
 
@@ -791,10 +791,10 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
 
     /**
      * @dataProvider provideInvalidNumericCodes
-     * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
      */
     public function testForNumericCodeFailsIfInvalidNumericCode($currency)
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MissingResourceException');
         $this->dataProvider->forNumericCode($currency);
     }
 

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLanguageDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLanguageDataProviderTest.php
@@ -938,10 +938,10 @@ abstract class AbstractLanguageDataProviderTest extends AbstractDataProviderTest
 
     /**
      * @dataProvider provideLanguagesWithoutAlpha3Equivalent
-     * @expectedException \Symfony\Component\Intl\Exception\MissingResourceException
      */
     public function testGetAlpha3CodeFailsIfNoAlpha3Equivalent($currency)
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MissingResourceException');
         $this->dataProvider->getAlpha3Code($currency);
     }
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Util/RingBufferTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Util/RingBufferTest.php
@@ -55,11 +55,9 @@ class RingBufferTest extends TestCase
         $this->assertSame('bam', $this->buffer[2]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\OutOfBoundsException
-     */
     public function testReadNonExistingFails()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\OutOfBoundsException');
         $this->buffer['foo'];
     }
 
@@ -75,11 +73,9 @@ class RingBufferTest extends TestCase
         $this->assertArrayNotHasKey('foo', $this->buffer);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\OutOfBoundsException
-     */
     public function testReadOverwrittenFails()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\OutOfBoundsException');
         $this->buffer[0] = 'foo';
         $this->buffer['bar'] = 'baz';
         $this->buffer[2] = 'bam';

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Intl\Tests\DateFormatter;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\DateFormatter\IntlDateFormatter;
 use Symfony\Component\Intl\Globals\IntlGlobals;
 
 class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $formatter = new IntlDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, 'y-M-d');
@@ -34,11 +37,9 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         $this->assertEquals('y-M-d', $formatter->getPattern());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
-     */
     public function testConstructorWithUnsupportedLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         new IntlDateFormatter('pt_BR', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
     }
 
@@ -73,21 +74,17 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\NotImplementedException
-     */
     public function testFormatWithUnimplementedChars()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\NotImplementedException');
         $pattern = 'Y';
         $formatter = new IntlDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, $pattern);
         $formatter->format(0);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\NotImplementedException
-     */
     public function testFormatWithNonIntegerTimestamp()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\NotImplementedException');
         $formatter = $this->getDefaultDateFormatter();
         $formatter->format([]);
     }
@@ -110,56 +107,44 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         $this->assertFalse($formatter->isLenient());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testLocaltime()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getDefaultDateFormatter();
         $formatter->localtime('Wednesday, December 31, 1969 4:00:00 PM PT');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentNotImplementedException
-     */
     public function testParseWithNotNullPositionValue()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentNotImplementedException');
         $position = 0;
         $formatter = $this->getDefaultDateFormatter('y');
         $this->assertSame(0, $formatter->parse('1970', $position));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testSetCalendar()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getDefaultDateFormatter();
         $formatter->setCalendar(IntlDateFormatter::GREGORIAN);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
-     */
     public function testSetLenient()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         $formatter = $this->getDefaultDateFormatter();
         $formatter->setLenient(true);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\NotImplementedException
-     */
     public function testFormatWithGmtTimeZoneAndMinutesOffset()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\NotImplementedException');
         parent::testFormatWithGmtTimeZoneAndMinutesOffset();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\NotImplementedException
-     */
     public function testFormatWithNonStandardTimezone()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\NotImplementedException');
         parent::testFormatWithNonStandardTimezone();
     }
 

--- a/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
@@ -11,21 +11,21 @@
 
 namespace Symfony\Component\Intl\Tests\Locale;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class LocaleTest extends AbstractLocaleTest
 {
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
+    use ForwardCompatTestTrait;
+
     public function testAcceptFromHttp()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('acceptFromHttp', 'pt-br,en-us;q=0.7,en;q=0.5');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testComposeLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $subtags = [
             'language' => 'pt',
             'script' => 'Latn',
@@ -34,99 +34,75 @@ class LocaleTest extends AbstractLocaleTest
         $this->call('composeLocale', $subtags);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testFilterMatches()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('filterMatches', 'pt-BR', 'pt-BR');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetAllVariants()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getAllVariants', 'pt_BR_Latn');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetDisplayLanguage()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getDisplayLanguage', 'pt-Latn-BR', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetDisplayName()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getDisplayName', 'pt-Latn-BR', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetDisplayRegion()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getDisplayRegion', 'pt-Latn-BR', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetDisplayScript()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getDisplayScript', 'pt-Latn-BR', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetDisplayVariant()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getDisplayVariant', 'pt-Latn-BR', 'en');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetKeywords()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getKeywords', 'pt-BR@currency=BRL');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetPrimaryLanguage()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getPrimaryLanguage', 'pt-Latn-BR');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetRegion()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getRegion', 'pt-Latn-BR');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetScript()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('getScript', 'pt-Latn-BR');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testLookup()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $langtag = [
             'pt-Latn-BR',
             'pt-BR',
@@ -134,19 +110,15 @@ class LocaleTest extends AbstractLocaleTest
         $this->call('lookup', $langtag, 'pt-BR-x-priv1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testParseLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('parseLocale', 'pt-Latn-BR');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testSetDefault()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $this->call('setDefault', 'pt_BR');
     }
 

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -23,44 +23,34 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
 {
     use ForwardCompatTestTrait;
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
-     */
     public function testConstructorWithUnsupportedLocale()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         new NumberFormatter('pt_BR');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
-     */
     public function testConstructorWithUnsupportedStyle()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         new NumberFormatter('en', NumberFormatter::PATTERN_DECIMAL);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentNotImplementedException
-     */
     public function testConstructorWithPatternDifferentThanNull()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentNotImplementedException');
         new NumberFormatter('en', NumberFormatter::DECIMAL, '');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
-     */
     public function testSetAttributeWithUnsupportedAttribute()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->setAttribute(NumberFormatter::LENIENT_PARSE, null);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
-     */
     public function testSetAttributeInvalidRoundingMode()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, null);
     }
@@ -81,73 +71,69 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         );
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testFormatWithCurrencyStyle()
     {
+        $this->expectException('RuntimeException');
         parent::testFormatWithCurrencyStyle();
     }
 
     /**
      * @dataProvider formatTypeInt32Provider
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
      */
     public function testFormatTypeInt32($formatter, $value, $expected, $message = '')
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         parent::testFormatTypeInt32($formatter, $value, $expected, $message);
     }
 
     /**
      * @dataProvider formatTypeInt32WithCurrencyStyleProvider
-     * @expectedException \Symfony\Component\Intl\Exception\NotImplementedException
      */
     public function testFormatTypeInt32WithCurrencyStyle($formatter, $value, $expected, $message = '')
     {
+        $this->expectException('Symfony\Component\Intl\Exception\NotImplementedException');
         parent::testFormatTypeInt32WithCurrencyStyle($formatter, $value, $expected, $message);
     }
 
     /**
      * @dataProvider formatTypeInt64Provider
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
      */
     public function testFormatTypeInt64($formatter, $value, $expected)
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         parent::testFormatTypeInt64($formatter, $value, $expected);
     }
 
     /**
      * @dataProvider formatTypeInt64WithCurrencyStyleProvider
-     * @expectedException \Symfony\Component\Intl\Exception\NotImplementedException
      */
     public function testFormatTypeInt64WithCurrencyStyle($formatter, $value, $expected)
     {
+        $this->expectException('Symfony\Component\Intl\Exception\NotImplementedException');
         parent::testFormatTypeInt64WithCurrencyStyle($formatter, $value, $expected);
     }
 
     /**
      * @dataProvider formatTypeDoubleProvider
-     * @expectedException \Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException
      */
     public function testFormatTypeDouble($formatter, $value, $expected)
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
         parent::testFormatTypeDouble($formatter, $value, $expected);
     }
 
     /**
      * @dataProvider formatTypeDoubleWithCurrencyStyleProvider
-     * @expectedException \Symfony\Component\Intl\Exception\NotImplementedException
      */
     public function testFormatTypeDoubleWithCurrencyStyle($formatter, $value, $expected)
     {
+        $this->expectException('Symfony\Component\Intl\Exception\NotImplementedException');
         parent::testFormatTypeDoubleWithCurrencyStyle($formatter, $value, $expected);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testGetPattern()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->getPattern();
     }
@@ -158,38 +144,30 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         $this->assertEquals(IntlGlobals::U_ZERO_ERROR, $formatter->getErrorCode());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testParseCurrency()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->parseCurrency(null, $currency);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testSetPattern()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->setPattern(null);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testSetSymbol()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->setSymbol(null, null);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Intl\Exception\MethodNotImplementedException
-     */
     public function testSetTextAttribute()
     {
+        $this->expectException('Symfony\Component\Intl\Exception\MethodNotImplementedException');
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->setTextAttribute(null, null);
     }

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
@@ -11,18 +11,19 @@
 namespace Symfony\Component\Ldap\Tests\Adapter\ExtLdap;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Connection;
 use Symfony\Component\Ldap\Adapter\ExtLdap\EntryManager;
 use Symfony\Component\Ldap\Entry;
 
 class EntryManagerTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Ldap\Exception\NotBoundException
-     * @expectedExceptionMessage Query execution is not possible without binding the connection first.
-     */
+    use ForwardCompatTestTrait;
+
     public function testGetResources()
     {
+        $this->expectException('Symfony\Component\Ldap\Exception\NotBoundException');
+        $this->expectExceptionMessage('Query execution is not possible without binding the connection first.');
         $connection = $this->getMockBuilder(Connection::class)->getMock();
         $connection
             ->expects($this->once())

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Lock\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\Lock;
@@ -23,6 +24,8 @@ use Symfony\Component\Lock\StoreInterface;
  */
 class LockTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testAcquireNoBlocking()
     {
         $key = new Key(uniqid(__METHOD__, true));
@@ -170,11 +173,9 @@ class LockTest extends TestCase
         unset($lock);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Lock\Exception\LockReleasingException
-     */
     public function testReleaseThrowsExceptionIfNotWellDeleted()
     {
+        $this->expectException('Symfony\Component\Lock\Exception\LockReleasingException');
         $key = new Key(uniqid(__METHOD__, true));
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
         $lock = new Lock($key, $store, 10);
@@ -193,11 +194,9 @@ class LockTest extends TestCase
         $lock->release();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Lock\Exception\LockReleasingException
-     */
     public function testReleaseThrowsAndLog()
     {
+        $this->expectException('Symfony\Component\Lock\Exception\LockReleasingException');
         $key = new Key(uniqid(__METHOD__, true));
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
         $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Store\RedisStore;
 
 /**
@@ -18,6 +19,7 @@ use Symfony\Component\Lock\Store\RedisStore;
  */
 abstract class AbstractRedisStoreTest extends AbstractStoreTest
 {
+    use ForwardCompatTestTrait;
     use ExpiringStoreTestTrait;
 
     /**

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -69,11 +69,9 @@ class CombinedStoreTest extends AbstractStoreTest
         $this->store = new CombinedStore([$this->store1, $this->store2], $this->strategy);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Lock\Exception\LockConflictedException
-     */
     public function testSaveThrowsExceptionOnFailure()
     {
+        $this->expectException('Symfony\Component\Lock\Exception\LockConflictedException');
         $key = new Key(uniqid(__METHOD__, true));
 
         $this->store1
@@ -166,11 +164,9 @@ class CombinedStoreTest extends AbstractStoreTest
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Lock\Exception\LockConflictedException
-     */
     public function testputOffExpirationThrowsExceptionOnFailure()
     {
+        $this->expectException('Symfony\Component\Lock\Exception\LockConflictedException');
         $key = new Key(uniqid(__METHOD__, true));
         $ttl = random_int(1, 10);
 

--- a/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
@@ -20,6 +21,8 @@ use Symfony\Component\Lock\StoreInterface;
  */
 trait ExpiringStoreTestTrait
 {
+    use ForwardCompatTestTrait;
+
     /**
      * Amount of microseconds used as a delay to test expiration. Should be
      * small enough not to slow the test suite too much, and high enough not to
@@ -57,11 +60,10 @@ trait ExpiringStoreTestTrait
 
     /**
      * Tests the store thrown exception when TTL expires.
-     *
-     * @expectedException \Symfony\Component\Lock\Exception\LockExpiredException
      */
     public function testAbortAfterExpiration()
     {
+        $this->expectException('\Symfony\Component\Lock\Exception\LockExpiredException');
         $key = new Key(uniqid(__METHOD__, true));
 
         /** @var StoreInterface $store */

--- a/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
@@ -21,8 +21,6 @@ use Symfony\Component\Lock\StoreInterface;
  */
 trait ExpiringStoreTestTrait
 {
-    use ForwardCompatTestTrait;
-
     /**
      * Amount of microseconds used as a delay to test expiration. Should be
      * small enough not to slow the test suite too much, and high enough not to

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\Store\FlockStore;
 
@@ -19,6 +20,7 @@ use Symfony\Component\Lock\Store\FlockStore;
  */
 class FlockStoreTest extends AbstractStoreTest
 {
+    use ForwardCompatTestTrait;
     use BlockingStoreTestTrait;
 
     /**
@@ -29,12 +31,10 @@ class FlockStoreTest extends AbstractStoreTest
         return new FlockStore();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Lock\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The directory "/a/b/c/d/e" is not writable.
-     */
     public function testConstructWhenRepositoryDoesNotExist()
     {
+        $this->expectException('Symfony\Component\Lock\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The directory "/a/b/c/d/e" is not writable.');
         if (!getenv('USER') || 'root' === getenv('USER')) {
             $this->markTestSkipped('This test will fail if run under superuser');
         }
@@ -42,12 +42,10 @@ class FlockStoreTest extends AbstractStoreTest
         new FlockStore('/a/b/c/d/e');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Lock\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The directory "/" is not writable.
-     */
     public function testConstructWhenRepositoryIsNotWriteable()
     {
+        $this->expectException('Symfony\Component\Lock\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The directory "/" is not writable.');
         if (!getenv('USER') || 'root' === getenv('USER')) {
             $this->markTestSkipped('This test will fail if run under superuser');
         }

--- a/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\OptionsResolver\Tests\Debug;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\OptionsResolver\Debug\OptionsResolverIntrospector;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class OptionsResolverIntrospectorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetDefault()
     {
         $resolver = new OptionsResolver();
@@ -36,12 +39,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertNull($debug->getDefault($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\NoConfigurationException
-     * @expectedExceptionMessage No default value was set for the "foo" option.
-     */
     public function testGetDefaultThrowsOnNoConfiguredValue()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\NoConfigurationException');
+        $this->expectExceptionMessage('No default value was set for the "foo" option.');
         $resolver = new OptionsResolver();
         $resolver->setDefined($option = 'foo');
 
@@ -49,12 +50,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame('bar', $debug->getDefault($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     * @expectedExceptionMessage The option "foo" does not exist.
-     */
     public function testGetDefaultThrowsOnNotDefinedOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
+        $this->expectExceptionMessage('The option "foo" does not exist.');
         $resolver = new OptionsResolver();
 
         $debug = new OptionsResolverIntrospector($resolver);
@@ -71,12 +70,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame($closures, $debug->getLazyClosures($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\NoConfigurationException
-     * @expectedExceptionMessage No lazy closures were set for the "foo" option.
-     */
     public function testGetLazyClosuresThrowsOnNoConfiguredValue()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\NoConfigurationException');
+        $this->expectExceptionMessage('No lazy closures were set for the "foo" option.');
         $resolver = new OptionsResolver();
         $resolver->setDefined($option = 'foo');
 
@@ -84,12 +81,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame('bar', $debug->getLazyClosures($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     * @expectedExceptionMessage The option "foo" does not exist.
-     */
     public function testGetLazyClosuresThrowsOnNotDefinedOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
+        $this->expectExceptionMessage('The option "foo" does not exist.');
         $resolver = new OptionsResolver();
 
         $debug = new OptionsResolverIntrospector($resolver);
@@ -106,12 +101,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame($allowedTypes, $debug->getAllowedTypes($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\NoConfigurationException
-     * @expectedExceptionMessage No allowed types were set for the "foo" option.
-     */
     public function testGetAllowedTypesThrowsOnNoConfiguredValue()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\NoConfigurationException');
+        $this->expectExceptionMessage('No allowed types were set for the "foo" option.');
         $resolver = new OptionsResolver();
         $resolver->setDefined($option = 'foo');
 
@@ -119,12 +112,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame('bar', $debug->getAllowedTypes($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     * @expectedExceptionMessage The option "foo" does not exist.
-     */
     public function testGetAllowedTypesThrowsOnNotDefinedOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
+        $this->expectExceptionMessage('The option "foo" does not exist.');
         $resolver = new OptionsResolver();
 
         $debug = new OptionsResolverIntrospector($resolver);
@@ -141,12 +132,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame($allowedValues, $debug->getAllowedValues($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\NoConfigurationException
-     * @expectedExceptionMessage No allowed values were set for the "foo" option.
-     */
     public function testGetAllowedValuesThrowsOnNoConfiguredValue()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\NoConfigurationException');
+        $this->expectExceptionMessage('No allowed values were set for the "foo" option.');
         $resolver = new OptionsResolver();
         $resolver->setDefined($option = 'foo');
 
@@ -154,12 +143,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame('bar', $debug->getAllowedValues($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     * @expectedExceptionMessage The option "foo" does not exist.
-     */
     public function testGetAllowedValuesThrowsOnNotDefinedOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
+        $this->expectExceptionMessage('The option "foo" does not exist.');
         $resolver = new OptionsResolver();
 
         $debug = new OptionsResolverIntrospector($resolver);
@@ -176,12 +163,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame($normalizer, $debug->getNormalizer($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\NoConfigurationException
-     * @expectedExceptionMessage No normalizer was set for the "foo" option.
-     */
     public function testGetNormalizerThrowsOnNoConfiguredValue()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\NoConfigurationException');
+        $this->expectExceptionMessage('No normalizer was set for the "foo" option.');
         $resolver = new OptionsResolver();
         $resolver->setDefined($option = 'foo');
 
@@ -189,12 +174,10 @@ class OptionsResolverIntrospectorTest extends TestCase
         $this->assertSame('bar', $debug->getNormalizer($option));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     * @expectedExceptionMessage The option "foo" does not exist.
-     */
     public function testGetNormalizerThrowsOnNotDefinedOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
+        $this->expectExceptionMessage('The option "foo" does not exist.');
         $resolver = new OptionsResolver();
 
         $debug = new OptionsResolverIntrospector($resolver);

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -32,35 +32,29 @@ class OptionsResolverTest extends TestCase
         $this->resolver = new OptionsResolver();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     * @expectedExceptionMessage The option "foo" does not exist. Defined options are: "a", "z".
-     */
     public function testResolveFailsIfNonExistingOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
+        $this->expectExceptionMessage('The option "foo" does not exist. Defined options are: "a", "z".');
         $this->resolver->setDefault('z', '1');
         $this->resolver->setDefault('a', '2');
 
         $this->resolver->resolve(['foo' => 'bar']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     * @expectedExceptionMessage The options "baz", "foo", "ping" do not exist. Defined options are: "a", "z".
-     */
     public function testResolveFailsIfMultipleNonExistingOptions()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
+        $this->expectExceptionMessage('The options "baz", "foo", "ping" do not exist. Defined options are: "a", "z".');
         $this->resolver->setDefault('z', '1');
         $this->resolver->setDefault('a', '2');
 
         $this->resolver->resolve(['ping' => 'pong', 'foo' => 'bar', 'baz' => 'bam']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testResolveFailsFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->resolve([]);
         });
@@ -84,11 +78,9 @@ class OptionsResolverTest extends TestCase
         ], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfSetDefaultFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('lazy', function (Options $options) {
             $options->setDefault('default', 42);
         });
@@ -228,11 +220,9 @@ class OptionsResolverTest extends TestCase
         $this->assertSame($this->resolver, $this->resolver->setRequired('foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfSetRequiredFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->setRequired('bar');
         });
@@ -240,11 +230,9 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
-     */
     public function testResolveFailsIfRequiredOptionMissing()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
         $this->resolver->setRequired('foo');
 
         $this->resolver->resolve();
@@ -356,11 +344,9 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['bar'], $this->resolver->getMissingOptions());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfSetDefinedFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->setDefined('bar');
         });
@@ -453,11 +439,9 @@ class OptionsResolverTest extends TestCase
         $this->assertFalse($this->resolver->isDefined('foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     */
     public function testSetAllowedTypesFailsIfUnknownOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
         $this->resolver->setAllowedTypes('foo', 'string');
     }
 
@@ -470,11 +454,9 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => ['bar', 'baz']], $options);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfSetAllowedTypesFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->setAllowedTypes('bar', 'string');
         });
@@ -484,36 +466,30 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but one of the elements is of type "DateTime[]".
-     */
     public function testResolveFailsIfInvalidTypedArray()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "int[]", but one of the elements is of type "DateTime[]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[]');
 
         $this->resolver->resolve(['foo' => [new \DateTime()]]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value "bar" is expected to be of type "int[]", but is of type "string".
-     */
     public function testResolveFailsWithNonArray()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value "bar" is expected to be of type "int[]", but is of type "string".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[]');
 
         $this->resolver->resolve(['foo' => 'bar']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but one of the elements is of type "stdClass[]".
-     */
     public function testResolveFailsIfTypedArrayContainsInvalidTypes()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "int[]", but one of the elements is of type "stdClass[]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[]');
         $values = range(1, 5);
@@ -525,12 +501,10 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve(['foo' => $values]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "double[][]".
-     */
     public function testResolveFailsWithCorrectLevelsButWrongScalar()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "double[][]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[][]');
 
@@ -577,12 +551,10 @@ class OptionsResolverTest extends TestCase
         $this->assertNotEmpty($this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value 42 is expected to be of type "string" or "bool", but is of type "integer".
-     */
     public function testResolveFailsIfInvalidTypeMultiple()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value 42 is expected to be of type "string" or "bool", but is of type "integer".');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->setAllowedTypes('foo', ['string', 'bool']);
 
@@ -620,30 +592,24 @@ class OptionsResolverTest extends TestCase
         $this->assertEquals($data, $result);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testResolveFailsIfNotInstanceOfClass()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 'bar');
         $this->resolver->setAllowedTypes('foo', '\stdClass');
 
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     */
     public function testAddAllowedTypesFailsIfUnknownOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
         $this->resolver->addAllowedTypes('foo', 'string');
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfAddAllowedTypesFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->addAllowedTypes('bar', 'string');
         });
@@ -653,11 +619,9 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testResolveFailsIfInvalidAddedType()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->addAllowedTypes('foo', 'string');
 
@@ -672,11 +636,9 @@ class OptionsResolverTest extends TestCase
         $this->assertNotEmpty($this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testResolveFailsIfInvalidAddedTypeMultiple()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->addAllowedTypes('foo', ['string', 'bool']);
 
@@ -713,19 +675,15 @@ class OptionsResolverTest extends TestCase
         $this->assertNotEmpty($this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     */
     public function testSetAllowedValuesFailsIfUnknownOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
         $this->resolver->setAllowedValues('foo', 'bar');
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfSetAllowedValuesFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->setAllowedValues('bar', 'baz');
         });
@@ -735,35 +693,29 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value 42 is invalid. Accepted values are: "bar".
-     */
     public function testResolveFailsIfInvalidValue()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value 42 is invalid. Accepted values are: "bar".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedValues('foo', 'bar');
 
         $this->resolver->resolve(['foo' => 42]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value null is invalid. Accepted values are: "bar".
-     */
     public function testResolveFailsIfInvalidValueIsNull()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value null is invalid. Accepted values are: "bar".');
         $this->resolver->setDefault('foo', null);
         $this->resolver->setAllowedValues('foo', 'bar');
 
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testResolveFailsIfInvalidValueStrict()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->setAllowedValues('foo', '42');
 
@@ -786,12 +738,10 @@ class OptionsResolverTest extends TestCase
         $this->assertEquals(['foo' => null], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value 42 is invalid. Accepted values are: "bar", false, null.
-     */
     public function testResolveFailsIfInvalidValueMultiple()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value 42 is invalid. Accepted values are: "bar", false, null.');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->setAllowedValues('foo', ['bar', false, null]);
 
@@ -837,11 +787,9 @@ class OptionsResolverTest extends TestCase
         $this->assertSame('bar', $passedValue);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testResolveFailsIfAllClosuresReturnFalse()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->setAllowedValues('foo', [
             function () { return false; },
@@ -864,19 +812,15 @@ class OptionsResolverTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     */
     public function testAddAllowedValuesFailsIfUnknownOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
         $this->resolver->addAllowedValues('foo', 'bar');
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfAddAllowedValuesFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->addAllowedValues('bar', 'baz');
         });
@@ -886,11 +830,9 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testResolveFailsIfInvalidAddedValue()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->addAllowedValues('foo', 'bar');
 
@@ -913,11 +855,9 @@ class OptionsResolverTest extends TestCase
         $this->assertEquals(['foo' => null], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testResolveFailsIfInvalidAddedValueMultiple()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->addAllowedValues('foo', ['bar', 'baz']);
 
@@ -950,11 +890,9 @@ class OptionsResolverTest extends TestCase
         $this->assertEquals(['foo' => 'baz'], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testResolveFailsIfAllAddedClosuresReturnFalse()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 42);
         $this->resolver->setAllowedValues('foo', function () { return false; });
         $this->resolver->addAllowedValues('foo', function () { return false; });
@@ -996,19 +934,15 @@ class OptionsResolverTest extends TestCase
         $this->assertEquals(['foo' => 'normalized'], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
-     */
     public function testSetNormalizerFailsIfUnknownOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
         $this->resolver->setNormalizer('foo', function () {});
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfSetNormalizerFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->setNormalizer('foo', function () {});
         });
@@ -1042,11 +976,9 @@ class OptionsResolverTest extends TestCase
         $this->assertEquals(['foo' => 'normalized[baz]'], $resolved);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testValidateTypeBeforeNormalization()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 'bar');
 
         $this->resolver->setAllowedTypes('foo', 'int');
@@ -1058,11 +990,9 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
     public function testValidateValueBeforeNormalization()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->resolver->setDefault('foo', 'bar');
 
         $this->resolver->setAllowedValues('foo', 'baz');
@@ -1112,11 +1042,9 @@ class OptionsResolverTest extends TestCase
         ], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
-     */
     public function testFailIfCyclicDependencyBetweenNormalizers()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\OptionDefinitionException');
         $this->resolver->setDefault('norm1', 'bar');
         $this->resolver->setDefault('norm2', 'baz');
 
@@ -1131,11 +1059,9 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
-     */
     public function testFailIfCyclicDependencyBetweenNormalizerAndLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\OptionDefinitionException');
         $this->resolver->setDefault('lazy', function (Options $options) {
             $options['norm'];
         });
@@ -1253,11 +1179,9 @@ class OptionsResolverTest extends TestCase
         ], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfSetDefaultsFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->setDefaults(['two' => '2']);
         });
@@ -1334,11 +1258,9 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfRemoveFromLazyOption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->remove('bar');
         });
@@ -1410,11 +1332,9 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $this->resolver->resolve());
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testFailIfClearFromLazyption()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', function (Options $options) {
             $options->clear();
         });
@@ -1469,50 +1389,40 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve(['default2' => 42, 'required' => 'value']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testArrayAccessGetFailsOutsideResolve()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('default', 0);
 
         $this->resolver['default'];
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testArrayAccessExistsFailsOutsideResolve()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('default', 0);
 
         isset($this->resolver['default']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testArrayAccessSetNotSupported()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver['default'] = 0;
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function testArrayAccessUnsetNotSupported()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('default', 0);
 
         unset($this->resolver['default']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\NoSuchOptionException
-     * @expectedExceptionMessage The option "undefined" does not exist. Defined options are: "foo", "lazy".
-     */
     public function testFailIfGetNonExisting()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\NoSuchOptionException');
+        $this->expectExceptionMessage('The option "undefined" does not exist. Defined options are: "foo", "lazy".');
         $this->resolver->setDefault('foo', 'bar');
 
         $this->resolver->setDefault('lazy', function (Options $options) {
@@ -1522,12 +1432,10 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\NoSuchOptionException
-     * @expectedExceptionMessage The optional option "defined" has no value set. You should make sure it is set with "isset" before reading it.
-     */
     public function testFailIfGetDefinedButUnset()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\NoSuchOptionException');
+        $this->expectExceptionMessage('The optional option "defined" has no value set. You should make sure it is set with "isset" before reading it.');
         $this->resolver->setDefined('defined');
 
         $this->resolver->setDefault('lazy', function (Options $options) {
@@ -1537,11 +1445,9 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
-     */
     public function testFailIfCyclicDependency()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\OptionDefinitionException');
         $this->resolver->setDefault('lazy1', function (Options $options) {
             $options['lazy2'];
         });
@@ -1571,11 +1477,10 @@ class OptionsResolverTest extends TestCase
      * In resolve() we count the options that are actually set (which may be
      * only a subset of the defined options). Outside of resolve(), it's not
      * clear what is counted.
-     *
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
      */
     public function testCountFailsOutsideResolve()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\AccessException');
         $this->resolver->setDefault('foo', 0);
         $this->resolver->setRequired('bar');
         $this->resolver->setDefined('bar');
@@ -1630,12 +1535,10 @@ class OptionsResolverTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "float[][][][]", but one of the elements is of type "integer[][][][]".
-     */
     public function testNestedArraysException()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "float[][][][]", but one of the elements is of type "integer[][][][]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'float[][][][]');
 
@@ -1650,12 +1553,10 @@ class OptionsResolverTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "boolean[][]".
-     */
     public function testNestedArrayException1()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "boolean[][]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[][]');
         $this->resolver->resolve([
@@ -1665,12 +1566,10 @@ class OptionsResolverTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "boolean[][]".
-     */
     public function testNestedArrayException2()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "boolean[][]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[][]');
         $this->resolver->resolve([
@@ -1680,12 +1579,10 @@ class OptionsResolverTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "string[][][]", but one of the elements is of type "string[][]".
-     */
     public function testNestedArrayException3()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "string[][][]", but one of the elements is of type "string[][]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'string[][][]');
         $this->resolver->resolve([
@@ -1695,12 +1592,10 @@ class OptionsResolverTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "string[][][]", but one of the elements is of type "integer[][][]".
-     */
     public function testNestedArrayException4()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "string[][][]", but one of the elements is of type "integer[][][]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'string[][][]');
         $this->resolver->resolve([
@@ -1711,12 +1606,10 @@ class OptionsResolverTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "string[]", but one of the elements is of type "array[]".
-     */
     public function testNestedArrayException5()
     {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The option "foo" with value array is expected to be of type "string[]", but one of the elements is of type "array[]".');
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'string[]');
         $this->resolver->resolve([

--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Process\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Process\ProcessBuilder;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\Process\ProcessBuilder;
  */
 class ProcessBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testInheritEnvironmentVars()
     {
         $proc = ProcessBuilder::create()
@@ -52,11 +55,9 @@ class ProcessBuilderTest extends TestCase
         $this->assertSame($env, $proc->getEnv());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     */
     public function testNegativeTimeoutFromSetter()
     {
+        $this->expectException('Symfony\Component\Process\Exception\InvalidArgumentException');
         $pb = new ProcessBuilder();
         $pb->setTimeout(-1);
     }
@@ -149,11 +150,9 @@ class ProcessBuilderTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\LogicException
-     */
     public function testShouldThrowALogicExceptionIfNoPrefixAndNoArgument()
     {
+        $this->expectException('Symfony\Component\Process\Exception\LogicException');
         ProcessBuilder::create()->getProcess();
     }
 
@@ -201,12 +200,10 @@ class ProcessBuilderTest extends TestCase
         $this->assertFalse($process->isOutputDisabled());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Symfony\Component\Process\ProcessBuilder::setInput only accepts strings, Traversable objects or stream resources.
-     */
     public function testInvalidInput()
     {
+        $this->expectException('Symfony\Component\Process\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Symfony\Component\Process\ProcessBuilder::setInput only accepts strings, Traversable objects or stream resources.');
         $builder = ProcessBuilder::create();
         $builder->setInput([]);
     }

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -82,19 +82,15 @@ class ProcessTest extends TestCase
         $this->assertEquals(E_USER_NOTICE, $actualError['type']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     */
     public function testNegativeTimeoutFromConstructor()
     {
+        $this->expectException('Symfony\Component\Process\Exception\InvalidArgumentException');
         $this->getProcess('', null, null, null, -1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     */
     public function testNegativeTimeoutFromSetter()
     {
+        $this->expectException('Symfony\Component\Process\Exception\InvalidArgumentException');
         $p = $this->getProcess('');
         $p->setTimeout(-1);
     }
@@ -247,12 +243,10 @@ class ProcessTest extends TestCase
         $this->assertSame('hello', $p->getOutput());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\LogicException
-     * @expectedExceptionMessage Input can not be set while the process is running.
-     */
     public function testSetInputWhileRunningThrowsAnException()
     {
+        $this->expectException('Symfony\Component\Process\Exception\LogicException');
+        $this->expectExceptionMessage('Input can not be set while the process is running.');
         $process = $this->getProcessForCode('sleep(30);');
         $process->start();
         try {
@@ -268,11 +262,11 @@ class ProcessTest extends TestCase
 
     /**
      * @dataProvider provideInvalidInputValues
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Symfony\Component\Process\Process::setInput only accepts strings, Traversable objects or stream resources.
      */
     public function testInvalidInput($value)
     {
+        $this->expectException('Symfony\Component\Process\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Symfony\Component\Process\Process::setInput only accepts strings, Traversable objects or stream resources.');
         $process = $this->getProcess('foo');
         $process->setInput($value);
     }
@@ -479,12 +473,10 @@ class ProcessTest extends TestCase
         $this->assertTrue($process->isSuccessful());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
-     * @expectedExceptionMessage TTY mode is not supported on Windows platform.
-     */
     public function testTTYInWindowsEnvironment()
     {
+        $this->expectException('Symfony\Component\Process\Exception\RuntimeException');
+        $this->expectExceptionMessage('TTY mode is not supported on Windows platform.');
         if ('\\' !== \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('This test is for Windows platform only');
         }
@@ -534,11 +526,9 @@ class ProcessTest extends TestCase
         $this->assertEquals(0, $process->getExitCode());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\ProcessFailedException
-     */
     public function testMustRunThrowsException()
     {
+        $this->expectException('Symfony\Component\Process\Exception\ProcessFailedException');
         $this->skipIfNotEnhancedSigchild();
 
         $process = $this->getProcess('exit 1');
@@ -707,12 +697,10 @@ class ProcessTest extends TestCase
         $this->assertEquals(15, $process->getTermSignal()); // SIGTERM
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
-     * @expectedExceptionMessage The process has been signaled
-     */
     public function testProcessThrowsExceptionWhenExternallySignaled()
     {
+        $this->expectException('Symfony\Component\Process\Exception\RuntimeException');
+        $this->expectExceptionMessage('The process has been signaled');
         if (!\function_exists('posix_kill')) {
             $this->markTestSkipped('Function posix_kill is required.');
         }
@@ -743,12 +731,10 @@ class ProcessTest extends TestCase
         $this->assertNotEquals($process1->getOutput(), $process2->getOutput());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\ProcessTimedOutException
-     * @expectedExceptionMessage exceeded the timeout of 0.1 seconds.
-     */
     public function testRunProcessWithTimeout()
     {
+        $this->expectException('Symfony\Component\Process\Exception\ProcessTimedOutException');
+        $this->expectExceptionMessage('exceeded the timeout of 0.1 seconds.');
         $process = $this->getProcessForCode('sleep(30);');
         $process->setTimeout(0.1);
         $start = microtime(true);
@@ -763,12 +749,10 @@ class ProcessTest extends TestCase
         throw $e;
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\ProcessTimedOutException
-     * @expectedExceptionMessage exceeded the timeout of 0.1 seconds.
-     */
     public function testIterateOverProcessWithTimeout()
     {
+        $this->expectException('Symfony\Component\Process\Exception\ProcessTimedOutException');
+        $this->expectExceptionMessage('exceeded the timeout of 0.1 seconds.');
         $process = $this->getProcessForCode('sleep(30);');
         $process->setTimeout(0.1);
         $start = microtime(true);
@@ -797,12 +781,10 @@ class ProcessTest extends TestCase
         $this->assertNull($process->checkTimeout());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\ProcessTimedOutException
-     * @expectedExceptionMessage exceeded the timeout of 0.1 seconds.
-     */
     public function testCheckTimeoutOnStartedProcess()
     {
+        $this->expectException('Symfony\Component\Process\Exception\ProcessTimedOutException');
+        $this->expectExceptionMessage('exceeded the timeout of 0.1 seconds.');
         $process = $this->getProcessForCode('sleep(33);');
         $process->setTimeout(0.1);
 
@@ -862,12 +844,10 @@ class ProcessTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\ProcessTimedOutException
-     * @expectedExceptionMessage exceeded the timeout of 0.1 seconds.
-     */
     public function testStartAfterATimeout()
     {
+        $this->expectException('Symfony\Component\Process\Exception\ProcessTimedOutException');
+        $this->expectExceptionMessage('exceeded the timeout of 0.1 seconds.');
         $process = $this->getProcessForCode('sleep(35);');
         $process->setTimeout(0.1);
 
@@ -943,12 +923,10 @@ class ProcessTest extends TestCase
         $this->assertEquals(137, $process->getExitCode());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\LogicException
-     * @expectedExceptionMessage Can not send signal on a non running process.
-     */
     public function testSignalProcessNotRunning()
     {
+        $this->expectException('Symfony\Component\Process\Exception\LogicException');
+        $this->expectExceptionMessage('Can not send signal on a non running process.');
         $process = $this->getProcess('foo');
         $process->signal(1); // SIGHUP
     }
@@ -979,11 +957,11 @@ class ProcessTest extends TestCase
 
     /**
      * @dataProvider provideMethodsThatNeedATerminatedProcess
-     * @expectedException \Symfony\Component\Process\Exception\LogicException
-     * @expectedExceptionMessage Process must be terminated before calling
      */
     public function testMethodsThatNeedATerminatedProcess($method)
     {
+        $this->expectException('Symfony\Component\Process\Exception\LogicException');
+        $this->expectExceptionMessage('Process must be terminated before calling');
         $process = $this->getProcessForCode('sleep(37);');
         $process->start();
         try {
@@ -1009,10 +987,10 @@ class ProcessTest extends TestCase
 
     /**
      * @dataProvider provideWrongSignal
-     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
      */
     public function testWrongSignal($signal)
     {
+        $this->expectException('Symfony\Component\Process\Exception\RuntimeException');
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('POSIX signals do not work on Windows');
         }
@@ -1047,23 +1025,19 @@ class ProcessTest extends TestCase
         $this->assertFalse($p->isOutputDisabled());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
-     * @expectedExceptionMessage Disabling output while the process is running is not possible.
-     */
     public function testDisableOutputWhileRunningThrowsException()
     {
+        $this->expectException('Symfony\Component\Process\Exception\RuntimeException');
+        $this->expectExceptionMessage('Disabling output while the process is running is not possible.');
         $p = $this->getProcessForCode('sleep(39);');
         $p->start();
         $p->disableOutput();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
-     * @expectedExceptionMessage Enabling output while the process is running is not possible.
-     */
     public function testEnableOutputWhileRunningThrowsException()
     {
+        $this->expectException('Symfony\Component\Process\Exception\RuntimeException');
+        $this->expectExceptionMessage('Enabling output while the process is running is not possible.');
         $p = $this->getProcessForCode('sleep(40);');
         $p->disableOutput();
         $p->start();
@@ -1080,23 +1054,19 @@ class ProcessTest extends TestCase
         $this->assertTrue($p->isOutputDisabled());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\LogicException
-     * @expectedExceptionMessage Output can not be disabled while an idle timeout is set.
-     */
     public function testDisableOutputWhileIdleTimeoutIsSet()
     {
+        $this->expectException('Symfony\Component\Process\Exception\LogicException');
+        $this->expectExceptionMessage('Output can not be disabled while an idle timeout is set.');
         $process = $this->getProcess('foo');
         $process->setIdleTimeout(1);
         $process->disableOutput();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\LogicException
-     * @expectedExceptionMessage timeout can not be set while the output is disabled.
-     */
     public function testSetIdleTimeoutWhileOutputIsDisabled()
     {
+        $this->expectException('Symfony\Component\Process\Exception\LogicException');
+        $this->expectExceptionMessage('timeout can not be set while the output is disabled.');
         $process = $this->getProcess('foo');
         $process->disableOutput();
         $process->setIdleTimeout(1);
@@ -1111,11 +1081,11 @@ class ProcessTest extends TestCase
 
     /**
      * @dataProvider provideOutputFetchingMethods
-     * @expectedException \Symfony\Component\Process\Exception\LogicException
-     * @expectedExceptionMessage Output has been disabled.
      */
     public function testGetOutputWhileDisabled($fetchMethod)
     {
+        $this->expectException('Symfony\Component\Process\Exception\LogicException');
+        $this->expectExceptionMessage('Output has been disabled.');
         $p = $this->getProcessForCode('sleep(41);');
         $p->disableOutput();
         $p->start();

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
@@ -48,11 +48,9 @@ abstract class PropertyAccessorArrayAccessTest extends TestCase
         $this->assertSame($value, $this->propertyAccessor->getValue($collection, $path));
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
-     */
     public function testGetValueFailsIfNoSuchIndex()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchIndexException');
         $this->propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
             ->enableExceptionOnInvalidIndex()
             ->getPropertyAccessor();

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -191,8 +191,8 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
     public function testSetValueFailsIfAdderAndRemoverExistButValueIsNotTraversable()
     {
-        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-expectedExceptionMessageRegExp /The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis()", "removeAxis()" but the new value must be an array or an instance of \Traversable, "string" given./');
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
+        $this->expectExceptionMessage('Could not determine access type for property "axes" in class "Symfony\Component\PropertyAccess\Tests\PropertyAccessorCollectionTest_Car".');
         $car = new PropertyAccessorCollectionTest_Car();
 
         $this->propertyAccessor->setValue($car, 'axes', 'Not an array or Traversable');

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\PropertyAccess\Tests;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+
 class PropertyAccessorCollectionTest_Car
 {
+    use ForwardCompatTestTrait;
+
     private $axes;
 
     public function __construct($axes = null)
@@ -146,12 +150,10 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
         $this->propertyAccessor->setValue($car, 'structure.axes', $axesAfter);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * @expectedExceptionMessageRegExp /Could not determine access type for property "axes" in class "Mock_PropertyAccessorCollectionTest_CarNoAdderAndRemover_[^"]*"./
-     */
     public function testSetValueFailsIfNoAdderNorRemoverFound()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
+        $this->expectExceptionMessageRegExp('/Could not determine access type for property "axes" in class "Mock_PropertyAccessorCollectionTest_CarNoAdderAndRemover_[^"]*"./');
         $car = $this->getMockBuilder(__CLASS__.'_CarNoAdderAndRemover')->getMock();
         $axesBefore = $this->getContainer([1 => 'second', 3 => 'fourth']);
         $axesAfter = $this->getContainer([0 => 'first', 1 => 'second', 2 => 'third']);
@@ -187,12 +189,10 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
         $this->assertFalse($this->propertyAccessor->isWritable($car, 'axes'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * expectedExceptionMessageRegExp /The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis()", "removeAxis()" but the new value must be an array or an instance of \Traversable, "string" given./
-     */
     public function testSetValueFailsIfAdderAndRemoverExistButValueIsNotTraversable()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+expectedExceptionMessageRegExp /The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis()", "removeAxis()" but the new value must be an array or an instance of \Traversable, "string" given./');
         $car = new PropertyAccessorCollectionTest_Car();
 
         $this->propertyAccessor->setValue($car, 'axes', 'Not an array or Traversable');

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -96,10 +96,10 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getPathsWithMissingProperty
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
      */
     public function testGetValueThrowsExceptionIfPropertyNotFound($objectOrArray, $path)
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
         $this->propertyAccessor->getValue($objectOrArray, $path);
     }
 
@@ -113,19 +113,17 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getPathsWithMissingIndex
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
      */
     public function testGetValueThrowsExceptionIfIndexNotFoundAndIndexExceptionsEnabled($objectOrArray, $path)
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchIndexException');
         $this->propertyAccessor = new PropertyAccessor(false, true);
         $this->propertyAccessor->getValue($objectOrArray, $path);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
-     */
     public function testGetValueThrowsExceptionIfNotArrayAccess()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchIndexException');
         $this->propertyAccessor->getValue(new \stdClass(), '[index]');
     }
 
@@ -172,11 +170,9 @@ class PropertyAccessorTest extends TestCase
         $this->assertSame(['Bernhard'], $object->firstName);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     */
     public function testGetValueDoesNotReadMagicCallByDefault()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
         $this->propertyAccessor->getValue(new TestClassMagicCall('Bernhard'), 'magicCallProperty');
     }
 
@@ -197,11 +193,11 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getPathsWithUnexpectedType
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException
-     * @expectedExceptionMessage PropertyAccessor requires a graph of objects or arrays to operate on
      */
     public function testGetValueThrowsExceptionIfNotObjectOrArray($objectOrArray, $path)
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException');
+        $this->expectExceptionMessage('PropertyAccessor requires a graph of objects or arrays to operate on');
         $this->propertyAccessor->getValue($objectOrArray, $path);
     }
 
@@ -217,10 +213,10 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getPathsWithMissingProperty
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
      */
     public function testSetValueThrowsExceptionIfPropertyNotFound($objectOrArray, $path)
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
         $this->propertyAccessor->setValue($objectOrArray, $path, 'Updated');
     }
 
@@ -245,11 +241,9 @@ class PropertyAccessorTest extends TestCase
         $this->assertSame('Updated', $this->propertyAccessor->getValue($objectOrArray, $path));
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
-     */
     public function testSetValueThrowsExceptionIfNotArrayAccess()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchIndexException');
         $object = new \stdClass();
 
         $this->propertyAccessor->setValue($object, '[index]', 'Updated');
@@ -264,21 +258,17 @@ class PropertyAccessorTest extends TestCase
         $this->assertEquals('Updated', $author->__get('magicProperty'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     */
     public function testSetValueThrowsExceptionIfThereAreMissingParameters()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
         $object = new TestClass('Bernhard');
 
         $this->propertyAccessor->setValue($object, 'publicAccessorWithMoreRequiredParameters', 'Updated');
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     */
     public function testSetValueDoesNotUpdateMagicCallByDefault()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
         $author = new TestClassMagicCall('Bernhard');
 
         $this->propertyAccessor->setValue($author, 'magicCallProperty', 'Updated');
@@ -297,11 +287,11 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @dataProvider getPathsWithUnexpectedType
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException
-     * @expectedExceptionMessage PropertyAccessor requires a graph of objects or arrays to operate on
      */
     public function testSetValueThrowsExceptionIfNotObjectOrArray($objectOrArray, $path)
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException');
+        $this->expectExceptionMessage('PropertyAccessor requires a graph of objects or arrays to operate on');
         $this->propertyAccessor->setValue($objectOrArray, $path, 'value');
     }
 
@@ -533,23 +523,19 @@ class PropertyAccessorTest extends TestCase
         $this->assertEquals($value, $this->propertyAccessor->isWritable($object, $path));
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Expected argument of type "DateTime", "string" given
-     */
     public function testThrowTypeError()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Expected argument of type "DateTime", "string" given');
         $object = new TypeHinted();
 
         $this->propertyAccessor->setValue($object, 'date', 'This is a string, \DateTime expected.');
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Expected argument of type "DateTime", "NULL" given
-     */
     public function testThrowTypeErrorWithNullArgument()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Expected argument of type "DateTime", "NULL" given');
         $object = new TypeHinted();
 
         $this->propertyAccessor->setValue($object, 'date', null);
@@ -598,12 +584,10 @@ class PropertyAccessorTest extends TestCase
         $this->assertSame('2', $propertyAccessor->getValue($obj, 'a%2Fb'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Expected argument of type "Countable", "string" given
-     */
     public function testThrowTypeErrorWithInterface()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Expected argument of type "Countable", "string" given');
         $object = new TypeHinted();
 
         $this->propertyAccessor->setValue($object, 'countable', 'This is a string, \Countable expected.');
@@ -671,10 +655,10 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @requires PHP 7.0
-     * @expectedException \TypeError
      */
     public function testThrowTypeErrorInsideSetterCall()
     {
+        $this->expectException('TypeError');
         $object = new TestClassTypeErrorInsideCall();
 
         $this->propertyAccessor->setValue($object, 'property', 'foo');
@@ -682,11 +666,10 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @requires PHP 7
-     *
-     * @expectedException \TypeError
      */
     public function testDoNotDiscardReturnTypeError()
     {
+        $this->expectException('TypeError');
         $object = new ReturnTyped();
 
         $this->propertyAccessor->setValue($object, 'foos', [new \DateTime()]);
@@ -694,11 +677,10 @@ class PropertyAccessorTest extends TestCase
 
     /**
      * @requires PHP 7
-     *
-     * @expectedException \TypeError
      */
     public function testDoNotDiscardReturnTypeErrorWhenWriterMethodIsMisconfigured()
     {
+        $this->expectException('TypeError');
         $object = new ReturnTyped();
 
         $this->propertyAccessor->setValue($object, 'name', 'foo');

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
@@ -119,19 +119,15 @@ class PropertyPathBuilderTest extends TestCase
         $this->assertEquals($path, $this->builder->getPropertyPath());
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testReplaceByIndexDoesNotAllowInvalidOffsets()
     {
+        $this->expectException('OutOfBoundsException');
         $this->builder->replaceByIndex(6, 'new1');
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testReplaceByIndexDoesNotAllowNegativeOffsets()
     {
+        $this->expectException('OutOfBoundsException');
         $this->builder->replaceByIndex(-1, 'new1');
     }
 
@@ -153,19 +149,15 @@ class PropertyPathBuilderTest extends TestCase
         $this->assertEquals($path, $this->builder->getPropertyPath());
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testReplaceByPropertyDoesNotAllowInvalidOffsets()
     {
+        $this->expectException('OutOfBoundsException');
         $this->builder->replaceByProperty(6, 'new1');
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testReplaceByPropertyDoesNotAllowNegativeOffsets()
     {
+        $this->expectException('OutOfBoundsException');
         $this->builder->replaceByProperty(-1, 'new1');
     }
 
@@ -198,10 +190,10 @@ class PropertyPathBuilderTest extends TestCase
 
     /**
      * @dataProvider provideInvalidOffsets
-     * @expectedException \OutOfBoundsException
      */
     public function testReplaceDoesNotAllowInvalidOffsets($offset)
     {
+        $this->expectException('OutOfBoundsException');
         $this->builder->replace($offset, 1, new PropertyPath('new1[new2].new3'));
     }
 
@@ -273,19 +265,15 @@ class PropertyPathBuilderTest extends TestCase
         $this->assertEquals($path, $this->builder->getPropertyPath());
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testRemoveDoesNotAllowInvalidOffsets()
     {
+        $this->expectException('OutOfBoundsException');
         $this->builder->remove(6);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testRemoveDoesNotAllowNegativeOffsets()
     {
+        $this->expectException('OutOfBoundsException');
         $this->builder->remove(-1);
     }
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\PropertyAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
 class PropertyPathTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testToString()
     {
         $path = new PropertyPath('reference.traversable[index].property');
@@ -23,19 +26,15 @@ class PropertyPathTest extends TestCase
         $this->assertEquals('reference.traversable[index].property', $path->__toString());
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException
-     */
     public function testDotIsRequiredBeforeProperty()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException');
         new PropertyPath('[index]property');
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException
-     */
     public function testDotCannotBePresentAtTheBeginning()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException');
         new PropertyPath('.property');
     }
 
@@ -54,34 +53,28 @@ class PropertyPathTest extends TestCase
 
     /**
      * @dataProvider providePathsContainingUnexpectedCharacters
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException
      */
     public function testUnexpectedCharacters($path)
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException');
         new PropertyPath($path);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException
-     */
     public function testPathCannotBeEmpty()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException');
         new PropertyPath('');
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidArgumentException
-     */
     public function testPathCannotBeNull()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidArgumentException');
         new PropertyPath(null);
     }
 
-    /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidArgumentException
-     */
     public function testPathCannotBeFalse()
     {
+        $this->expectException('Symfony\Component\PropertyAccess\Exception\InvalidArgumentException');
         new PropertyPath(false);
     }
 
@@ -128,21 +121,17 @@ class PropertyPathTest extends TestCase
         $this->assertEquals('child', $propertyPath->getElement(2));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testGetElementDoesNotAcceptInvalidIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $propertyPath->getElement(3);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testGetElementDoesNotAcceptNegativeIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $propertyPath->getElement(-1);
@@ -156,21 +145,17 @@ class PropertyPathTest extends TestCase
         $this->assertFalse($propertyPath->isProperty(2));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testIsPropertyDoesNotAcceptInvalidIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $propertyPath->isProperty(3);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testIsPropertyDoesNotAcceptNegativeIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $propertyPath->isProperty(-1);
@@ -184,21 +169,17 @@ class PropertyPathTest extends TestCase
         $this->assertTrue($propertyPath->isIndex(2));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testIsIndexDoesNotAcceptInvalidIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $propertyPath->isIndex(3);
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
     public function testIsIndexDoesNotAcceptNegativeIndices()
     {
+        $this->expectException('OutOfBoundsException');
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $propertyPath->isIndex(-1);

--- a/src/Symfony/Component/PropertyInfo/Tests/TypeTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/TypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class TypeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstruct()
     {
         $type = new Type('object', true, 'ArrayObject', true, new Type('int'), new Type('string'));
@@ -43,12 +46,10 @@ class TypeTest extends TestCase
         $this->assertSame('iterable', $type->getBuiltinType());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage "foo" is not a valid PHP type.
-     */
     public function testInvalidType()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('"foo" is not a valid PHP type.');
         new Type('foo');
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
@@ -12,15 +12,16 @@
 namespace Symfony\Component\Routing\Tests\Annotation;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Annotation\Route;
 
 class RouteTest extends TestCase
 {
-    /**
-     * @expectedException \BadMethodCallException
-     */
+    use ForwardCompatTestTrait;
+
     public function testInvalidRouteParameter()
     {
+        $this->expectException('BadMethodCallException');
         $route = new Route(['foo' => 'bar']);
     }
 

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -118,11 +118,9 @@ class PhpGeneratorDumperTest extends TestCase
         $this->assertEquals('/app.php/testing2', $relativeUrlWithoutParameter);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDumpWithoutRoutes()
     {
+        $this->expectException('InvalidArgumentException');
         file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump(['class' => 'WithoutRoutesUrlGenerator']));
         include $this->testTmpFilepath;
 
@@ -131,11 +129,9 @@ class PhpGeneratorDumperTest extends TestCase
         $projectUrlGenerator->generate('Test', []);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
-     */
     public function testGenerateNonExistingRoute()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
         $this->routeCollection->add('Test', new Route('/test'));
 
         file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump(['class' => 'NonExistingRoutesUrlGenerator']));

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -79,11 +79,9 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('/app.php/testing', $url);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testRelativeUrlWithNullParameterButNotOptional()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/testing/{foo}/bar', ['foo' => null]));
         // This must raise an exception because the default requirement for "foo" is "[^/]+" which is not met with these params.
         // Generating path "/testing//bar" would be wrong as matching this route would fail.
@@ -165,38 +163,30 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/de', $url);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
-     */
     public function testGenerateWithoutRoutes()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
         $routes = $this->getRoutes('foo', new Route('/testing/{foo}'));
         $this->getGenerator($routes)->generate('test', [], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\MissingMandatoryParametersException
-     */
     public function testGenerateForRouteWithoutMandatoryParameter()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\MissingMandatoryParametersException');
         $routes = $this->getRoutes('test', new Route('/testing/{foo}'));
         $this->getGenerator($routes)->generate('test', [], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testGenerateForRouteWithInvalidOptionalParameter()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', ['foo' => '1'], ['foo' => 'd+']));
         $this->getGenerator($routes)->generate('test', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testGenerateForRouteWithInvalidParameter()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', [], ['foo' => '1|2']));
         $this->getGenerator($routes)->generate('test', ['foo' => '0'], UrlGeneratorInterface::ABSOLUTE_URL);
     }
@@ -228,29 +218,23 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/testing/bar', $generator->generate('test', ['foo' => 'bar']));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testGenerateForRouteWithInvalidMandatoryParameter()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', [], ['foo' => 'd+']));
         $this->getGenerator($routes)->generate('test', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testGenerateForRouteWithInvalidUtf8Parameter()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', [], ['foo' => '\pL+'], ['utf8' => true]));
         $this->getGenerator($routes)->generate('test', ['foo' => 'abc123'], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testRequiredParamAndEmptyPassed()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/{slug}', [], ['slug' => '.+']));
         $this->getGenerator($routes)->generate('test', ['slug' => '']);
     }
@@ -400,20 +384,16 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/index.mobile.html', $generator->generate('test', ['page' => 'index', '_format' => 'mobile.html']));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testDefaultRequirementOfVariableDisallowsSlash()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/{page}.{_format}'));
         $this->getGenerator($routes)->generate('test', ['page' => 'index', '_format' => 'sl/ash']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testDefaultRequirementOfVariableDisallowsNextSeparator()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/{page}.{_format}'));
         $this->getGenerator($routes)->generate('test', ['page' => 'do.t', '_format' => 'html']);
     }
@@ -439,29 +419,23 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('http://fr.example.com/app.php/Fabien', $this->getGenerator($routes, ['host' => 'fr.example.com'])->generate('test', ['name' => 'Fabien', 'locale' => 'fr'], UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testUrlWithInvalidParameterInHost()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/', [], ['foo' => 'bar'], [], '{foo}.example.com'));
         $this->getGenerator($routes)->generate('test', ['foo' => 'baz'], UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testUrlWithInvalidParameterInHostWhenParamHasADefaultValue()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/', ['foo' => 'bar'], ['foo' => 'bar'], [], '{foo}.example.com'));
         $this->getGenerator($routes)->generate('test', ['foo' => 'baz'], UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testUrlWithInvalidParameterEqualsDefaultValueInHost()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\InvalidParameterException');
         $routes = $this->getRoutes('test', new Route('/', ['foo' => 'baz'], ['foo' => 'bar'], [], '{foo}.example.com'));
         $this->getGenerator($routes)->generate('test', ['foo' => 'baz'], UrlGeneratorInterface::ABSOLUTE_PATH);
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -29,19 +29,15 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->loader = $this->getClassLoader($this->reader);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLoadMissingClass()
     {
+        $this->expectException('InvalidArgumentException');
         $this->loader->load('MissingClass');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLoadAbstractClass()
     {
+        $this->expectException('InvalidArgumentException');
         $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\AbstractClass');
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -48,12 +48,10 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/FooTrait.php');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Did you forgot to add the "<?php" start tag at the beginning of the file?
-     */
     public function testLoadFileWithoutStartTag()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Did you forgot to add the "<?php" start tag at the beginning of the file?');
         $this->loader->load(__DIR__.'/../Fixtures/OtherAnnotatedClasses/NoStartTagClass.php');
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Loader\ObjectRouteLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class ObjectRouteLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoadCallsServiceAndReturnsCollection()
     {
         $loader = new ObjectRouteLoaderForTest();
@@ -41,11 +44,11 @@ class ObjectRouteLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider getBadResourceStrings
      */
     public function testExceptionWithoutSyntax($resourceString)
     {
+        $this->expectException('InvalidArgumentException');
         $loader = new ObjectRouteLoaderForTest();
         $loader->load($resourceString);
     }
@@ -59,31 +62,25 @@ class ObjectRouteLoaderTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testExceptionOnNoObjectReturned()
     {
+        $this->expectException('LogicException');
         $loader = new ObjectRouteLoaderForTest();
         $loader->loaderMap = ['my_service' => 'NOT_AN_OBJECT'];
         $loader->load('my_service:method');
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testExceptionOnBadMethod()
     {
+        $this->expectException('BadMethodCallException');
         $loader = new ObjectRouteLoaderForTest();
         $loader->loaderMap = ['my_service' => new \stdClass()];
         $loader->load('my_service:method');
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testExceptionOnMethodNotReturningCollection()
     {
+        $this->expectException('LogicException');
         $service = $this->getMockBuilder('stdClass')
             ->setMethods(['loadRoutes'])
             ->getMock();

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\Tests\Fixtures\CustomXmlFileLoader;
 
 class XmlFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSupports()
     {
         $loader = new XmlFileLoader($this->getMockBuilder('Symfony\Component\Config\FileLocator')->getMock());
@@ -104,21 +107,21 @@ class XmlFileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles
      */
     public function testLoadThrowsExceptionWithInvalidFile($filePath)
     {
+        $this->expectException('InvalidArgumentException');
         $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
         $loader->load($filePath);
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles
      */
     public function testLoadThrowsExceptionWithInvalidFileEvenWithoutSchemaValidation($filePath)
     {
+        $this->expectException('InvalidArgumentException');
         $loader = new CustomXmlFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
         $loader->load($filePath);
     }
@@ -128,12 +131,10 @@ class XmlFileLoaderTest extends TestCase
         return [['nonvalidnode.xml'], ['nonvalidroute.xml'], ['nonvalid.xml'], ['missing_id.xml'], ['missing_path.xml']];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Document types are not allowed.
-     */
     public function testDocTypeIsNotAllowed()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Document types are not allowed.');
         $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
         $loader->load('withdoctype.xml');
     }
@@ -338,12 +339,10 @@ class XmlFileLoaderTest extends TestCase
         $this->assertSame('AppBundle:Blog:list', $route->getDefault('_controller'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The routing file "[^"]*" must not specify both the "controller" attribute and the defaults key "_controller" for "app_blog"/
-     */
     public function testOverrideControllerInDefaults()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The routing file "[^"]*" must not specify both the "controller" attribute and the defaults key "_controller" for "app_blog"/');
         $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/controller']));
         $loader->load('override_defaults.xml');
     }
@@ -372,12 +371,10 @@ class XmlFileLoaderTest extends TestCase
         yield ['import__controller.xml'];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The routing file "[^"]*" must not specify both the "controller" attribute and the defaults key "_controller" for the "import" tag/
-     */
     public function testImportWithOverriddenController()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The routing file "[^"]*" must not specify both the "controller" attribute and the defaults key "_controller" for the "import" tag/');
         $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/controller']));
         $loader->load('import_override_defaults.xml');
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Routing\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 
 class YamlFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSupports()
     {
         $loader = new YamlFileLoader($this->getMockBuilder('Symfony\Component\Config\FileLocator')->getMock());
@@ -41,11 +44,11 @@ class YamlFileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles
      */
     public function testLoadThrowsExceptionWithInvalidFile($filePath)
     {
+        $this->expectException('InvalidArgumentException');
         $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
         $loader->load($filePath);
     }
@@ -139,12 +142,10 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame('AppBundle:Blog:list', $route->getDefault('_controller'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The routing file "[^"]*" must not specify both the "controller" key and the defaults key "_controller" for "app_blog"/
-     */
     public function testOverrideControllerInDefaults()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The routing file "[^"]*" must not specify both the "controller" key and the defaults key "_controller" for "app_blog"/');
         $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures/controller']));
         $loader->load('override_defaults.yml');
     }
@@ -173,12 +174,10 @@ class YamlFileLoaderTest extends TestCase
         yield ['import__controller.yml'];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The routing file "[^"]*" must not specify both the "controller" key and the defaults key "_controller" for "_static"/
-     */
     public function testImportWithOverriddenController()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/The routing file "[^"]*" must not specify both the "controller" key and the defaults key "_controller" for "_static"/');
         $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures/controller']));
         $loader->load('import_override_defaults.yml');
     }

--- a/src/Symfony/Component/Routing/Tests/Matcher/DumpedUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/DumpedUrlMatcherTest.php
@@ -11,27 +11,26 @@
 
 namespace Symfony\Component\Routing\Tests\Matcher;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
 
 class DumpedUrlMatcherTest extends UrlMatcherTest
 {
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The "schemes" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.
-     */
+    use ForwardCompatTestTrait;
+
     public function testSchemeRequirement()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('The "schemes" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.');
         parent::testSchemeRequirement();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The "schemes" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.
-     */
     public function testSchemeAndMethodMismatch()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('The "schemes" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.');
         parent::testSchemeRequirement();
     }
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -49,11 +49,9 @@ class PhpMatcherDumperTest extends TestCase
         @unlink($this->dumpPath);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testDumpWhenSchemeIsUsedWithoutAProperDumper()
     {
+        $this->expectException('LogicException');
         $collection = new RouteCollection();
         $collection->add('secure', new Route(
             '/secure',

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Routing\Tests\Matcher;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class RedirectableUrlMatcherTest extends UrlMatcherTest
 {
+    use ForwardCompatTestTrait;
+
     public function testMissingTrailingSlash()
     {
         $coll = new RouteCollection();
@@ -27,11 +30,9 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $matcher->match('/foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testRedirectWhenNoSlashForNonSafeMethod()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/'));
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -339,7 +339,7 @@ class UrlMatcherTest extends TestCase
 
     public function testSchemeRequirement()
     {
-        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
+        $this->getExpectedException() ?: $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', [], [], [], '', ['https']));
         $matcher = $this->getUrlMatcher($coll);

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -180,11 +180,9 @@ class UrlMatcherTest extends TestCase
         $this->assertEquals(['_route' => '$péß^a|'], $matcher->match('/bar'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testTrailingEncodedNewlineIsNotOverlooked()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo'));
 
@@ -319,11 +317,9 @@ class UrlMatcherTest extends TestCase
         $this->assertEquals(['page' => 'index', '_format' => 'mobile.html', '_route' => 'test'], $matcher->match('/index.mobile.html'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testDefaultRequirementOfVariableDisallowsSlash()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $coll->add('test', new Route('/{page}.{_format}'));
         $matcher = $this->getUrlMatcher($coll);
@@ -331,11 +327,9 @@ class UrlMatcherTest extends TestCase
         $matcher->match('/index.sl/ash');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testDefaultRequirementOfVariableDisallowsNextSeparator()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $coll->add('test', new Route('/{page}.{_format}', [], ['_format' => 'html|xml']));
         $matcher = $this->getUrlMatcher($coll);
@@ -343,22 +337,18 @@ class UrlMatcherTest extends TestCase
         $matcher->match('/do.t.html');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testSchemeRequirement()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', [], [], [], '', ['https']));
         $matcher = $this->getUrlMatcher($coll);
         $matcher->match('/foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testCondition()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $route = new Route('/foo');
         $route->setCondition('context.getMethod() == "POST"');
@@ -425,11 +415,9 @@ class UrlMatcherTest extends TestCase
         $this->assertEquals(['foo' => 'bar', '_route' => 'bar', 'locale' => 'en'], $matcher->match('/bar/bar'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testWithOutHostHostDoesNotMatch()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/{foo}', [], [], [], '{locale}.example.com'));
 
@@ -437,11 +425,9 @@ class UrlMatcherTest extends TestCase
         $matcher->match('/foo/bar');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testPathIsCaseSensitive()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/locale', [], ['locale' => 'EN|FR|DE']));
 
@@ -458,11 +444,9 @@ class UrlMatcherTest extends TestCase
         $this->assertEquals(['_route' => 'foo', 'locale' => 'en'], $matcher->match('/'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\NoConfigurationException
-     */
     public function testNoConfiguration()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\NoConfigurationException');
         $coll = new RouteCollection();
 
         $matcher = $this->getUrlMatcher($coll);
@@ -493,11 +477,9 @@ class UrlMatcherTest extends TestCase
         $this->assertEquals(['_route' => 'buz'], $matcher->match('/prefix/buz'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
-     */
     public function testSchemeAndMethodMismatch()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/', [], [], [], null, ['https'], ['POST']));
 

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
@@ -21,6 +22,8 @@ use Symfony\Component\Routing\RouteCollectionBuilder;
 
 class RouteCollectionBuilderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testImport()
     {
         $resolvedLoader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
@@ -75,11 +78,9 @@ class RouteCollectionBuilderTest extends TestCase
         $this->assertCount(1, $routeCollection->getResources());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testImportWithoutLoaderThrowsException()
     {
+        $this->expectException('BadMethodCallException');
         $collectionBuilder = new RouteCollectionBuilder();
         $collectionBuilder->import('routing.yml');
     }

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Routing\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCompiler;
 
 class RouteCompilerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider provideCompileData
      */
@@ -243,41 +246,33 @@ class RouteCompilerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRouteWithSameVariableTwice()
     {
+        $this->expectException('LogicException');
         $route = new Route('/{name}/{name}');
 
         $compiled = $route->compile();
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRouteCharsetMismatch()
     {
+        $this->expectException('LogicException');
         $route = new Route("/\xE9/{bar}", [], ['bar' => '.'], ['utf8' => true]);
 
         $compiled = $route->compile();
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testRequirementCharsetMismatch()
     {
+        $this->expectException('LogicException');
         $route = new Route('/foo/{bar}', [], ['bar' => "\xE9"], ['utf8' => true]);
 
         $compiled = $route->compile();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRouteWithFragmentAsPathParameter()
     {
+        $this->expectException('InvalidArgumentException');
         $route = new Route('/{_fragment}');
 
         $compiled = $route->compile();
@@ -285,10 +280,10 @@ class RouteCompilerTest extends TestCase
 
     /**
      * @dataProvider getVariableNamesStartingWithADigit
-     * @expectedException \DomainException
      */
     public function testRouteWithVariableNameStartingWithADigit($name)
     {
+        $this->expectException('DomainException');
         $route = new Route('/{'.$name.'}');
         $route->compile();
     }
@@ -373,11 +368,9 @@ class RouteCompilerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \DomainException
-     */
     public function testRouteWithTooLongVariableName()
     {
+        $this->expectException('DomainException');
         $route = new Route(sprintf('/{%s}', str_repeat('a', RouteCompiler::VARIABLE_MAXIMUM_LENGTH + 1)));
         $route->compile();
     }

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Routing\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Routing\Route;
 
 class RouteTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $route = new Route('/{foo}', ['foo' => 'bar'], ['foo' => '\d+'], ['foo' => 'bar'], '{locale}.example.com');
@@ -124,10 +127,10 @@ class RouteTest extends TestCase
 
     /**
      * @dataProvider getInvalidRequirements
-     * @expectedException \InvalidArgumentException
      */
     public function testSetInvalidRequirement($req)
     {
+        $this->expectException('InvalidArgumentException');
         $route = new Route('/{foo}');
         $route->setRequirement('foo', $req);
     }

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -44,12 +44,10 @@ class RouterTest extends TestCase
         $this->assertSame('ResourceType', $this->router->getOption('resource_type'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The Router does not support the following options: "option_foo", "option_bar"
-     */
     public function testSetOptionsWithUnsupportedOptions()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The Router does not support the following options: "option_foo", "option_bar"');
         $this->router->setOptions([
             'cache_dir' => './cache',
             'option_foo' => true,
@@ -65,21 +63,17 @@ class RouterTest extends TestCase
         $this->assertSame('./cache', $this->router->getOption('cache_dir'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The Router does not support the "option_foo" option
-     */
     public function testSetOptionWithUnsupportedOption()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The Router does not support the "option_foo" option');
         $this->router->setOption('option_foo', true);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The Router does not support the "option_foo" option
-     */
     public function testGetOptionWithUnsupportedOption()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The Router does not support the "option_foo" option');
         $this->router->getOption('option_foo', true);
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -24,19 +25,17 @@ use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
 
 class AuthenticationProviderManagerTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    use ForwardCompatTestTrait;
+
     public function testAuthenticateWithoutProviders()
     {
+        $this->expectException('InvalidArgumentException');
         new AuthenticationProviderManager([]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAuthenticateWithProvidersWithIncorrectInterface()
     {
+        $this->expectException('InvalidArgumentException');
         (new AuthenticationProviderManager([
             new \stdClass(),
         ]))->authenticate($this->getMockBuilder(TokenInterface::class)->getMock());

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider;
 
 class AnonymousAuthenticationProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSupports()
     {
         $provider = $this->getProvider('foo');
@@ -24,22 +27,18 @@ class AnonymousAuthenticationProviderTest extends TestCase
         $this->assertFalse($provider->supports($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
-     * @expectedExceptionMessage The token is not supported by this authentication provider.
-     */
     public function testAuthenticateWhenTokenIsNotSupported()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationException');
+        $this->expectExceptionMessage('The token is not supported by this authentication provider.');
         $provider = $this->getProvider('foo');
 
         $provider->authenticate($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testAuthenticateWhenSecretIsNotValid()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $provider = $this->getProvider('foo');
 
         $provider->authenticate($this->getSupportedToken('bar'));

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -12,17 +12,18 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
 class DaoAuthenticationProviderTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationServiceException
-     */
+    use ForwardCompatTestTrait;
+
     public function testRetrieveUserWhenProviderDoesNotReturnAnUserInterface()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationServiceException');
         $provider = $this->getProvider('fabien');
         $method = new \ReflectionMethod($provider, 'retrieveUser');
         $method->setAccessible(true);
@@ -30,11 +31,9 @@ class DaoAuthenticationProviderTest extends TestCase
         $method->invoke($provider, 'fabien', $this->getSupportedToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
     public function testRetrieveUserWhenUsernameIsNotFound()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\UsernameNotFoundException');
         $userProvider = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface')->getMock();
         $userProvider->expects($this->once())
                      ->method('loadUserByUsername')
@@ -48,11 +47,9 @@ class DaoAuthenticationProviderTest extends TestCase
         $method->invoke($provider, 'fabien', $this->getSupportedToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationServiceException
-     */
     public function testRetrieveUserWhenAnExceptionOccurs()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationServiceException');
         $userProvider = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface')->getMock();
         $userProvider->expects($this->once())
                      ->method('loadUserByUsername')
@@ -105,11 +102,9 @@ class DaoAuthenticationProviderTest extends TestCase
         $this->assertSame($user, $method->invoke($provider, 'fabien', $this->getSupportedToken()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testCheckAuthenticationWhenCredentialsAreEmpty()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $encoder = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\PasswordEncoderInterface')->getMock();
         $encoder
             ->expects($this->never())
@@ -161,11 +156,9 @@ class DaoAuthenticationProviderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testCheckAuthenticationWhenCredentialsAreNotValid()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $encoder = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\Encoder\\PasswordEncoderInterface')->getMock();
         $encoder->expects($this->once())
                 ->method('isPasswordValid')
@@ -185,11 +178,9 @@ class DaoAuthenticationProviderTest extends TestCase
         $method->invoke($provider, $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock(), $token);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testCheckAuthenticationDoesNotReauthenticateWhenPasswordHasChanged()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $user = $this->getMockBuilder('Symfony\\Component\\Security\\Core\\User\\UserInterface')->getMock();
         $user->expects($this->once())
              ->method('getPassword')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Ldap\Adapter\CollectionInterface;
 use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Entry;
@@ -28,12 +29,12 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 class LdapBindAuthenticationProviderTest extends TestCase
 {
-    /**
-     * @expectedException        \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     * @expectedExceptionMessage The presented password must not be empty.
-     */
+    use ForwardCompatTestTrait;
+
     public function testEmptyPasswordShouldThrowAnException()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
+        $this->expectExceptionMessage('The presented password must not be empty.');
         $userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
@@ -45,12 +46,10 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $reflection->invoke($provider, new User('foo', null), new UsernamePasswordToken('foo', '', 'key'));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     * @expectedExceptionMessage The presented password must not be empty.
-     */
     public function testNullPasswordShouldThrowAnException()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
+        $this->expectExceptionMessage('The presented password must not be empty.');
         $userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();
         $ldap = $this->getMockBuilder('Symfony\Component\Ldap\LdapInterface')->getMock();
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
@@ -62,12 +61,10 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $reflection->invoke($provider, new User('foo', null), new UsernamePasswordToken('foo', null, 'key'));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     * @expectedExceptionMessage The presented password is invalid.
-     */
     public function testBindFailureShouldThrowAnException()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
+        $this->expectExceptionMessage('The presented password is invalid.');
         $userProvider = $this->getMockBuilder(UserProviderInterface::class)->getMock();
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $ldap
@@ -139,12 +136,10 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $reflection->invoke($provider, new User('foo', null), new UsernamePasswordToken('foo', 'bar', 'key'));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     * @expectedExceptionMessage The presented username is invalid.
-     */
     public function testEmptyQueryResultShouldThrowAnException()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
+        $this->expectExceptionMessage('The presented username is invalid.');
         $userProvider = $this->getMockBuilder(UserProviderInterface::class)->getMock();
 
         $collection = $this->getMockBuilder(CollectionInterface::class)->getMock();

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Provider\PreAuthenticatedAuthenticationProvider;
 use Symfony\Component\Security\Core\Exception\LockedException;
 
 class PreAuthenticatedAuthenticationProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSupports()
     {
         $provider = $this->getProvider();
@@ -36,22 +39,18 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         $this->assertFalse($provider->supports($token));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
-     * @expectedExceptionMessage The token is not supported by this authentication provider.
-     */
     public function testAuthenticateWhenTokenIsNotSupported()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationException');
+        $this->expectExceptionMessage('The token is not supported by this authentication provider.');
         $provider = $this->getProvider();
 
         $provider->authenticate($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testAuthenticateWhenNoUserIsSet()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $provider = $this->getProvider();
         $provider->authenticate($this->getSupportedToken(''));
     }
@@ -75,11 +74,9 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         $this->assertSame($user, $token->getUser());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\LockedException
-     */
     public function testAuthenticateWhenUserCheckerThrowsException()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\LockedException');
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
 
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Role\Role;
 
 class RememberMeAuthenticationProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSupports()
     {
         $provider = $this->getProvider();
@@ -26,34 +29,28 @@ class RememberMeAuthenticationProviderTest extends TestCase
         $this->assertFalse($provider->supports($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
-     * @expectedExceptionMessage The token is not supported by this authentication provider.
-     */
     public function testAuthenticateWhenTokenIsNotSupported()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationException');
+        $this->expectExceptionMessage('The token is not supported by this authentication provider.');
         $provider = $this->getProvider();
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $provider->authenticate($token);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testAuthenticateWhenSecretsDoNotMatch()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $provider = $this->getProvider(null, 'secret1');
         $token = $this->getSupportedToken(null, 'secret2');
 
         $provider->authenticate($token);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\DisabledException
-     */
     public function testAuthenticateWhenPreChecksFails()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\DisabledException');
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
         $userChecker->expects($this->once())
             ->method('checkPreAuth')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Provider\SimpleAuthenticationProvider;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\LockedException;
@@ -19,11 +20,11 @@ use Symfony\Component\Security\Core\User\UserChecker;
 
 class SimpleAuthenticationProviderTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\DisabledException
-     */
+    use ForwardCompatTestTrait;
+
     public function testAuthenticateWhenPreChecksFails()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\DisabledException');
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
@@ -46,11 +47,9 @@ class SimpleAuthenticationProviderTest extends TestCase
         $provider->authenticate($token);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\LockedException
-     */
     public function testAuthenticateWhenPostChecksFails()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\LockedException');
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
 
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Exception\AccountExpiredException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
@@ -21,6 +22,8 @@ use Symfony\Component\Security\Core\Role\SwitchUserRole;
 
 class UserAuthenticationProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSupports()
     {
         $provider = $this->getProvider();
@@ -29,22 +32,18 @@ class UserAuthenticationProviderTest extends TestCase
         $this->assertFalse($provider->supports($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
-     * @expectedExceptionMessage The token is not supported by this authentication provider.
-     */
     public function testAuthenticateWhenTokenIsNotSupported()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationException');
+        $this->expectExceptionMessage('The token is not supported by this authentication provider.');
         $provider = $this->getProvider();
 
         $provider->authenticate($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
     public function testAuthenticateWhenUsernameIsNotFound()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\UsernameNotFoundException');
         $provider = $this->getProvider(false, false);
         $provider->expects($this->once())
                  ->method('retrieveUser')
@@ -54,11 +53,9 @@ class UserAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->getSupportedToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testAuthenticateWhenUsernameIsNotFoundAndHideIsTrue()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $provider = $this->getProvider(false, true);
         $provider->expects($this->once())
                  ->method('retrieveUser')
@@ -68,11 +65,9 @@ class UserAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->getSupportedToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationServiceException
-     */
     public function testAuthenticateWhenProviderDoesNotReturnAnUserInterface()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationServiceException');
         $provider = $this->getProvider(false, true);
         $provider->expects($this->once())
                  ->method('retrieveUser')
@@ -82,11 +77,9 @@ class UserAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->getSupportedToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\CredentialsExpiredException
-     */
     public function testAuthenticateWhenPreChecksFails()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\CredentialsExpiredException');
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
         $userChecker->expects($this->once())
                     ->method('checkPreAuth')
@@ -102,11 +95,9 @@ class UserAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->getSupportedToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccountExpiredException
-     */
     public function testAuthenticateWhenPostChecksFails()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccountExpiredException');
         $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
         $userChecker->expects($this->once())
                     ->method('checkPostAuth')
@@ -122,12 +113,10 @@ class UserAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->getSupportedToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     * @expectedExceptionMessage Bad credentials
-     */
     public function testAuthenticateWhenPostCheckAuthenticationFails()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
+        $this->expectExceptionMessage('Bad credentials');
         $provider = $this->getProvider();
         $provider->expects($this->once())
                  ->method('retrieveUser')
@@ -141,12 +130,10 @@ class UserAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->getSupportedToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     * @expectedExceptionMessage Foo
-     */
     public function testAuthenticateWhenPostCheckAuthenticationFailsWithHideFalse()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
+        $this->expectExceptionMessage('Foo');
         $provider = $this->getProvider(false, false);
         $provider->expects($this->once())
                  ->method('retrieveUser')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/InMemoryTokenProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/InMemoryTokenProviderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\RememberMe;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\RememberMe\InMemoryTokenProvider;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 
 class InMemoryTokenProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCreateNewToken()
     {
         $provider = new InMemoryTokenProvider();
@@ -27,11 +30,9 @@ class InMemoryTokenProviderTest extends TestCase
         $this->assertSame($provider->loadTokenBySeries('foo'), $token);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\TokenNotFoundException
-     */
     public function testLoadTokenBySeriesThrowsNotFoundException()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\TokenNotFoundException');
         $provider = new InMemoryTokenProvider();
         $provider->loadTokenBySeries('foo');
     }
@@ -49,11 +50,9 @@ class InMemoryTokenProviderTest extends TestCase
         $this->assertSame($token->getLastUsed(), $lastUsed);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\TokenNotFoundException
-     */
     public function testDeleteToken()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\TokenNotFoundException');
         $provider = new InMemoryTokenProvider();
 
         $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTime());

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Role\Role;
 
 class RememberMeTokenTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $user = $this->getUser();
@@ -29,11 +32,9 @@ class RememberMeTokenTest extends TestCase
         $this->assertTrue($token->isAuthenticated());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorSecretCannotBeNull()
     {
+        $this->expectException('InvalidArgumentException');
         new RememberMeToken(
             $this->getUser(),
             null,
@@ -41,11 +42,9 @@ class RememberMeTokenTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorSecretCannotBeEmptyString()
     {
+        $this->expectException('InvalidArgumentException');
         new RememberMeToken(
             $this->getUser(),
             '',

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Role\Role;
 
 class UsernamePasswordTokenTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $token = new UsernamePasswordToken('foo', 'bar', 'key');
@@ -28,11 +31,9 @@ class UsernamePasswordTokenTest extends TestCase
         $this->assertEquals('key', $token->getProviderKey());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testSetAuthenticatedToTrue()
     {
+        $this->expectException('LogicException');
         $token = new UsernamePasswordToken('foo', 'bar', 'key');
         $token->setAuthenticated(true);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -23,11 +23,9 @@ class AccessDecisionManagerTest extends TestCase
 {
     use ForwardCompatTestTrait;
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetUnsupportedStrategy()
     {
+        $this->expectException('InvalidArgumentException');
         new AccessDecisionManager([$this->getVoter(VoterInterface::ACCESS_GRANTED)], 'fooBar');
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -69,11 +69,9 @@ class AuthorizationCheckerTest extends TestCase
         $this->assertSame($newToken, $this->tokenStorage->getToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
-     */
     public function testVoteWithoutAuthenticationToken()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException');
         $this->authorizationChecker->isGranted('ROLE_FOO');
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
@@ -39,11 +39,9 @@ class Argon2iPasswordEncoderTest extends TestCase
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testEncodePasswordLength()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $encoder = new Argon2iPasswordEncoder();
         $encoder->encodePassword(str_repeat('a', 4097), 'salt');
     }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
 
 /**
@@ -19,22 +20,20 @@ use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
  */
 class BCryptPasswordEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const PASSWORD = 'password';
     const VALID_COST = '04';
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCostBelowRange()
     {
+        $this->expectException('InvalidArgumentException');
         new BCryptPasswordEncoder(3);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCostAboveRange()
     {
+        $this->expectException('InvalidArgumentException');
         new BCryptPasswordEncoder(32);
     }
 
@@ -69,11 +68,9 @@ class BCryptPasswordEncoderTest extends TestCase
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testEncodePasswordLength()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
 
         $encoder->encodePassword(str_repeat('a', 73), 'salt');

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BasePasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BasePasswordEncoderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Encoder\BasePasswordEncoder;
 
 class PasswordEncoder extends BasePasswordEncoder
@@ -27,6 +28,8 @@ class PasswordEncoder extends BasePasswordEncoder
 
 class BasePasswordEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testComparePassword()
     {
         $this->assertTrue($this->invokeComparePasswords('password', 'password'));
@@ -46,11 +49,9 @@ class BasePasswordEncoderTest extends TestCase
         $this->assertEquals('password', $this->invokeMergePasswordAndSalt('password', ''));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMergePasswordAndSaltWithException()
     {
+        $this->expectException('InvalidArgumentException');
         $this->invokeMergePasswordAndSalt('password', '{foo}');
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Encoder\EncoderAwareInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactory;
 use Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder;
@@ -20,6 +21,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class EncoderFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetEncoderWithMessageDigestEncoder()
     {
         $factory = new EncoderFactory(['Symfony\Component\Security\Core\User\UserInterface' => [
@@ -107,11 +110,9 @@ class EncoderFactoryTest extends TestCase
         $this->assertEquals($expectedEncoder->encodePassword('foo', ''), $encoder->encodePassword('foo', ''));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetInvalidNamedEncoderForEncoderAware()
     {
+        $this->expectException('RuntimeException');
         $factory = new EncoderFactory([
             'Symfony\Component\Security\Core\Tests\Encoder\EncAwareUser' => new MessageDigestPasswordEncoder('sha1'),
             'encoder_name' => new MessageDigestPasswordEncoder('sha256'),

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/MessageDigestPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/MessageDigestPasswordEncoderTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Security\Core\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder;
 
 class MessageDigestPasswordEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testIsPasswordValid()
     {
         $encoder = new MessageDigestPasswordEncoder('sha256', false, 1);
@@ -35,20 +38,16 @@ class MessageDigestPasswordEncoderTest extends TestCase
         $this->assertSame(hash('sha256', hash('sha256', 'password', true).'password'), $encoder->encodePassword('password', ''));
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testEncodePasswordAlgorithmDoesNotExist()
     {
+        $this->expectException('LogicException');
         $encoder = new MessageDigestPasswordEncoder('foobar');
         $encoder->encodePassword('password', '');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testEncodePasswordLength()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $encoder = new MessageDigestPasswordEncoder();
 
         $encoder->encodePassword(str_repeat('a', 5000), 'salt');

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/Pbkdf2PasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/Pbkdf2PasswordEncoderTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Security\Core\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Encoder\Pbkdf2PasswordEncoder;
 
 class Pbkdf2PasswordEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testIsPasswordValid()
     {
         $encoder = new Pbkdf2PasswordEncoder('sha256', false, 1, 40);
@@ -35,20 +38,16 @@ class Pbkdf2PasswordEncoderTest extends TestCase
         $this->assertSame('8bc2f9167a81cdcfad1235cd9047f1136271c1f978fcfcb35e22dbeafa4634f6fd2214218ed63ebb', $encoder->encodePassword('password', ''));
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testEncodePasswordAlgorithmDoesNotExist()
     {
+        $this->expectException('LogicException');
         $encoder = new Pbkdf2PasswordEncoder('foobar');
         $encoder->encodePassword('password', '');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testEncodePasswordLength()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $encoder = new Pbkdf2PasswordEncoder('foobar');
 
         $encoder->encodePassword(str_repeat('a', 5000), 'salt');

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/PlaintextPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/PlaintextPasswordEncoderTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Security\Core\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 
 class PlaintextPasswordEncoderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testIsPasswordValid()
     {
         $encoder = new PlaintextPasswordEncoder();
@@ -38,11 +41,9 @@ class PlaintextPasswordEncoderTest extends TestCase
         $this->assertSame('foo', $encoder->encodePassword('foo', ''));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testEncodePasswordLength()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $encoder = new PlaintextPasswordEncoder();
 
         $encoder->encodePassword(str_repeat('a', 5000), 'salt');

--- a/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
@@ -12,19 +12,16 @@
 namespace Symfony\Component\Security\Core\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 class TranslationFilesTest extends TestCase
 {
-    use ForwardCompatTestTrait;
-
     /**
      * @dataProvider provideTranslationFiles
      */
     public function testTranslationFileIsValid($filePath)
     {
         if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
+            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }

--- a/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\Security\Core\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 class TranslationFilesTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider provideTranslationFiles
      */
     public function testTranslationFileIsValid($filePath)
     {
         if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
+            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }

--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Security\Core\Tests\User;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\ChainUserProvider;
 
 class ChainUserProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoadUserByUsername()
     {
         $provider1 = $this->getProvider();
@@ -40,11 +43,9 @@ class ChainUserProviderTest extends TestCase
         $this->assertSame($account, $provider->loadUserByUsername('foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
     public function testLoadUserByUsernameThrowsUsernameNotFoundException()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\UsernameNotFoundException');
         $provider1 = $this->getProvider();
         $provider1
             ->expects($this->once())
@@ -105,11 +106,9 @@ class ChainUserProviderTest extends TestCase
         $this->assertSame($account, $provider->refreshUser($this->getAccount()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UnsupportedUserException
-     */
     public function testRefreshUserThrowsUnsupportedUserException()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\UnsupportedUserException');
         $provider1 = $this->getProvider();
         $provider1
             ->expects($this->once())

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Security\Core\Tests\User;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\User;
 
 class InMemoryUserProviderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testConstructor()
     {
         $provider = $this->createProvider();
@@ -63,21 +66,17 @@ class InMemoryUserProviderTest extends TestCase
         $this->assertEquals('foo', $user->getPassword());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testCreateUserAlreadyExist()
     {
+        $this->expectException('LogicException');
         $provider = new InMemoryUserProvider();
         $provider->createUser(new User('fabien', 'foo'));
         $provider->createUser(new User('fabien', 'foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
     public function testLoadUserByUsernameDoesNotExist()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\UsernameNotFoundException');
         $provider = new InMemoryUserProvider();
         $provider->loadUserByUsername('fabien');
     }

--- a/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\User;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Ldap\Adapter\CollectionInterface;
 use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Entry;
@@ -24,11 +25,11 @@ use Symfony\Component\Security\Core\User\LdapUserProvider;
  */
 class LdapUserProviderTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
+    use ForwardCompatTestTrait;
+
     public function testLoadUserByUsernameFailsIfCantConnectToLdap()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\UsernameNotFoundException');
         $ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
         $ldap
             ->expects($this->once())
@@ -40,11 +41,9 @@ class LdapUserProviderTest extends TestCase
         $provider->loadUserByUsername('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
     public function testLoadUserByUsernameFailsIfNoLdapEntries()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\UsernameNotFoundException');
         $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
         $query = $this->getMockBuilder(QueryInterface::class)->getMock();
         $query
@@ -73,11 +72,9 @@ class LdapUserProviderTest extends TestCase
         $provider->loadUserByUsername('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
     public function testLoadUserByUsernameFailsIfMoreThanOneLdapEntry()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\UsernameNotFoundException');
         $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
         $query = $this->getMockBuilder(QueryInterface::class)->getMock();
         $query
@@ -106,11 +103,9 @@ class LdapUserProviderTest extends TestCase
         $provider->loadUserByUsername('foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\InvalidArgumentException
-     */
     public function testLoadUserByUsernameFailsIfMoreThanOneLdapPasswordsInEntry()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\InvalidArgumentException');
         $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
         $query = $this->getMockBuilder(QueryInterface::class)->getMock();
         $query
@@ -191,11 +186,9 @@ class LdapUserProviderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\InvalidArgumentException
-     */
     public function testLoadUserByUsernameFailsIfEntryHasNoPasswordAttribute()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\InvalidArgumentException');
         $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
         $query = $this->getMockBuilder(QueryInterface::class)->getMock();
         $query

--- a/src/Symfony/Component/Security/Core/Tests/User/UserCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/UserCheckerTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Security\Core\Tests\User;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\User\UserChecker;
 
 class UserCheckerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCheckPostAuthNotAdvancedUserInterface()
     {
         $checker = new UserChecker();
@@ -33,11 +36,9 @@ class UserCheckerTest extends TestCase
         $this->assertNull($checker->checkPostAuth($account));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\CredentialsExpiredException
-     */
     public function testCheckPostAuthCredentialsExpired()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\CredentialsExpiredException');
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
@@ -65,11 +66,9 @@ class UserCheckerTest extends TestCase
         $this->assertNull($checker->checkPreAuth($account));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\LockedException
-     */
     public function testCheckPreAuthAccountLocked()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\LockedException');
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
@@ -78,11 +77,9 @@ class UserCheckerTest extends TestCase
         $checker->checkPreAuth($account);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\DisabledException
-     */
     public function testCheckPreAuthDisabled()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\DisabledException');
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();
@@ -92,11 +89,9 @@ class UserCheckerTest extends TestCase
         $checker->checkPreAuth($account);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccountExpiredException
-     */
     public function testCheckPreAuthAccountExpired()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccountExpiredException');
         $checker = new UserChecker();
 
         $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\AdvancedUserInterface')->getMock();

--- a/src/Symfony/Component/Security/Core/Tests/User/UserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/UserTest.php
@@ -12,15 +12,16 @@
 namespace Symfony\Component\Security\Core\Tests\User;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Core\User\User;
 
 class UserTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    use ForwardCompatTestTrait;
+
     public function testConstructorException()
     {
+        $this->expectException('InvalidArgumentException');
         new User('', 'superpass');
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
@@ -115,11 +115,9 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testUserIsNotValid()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $user = $this->getMockBuilder('Foo\Bar\User')->getMock();
 
         $this->tokenStorage = $this->createTokenStorage($user);

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
@@ -89,11 +89,9 @@ class NativeSessionTokenStorageTest extends TestCase
         $this->assertSame('TOKEN', $this->storage->getToken('token_id'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Csrf\Exception\TokenNotFoundException
-     */
     public function testGetNonExistingToken()
     {
+        $this->expectException('Symfony\Component\Security\Csrf\Exception\TokenNotFoundException');
         $this->storage->getToken('token_id');
     }
 

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
@@ -89,19 +89,15 @@ class SessionTokenStorageTest extends TestCase
         $this->assertSame('RESULT', $this->storage->getToken('token_id'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Csrf\Exception\TokenNotFoundException
-     */
     public function testGetNonExistingTokenFromClosedSession()
     {
+        $this->expectException('Symfony\Component\Security\Csrf\Exception\TokenNotFoundException');
         $this->storage->getToken('token_id');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Csrf\Exception\TokenNotFoundException
-     */
     public function testGetNonExistingTokenFromActiveSession()
     {
+        $this->expectException('Symfony\Component\Security\Csrf\Exception\TokenNotFoundException');
         $this->session->start();
         $this->storage->getToken('token_id');
     }

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -362,11 +362,9 @@ class GuardAuthenticationListenerTest extends TestCase
         $listener->handle($this->event);
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     */
     public function testReturnNullFromGetCredentials()
     {
+        $this->expectException('UnexpectedValueException');
         $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
         $providerKey = 'my_firewall4';
 

--- a/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
@@ -152,11 +152,9 @@ class GuardAuthenticationProviderTest extends TestCase
         $this->assertSame($authedToken, $actualAuthedToken);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testCheckCredentialsReturningNonTrueFailsAuthentication()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $providerKey = 'my_uncool_firewall';
 
         $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
@@ -185,11 +183,9 @@ class GuardAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->preAuthenticationToken);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationExpiredException
-     */
     public function testGuardWithNoLongerAuthenticatedTriggersLogout()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationExpiredException');
         $providerKey = 'my_firewall_abc';
 
         // create a token and mark it as NOT authenticated anymore
@@ -220,12 +216,10 @@ class GuardAuthenticationProviderTest extends TestCase
         $this->assertFalse($supports);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
-     * @expectedExceptionMessageRegExp /second_firewall_0/
-     */
     public function testAuthenticateFailsOnNonOriginatingToken()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationException');
+        $this->expectExceptionMessageRegExp('/second_firewall_0/');
         $authenticatorA = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
         $authenticators = [$authenticatorA];
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -81,12 +81,10 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->assertSame($this->response, $result);
     }
 
-    /**
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage onAuthenticationSuccess method must return null to use the default success handler, or a Response object
-     */
     public function testOnAuthenticationSuccessThrowsAnExceptionIfNonResponseIsReturned()
     {
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('onAuthenticationSuccess method must return null to use the default success handler, or a Response object');
         $this->successHandler->expects($this->never())
             ->method('onAuthenticationSuccess');
 
@@ -151,12 +149,10 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->assertSame($this->response, $result);
     }
 
-    /**
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage onAuthenticationFailure method must return null to use the default failure handler, or a Response object
-     */
     public function testOnAuthenticationFailureThrowsAnExceptionIfNonResponseIsReturned()
     {
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('onAuthenticationFailure method must return null to use the default failure handler, or a Response object');
         $this->failureHandler->expects($this->never())
             ->method('onAuthenticationFailure');
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -12,15 +12,16 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Http\Firewall\AccessListener;
 
 class AccessListenerTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
-     */
+    use ForwardCompatTestTrait;
+
     public function testHandleWhenTheAccessDecisionManagerDecidesToRefuseAccess()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
 
         $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
@@ -183,11 +184,9 @@ class AccessListenerTest extends TestCase
         $listener->handle($event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
-     */
     public function testHandleWhenTheSecurityTokenStorageHasNoToken()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException');
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
             ->expects($this->any())

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager;
@@ -21,6 +22,8 @@ use Symfony\Component\Security\Http\Firewall\BasicAuthenticationListener;
 
 class BasicAuthenticationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testHandleWithValidUsernameAndPasswordServerParameters()
     {
         $request = new Request([], [], [], [], [], [
@@ -182,12 +185,10 @@ class BasicAuthenticationListenerTest extends TestCase
         $listener->handle($event);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $providerKey must not be empty
-     */
     public function testItRequiresProviderKey()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('$providerKey must not be empty');
         new BasicAuthenticationListener(
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock(),
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock(),

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,12 +35,12 @@ use Symfony\Component\Security\Http\Firewall\ContextListener;
 
 class ContextListenerTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $contextKey must not be empty
-     */
+    use ForwardCompatTestTrait;
+
     public function testItRequiresContextKey()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('$contextKey must not be empty');
         new ContextListener(
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock(),
             [],
@@ -47,12 +48,10 @@ class ContextListenerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage User provider "stdClass" must implement "Symfony\Component\Security\Core\User\UserProviderInterface
-     */
     public function testUserProvidersNeedToImplementAnInterface()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('User provider "stdClass" must implement "Symfony\Component\Security\Core\User\UserProviderInterface');
         $this->handleEventWithPreviousSession(new TokenStorage(), [new \stdClass()]);
     }
 
@@ -308,11 +307,9 @@ class ContextListenerTest extends TestCase
         $this->assertNull($tokenStorage->getToken());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testRuntimeExceptionIsThrownIfNoSupportingUserProviderWasRegistered()
     {
+        $this->expectException('RuntimeException');
         $this->handleEventWithPreviousSession(new TokenStorage(), [new NotSupportingUserProvider(), new NotSupportingUserProvider()]);
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Firewall\LogoutListener;
 
 class LogoutListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testHandleUnmatchedPath()
     {
         list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener();
@@ -122,11 +125,9 @@ class LogoutListenerTest extends TestCase
         $listener->handle($event);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testSuccessHandlerReturnsNonResponse()
     {
+        $this->expectException('RuntimeException');
         $successHandler = $this->getSuccessHandler();
 
         list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($successHandler);
@@ -146,11 +147,9 @@ class LogoutListenerTest extends TestCase
         $listener->handle($event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\LogoutException
-     */
     public function testCsrfValidationFails()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\LogoutException');
         $tokenManager = $this->getTokenManager();
 
         list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener(null, $tokenManager);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\RememberMeListener;
@@ -19,6 +20,8 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 class RememberMeListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testOnCoreSecurityDoesNotTryToPopulateNonEmptyTokenStorage()
     {
         list($listener, $tokenStorage) = $this->getListener();
@@ -103,12 +106,10 @@ class RememberMeListenerTest extends TestCase
         $listener->handle($event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
-     * @expectedExceptionMessage Authentication failed.
-     */
     public function testOnCoreSecurityIgnoresAuthenticationOptionallyRethrowsExceptionThrownAuthenticationManagerImplementation()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationException');
+        $this->expectExceptionMessage('Authentication failed.');
         list($listener, $tokenStorage, $service, $manager) = $this->getListener(false, false);
 
         $tokenStorage

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RemoteUserAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RemoteUserAuthenticationListenerTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Firewall\RemoteUserAuthenticationListener;
 
 class RemoteUserAuthenticationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetPreAuthenticatedData()
     {
         $serverVars = [
@@ -42,11 +45,9 @@ class RemoteUserAuthenticationListenerTest extends TestCase
         $this->assertSame($result, ['TheUser', null]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testGetPreAuthenticatedDataNoUser()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $request = new Request([], [], [], [], [], []);
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -50,12 +50,10 @@ class SwitchUserListenerTest extends TestCase
         $this->event = new GetResponseEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $this->request, HttpKernelInterface::MASTER_REQUEST);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $providerKey must not be empty
-     */
     public function testProviderKeyIsRequired()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('$providerKey must not be empty');
         new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, '', $this->accessDecisionManager);
     }
 
@@ -68,22 +66,18 @@ class SwitchUserListenerTest extends TestCase
         $this->assertNull($this->tokenStorage->getToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
-     */
     public function testExitUserThrowsAuthenticationExceptionIfNoCurrentToken()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException');
         $this->tokenStorage->setToken(null);
         $this->request->query->set('_switch_user', '_exit');
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
-     */
     public function testExitUserThrowsAuthenticationExceptionIfOriginalTokenCannotBeFound()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException');
         $token = new UsernamePasswordToken('username', '', 'key', ['ROLE_FOO']);
 
         $this->tokenStorage->setToken($token);
@@ -158,11 +152,9 @@ class SwitchUserListenerTest extends TestCase
         $listener->handle($this->event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
-     */
     public function testSwitchUserIsDisallowed()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
         $token = new UsernamePasswordToken('username', '', 'key', ['ROLE_FOO']);
 
         $this->tokenStorage->setToken($token);
@@ -270,11 +262,9 @@ class SwitchUserListenerTest extends TestCase
         $this->assertSame($replacedToken, $this->tokenStorage->getToken());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
-     */
     public function testSwitchtUserThrowsAuthenticationExceptionIfNoCurrentToken()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException');
         $this->tokenStorage->setToken(null);
         $this->request->query->set('_switch_user', 'username');
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Tests\Http\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -26,6 +27,8 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 
 class UsernamePasswordFormAuthenticationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getUsernameForLength
      */
@@ -78,11 +81,11 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
 
     /**
      * @dataProvider postOnlyDataProvider
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage The key "_username" must be a string, "array" given.
      */
     public function testHandleNonStringUsernameWithArray($postOnly)
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
+        $this->expectExceptionMessage('The key "_username" must be a string, "array" given.');
         $request = Request::create('/login_check', 'POST', ['_username' => []]);
         $request->setSession($this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock());
         $listener = new UsernamePasswordFormAuthenticationListener(
@@ -101,11 +104,11 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
 
     /**
      * @dataProvider postOnlyDataProvider
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage The key "_username" must be a string, "integer" given.
      */
     public function testHandleNonStringUsernameWithInt($postOnly)
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
+        $this->expectExceptionMessage('The key "_username" must be a string, "integer" given.');
         $request = Request::create('/login_check', 'POST', ['_username' => 42]);
         $request->setSession($this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock());
         $listener = new UsernamePasswordFormAuthenticationListener(
@@ -124,11 +127,11 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
 
     /**
      * @dataProvider postOnlyDataProvider
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage The key "_username" must be a string, "object" given.
      */
     public function testHandleNonStringUsernameWithObject($postOnly)
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
+        $this->expectExceptionMessage('The key "_username" must be a string, "object" given.');
         $request = Request::create('/login_check', 'POST', ['_username' => new \stdClass()]);
         $request->setSession($this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock());
         $listener = new UsernamePasswordFormAuthenticationListener(

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordJsonAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordJsonAuthenticationListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Tests\Http\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -31,6 +32,8 @@ use Symfony\Component\Security\Http\HttpUtils;
  */
 class UsernamePasswordJsonAuthenticationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @var UsernamePasswordJsonAuthenticationListener
      */
@@ -104,12 +107,10 @@ class UsernamePasswordJsonAuthenticationListenerTest extends TestCase
         $this->assertEquals('ok', $event->getResponse()->getContent());
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage Invalid JSON
-     */
     public function testAttemptAuthenticationNoJson()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
+        $this->expectExceptionMessage('Invalid JSON');
         $this->createListener();
         $request = new Request();
         $request->setRequestFormat('json');
@@ -118,12 +119,10 @@ class UsernamePasswordJsonAuthenticationListenerTest extends TestCase
         $this->listener->handle($event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage The key "username" must be provided
-     */
     public function testAttemptAuthenticationNoUsername()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
+        $this->expectExceptionMessage('The key "username" must be provided');
         $this->createListener();
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"usr": "dunglas", "password": "foo"}');
         $event = new GetResponseEvent($this->getMockBuilder(KernelInterface::class)->getMock(), $request, KernelInterface::MASTER_REQUEST);
@@ -131,12 +130,10 @@ class UsernamePasswordJsonAuthenticationListenerTest extends TestCase
         $this->listener->handle($event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage The key "password" must be provided
-     */
     public function testAttemptAuthenticationNoPassword()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
+        $this->expectExceptionMessage('The key "password" must be provided');
         $this->createListener();
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"username": "dunglas", "pass": "foo"}');
         $event = new GetResponseEvent($this->getMockBuilder(KernelInterface::class)->getMock(), $request, KernelInterface::MASTER_REQUEST);
@@ -144,12 +141,10 @@ class UsernamePasswordJsonAuthenticationListenerTest extends TestCase
         $this->listener->handle($event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage The key "username" must be a string.
-     */
     public function testAttemptAuthenticationUsernameNotAString()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
+        $this->expectExceptionMessage('The key "username" must be a string.');
         $this->createListener();
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"username": 1, "password": "foo"}');
         $event = new GetResponseEvent($this->getMockBuilder(KernelInterface::class)->getMock(), $request, KernelInterface::MASTER_REQUEST);
@@ -157,12 +152,10 @@ class UsernamePasswordJsonAuthenticationListenerTest extends TestCase
         $this->listener->handle($event);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage The key "password" must be a string.
-     */
     public function testAttemptAuthenticationPasswordNotAString()
     {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
+        $this->expectExceptionMessage('The key "password" must be a string.');
         $this->createListener();
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"username": "dunglas", "password": 1}');
         $event = new GetResponseEvent($this->getMockBuilder(KernelInterface::class)->getMock(), $request, KernelInterface::MASTER_REQUEST);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/X509AuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/X509AuthenticationListenerTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Firewall\X509AuthenticationListener;
 
 class X509AuthenticationListenerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider dataProviderGetPreAuthenticatedData
      */
@@ -83,11 +86,9 @@ class X509AuthenticationListenerTest extends TestCase
         yield ['cert+something@example.com', 'emailAddress=cert+something@example.com'];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
-     */
     public function testGetPreAuthenticatedDataNoData()
     {
+        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
         $request = new Request([], [], [], [], [], []);
 
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -21,6 +22,8 @@ use Symfony\Component\Security\Http\HttpUtils;
 
 class HttpUtilsTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testCreateRedirectResponseWithPath()
     {
         $utils = new HttpUtils($this->getUrlGenerator());
@@ -251,11 +254,9 @@ class HttpUtilsTest extends TestCase
         $this->assertTrue($utils->checkRequestPath($request, 'foobar'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCheckRequestPathWithUrlMatcherLoadingException()
     {
+        $this->expectException('RuntimeException');
         $urlMatcher = $this->getMockBuilder('Symfony\Component\Routing\Matcher\UrlMatcherInterface')->getMock();
         $urlMatcher
             ->expects($this->any())
@@ -280,12 +281,10 @@ class HttpUtilsTest extends TestCase
         $this->assertFalse($utils->checkRequestPath($this->getRequest(), 'path/index.html'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Matcher must either implement UrlMatcherInterface or RequestMatcherInterface
-     */
     public function testUrlMatcher()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Matcher must either implement UrlMatcherInterface or RequestMatcherInterface');
         new HttpUtils($this->getUrlGenerator(), new \stdClass());
     }
 
@@ -307,12 +306,10 @@ class HttpUtilsTest extends TestCase
         $this->assertEquals('/foo/bar#fragment', $utils->generateUri(new Request(), 'route_name'));
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage You must provide a UrlGeneratorInterface instance to be able to use routes.
-     */
     public function testUrlGeneratorIsRequiredToGenerateUrl()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('You must provide a UrlGeneratorInterface instance to be able to use routes.');
         $utils = new HttpUtils();
         $utils->generateUri(new Request(), 'route_name');
     }

--- a/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
@@ -50,12 +50,10 @@ class LogoutUrlGeneratorTest extends TestCase
         $this->assertSame('/logout', $this->generator->getLogoutPath('secured_area'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage No LogoutListener found for firewall key "unregistered_key".
-     */
     public function testGetLogoutPathWithoutLogoutListenerRegisteredForKeyThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('No LogoutListener found for firewall key "unregistered_key".');
         $this->generator->registerListener('secured_area', '/logout', null, null, null);
 
         $this->generator->getLogoutPath('unregistered_key');
@@ -69,12 +67,10 @@ class LogoutUrlGeneratorTest extends TestCase
         $this->assertSame('/logout', $this->generator->getLogoutPath());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unable to generate a logout url for an anonymous token.
-     */
     public function testGuessFromAnonymousTokenThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Unable to generate a logout url for an anonymous token.');
         $this->tokenStorage->setToken(new AnonymousToken('default', 'anon.'));
 
         $this->generator->getLogoutPath();
@@ -105,12 +101,10 @@ class LogoutUrlGeneratorTest extends TestCase
         $this->assertSame('/logout', $this->generator->getLogoutPath());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unable to find the current firewall LogoutListener, please provide the provider key manually
-     */
     public function testUnableToGuessThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Unable to find the current firewall LogoutListener, please provide the provider key manually');
         $this->generator->registerListener('secured_area', '/logout', null, null);
 
         $this->generator->getLogoutPath();

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -42,11 +42,9 @@ class AbstractRememberMeServicesTest extends TestCase
         $this->assertNull($service->autoLogin(new Request()));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testAutoLoginThrowsExceptionWhenImplementationDoesNotReturnUserInterface()
     {
+        $this->expectException('RuntimeException');
         $service = $this->getService(null, ['name' => 'foo', 'path' => null, 'domain' => null]);
         $request = new Request();
         $request->cookies->set('foo', 'foo');
@@ -270,12 +268,10 @@ class AbstractRememberMeServicesTest extends TestCase
         $this->assertSame($cookieParts, $decoded);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage cookie delimiter
-     */
     public function testThereShouldBeNoCookieDelimiterInCookieParts()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('cookie delimiter');
         $cookieParts = ['aa', 'b'.AbstractRememberMeServices::COOKIE_DELIMITER.'b', 'cc'];
         $service = $this->getService();
 

--- a/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Security\Http\Tests\Session;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 
 class SessionAuthenticationStrategyTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testSessionIsNotChanged()
     {
         $request = $this->getRequest();
@@ -25,12 +28,10 @@ class SessionAuthenticationStrategyTest extends TestCase
         $strategy->onAuthentication($request, $this->getToken());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Invalid session authentication strategy "foo"
-     */
     public function testUnsupportedStrategy()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Invalid session authentication strategy "foo"');
         $request = $this->getRequest();
         $request->expects($this->never())->method('getSession');
 

--- a/src/Symfony/Component/Serializer/Tests/Annotation/GroupsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/GroupsTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Annotation;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
@@ -19,27 +20,23 @@ use Symfony\Component\Serializer\Annotation\Groups;
  */
 class GroupsTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     */
+    use ForwardCompatTestTrait;
+
     public function testEmptyGroupsParameter()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
         new Groups(['value' => []]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     */
     public function testNotAnArrayGroupsParameter()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
         new Groups(['value' => 12]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     */
     public function testInvalidGroupsParameter()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
         new Groups(['value' => ['a', 1, new \stdClass()]]);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Annotation;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Annotation\MaxDepth;
 
 /**
@@ -19,12 +20,12 @@ use Symfony\Component\Serializer\Annotation\MaxDepth;
  */
 class MaxDepthTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" should be set.
-     */
+    use ForwardCompatTestTrait;
+
     public function testNotSetMaxDepthParameter()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" should be set.');
         new MaxDepth([]);
     }
 
@@ -40,12 +41,11 @@ class MaxDepthTest extends TestCase
 
     /**
      * @dataProvider provideInvalidValues
-     *
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" must be a positive integer.
      */
     public function testNotAnIntMaxDepthParameter($value)
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" must be a positive integer.');
         new MaxDepth(['value' => $value]);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
@@ -23,12 +24,12 @@ use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
  */
 class SerializerPassTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage You must tag at least one service as "serializer.normalizer" to use the "serializer" service
-     */
+    use ForwardCompatTestTrait;
+
     public function testThrowExceptionWhenNoNormalizers()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('You must tag at least one service as "serializer.normalizer" to use the "serializer" service');
         $container = new ContainerBuilder();
         $container->register('serializer');
 
@@ -36,12 +37,10 @@ class SerializerPassTest extends TestCase
         $serializerPass->process($container);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage You must tag at least one service as "serializer.encoder" to use the "serializer" service
-     */
     public function testThrowExceptionWhenNoEncoders()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('You must tag at least one service as "serializer.encoder" to use the "serializer" service');
         $container = new ContainerBuilder();
         $container->register('serializer')
             ->addArgument([])

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -73,11 +73,9 @@ class ChainDecoderTest extends TestCase
         $this->chainDecoder->decode('string_to_decode', self::FORMAT_2);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\RuntimeException
-     */
     public function testDecodeUnsupportedFormat()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\RuntimeException');
         $this->chainDecoder->decode('string_to_decode', self::FORMAT_3);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -75,11 +75,9 @@ class ChainEncoderTest extends TestCase
         $this->chainEncoder->encode(['foo' => 123], self::FORMAT_2);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\RuntimeException
-     */
     public function testEncodeUnsupportedFormat()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\RuntimeException');
         $this->chainEncoder->encode(['foo' => 123], self::FORMAT_3);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
@@ -61,10 +61,10 @@ class JsonDecodeTest extends TestCase
     /**
      * @requires function json_last_error_msg
      * @dataProvider decodeProviderException
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
      */
     public function testDecodeWithException($value)
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->decode->decode($value, JsonEncoder::FORMAT);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncodeTest.php
@@ -54,10 +54,10 @@ class JsonEncodeTest extends TestCase
 
     /**
      * @requires function json_last_error_msg
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
      */
     public function testEncodeWithError()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->encode->encode("\xB1\x31", JsonEncoder::FORMAT);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
@@ -68,11 +68,9 @@ class JsonEncoderTest extends TestCase
         $this->assertEquals($expected, $this->serializer->serialize($arr, 'json'), 'Context should not be persistent');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testEncodeNotUtf8WithoutPartialOnError()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $arr = [
             'utf8' => 'Hello World!',
             'notUtf8' => "\xb0\xd0\xb5\xd0",

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -62,12 +62,10 @@ class XmlEncoderTest extends TestCase
         $this->assertEquals($expected, $this->encoder->encode($obj, 'xml'));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     * @expectedExceptionMessage Document types are not allowed.
-     */
     public function testDocTypeIsNotAllowed()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
+        $this->expectExceptionMessage('Document types are not allowed.');
         $this->encoder->decode('<?xml version="1.0"?><!DOCTYPE foo><foo></foo>', 'foo');
     }
 
@@ -562,19 +560,15 @@ XML;
         $this->assertEquals($expected, $this->encoder->decode($xml, 'xml'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDecodeInvalidXml()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->encoder->decode('<?xml version="1.0"?><invalid><xml>', 'xml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testPreventsComplexExternalEntities()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->encoder->decode('<?xml version="1.0"?><!DOCTYPE scan[<!ENTITY test SYSTEM "php://filter/read=convert.base64-encode/resource=XmlEncoderTest.php">]><scan>&test;</scan>', 'xml');
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Mapping\Factory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
@@ -23,6 +24,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
  */
 class CacheMetadataFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetMetadataFor()
     {
         $metadata = new ClassMetadata(Dummy::class);
@@ -55,11 +58,9 @@ class CacheMetadataFactoryTest extends TestCase
         $this->assertTrue($factory->hasMetadataFor(Dummy::class));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     */
     public function testInvalidClassThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
         $decorated = $this->getMockBuilder(ClassMetadataFactoryInterface::class)->getMock();
         $factory = new CacheClassMetadataFactory($decorated, new ArrayAdapter());
 

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -55,11 +55,9 @@ class YamlFileLoaderTest extends TestCase
         $this->assertFalse($loader->loadClassMetadata($this->metadata));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\MappingException
-     */
     public function testLoadClassMetadataReturnsThrowsInvalidMapping()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\MappingException');
         $loader = new YamlFileLoader(__DIR__.'/../../Fixtures/invalid-mapping.yml');
         $loader->loadClassMetadata($this->metadata);
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -50,12 +50,10 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertInstanceOf(__NAMESPACE__.'\Dummy', $normalizer->instantiateObject($data, $class, $context, new \ReflectionClass($class), []));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\ExtraAttributesException
-     * @expectedExceptionMessage Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).
-     */
     public function testDenormalizeWithExtraAttributes()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\ExtraAttributesException');
+        $this->expectExceptionMessage('Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).');
         $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $normalizer = new AbstractObjectNormalizerDummy($factory);
         $normalizer->denormalize(
@@ -66,12 +64,10 @@ class AbstractObjectNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\ExtraAttributesException
-     * @expectedExceptionMessage Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).
-     */
     public function testDenormalizeWithExtraAttributesAndNoGroupsWithMetadataFactory()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\ExtraAttributesException');
+        $this->expectExceptionMessage('Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).');
         $normalizer = new AbstractObjectNormalizerWithMetadata();
         $normalizer->denormalize(
             ['fooFoo' => 'foo', 'fooBar' => 'bar', 'bar' => 'bar'],
@@ -152,12 +148,11 @@ class AbstractObjectNormalizerTest extends TestCase
 
     /**
      * Test that additional attributes throw an exception if no metadata factory is specified.
-     *
-     * @expectedException \Symfony\Component\Serializer\Exception\LogicException
-     * @expectedExceptionMessage A class metadata factory must be provided in the constructor when setting "allow_extra_attributes" to false.
      */
     public function testExtraAttributesException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\LogicException');
+        $this->expectExceptionMessage('A class metadata factory must be provided in the constructor when setting "allow_extra_attributes" to false.');
         $normalizer = new ObjectNormalizer();
 
         $normalizer->denormalize([], \stdClass::class, 'xml', [

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
@@ -114,21 +114,19 @@ class DataUriNormalizerTest extends TestCase
         $this->assertSame(file_get_contents(self::TEST_GIF_DATA), $this->getContent($file->openFile()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     * @expectedExceptionMessage The provided "data:" URI is not valid.
-     */
     public function testGiveNotAccessToLocalFiles()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
+        $this->expectExceptionMessage('The provided "data:" URI is not valid.');
         $this->normalizer->denormalize('/etc/shadow', 'SplFileObject');
     }
 
     /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
      * @dataProvider invalidUriProvider
      */
     public function testInvalidData($uri)
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->normalizer->denormalize($uri, 'SplFileObject');
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
@@ -64,12 +64,10 @@ class DateIntervalNormalizerTest extends TestCase
         $this->assertEquals($output, (new DateIntervalNormalizer($format))->normalize(new \DateInterval($input)));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The object must be an instance of "\DateInterval".
-     */
     public function testNormalizeInvalidObjectThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The object must be an instance of "\DateInterval".');
         $this->normalizer->normalize(new \stdClass());
     }
 
@@ -100,36 +98,28 @@ class DateIntervalNormalizerTest extends TestCase
         $this->assertDateIntervalEquals(new \DateInterval($output), (new DateIntervalNormalizer($format))->denormalize($input, \DateInterval::class));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     */
     public function testDenormalizeExpectsString()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
         $this->normalizer->denormalize(1234, \DateInterval::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     * @expectedExceptionMessage Expected a valid ISO 8601 interval string.
-     */
     public function testDenormalizeNonISO8601IntervalStringThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
+        $this->expectExceptionMessage('Expected a valid ISO 8601 interval string.');
         $this->normalizer->denormalize('10 years 2 months 3 days', \DateInterval::class, null);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDenormalizeInvalidDataThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->normalizer->denormalize('invalid interval', \DateInterval::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDenormalizeFormatMismatchThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->normalizer->denormalize('P00Y00M00DT00H00M00S', \DateInterval::class, null, [DateIntervalNormalizer::FORMAT_KEY => 'P%yY%mM%dD']);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -157,12 +157,10 @@ class DateTimeNormalizerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The object must implement the "\DateTimeInterface".
-     */
     public function testNormalizeInvalidObjectThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The object must implement the "\DateTimeInterface".');
         $this->normalizer->normalize(new \stdClass());
     }
 
@@ -238,37 +236,29 @@ class DateTimeNormalizerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDenormalizeInvalidDataThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->normalizer->denormalize('invalid date', \DateTimeInterface::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     * @expectedExceptionMessage The data is either an empty string or null, you should pass a string that can be parsed with the passed format or a valid DateTime string.
-     */
     public function testDenormalizeNullThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
+        $this->expectExceptionMessage('The data is either an empty string or null, you should pass a string that can be parsed with the passed format or a valid DateTime string.');
         $this->normalizer->denormalize(null, \DateTimeInterface::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     * @expectedExceptionMessage The data is either an empty string or null, you should pass a string that can be parsed with the passed format or a valid DateTime string.
-     */
     public function testDenormalizeEmptyStringThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
+        $this->expectExceptionMessage('The data is either an empty string or null, you should pass a string that can be parsed with the passed format or a valid DateTime string.');
         $this->normalizer->denormalize('', \DateTimeInterface::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDenormalizeFormatMismatchThrowsException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTimeInterface::class, null, [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d|']);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -322,11 +322,9 @@ class GetSetMethodNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUncallableCallbacks()
     {
+        $this->expectException('InvalidArgumentException');
         $this->normalizer->setCallbacks(['bar' => null]);
 
         $obj = new GetConstructorDummy('baz', 'quux', true);
@@ -409,12 +407,10 @@ class GetSetMethodNormalizerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\LogicException
-     * @expectedExceptionMessage Cannot normalize attribute "object" because the injected serializer is not a normalizer
-     */
     public function testUnableToNormalizeObjectAttribute()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\LogicException');
+        $this->expectExceptionMessage('Cannot normalize attribute "object" because the injected serializer is not a normalizer');
         $serializer = $this->getMockBuilder('Symfony\Component\Serializer\SerializerInterface')->getMock();
         $this->normalizer->setSerializer($serializer);
 
@@ -425,11 +421,9 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->normalizer->normalize($obj, 'any');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\CircularReferenceException
-     */
     public function testUnableToNormalizeCircularReference()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\CircularReferenceException');
         $serializer = new Serializer([$this->normalizer]);
         $this->normalizer->setSerializer($serializer);
         $this->normalizer->setCircularReferenceLimit(2);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
@@ -63,11 +63,9 @@ class JsonSerializableNormalizerTest extends TestCase
         $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\CircularReferenceException
-     */
     public function testCircularNormalize()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\CircularReferenceException');
         $this->normalizer->setCircularReferenceLimit(1);
 
         $this->serializer
@@ -83,12 +81,10 @@ class JsonSerializableNormalizerTest extends TestCase
         $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The object must implement "JsonSerializable".
-     */
     public function testInvalidDataThrowException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The object must implement "JsonSerializable".');
         $this->normalizer->normalize(new \stdClass());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -185,12 +185,10 @@ class ObjectNormalizerTest extends TestCase
         $this->assertEquals('rab', $obj->getInner()->bar);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\RuntimeException
-     * @expectedExceptionMessage Could not determine the class of the parameter "unknown".
-     */
     public function testConstructorWithUnknownObjectTypeHintDenormalize()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\RuntimeException');
+        $this->expectExceptionMessage('Could not determine the class of the parameter "unknown".');
         $data = [
             'id' => 10,
             'unknown' => [
@@ -358,11 +356,9 @@ class ObjectNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUncallableCallbacks()
     {
+        $this->expectException('InvalidArgumentException');
         $this->normalizer->setCallbacks(['bar' => null]);
 
         $obj = new ObjectConstructorDummy('baz', 'quux', true);
@@ -469,12 +465,10 @@ class ObjectNormalizerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\LogicException
-     * @expectedExceptionMessage Cannot normalize attribute "object" because the injected serializer is not a normalizer
-     */
     public function testUnableToNormalizeObjectAttribute()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\LogicException');
+        $this->expectExceptionMessage('Cannot normalize attribute "object" because the injected serializer is not a normalizer');
         $serializer = $this->getMockBuilder('Symfony\Component\Serializer\SerializerInterface')->getMock();
         $this->normalizer->setSerializer($serializer);
 
@@ -485,11 +479,9 @@ class ObjectNormalizerTest extends TestCase
         $this->normalizer->normalize($obj, 'any');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\CircularReferenceException
-     */
     public function testUnableToNormalizeCircularReference()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\CircularReferenceException');
         $serializer = new Serializer([$this->normalizer]);
         $this->normalizer->setSerializer($serializer);
         $this->normalizer->setCircularReferenceLimit(2);
@@ -603,11 +595,9 @@ class ObjectNormalizerTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testThrowUnexpectedValueException()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $this->normalizer->denormalize(['foo' => 'bar'], ObjectTypeHinted::class);
     }
 
@@ -640,24 +630,20 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame(10.0, $serializer->denormalize(['number' => 10], JsonNumber::class, 'jsonld')->number);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     * @expectedExceptionMessage The type of the "date" attribute for class "Symfony\Component\Serializer\Tests\Normalizer\ObjectOuter" must be one of "DateTimeInterface" ("string" given).
-     */
     public function testRejectInvalidType()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
+        $this->expectExceptionMessage('The type of the "date" attribute for class "Symfony\Component\Serializer\Tests\Normalizer\ObjectOuter" must be one of "DateTimeInterface" ("string" given).');
         $normalizer = new ObjectNormalizer(null, null, null, new ReflectionExtractor());
         $serializer = new Serializer([$normalizer]);
 
         $serializer->denormalize(['date' => 'foo'], ObjectOuter::class);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     * @expectedExceptionMessage The type of the key "a" must be "int" ("string" given).
-     */
     public function testRejectInvalidKey()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
+        $this->expectExceptionMessage('The type of the key "a" must be "int" ("string" given).');
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = new ObjectNormalizer(null, null, null, $extractor);
         $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -135,11 +135,9 @@ class PropertyNormalizerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUncallableCallbacks()
     {
+        $this->expectException('InvalidArgumentException');
         $this->normalizer->setCallbacks(['bar' => null]);
 
         $obj = new PropertyConstructorDummy('baz', 'quux');
@@ -323,11 +321,9 @@ class PropertyNormalizerTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\CircularReferenceException
-     */
     public function testUnableToNormalizeCircularReference()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\CircularReferenceException');
         $serializer = new Serializer([$this->normalizer]);
         $this->normalizer->setSerializer($serializer);
         $this->normalizer->setCircularReferenceLimit(2);
@@ -382,12 +378,10 @@ class PropertyNormalizerTest extends TestCase
         $this->assertEquals('out_of_scope', PropertyDummy::$outOfScope);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\LogicException
-     * @expectedExceptionMessage Cannot normalize attribute "bar" because the injected serializer is not a normalizer
-     */
     public function testUnableToNormalizeObjectAttribute()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\LogicException');
+        $this->expectExceptionMessage('Cannot normalize attribute "bar" because the injected serializer is not a normalizer');
         $serializer = $this->getMockBuilder('Symfony\Component\Serializer\SerializerInterface')->getMock();
         $this->normalizer->setSerializer($serializer);
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
@@ -30,6 +31,8 @@ use Symfony\Component\Serializer\Tests\Normalizer\TestNormalizer;
 
 class SerializerTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testInterface()
     {
         $serializer = new Serializer();
@@ -41,11 +44,9 @@ class SerializerTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\Serializer\Encoder\DecoderInterface', $serializer);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testNormalizeNoMatch()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([$this->getMockBuilder('Symfony\Component\Serializer\Normalizer\CustomNormalizer')->getMock()]);
         $serializer->normalize(new \stdClass(), 'xml');
     }
@@ -64,29 +65,23 @@ class SerializerTest extends TestCase
         $this->assertEquals('{"foo":"normalizedFoo","bar":"normalizedBar"}', $result);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testNormalizeOnDenormalizer()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([new TestDenormalizer()], []);
         $this->assertTrue($serializer->normalize(new \stdClass(), 'json'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDenormalizeNoMatch()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([$this->getMockBuilder('Symfony\Component\Serializer\Normalizer\CustomNormalizer')->getMock()]);
         $serializer->denormalize('foo', 'stdClass');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDenormalizeOnNormalizer()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([new TestNormalizer()], []);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $this->assertTrue($serializer->denormalize(json_encode($data), 'stdClass', 'json'));
@@ -168,21 +163,17 @@ class SerializerTest extends TestCase
         $this->assertEquals(json_encode($data), $result);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testSerializeNoEncoder()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([], []);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $serializer->serialize($data, 'json');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\LogicException
-     */
     public function testSerializeNoNormalizer()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\LogicException');
         $serializer = new Serializer([], ['json' => new JsonEncoder()]);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $serializer->serialize(Model::fromArray($data), 'json');
@@ -206,31 +197,25 @@ class SerializerTest extends TestCase
         $this->assertEquals($data, $result->toArray());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\LogicException
-     */
     public function testDeserializeNoNormalizer()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\LogicException');
         $serializer = new Serializer([], ['json' => new JsonEncoder()]);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $serializer->deserialize(json_encode($data), '\Symfony\Component\Serializer\Tests\Model', 'json');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDeserializeWrongNormalizer()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([new CustomNormalizer()], ['json' => new JsonEncoder()]);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $serializer->deserialize(json_encode($data), '\Symfony\Component\Serializer\Tests\Model', 'json');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
-     */
     public function testDeserializeNoEncoder()
     {
+        $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([], []);
         $data = ['title' => 'foo', 'numbers' => [5, 3]];
         $serializer->deserialize(json_encode($data), '\Symfony\Component\Serializer\Tests\Model', 'json');

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Stopwatch\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
 /**
@@ -23,6 +24,8 @@ use Symfony\Component\Stopwatch\StopwatchEvent;
  */
 class StopwatchEventTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const DELTA = 37;
 
     public function testGetOrigin()
@@ -103,11 +106,9 @@ class StopwatchEventTest extends TestCase
         $this->assertEquals(100, $event->getDuration(), '', self::DELTA);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testStopWithoutStart()
     {
+        $this->expectException('LogicException');
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->stop();
     }
@@ -154,11 +155,9 @@ class StopwatchEventTest extends TestCase
         $this->assertEquals(0, $event->getStartTime(), '', self::DELTA);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidOriginThrowsAnException()
     {
+        $this->expectException('InvalidArgumentException');
         new StopwatchEvent('abc');
     }
 

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -93,20 +93,16 @@ class StopwatchTest extends TestCase
         $this->assertEquals(200, $event->getDuration(), '', self::DELTA);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testUnknownEvent()
     {
+        $this->expectException('LogicException');
         $stopwatch = new Stopwatch();
         $stopwatch->getEvent('foo');
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testStopWithoutStart()
     {
+        $this->expectException('LogicException');
         $stopwatch = new Stopwatch();
         $stopwatch->stop('foo');
     }
@@ -168,11 +164,9 @@ class StopwatchTest extends TestCase
         $this->assertCount(2, $events['__section__']->getPeriods());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testReopenANewSectionShouldThrowAnException()
     {
+        $this->expectException('LogicException');
         $stopwatch = new Stopwatch();
         $stopwatch->openSection('section');
     }

--- a/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Templating\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Templating\DelegatingEngine;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Templating\StreamingEngineInterface;
 
 class DelegatingEngineTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testRenderDelegatesToSupportedEngine()
     {
         $firstEngine = $this->getEngineMock('template.php', false);
@@ -34,12 +37,10 @@ class DelegatingEngineTest extends TestCase
         $this->assertSame('<html />', $result);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No engine is able to work with the template "template.php"
-     */
     public function testRenderWithNoSupportedEngine()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('No engine is able to work with the template "template.php"');
         $firstEngine = $this->getEngineMock('template.php', false);
         $secondEngine = $this->getEngineMock('template.php', false);
 
@@ -61,12 +62,10 @@ class DelegatingEngineTest extends TestCase
         $this->assertNull($result);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Template "template.php" cannot be streamed as the engine supporting it does not implement StreamingEngineInterface
-     */
     public function testStreamRequiresStreamingEngine()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Template "template.php" cannot be streamed as the engine supporting it does not implement StreamingEngineInterface');
         $delegatingEngine = new DelegatingEngine([new TestEngine()]);
         $delegatingEngine->stream('template.php', ['foo' => 'bar']);
     }
@@ -112,12 +111,10 @@ class DelegatingEngineTest extends TestCase
         $this->assertSame($secondEngine, $delegatingEngine->getEngine('template.php'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No engine is able to work with the template "template.php"
-     */
     public function testGetInvalidEngine()
     {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('No engine is able to work with the template "template.php"');
         $firstEngine = $this->getEngineMock('template.php', false);
         $secondEngine = $this->getEngineMock('template.php', false);
 

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -127,11 +127,11 @@ class PhpEngineTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider forbiddenParameterNames
      */
     public function testRenderForbiddenParameter($name)
     {
+        $this->expectException('InvalidArgumentException');
         $engine = new ProjectTemplateEngine(new TemplateNameParser(), $this->loader);
         $this->loader->setTemplate('foo.php', 'bar');
         $engine->render('foo.php', [$name => 'foo']);

--- a/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslationExtractorPassTest.php
+++ b/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslationExtractorPassTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Translation\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Translation\DependencyInjection\TranslationExtractorPass;
 
 class TranslationExtractorPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -46,12 +49,10 @@ class TranslationExtractorPassTest extends TestCase
         $this->assertCount($aliasesBefore, $container->getAliases());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The alias for the tag "translation.extractor" of service "foo.id" must be set.
-     */
     public function testProcessMissingAlias()
     {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The alias for the tag "translation.extractor" of service "foo.id" must be set.');
         $definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->disableOriginalConstructor()->getMock();
         $container = new ContainerBuilder();
         $container->register('translation.extractor');

--- a/src/Symfony/Component/Translation/Tests/IntervalTest.php
+++ b/src/Symfony/Component/Translation/Tests/IntervalTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Translation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Translation\Interval;
 
 class IntervalTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getTests
      */
@@ -24,11 +27,9 @@ class IntervalTest extends TestCase
         $this->assertEquals($expected, Interval::test($number, $interval));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
-     */
     public function testTestException()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
         Interval::test(1, 'foobar');
     }
 

--- a/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Loader\CsvFileLoader;
 
 class CsvFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoad()
     {
         $loader = new CsvFileLoader();
@@ -39,21 +42,17 @@ class CsvFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new CsvFileLoader();
         $resource = __DIR__.'/../fixtures/not-exists.csv';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadNonLocalResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new CsvFileLoader();
         $resource = 'http://example.com/resources.csv';
         $loader->load($resource, 'en', 'domain1');

--- a/src/Symfony/Component/Translation/Tests/Loader/IcuDatFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IcuDatFileLoaderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation\Tests\Loader;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Loader\IcuDatFileLoader;
 
@@ -19,11 +20,11 @@ use Symfony\Component\Translation\Loader\IcuDatFileLoader;
  */
 class IcuDatFileLoaderTest extends LocalizedTestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
+    use ForwardCompatTestTrait;
+
     public function testLoadInvalidResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new IcuDatFileLoader();
         $loader->load(__DIR__.'/../fixtures/resourcebundle/corrupted/resources', 'es', 'domain2');
     }
@@ -53,11 +54,9 @@ class IcuDatFileLoaderTest extends LocalizedTestCase
         $this->assertEquals([new FileResource($resource.'.dat')], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new IcuDatFileLoader();
         $loader->load(__DIR__.'/../fixtures/non-existing.txt', 'en', 'domain1');
     }

--- a/src/Symfony/Component/Translation/Tests/Loader/IcuResFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IcuResFileLoaderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation\Tests\Loader;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Translation\Loader\IcuResFileLoader;
 
@@ -19,6 +20,8 @@ use Symfony\Component\Translation\Loader\IcuResFileLoader;
  */
 class IcuResFileLoaderTest extends LocalizedTestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoad()
     {
         // resource is build using genrb command
@@ -31,20 +34,16 @@ class IcuResFileLoaderTest extends LocalizedTestCase
         $this->assertEquals([new DirectoryResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new IcuResFileLoader();
         $loader->load(__DIR__.'/../fixtures/non-existing.txt', 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadInvalidResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new IcuResFileLoader();
         $loader->load(__DIR__.'/../fixtures/resourcebundle/corrupted', 'en', 'domain1');
     }

--- a/src/Symfony/Component/Translation/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IniFileLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Loader\IniFileLoader;
 
 class IniFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoad()
     {
         $loader = new IniFileLoader();
@@ -39,11 +42,9 @@ class IniFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new IniFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.ini';
         $loader->load($resource, 'en', 'domain1');

--- a/src/Symfony/Component/Translation/Tests/Loader/JsonFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/JsonFileLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Loader\JsonFileLoader;
 
 class JsonFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoad()
     {
         $loader = new JsonFileLoader();
@@ -39,22 +42,18 @@ class JsonFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new JsonFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.json';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException           \Symfony\Component\Translation\Exception\InvalidResourceException
-     * @expectedExceptionMessage    Error parsing JSON - Syntax error, malformed JSON
-     */
     public function testParseException()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
+        $this->expectExceptionMessage('Error parsing JSON - Syntax error, malformed JSON');
         $loader = new JsonFileLoader();
         $resource = __DIR__.'/../fixtures/malformed.json';
         $loader->load($resource, 'en', 'domain1');

--- a/src/Symfony/Component/Translation/Tests/Loader/MoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/MoFileLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Loader\MoFileLoader;
 
 class MoFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoad()
     {
         $loader = new MoFileLoader();
@@ -42,21 +45,17 @@ class MoFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new MoFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.mo';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadInvalidResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new MoFileLoader();
         $resource = __DIR__.'/../fixtures/empty.mo';
         $loader->load($resource, 'en', 'domain1');

--- a/src/Symfony/Component/Translation/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PhpFileLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Loader\PhpFileLoader;
 
 class PhpFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoad()
     {
         $loader = new PhpFileLoader();
@@ -28,21 +31,17 @@ class PhpFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new PhpFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.php';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadThrowsAnExceptionIfFileNotLocal()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new PhpFileLoader();
         $resource = 'http://example.com/resources.php';
         $loader->load($resource, 'en', 'domain1');

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Loader\PoFileLoader;
 
 class PoFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoad()
     {
         $loader = new PoFileLoader();
@@ -53,11 +56,9 @@ class PoFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new PoFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.po';
         $loader->load($resource, 'en', 'domain1');

--- a/src/Symfony/Component/Translation/Tests/Loader/QtFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/QtFileLoaderTest.php
@@ -31,31 +31,25 @@ class QtFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new QtFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.ts';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadNonLocalResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new QtFileLoader();
         $resource = 'http://domain1.com/resources.ts';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadInvalidResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new QtFileLoader();
         $resource = __DIR__.'/../fixtures/invalid-xml-resources.xlf';
         $loader->load($resource, 'en', 'domain1');

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -99,50 +99,40 @@ class XliffFileLoaderTest extends TestCase
         $this->assertEquals('translated', $metadata['target-attributes']['state']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadInvalidResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new XliffFileLoader();
         $loader->load(__DIR__.'/../fixtures/resources.php', 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadResourceDoesNotValidate()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new XliffFileLoader();
         $loader->load(__DIR__.'/../fixtures/non-valid.xlf', 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new XliffFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.xlf';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadThrowsAnExceptionIfFileNotLocal()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new XliffFileLoader();
         $resource = 'http://example.com/resources.xlf';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Translation\Exception\InvalidResourceException
-     * @expectedExceptionMessage Document types are not allowed.
-     */
     public function testDocTypeIsNotAllowed()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
+        $this->expectExceptionMessage('Document types are not allowed.');
         $loader = new XliffFileLoader();
         $loader->load(__DIR__.'/../fixtures/withdoctype.xlf', 'en', 'domain1');
     }

--- a/src/Symfony/Component/Translation/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/YamlFileLoaderTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Loader\YamlFileLoader;
 
 class YamlFileLoaderTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testLoad()
     {
         $loader = new YamlFileLoader();
@@ -39,31 +42,25 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
-     */
     public function testLoadNonExistingResource()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loader = new YamlFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.yml';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadThrowsAnExceptionIfFileNotLocal()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new YamlFileLoader();
         $resource = 'http://example.com/resources.yml';
         $loader->load($resource, 'en', 'domain1');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidResourceException
-     */
     public function testLoadThrowsAnExceptionIfNotAnArray()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidResourceException');
         $loader = new YamlFileLoader();
         $resource = __DIR__.'/../fixtures/non-valid.yml';
         $loader->load($resource, 'en', 'domain1');

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Translation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Translation\MessageCatalogue;
 
 class MessageCatalogueTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetLocale()
     {
         $catalogue = new MessageCatalogue('en');
@@ -132,11 +135,9 @@ class MessageCatalogueTest extends TestCase
         $this->assertEquals([$r, $r1, $r2], $catalogue->getResources());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\LogicException
-     */
     public function testAddFallbackCatalogueWithParentCircularReference()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\LogicException');
         $main = new MessageCatalogue('en_US');
         $fallback = new MessageCatalogue('fr_FR');
 
@@ -144,11 +145,9 @@ class MessageCatalogueTest extends TestCase
         $main->addFallbackCatalogue($fallback);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\LogicException
-     */
     public function testAddFallbackCatalogueWithFallbackCircularReference()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\LogicException');
         $fr = new MessageCatalogue('fr');
         $en = new MessageCatalogue('en');
         $es = new MessageCatalogue('es');
@@ -158,11 +157,9 @@ class MessageCatalogueTest extends TestCase
         $en->addFallbackCatalogue($fr);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\LogicException
-     */
     public function testAddCatalogueWhenLocaleIsNotTheSameAsTheCurrentOne()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\LogicException');
         $catalogue = new MessageCatalogue('en');
         $catalogue->addCatalogue(new MessageCatalogue('fr', []));
     }

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Translation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Translation\MessageSelector;
 
 class MessageSelectorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider getChooseTests
      */
@@ -35,10 +38,10 @@ class MessageSelectorTest extends TestCase
 
     /**
      * @dataProvider getNonMatchingMessages
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function testThrowExceptionIfMatchingMessageCannotBeFound($id, $number)
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
         $selector = new MessageSelector();
 
         $selector->choose($id, $number, 'en');

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -12,18 +12,21 @@
 namespace Symfony\Component\Translation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Translator;
 
 class TranslatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
-     * @dataProvider      getInvalidLocalesTests
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @dataProvider getInvalidLocalesTests
      */
     public function testConstructorInvalidLocale($locale)
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
         new Translator($locale);
     }
 
@@ -55,11 +58,11 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getInvalidLocalesTests
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @dataProvider getInvalidLocalesTests
      */
     public function testSetInvalidLocale($locale)
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
         $translator = new Translator('fr');
         $translator->setLocale($locale);
     }
@@ -138,11 +141,11 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getInvalidLocalesTests
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @dataProvider getInvalidLocalesTests
      */
     public function testSetFallbackInvalidLocales($locale)
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
         $translator = new Translator('fr');
         $translator->setFallbackLocales(['fr', $locale]);
     }
@@ -170,11 +173,11 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getInvalidLocalesTests
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @dataProvider getInvalidLocalesTests
      */
     public function testAddResourceInvalidLocales($locale)
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
         $translator = new Translator('fr');
         $translator->addResource('array', ['foo' => 'foofoo'], $locale);
     }
@@ -205,11 +208,11 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getTransFileTests
-     * @expectedException \Symfony\Component\Translation\Exception\NotFoundResourceException
+     * @dataProvider getTransFileTests
      */
     public function testTransWithoutFallbackLocaleFile($format, $loader)
     {
+        $this->expectException('Symfony\Component\Translation\Exception\NotFoundResourceException');
         $loaderClass = 'Symfony\\Component\\Translation\\Loader\\'.$loader;
         $translator = new Translator('en');
         $translator->addLoader($format, new $loaderClass());
@@ -264,11 +267,9 @@ class TranslatorTest extends TestCase
         $this->assertEquals('non-existent', $translator->trans('non-existent'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Translation\Exception\RuntimeException
-     */
     public function testWhenAResourceHasNoRegisteredLoader()
     {
+        $this->expectException('Symfony\Component\Translation\Exception\RuntimeException');
         $translator = new Translator('en');
         $translator->addResource('array', ['foo' => 'foofoo'], 'en');
 
@@ -318,11 +319,11 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getInvalidLocalesTests
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @dataProvider getInvalidLocalesTests
      */
     public function testTransInvalidLocale($locale)
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
         $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', ['foo' => 'foofoo'], 'en');
@@ -331,7 +332,7 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getValidLocalesTests
+     * @dataProvider getValidLocalesTests
      */
     public function testTransValidLocale($locale)
     {
@@ -368,11 +369,11 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getInvalidLocalesTests
-     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @dataProvider getInvalidLocalesTests
      */
     public function testTransChoiceInvalidLocale($locale)
     {
+        $this->expectException('Symfony\Component\Translation\Exception\InvalidArgumentException');
         $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', ['foo' => 'foofoo'], 'en');
@@ -381,7 +382,7 @@ class TranslatorTest extends TestCase
     }
 
     /**
-     * @dataProvider      getValidLocalesTests
+     * @dataProvider getValidLocalesTests
      */
     public function testTransChoiceValidLocale($locale)
     {

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -207,11 +207,9 @@ class ConstraintTest extends TestCase
         $this->assertSame(['MyGroup'], $constraint->groups);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\InvalidArgumentException
-     */
     public function testGetErrorNameForUnknownCode()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\InvalidArgumentException');
         Constraint::getErrorName(1);
     }
 
@@ -226,12 +224,10 @@ class ConstraintTest extends TestCase
         $this->assertEquals($options, $constraint->property2);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The options "0", "5" do not exist in constraint "Symfony\Component\Validator\Tests\Fixtures\ConstraintA".
-     */
     public function testInvalidOptions()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\InvalidOptionsException');
+        $this->expectExceptionMessage('The options "0", "5" do not exist in constraint "Symfony\Component\Validator\Tests\Fixtures\ConstraintA".');
         new ConstraintA(['property2' => 'foo', 'bar', 5 => 'baz']);
     }
 
@@ -246,12 +242,10 @@ class ConstraintTest extends TestCase
         $this->assertEquals('foo', $constraint->property1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     * @expectedExceptionMessage No default option is configured for constraint "Symfony\Component\Validator\Tests\Fixtures\ConstraintB".
-     */
     public function testAnnotationSetUndefinedDefaultOption()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('No default option is configured for constraint "Symfony\Component\Validator\Tests\Fixtures\ConstraintB".');
         new ConstraintB(['value' => 1]);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -84,20 +84,18 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
 
     /**
      * @dataProvider provideInvalidConstraintOptions
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     * @expectedExceptionMessage requires either the "value" or "propertyPath" option to be set.
      */
     public function testThrowsConstraintExceptionIfNoValueOrPropertyPath($options)
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('requires either the "value" or "propertyPath" option to be set.');
         $this->createConstraint($options);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     * @expectedExceptionMessage requires only one of the "value" or "propertyPath" options to be set, not both.
-     */
     public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('requires only one of the "value" or "propertyPath" options to be set, not both.');
         $this->createConstraint(([
             'value' => 'value',
             'propertyPath' => 'propertyPath',

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Valid;
 
@@ -20,21 +21,19 @@ use Symfony\Component\Validator\Constraints\Valid;
  */
 class AllTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
+    use ForwardCompatTestTrait;
+
     public function testRejectNonConstraints()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new All([
             'foo',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testRejectValidConstraint()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new All([
             new Valid(),
         ]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\AllValidator;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -19,6 +20,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class AllValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new AllValidator();
@@ -31,11 +34,9 @@ class AllValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testThrowsExceptionIfNotTraversable()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate('foo.barbar', new All(new Range(['min' => 4])));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\CallbackValidator;
@@ -46,6 +47,8 @@ class CallbackValidatorTest_Object
 
 class CallbackValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new CallbackValidator();
@@ -180,21 +183,17 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testExpectValidMethods()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $object = new CallbackValidatorTest_Object();
 
         $this->validator->validate($object, new Callback(['callback' => ['foobar']]));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testExpectValidCallbacks()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $object = new CallbackValidatorTest_Object();
 
         $this->validator->validate($object, new Callback(['callback' => ['foo', 'bar']]));

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\ChoiceValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -22,6 +23,8 @@ function choice_callback()
 
 class ChoiceValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new ChoiceValidator();
@@ -37,11 +40,9 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         return ['foo', 'bar'];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectArrayIfMultipleIsTrue()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $constraint = new Choice([
             'choices' => ['foo', 'bar'],
             'multiple' => true,
@@ -64,19 +65,15 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testChoicesOrCallbackExpected()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $this->validator->validate('foobar', new Choice(['strict' => true]));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testValidCallbackExpected()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $this->validator->validate('foobar', new Choice(['callback' => 'abcd', 'strict' => true]));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Optional;
@@ -23,51 +24,43 @@ use Symfony\Component\Validator\Constraints\Valid;
  */
 class CollectionTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
+    use ForwardCompatTestTrait;
+
     public function testRejectInvalidFieldsOption()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new Collection([
             'fields' => 'foo',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testRejectNonConstraints()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new Collection([
             'foo' => 'bar',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testRejectValidConstraint()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new Collection([
             'foo' => new Valid(),
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testRejectValidConstraintWithinOptional()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new Collection([
             'foo' => new Optional(new Valid()),
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testRejectValidConstraintWithinRequired()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new Collection([
             'foo' => new Required(new Valid()),
         ]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\CollectionValidator;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -21,6 +22,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 abstract class CollectionValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new CollectionValidator();
@@ -52,11 +55,9 @@ abstract class CollectionValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testThrowsExceptionIfNotTraversable()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate('foobar', new Collection(['fields' => [
             'foo' => new Range(['min' => 4]),
         ]]));

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Composite;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -37,6 +38,8 @@ class ConcreteComposite extends Composite
  */
 class CompositeTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testMergeNestedGroupsIfNoExplicitParentGroup()
     {
         $constraint = new ConcreteComposite([
@@ -79,11 +82,9 @@ class CompositeTest extends TestCase
         $this->assertEquals(['Strict'], $constraint->constraints[1]->groups);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testFailIfExplicitNestedGroupsNotSubsetOfExplicitParentGroups()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new ConcreteComposite([
             'constraints' => [
                 new NotNull(['groups' => ['Default', 'Foobar']]),
@@ -114,33 +115,27 @@ class CompositeTest extends TestCase
         $this->assertEquals([$nestedConstraint], $constraint->constraints);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testFailIfNoConstraint()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new ConcreteComposite([
             new NotNull(['groups' => 'Default']),
             'NotBlank',
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testFailIfNoConstraintObject()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new ConcreteComposite([
             new NotNull(['groups' => 'Default']),
             new \ArrayObject(),
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testValidCantBeNested()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new ConcreteComposite([
             new Valid(),
         ]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\CountValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 abstract class CountValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new CountValidator();
@@ -34,11 +37,9 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsCountableType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Count(5));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Country;
 use Symfony\Component\Validator\Constraints\CountryValidator;
@@ -18,6 +19,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class CountryValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new CountryValidator();
@@ -37,11 +40,9 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Country());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Currency;
 use Symfony\Component\Validator\Constraints\CurrencyValidator;
@@ -18,6 +19,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class CurrencyValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new CurrencyValidator();
@@ -37,11 +40,9 @@ class CurrencyValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Currency());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\DateTimeValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class DateTimeValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new DateTimeValidator();
@@ -50,11 +53,9 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new DateTime());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Date;
 use Symfony\Component\Validator\Constraints\DateValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class DateValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new DateValidator();
@@ -50,11 +53,9 @@ class DateValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Date());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Bridge\PhpUnit\DnsMock;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\EmailValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -21,6 +22,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class EmailValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new EmailValidator(false);
@@ -40,11 +43,9 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Email());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 class FileTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider provideValidSizes
      */
@@ -52,10 +55,10 @@ class FileTest extends TestCase
 
     /**
      * @dataProvider provideInvalidSizes
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
     public function testInvalidValueForMaxSizeThrowsExceptionAfterInitialization($maxSize)
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $file = new File(['maxSize' => 1000]);
         $file->maxSize = $maxSize;
     }
@@ -77,10 +80,10 @@ class FileTest extends TestCase
 
     /**
      * @dataProvider provideInValidSizes
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
     public function testInvalidMaxSize($maxSize)
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new File(['maxSize' => $maxSize]);
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -69,11 +69,9 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleTypeOrFile()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new File());
     }
 
@@ -225,11 +223,9 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMaxSize()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new File([
             'maxSize' => '1abc',
         ]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -203,11 +203,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMinWidth()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new Image([
             'minWidth' => '1abc',
         ]);
@@ -215,11 +213,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($this->image, $constraint);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMaxWidth()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new Image([
             'maxWidth' => '1abc',
         ]);
@@ -227,11 +223,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($this->image, $constraint);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMinHeight()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new Image([
             'minHeight' => '1abc',
         ]);
@@ -239,11 +233,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($this->image, $constraint);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMaxHeight()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new Image([
             'maxHeight' => '1abc',
         ]);
@@ -251,11 +243,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($this->image, $constraint);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMinPixels()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new Image([
             'minPixels' => '1abc',
         ]);
@@ -263,11 +253,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($this->image, $constraint);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMaxPixels()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new Image([
             'maxPixels' => '1abc',
         ]);
@@ -318,11 +306,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMinRatio()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new Image([
             'minRatio' => '1abc',
         ]);
@@ -330,11 +316,9 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($this->image, $constraint);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidMaxRatio()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint = new Image([
             'maxRatio' => '1abc',
         ]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Ip;
 use Symfony\Component\Validator\Constraints\IpValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class IpValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new IpValidator();
@@ -36,19 +39,15 @@ class IpValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Ip());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testInvalidValidatorVersion()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         new Ip([
             'version' => 666,
         ]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Isbn;
 use Symfony\Component\Validator\Constraints\IsbnValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class IsbnValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new IsbnValidator();
@@ -136,11 +139,9 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $constraint = new Isbn(true);
 
         $this->validator->validate(new \stdClass(), $constraint);

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Issn;
 use Symfony\Component\Validator\Constraints\IssnValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class IssnValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new IssnValidator();
@@ -106,11 +109,9 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $constraint = new Issn();
         $this->validator->validate(new \stdClass(), $constraint);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Language;
 use Symfony\Component\Validator\Constraints\LanguageValidator;
@@ -18,6 +19,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class LanguageValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new LanguageValidator();
@@ -37,11 +40,9 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Language());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\LengthValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class LengthValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new LengthValidator();
@@ -36,11 +39,9 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Length(5));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Locale;
 use Symfony\Component\Validator\Constraints\LocaleValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class LocaleValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new LocaleValidator();
@@ -36,11 +39,9 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Locale());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Luhn;
 use Symfony\Component\Validator\Constraints\LuhnValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class LuhnValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new LuhnValidator();
@@ -99,11 +102,11 @@ class LuhnValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
      * @dataProvider getInvalidTypes
      */
     public function testInvalidTypes($number)
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $constraint = new Luhn();
 
         $this->validator->validate($number, $constraint);

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\RegexValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class RegexValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new RegexValidator();
@@ -36,11 +39,9 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Regex(['pattern' => '/^[0-9]+$/']));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Time;
 use Symfony\Component\Validator\Constraints\TimeValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class TimeValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new TimeValidator();
@@ -43,11 +46,9 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Time());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Bridge\PhpUnit\DnsMock;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Constraints\UrlValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -21,6 +22,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class UrlValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new UrlValidator();
@@ -47,11 +50,9 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Url());
     }
 
@@ -281,11 +282,11 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Validator\Exception\InvalidOptionsException
      * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
      */
     public function testCheckDnsWithInvalidType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\InvalidOptionsException');
         DnsMock::withMockedHosts(['example.com' => [['type' => 'A']]]);
 
         $constraint = new Url([

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Uuid;
 use Symfony\Component\Validator\Constraints\UuidValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class UuidValidatorTest extends ConstraintValidatorTestCase
 {
+    use ForwardCompatTestTrait;
+
     protected function createValidator()
     {
         return new UuidValidator();
@@ -39,21 +42,17 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsUuidConstraintCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $constraint = $this->getMockForAbstractClass('Symfony\\Component\\Validator\\Constraint');
 
         $this->validator->validate('216fff40-98d9-11e3-a5e2-0800200c9a66', $constraint);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
         $this->validator->validate(new \stdClass(), new Uuid());
     }
 

--- a/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Blank as BlankConstraint;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 
 class ContainerConstraintValidatorFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testGetInstanceCreatesValidator()
     {
         $factory = new ContainerConstraintValidatorFactory(new Container());
@@ -45,11 +48,9 @@ class ContainerConstraintValidatorFactoryTest extends TestCase
         $this->assertSame($validator, $factory->getInstance(new DummyConstraint()));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ValidatorException
-     */
     public function testGetInstanceInvalidValidatorClass()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ValidatorException');
         $constraint = $this->getMockBuilder(Constraint::class)->getMock();
         $constraint
             ->expects($this->once())

--- a/src/Symfony/Component/Validator/Tests/DependencyInjection/AddConstraintValidatorsPassTest.php
+++ b/src/Symfony/Component/Validator/Tests/DependencyInjection/AddConstraintValidatorsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -21,6 +22,8 @@ use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 
 class AddConstraintValidatorsPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testThatConstraintValidatorServicesAreProcessed()
     {
         $container = new ContainerBuilder();
@@ -43,12 +46,10 @@ class AddConstraintValidatorsPassTest extends TestCase
         $this->assertEquals($expected, $container->getDefinition((string) $validatorFactory->getArgument(0)));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "my_abstract_constraint_validator" tagged "validator.constraint_validator" must not be abstract.
-     */
     public function testAbstractConstraintValidator()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The service "my_abstract_constraint_validator" tagged "validator.constraint_validator" must not be abstract.');
         $container = new ContainerBuilder();
         $container->register('validator.validator_factory')
             ->addArgument([]);

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -253,47 +253,37 @@ class ClassMetadataTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\Validator\Constraints\GroupSequence', $this->metadata->getGroupSequence());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
-     */
     public function testGroupSequencesFailIfNotContainingDefaultGroup()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\GroupDefinitionException');
         $this->metadata->setGroupSequence(['Foo', 'Bar']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
-     */
     public function testGroupSequencesFailIfContainingDefault()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\GroupDefinitionException');
         $this->metadata->setGroupSequence(['Foo', $this->metadata->getDefaultGroup(), Constraint::DEFAULT_GROUP]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
-     */
     public function testGroupSequenceFailsIfGroupSequenceProviderIsSet()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\GroupDefinitionException');
         $metadata = new ClassMetadata(self::PROVIDERCLASS);
         $metadata->setGroupSequenceProvider(true);
         $metadata->setGroupSequence(['GroupSequenceProviderEntity', 'Foo']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
-     */
     public function testGroupSequenceProviderFailsIfGroupSequenceIsSet()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\GroupDefinitionException');
         $metadata = new ClassMetadata(self::PROVIDERCLASS);
         $metadata->setGroupSequence(['GroupSequenceProviderEntity', 'Foo']);
         $metadata->setGroupSequenceProvider(true);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
-     */
     public function testGroupSequenceProviderFailsIfDomainClassIsInvalid()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\GroupDefinitionException');
         $metadata = new ClassMetadata('stdClass');
         $metadata->setGroupSequenceProvider(true);
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/BlackHoleMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/BlackHoleMetadataFactoryTest.php
@@ -12,15 +12,16 @@
 namespace Symfony\Component\Validator\Tests\Mapping\Factory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Mapping\Factory\BlackHoleMetadataFactory;
 
 class BlackHoleMetadataFactoryTest extends TestCase
 {
-    /**
-     * @expectedException \LogicException
-     */
+    use ForwardCompatTestTrait;
+
     public function testGetMetadataForThrowsALogicException()
     {
+        $this->expectException('LogicException');
         $metadataFactory = new BlackHoleMetadataFactory();
         $metadataFactory->getMetadataFor('foo');
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Mapping\Factory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
@@ -20,6 +21,8 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 
 class LazyLoadingMetadataFactoryTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     const CLASS_NAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
     const PARENT_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
     const INTERFACE_A_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityInterfaceA';
@@ -149,11 +152,9 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $this->assertEquals($metadata, $factory->getMetadataFor(self::PARENT_CLASS));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\NoSuchMetadataException
-     */
     public function testNonClassNameStringValues()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\NoSuchMetadataException');
         $testedValue = 'error@example.com';
         $loader = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
         $cache = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Cache\CacheInterface')->getMock();

--- a/src/Symfony/Component/Validator/Tests/Mapping/GetterMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/GetterMetadataTest.php
@@ -64,12 +64,10 @@ class GetterMetadataTest extends TestCase
         $this->assertEquals('permissions', $metadata->getPropertyValue($entity));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ValidatorException
-     * @expectedExceptionMessage The hasLastName() method does not exist in class Symfony\Component\Validator\Tests\Fixtures\Entity.
-     */
     public function testUndefinedMethodNameThrowsException()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ValidatorException');
+        $this->expectExceptionMessage('The hasLastName() method does not exist in class Symfony\Component\Validator\Tests\Fixtures\Entity.');
         new GetterMetadata(self::CLASSNAME, 'lastName', 'hasLastName');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -43,10 +43,10 @@ class YamlFileLoaderTest extends TestCase
 
     /**
      * @dataProvider provideInvalidYamlFiles
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidYamlFiles($path)
     {
+        $this->expectException('InvalidArgumentException');
         $loader = new YamlFileLoader(__DIR__.'/'.$path);
         $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
 

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -12,19 +12,16 @@
 namespace Symfony\Component\Validator\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 class TranslationFilesTest extends TestCase
 {
-    use ForwardCompatTestTrait;
-
     /**
      * @dataProvider provideTranslationFiles
      */
     public function testTranslationFileIsValid($filePath)
     {
         if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
+            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -12,16 +12,19 @@
 namespace Symfony\Component\Validator\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 
 class TranslationFilesTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     /**
      * @dataProvider provideTranslationFiles
      */
     public function testTranslationFileIsValid($filePath)
     {
         if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
+            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
@@ -414,11 +414,9 @@ abstract class AbstractTest extends AbstractValidatorTest
         $this->assertCount(0, $violations);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
-     */
     public function testExpectTraversableIfTraversalEnabledOnClass()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $entity = new Entity();
 
         $this->metadata->addConstraint(new Traverse(true));
@@ -572,11 +570,9 @@ abstract class AbstractTest extends AbstractValidatorTest
         $this->assertCount(1, $violations);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\RuntimeException
-     */
     public function testValidateFailsIfNoConstraintsAndNoObjectOrArray()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\RuntimeException');
         $this->validate('Foobar');
     }
 

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
@@ -502,11 +502,9 @@ abstract class AbstractValidatorTest extends TestCase
         $this->assertCount(0, $violations);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\NoSuchMetadataException
-     */
     public function testFailOnScalarReferences()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\NoSuchMetadataException');
         $entity = new Entity();
         $entity->reference = 'string';
 
@@ -741,11 +739,9 @@ abstract class AbstractValidatorTest extends TestCase
         $this->assertCount(0, $violations);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\NoSuchMetadataException
-     */
     public function testMetadataMustExistIfTraversalIsDisabled()
     {
+        $this->expectException('Symfony\Component\Validator\Exception\NoSuchMetadataException');
         $entity = new Entity();
         $entity->reference = new \ArrayIterator();
 

--- a/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
@@ -3,16 +3,17 @@
 namespace Symfony\Component\Workflow\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Workflow\DefinitionBuilder;
 use Symfony\Component\Workflow\Transition;
 
 class DefinitionBuilderTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidArgumentException
-     */
+    use ForwardCompatTestTrait;
+
     public function testAddPlaceInvalidName()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidArgumentException');
         $builder = new DefinitionBuilder(['a"', 'b']);
     }
 

--- a/src/Symfony/Component/Workflow/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionTest.php
@@ -3,11 +3,14 @@
 namespace Symfony\Component\Workflow\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Transition;
 
 class DefinitionTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testAddPlaces()
     {
         $places = range('a', 'e');
@@ -18,11 +21,9 @@ class DefinitionTest extends TestCase
         $this->assertEquals('a', $definition->getInitialPlace());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidArgumentException
-     */
     public function testAddPlacesInvalidArgument()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidArgumentException');
         $places = ['a"', 'e"'];
         $definition = new Definition($places, []);
     }
@@ -35,12 +36,10 @@ class DefinitionTest extends TestCase
         $this->assertEquals($places[3], $definition->getInitialPlace());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\LogicException
-     * @expectedExceptionMessage Place "d" cannot be the initial place as it does not exist.
-     */
     public function testSetInitialPlaceAndPlaceIsNotDefined()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\LogicException');
+        $this->expectExceptionMessage('Place "d" cannot be the initial place as it does not exist.');
         $definition = new Definition([], [], 'd');
     }
 
@@ -55,23 +54,19 @@ class DefinitionTest extends TestCase
         $this->assertSame($transition, $definition->getTransitions()[0]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\LogicException
-     * @expectedExceptionMessage Place "c" referenced in transition "name" does not exist.
-     */
     public function testAddTransitionAndFromPlaceIsNotDefined()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\LogicException');
+        $this->expectExceptionMessage('Place "c" referenced in transition "name" does not exist.');
         $places = range('a', 'b');
 
         new Definition($places, [new Transition('name', 'c', $places[1])]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\LogicException
-     * @expectedExceptionMessage Place "c" referenced in transition "name" does not exist.
-     */
     public function testAddTransitionAndToPlaceIsNotDefined()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\LogicException');
+        $this->expectExceptionMessage('Place "c" referenced in transition "name" does not exist.');
         $places = range('a', 'b');
 
         new Definition($places, [new Transition('name', $places[0], 'c')]);

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -46,23 +46,19 @@ class RegistryTest extends TestCase
         $this->assertSame('workflow2', $workflow->getName());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidArgumentException
-     * @expectedExceptionMessage At least two workflows match this subject. Set a different name on each and use the second (name) argument of this method.
-     */
     public function testGetWithMultipleMatch()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('At least two workflows match this subject. Set a different name on each and use the second (name) argument of this method.');
         $w1 = $this->registry->get(new Subject2());
         $this->assertInstanceOf(Workflow::class, $w1);
         $this->assertSame('workflow1', $w1->getName());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Unable to find a workflow for class "stdClass".
-     */
     public function testGetWithNoMatch()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Unable to find a workflow for class "stdClass".');
         $w1 = $this->registry->get(new \stdClass());
         $this->assertInstanceOf(Workflow::class, $w1);
         $this->assertSame('workflow1', $w1->getName());

--- a/src/Symfony/Component/Workflow/Tests/TransitionTest.php
+++ b/src/Symfony/Component/Workflow/Tests/TransitionTest.php
@@ -3,16 +3,17 @@
 namespace Symfony\Component\Workflow\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Workflow\Transition;
 
 class TransitionTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The transition "foo.bar" contains invalid characters.
-     */
+    use ForwardCompatTestTrait;
+
     public function testValidateName()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The transition "foo.bar" contains invalid characters.');
         $transition = new Transition('foo.bar', 'a', 'b');
     }
 

--- a/src/Symfony/Component/Workflow/Tests/Validator/StateMachineValidatorTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Validator/StateMachineValidatorTest.php
@@ -3,18 +3,19 @@
 namespace Symfony\Component\Workflow\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\Validator\StateMachineValidator;
 
 class StateMachineValidatorTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidDefinitionException
-     * @expectedExceptionMessage A transition from a place/state must have an unique name.
-     */
+    use ForwardCompatTestTrait;
+
     public function testWithMultipleTransitionWithSameNameShareInput()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidDefinitionException');
+        $this->expectExceptionMessage('A transition from a place/state must have an unique name.');
         $places = ['a', 'b', 'c'];
         $transitions[] = new Transition('t1', 'a', 'b');
         $transitions[] = new Transition('t1', 'a', 'c');
@@ -35,12 +36,10 @@ class StateMachineValidatorTest extends TestCase
         //  +----+     +----+
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidDefinitionException
-     * @expectedExceptionMessage A transition in StateMachine can only have one output.
-     */
     public function testWithMultipleTos()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidDefinitionException');
+        $this->expectExceptionMessage('A transition in StateMachine can only have one output.');
         $places = ['a', 'b', 'c'];
         $transitions[] = new Transition('t1', 'a', ['b', 'c']);
         $definition = new Definition($places, $transitions);
@@ -60,12 +59,10 @@ class StateMachineValidatorTest extends TestCase
         //           +----+
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidDefinitionException
-     * @expectedExceptionMessage A transition in StateMachine can only have one input.
-     */
     public function testWithMultipleFroms()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidDefinitionException');
+        $this->expectExceptionMessage('A transition in StateMachine can only have one input.');
         $places = ['a', 'b', 'c'];
         $transitions[] = new Transition('t1', ['a', 'b'], 'c');
         $definition = new Definition($places, $transitions);

--- a/src/Symfony/Component/Workflow/Tests/Validator/WorkflowValidatorTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Validator/WorkflowValidatorTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Workflow\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Tests\WorkflowBuilderTrait;
 use Symfony\Component\Workflow\Transition;
@@ -10,14 +11,13 @@ use Symfony\Component\Workflow\Validator\WorkflowValidator;
 
 class WorkflowValidatorTest extends TestCase
 {
+    use ForwardCompatTestTrait;
     use WorkflowBuilderTrait;
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidDefinitionException
-     * @expectedExceptionMessage The marking store of workflow "foo" can not store many places.
-     */
     public function testSinglePlaceWorkflowValidatorAndComplexWorkflow()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidDefinitionException');
+        $this->expectExceptionMessage('The marking store of workflow "foo" can not store many places.');
         $definition = $this->createComplexWorkflowDefinition();
 
         (new WorkflowValidator(true))->validate($definition, 'foo');
@@ -33,12 +33,10 @@ class WorkflowValidatorTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\InvalidDefinitionException
-     * @expectedExceptionMessage All transitions for a place must have an unique name. Multiple transitions named "t1" where found for place "a" in workflow "foo".
-     */
     public function testWorkflowWithInvalidNames()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\InvalidDefinitionException');
+        $this->expectExceptionMessage('All transitions for a place must have an unique name. Multiple transitions named "t1" where found for place "a" in workflow "foo".');
         $places = range('a', 'c');
 
         $transitions = [];

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Workflow\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Event\Event;
@@ -15,14 +16,13 @@ use Symfony\Component\Workflow\Workflow;
 
 class WorkflowTest extends TestCase
 {
+    use ForwardCompatTestTrait;
     use WorkflowBuilderTrait;
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\LogicException
-     * @expectedExceptionMessage The value returned by the MarkingStore is not an instance of "Symfony\Component\Workflow\Marking" for workflow "unnamed".
-     */
     public function testGetMarkingWithInvalidStoreReturn()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\LogicException');
+        $this->expectExceptionMessage('The value returned by the MarkingStore is not an instance of "Symfony\Component\Workflow\Marking" for workflow "unnamed".');
         $subject = new \stdClass();
         $subject->marking = null;
         $workflow = new Workflow(new Definition([], []), $this->getMockBuilder(MarkingStoreInterface::class)->getMock());
@@ -30,12 +30,10 @@ class WorkflowTest extends TestCase
         $workflow->getMarking($subject);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\LogicException
-     * @expectedExceptionMessage The Marking is empty and there is no initial place for workflow "unnamed".
-     */
     public function testGetMarkingWithEmptyDefinition()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\LogicException');
+        $this->expectExceptionMessage('The Marking is empty and there is no initial place for workflow "unnamed".');
         $subject = new \stdClass();
         $subject->marking = null;
         $workflow = new Workflow(new Definition([], []), new MultipleStateMarkingStore());
@@ -43,12 +41,10 @@ class WorkflowTest extends TestCase
         $workflow->getMarking($subject);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\LogicException
-     * @expectedExceptionMessage Place "nope" is not valid for workflow "unnamed".
-     */
     public function testGetMarkingWithImpossiblePlace()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\LogicException');
+        $this->expectExceptionMessage('Place "nope" is not valid for workflow "unnamed".');
         $subject = new \stdClass();
         $subject->marking = ['nope' => 1];
         $workflow = new Workflow(new Definition([], []), new MultipleStateMarkingStore());
@@ -162,12 +158,10 @@ class WorkflowTest extends TestCase
         $this->assertSame(['workflow_name.guard.t3'], $dispatchedEvents);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Workflow\Exception\LogicException
-     * @expectedExceptionMessage Unable to apply transition "t2" for workflow "unnamed".
-     */
     public function testApplyWithImpossibleTransition()
     {
+        $this->expectException('Symfony\Component\Workflow\Exception\LogicException');
+        $this->expectExceptionMessage('Unable to apply transition "t2" for workflow "unnamed".');
         $definition = $this->createComplexWorkflowDefinition();
         $subject = new \stdClass();
         $subject->marking = null;

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -81,11 +81,9 @@ YAML;
         $this->assertSame(1, $ret, 'lint:yaml exits with code 1 in case of error');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testLintFileNotReadable()
     {
+        $this->expectException('RuntimeException');
         $tester = $this->createCommandTester();
         $filename = $this->createFile('');
         unlink($filename);

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -234,20 +234,18 @@ EOF;
         $this->assertEquals('{ foo: null, bar: 1 }', $dump, '->dump() does not dump objects when disabled');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\DumpException
-     */
     public function testObjectSupportDisabledWithExceptions()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\DumpException');
         $this->dumper->dump(['foo' => new A(), 'bar' => 1], 0, 0, Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE);
     }
 
     /**
      * @group legacy
-     * @expectedException \Symfony\Component\Yaml\Exception\DumpException
      */
     public function testObjectSupportDisabledWithExceptionsPassingTrue()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\DumpException');
         $this->dumper->dump(['foo' => new A(), 'bar' => 1], 0, 0, true);
     }
 
@@ -562,21 +560,17 @@ YAML;
         $this->assertSame("- \"a\\r\\nb\\nc\"\n", $this->dumper->dump(["a\r\nb\nc"], 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The indentation must be greater than zero
-     */
     public function testZeroIndentationThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The indentation must be greater than zero');
         new Dumper(0);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The indentation must be greater than zero
-     */
     public function testNegativeIndentationThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The indentation must be greater than zero');
         new Dumper(-4);
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -65,21 +65,17 @@ class InlineTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage The constant "WRONG_CONSTANT" is not defined
-     */
     public function testParsePhpConstantThrowsExceptionWhenUndefined()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('The constant "WRONG_CONSTANT" is not defined');
         Inline::parse('!php/const WRONG_CONSTANT', Yaml::PARSE_CONSTANT);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp #The string "!php/const PHP_INT_MAX" could not be parsed as a constant.*#
-     */
     public function testParsePhpConstantThrowsExceptionOnInvalidType()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessageRegExp('#The string "!php/const PHP_INT_MAX" could not be parsed as a constant.*#');
         Inline::parse('!php/const PHP_INT_MAX', Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
     }
 
@@ -152,46 +148,36 @@ class InlineTest extends TestCase
         $this->assertSame($value, Inline::parse(Inline::dump($value)));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Found unknown escape character "\V".
-     */
     public function testParseScalarWithNonEscapedBlackslashShouldThrowException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('Found unknown escape character "\V".');
         Inline::parse('"Foo\Var"');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseScalarWithNonEscapedBlackslashAtTheEndShouldThrowException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         Inline::parse('"Foo\\"');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseScalarWithIncorrectlyQuotedStringShouldThrowException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $value = "'don't do somthin' like that'";
         Inline::parse($value);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseScalarWithIncorrectlyDoubleQuotedStringShouldThrowException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $value = '"don"t do somthin" like that"';
         Inline::parse($value);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseInvalidMappingKeyShouldThrowException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $value = '{ "foo " bar": "bar" }';
         Inline::parse($value);
     }
@@ -206,19 +192,15 @@ class InlineTest extends TestCase
         Inline::parse('{1:""}');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseInvalidMappingShouldThrowException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         Inline::parse('[foo] bar');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseInvalidSequenceShouldThrowException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         Inline::parse('{ foo: bar } bar');
     }
 
@@ -284,21 +266,17 @@ class InlineTest extends TestCase
         $this->assertSame([$foo], Inline::parse('[*foo]', false, false, false, ['foo' => $foo]));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage A reference must contain at least one character at line 1.
-     */
     public function testParseUnquotedAsterisk()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('A reference must contain at least one character at line 1.');
         Inline::parse('{ foo: * }');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage A reference must contain at least one character at line 1.
-     */
     public function testParseUnquotedAsteriskFollowedByAComment()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('A reference must contain at least one character at line 1.');
         Inline::parse('{ foo: * #foo }');
     }
 
@@ -688,10 +666,10 @@ class InlineTest extends TestCase
 
     /**
      * @dataProvider getInvalidBinaryData
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testParseInvalidBinaryData($data, $expectedMessage)
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $this->expectExceptionMessageRegExp($expectedMessage);
 
         Inline::parse($data);
@@ -707,12 +685,10 @@ class InlineTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Malformed inline YAML string: {this, is not, supported} at line 1.
-     */
     public function testNotSupportedMissingValue()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('Malformed inline YAML string: {this, is not, supported} at line 1.');
         Inline::parse('{this, is not, supported}');
     }
 
@@ -796,12 +772,10 @@ class InlineTest extends TestCase
         $this->assertSame(['foo' => 'bar'], Inline::parse('{ foo: !str bar }'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Unexpected end of line, expected one of ",}" at line 1 (near "{abc: 'def'").
-     */
     public function testUnfinishedInlineMap()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('Unexpected end of line, expected one of ",}" at line 1 (near "{abc: \'def\'").');
         Inline::parse("{abc: 'def'");
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -613,10 +613,10 @@ YAML;
 
     /**
      * @dataProvider invalidDumpedObjectProvider
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testObjectsSupportDisabledWithExceptions($yaml)
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $this->parser->parse($yaml, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
     }
 
@@ -634,10 +634,10 @@ YAML;
     /**
      * @group legacy
      * @dataProvider invalidDumpedObjectProvider
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testObjectsSupportDisabledWithExceptionsUsingBooleanToggles($yaml)
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $this->parser->parse($yaml, true);
     }
 
@@ -680,11 +680,9 @@ EOF;
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testUnindentedCollectionException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $yaml = <<<'EOF'
 
 collection:
@@ -697,11 +695,9 @@ EOF;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testShortcutKeyUnindentedCollectionException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $yaml = <<<'EOF'
 
 collection:
@@ -713,12 +709,10 @@ EOF;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp /^Multiple documents are not supported.+/
-     */
     public function testMultipleDocumentsNotSupportedException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessageRegExp('/^Multiple documents are not supported.+/');
         Yaml::parse(<<<'EOL'
 # Ranking of 1998 home runs
 ---
@@ -734,11 +728,9 @@ EOL
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testSequenceInAMapping()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         Yaml::parse(<<<'EOF'
 yaml:
   hash: me
@@ -843,10 +835,10 @@ EOT;
 
     /**
      * @dataProvider getParseExceptionNotAffectedMultiLineStringLastResortParsing
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testParseExceptionNotAffectedByMultiLineStringLastResortParsing($yaml)
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $this->parser->parse($yaml);
     }
 
@@ -876,11 +868,9 @@ EOT;
         $this->assertSame($expected, $this->parser->parse($yaml));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testMappingInASequence()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         Yaml::parse(<<<'EOF'
 yaml:
   - array stuff
@@ -889,12 +879,10 @@ EOF
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage missing colon
-     */
     public function testScalarInSequence()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('missing colon');
         Yaml::parse(<<<'EOF'
 foo:
     - bar
@@ -1245,12 +1233,10 @@ EOF;
         $this->assertEquals($expected, $this->parser->parse($yaml));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage A colon cannot be used in an unquoted mapping value
-     */
     public function testColonInMappingValueException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('A colon cannot be used in an unquoted mapping value');
         $yaml = <<<'EOF'
 foo: bar: baz
 EOF;
@@ -1484,10 +1470,10 @@ EOT
 
     /**
      * @dataProvider getInvalidBinaryData
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testParseInvalidBinaryData($data, $expectedMessage)
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $this->expectExceptionMessageRegExp($expectedMessage);
 
         $this->parser->parse($data);
@@ -1798,12 +1784,10 @@ YAML
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Tags support is not enabled. Enable the `Yaml::PARSE_CUSTOM_TAGS` flag to use "!iterator" at line 1 (near "!iterator [foo]").
-     */
     public function testCustomTagsDisabled()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('Tags support is not enabled. Enable the `Yaml::PARSE_CUSTOM_TAGS` flag to use "!iterator" at line 1 (near "!iterator [foo]").');
         $this->parser->parse('!iterator [foo]');
     }
 
@@ -1816,12 +1800,10 @@ YAML
         $this->assertEquals('!iterator foo', $this->parser->parse('!iterator foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage The built-in tag "!!foo" is not implemented at line 1 (near "!!foo").
-     */
     public function testExceptionWhenUsingUnsuportedBuiltInTags()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('The built-in tag "!!foo" is not implemented at line 1 (near "!!foo").');
         $this->parser->parse('!!foo');
     }
 
@@ -1871,12 +1853,10 @@ YAML;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Unable to parse at line 1 (near "[parameters]").
-     */
     public function testParsingIniThrowsException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('Unable to parse at line 1 (near "[parameters]").');
         $ini = <<<INI
 [parameters]
   foo = bar
@@ -1926,12 +1906,10 @@ INI;
         $this->assertEquals($trickyVal, $arrayFromYaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Reference "foo" does not exist at line 2
-     */
     public function testParserCleansUpReferencesBetweenRuns()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('Reference "foo" does not exist at line 2');
         $yaml = <<<YAML
 foo: &foo
     baz: foobar
@@ -2075,21 +2053,17 @@ YAML;
         $this->assertIsArray($this->parser->parseFile(__DIR__.'/Fixtures/index.yml'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp #^File ".+/Fixtures/nonexistent.yml" does not exist\.$#
-     */
     public function testParsingNonExistentFilesThrowsException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessageRegExp('#^File ".+/Fixtures/nonexistent.yml" does not exist\.$#');
         $this->parser->parseFile(__DIR__.'/Fixtures/nonexistent.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp #^File ".+/Fixtures/not_readable.yml" cannot be read\.$#
-     */
     public function testParsingNotReadableFilesThrowsException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessageRegExp('#^File ".+/Fixtures/not_readable.yml" cannot be read\.$#');
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('chmod is not supported on Windows');
         }
@@ -2160,12 +2134,10 @@ YAML;
         $this->assertEquals($expected, $this->parser->parse($yaml, Yaml::PARSE_OBJECT_FOR_MAP));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Reference "foo" does not exist
-     */
     public function testEvalRefException()
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('Reference "foo" does not exist');
         $yaml = <<<EOE
 foo: { &foo { a: Steve, <<: *foo} }
 EOE;
@@ -2174,11 +2146,11 @@ EOE;
 
     /**
      * @dataProvider circularReferenceProvider
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Circular reference [foo, bar, foo] detected
      */
     public function testDetectCircularReferences($yaml)
     {
+        $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
+        $this->expectExceptionMessage('Circular reference [foo, bar, foo] detected');
         $this->parser->parse($yaml, Yaml::PARSE_CUSTOM_TAGS);
     }
 

--- a/src/Symfony/Component/Yaml/Tests/YamlTest.php
+++ b/src/Symfony/Component/Yaml/Tests/YamlTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Yaml\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Yaml\Yaml;
 
 class YamlTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     public function testParseAndDump()
     {
         $data = ['lorem' => 'ipsum', 'dolor' => 'sit'];
@@ -24,21 +27,17 @@ class YamlTest extends TestCase
         $this->assertEquals($data, $parsed);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The indentation must be greater than zero
-     */
     public function testZeroIndentationThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The indentation must be greater than zero');
         Yaml::dump(['lorem' => 'ipsum', 'dolor' => 'sit'], 2, 0);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The indentation must be greater than zero
-     */
     public function testNegativeIndentationThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The indentation must be greater than zero');
         Yaml::dump(['lorem' => 'ipsum', 'dolor' => 'sit'], 2, -4);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

this PR replaces the deprecated annotation `@expectedException` by calls to the method `expectException`.

To automate the process, I used rector/rector:
```
./vendor/bin/rector process src/Symfony --set phpunit60 -a .phpunit/phpunit-6.5/vendor/autoload.php 
```
Which also replace `PHPUnit_Framework_Error_X` by `\PHPUnit\Framework\Error\X`