### PR TITLE
[Mailer] added debug info to TransportExceptionInterface

### DIFF
--- a/src/Symfony/Component/Mailer/Exception/TransportException.php
+++ b/src/Symfony/Component/Mailer/Exception/TransportException.php
@@ -16,4 +16,15 @@ namespace Symfony\Component\Mailer\Exception;
  */
 class TransportException extends RuntimeException implements TransportExceptionInterface
 {
+    private $debug = '';
+
+    public function getDebug(): string
+    {
+        return $this->debug;
+    }
+
+    public function appendDebug(string $debug): void
+    {
+        $this->debug .= $debug;
+    }
 }

--- a/src/Symfony/Component/Mailer/Exception/TransportExceptionInterface.php
+++ b/src/Symfony/Component/Mailer/Exception/TransportExceptionInterface.php
@@ -16,4 +16,7 @@ namespace Symfony\Component\Mailer\Exception;
  */
 interface TransportExceptionInterface extends ExceptionInterface
 {
+    public function getDebug(): string;
+
+    public function appendDebug(string $debug): void;
 }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -157,8 +157,11 @@ class SmtpTransport extends AbstractTransport
             }
             $this->stream->flush();
             $this->executeCommand("\r\n.\r\n", [250]);
-        } finally {
             $message->appendDebug($this->stream->getDebug());
+        } catch (TransportExceptionInterface $e) {
+            $e->appendDebug($this->stream->getDebug());
+
+            throw $e;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | ~

In 4.4, you can get the debug information for the SMTP/HTTP data via `$message->getDebug()` (see #32583). But the data are probably even more important when there is an exception. That's what I implemented in this PR.
