### PR TITLE
[Mailer] Change the order of authenticators

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -38,10 +38,10 @@ class EsmtpTransport extends SmtpTransport
         parent::__construct(null, $dispatcher, $logger);
 
         $this->authenticators = [
-            new Auth\PlainAuthenticator(),
-            new Auth\LoginAuthenticator(),
-            new Auth\XOAuth2Authenticator(),
             new Auth\CramMd5Authenticator(),
+            new Auth\LoginAuthenticator(),
+            new Auth\PlainAuthenticator(),
+            new Auth\XOAuth2Authenticator(),
         ];
 
         /** @var SocketStream $stream */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR uses the same order of SMTP authenticators as Swiftmailer. It should not change anything, but it does not hurt while I'm hunting for #32148 :)
