### PR TITLE
[Mailer] fix wrong error message when connection closes unexpectedly

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
@@ -74,6 +74,9 @@ abstract class AbstractStream
             if ($metas['timed_out']) {
                 throw new TransportException(sprintf('Connection to "%s" timed out.', $this->getReadConnectionDescription()));
             }
+            if ($metas['eof']) {
+                throw new TransportException(sprintf('Connection to "%s" has been closed unexpectedly.', $this->getReadConnectionDescription()));
+            }
         }
 
         return $line;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When the initial connection to the SMTP is closed immediately by the server, the error is now  more explicit.
