### PR TITLE
[Mailer] Fix error not being thrown properly

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -114,7 +114,11 @@ class SmtpTransport extends AbstractTransport
         try {
             $message = parent::send($message, $envelope);
         } catch (TransportExceptionInterface $e) {
-            $this->executeCommand("RSET\r\n", [250]);
+            try {
+                $this->executeCommand("RSET\r\n", [250]);
+            } catch (TransportExceptionInterface $_) {
+                // ignore this exception as it probably means that the server error was final
+            }
 
             throw $e;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When the SMTP server returns a fatal error, the error is not thrown properly as catched and another error (empty) is thrown. That makes debugging very difficult and what we would expect anyway.
