### PR TITLE
Fixed PHPUnit 8.3 incompatibility: method handleError was renamed to __invoke

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/ErrorHandlerCallerV83.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ErrorHandlerCallerV83.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+use PHPUnit\TextUI\Command;
+use PHPUnit\Util\Configuration;
+use PHPUnit\Util\ErrorHandler;
+
+/**
+ * Since PHPUnit v8.3 ErrorHandler is invokable and requires variables in constructor.
+ * This class reuses PHPUnit infrastructure to get these variables.
+ *
+ * @author Dmitrii Poddubnyi <dpoddubny@gmail.com>
+ *
+ * @internal
+ */
+class ErrorHandlerCallerV83 extends Command
+{
+    public function __construct(array $argv)
+    {
+        $this->handleArguments($argv);
+    }
+
+    public function handleError($type, $msg, $file, $line, $context)
+    {
+        $arguments = $this->arguments;
+        $this->handleConfiguration($arguments);
+        $object = new ErrorHandler(
+            $arguments['convertDeprecationsToExceptions'],
+            $arguments['convertErrorsToExceptions'],
+            $arguments['convertNoticesToExceptions'],
+            $arguments['convertWarningsToExceptions']
+        );
+
+        return $object($type, $msg, $file, $line, $context);
+    }
+
+    /**
+     * This is simplified version of PHPUnit\TextUI\TestRunner::handleConfiguration.
+     * https://github.com/sebastianbergmann/phpunit/blob/8.3.2/src/TextUI/TestRunner.php#L815-L1243.
+     */
+    private function handleConfiguration(array &$arguments): void
+    {
+        if (isset($arguments['configuration']) &&
+            !$arguments['configuration'] instanceof Configuration) {
+            $arguments['configuration'] = Configuration::getInstance(
+                $arguments['configuration']
+            );
+        }
+
+        if (isset($arguments['configuration'])) {
+            $arguments['configuration']->handlePHPConfiguration();
+
+            $phpunitConfiguration = $arguments['configuration']->getPHPUnitConfiguration();
+
+            if (isset($phpunitConfiguration['convertDeprecationsToExceptions']) && !isset($arguments['convertDeprecationsToExceptions'])) {
+                $arguments['convertDeprecationsToExceptions'] = $phpunitConfiguration['convertDeprecationsToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertErrorsToExceptions']) && !isset($arguments['convertErrorsToExceptions'])) {
+                $arguments['convertErrorsToExceptions'] = $phpunitConfiguration['convertErrorsToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertNoticesToExceptions']) && !isset($arguments['convertNoticesToExceptions'])) {
+                $arguments['convertNoticesToExceptions'] = $phpunitConfiguration['convertNoticesToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertWarningsToExceptions']) && !isset($arguments['convertWarningsToExceptions'])) {
+                $arguments['convertWarningsToExceptions'] = $phpunitConfiguration['convertWarningsToExceptions'];
+            }
+        }
+        $arguments['convertDeprecationsToExceptions'] = $arguments['convertDeprecationsToExceptions'] ?? true;
+        $arguments['convertErrorsToExceptions'] = $arguments['convertErrorsToExceptions'] ?? true;
+        $arguments['convertNoticesToExceptions'] = $arguments['convertNoticesToExceptions'] ?? true;
+        $arguments['convertWarningsToExceptions'] = $arguments['convertWarningsToExceptions'] ?? true;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32879   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

The PHPUnit method  [handleError](https://github.com/sebastianbergmann/phpunit/blob/8.2.5/src/Util/ErrorHandler.php#L38) was renamed to [__invoke](https://github.com/sebastianbergmann/phpunit/blob/8.3/src/Util/ErrorHandler.php#L71) in v8.3.

So we should check in Symfony [DeprecationErrorHandler](https://github.com/symfony/symfony/blob/v4.3.3/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php) if method `handleError` exists, otherwise call `__invoke`

It works with phpunit v8.2.5 and 8.3.2.
The PHPUnit handler is called when I trigger some error, e.g `iconv('fdsfs', 'fsdfds', '');`