### PR TITLE
Adopt `@PHPUnit55Migration:risky` rule of php-cs-fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,8 +8,7 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHPUnit48Migration:risky' => true,
-        'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
+        '@PHPUnit55Migration:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
         'fopen_flags' => false,
         'ordered_imports' => true,

--- a/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
+++ b/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
@@ -165,7 +165,7 @@ class ConsoleLoggerTest extends TestCase
         if (method_exists($this, 'createPartialMock')) {
             $dummy = $this->createPartialMock('Symfony\Component\Console\Tests\Logger\DummyTest', ['__toString']);
         } else {
-            $dummy = $this->getMock('Symfony\Component\Console\Tests\Logger\DummyTest', ['__toString']);
+            $dummy = $this->createPartialMock('Symfony\Component\Console\Tests\Logger\DummyTest', ['__toString']);
         }
         $dummy->method('__toString')->willReturn('DUMMY');
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -946,8 +946,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * This methods allows for simple registration of service definition
      * with a fluid interface.
      *
-     * @param string $id         The service identifier
-     * @param string $class|null The service class
+     * @param string      $id    The service identifier
+     * @param string|null $class The service class
      *
      * @return Definition A Definition instance
      */

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
-use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -509,6 +509,7 @@ class NumberToLocalizedStringTransformerTest extends TestCase
 
     /**
      * @dataProvider nanRepresentationProvider
+     *
      * @see https://github.com/symfony/symfony/issues/3161
      */
     public function testReverseTransformDisallowsNaN($nan)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -28,7 +28,6 @@ class ButtonTypeTest extends BaseTypeTest
     }
 
     /**
-     *
      * @param string $emptyData
      * @param null   $expectedData
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
@@ -142,7 +142,7 @@ class LoggerTest extends TestCase
         if (method_exists($this, 'createPartialMock')) {
             $dummy = $this->createPartialMock(DummyTest::class, ['__toString']);
         } else {
-            $dummy = $this->getMock(DummyTest::class, ['__toString']);
+            $dummy = $this->createPartialMock(DummyTest::class, ['__toString']);
         }
         $dummy->expects($this->atLeastOnce())
             ->method('__toString')

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimezoneTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimezoneTransformer.php
@@ -92,8 +92,8 @@ class TimezoneTransformer extends Transformer
      *
      * @return string A timezone identifier
      *
-     * @see    http://php.net/manual/en/timezones.others.php
-     * @see    http://www.twinsun.com/tz/tz-link.htm
+     * @see http://php.net/manual/en/timezones.others.php
+     * @see http://www.twinsun.com/tz/tz-link.htm
      *
      * @throws NotImplementedException   When the GMT time zone have minutes offset different than zero
      * @throws \InvalidArgumentException When the value can not be matched with pattern

--- a/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
-use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
 use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Yaml\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
-use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Tag\TaggedValue;
 use Symfony\Component\Yaml\Yaml;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

We might have to polyfill `createPartialMock` before merging this one.