### PR TITLE
[PhpUnitBridge] Polyfill the method createPartialMock

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ForwardCompatTestTraitForV5.php
@@ -106,6 +106,26 @@ trait ForwardCompatTestTraitForV5
     }
 
     /**
+     * @param string $originalClassName
+     *
+     * @return MockObject
+     */
+    protected function createPartialMock($originalClassName, array $methods)
+    {
+        $mock = $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->setMethods(empty($methods) ? null : $methods);
+
+        if (method_exists($mock, 'disallowMockingUnknownTypes')) {
+            $mock = $mock->disallowMockingUnknownTypes();
+        }
+
+        return $mock->getMock();
+    }
+
+    /**
      * @param string $message
      *
      * @return void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

Provide a polyfill for `createPartialMock` required by #32885