### PR TITLE
[PhpUnitBridge] Allow sutFqcnResolver to return array

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
@@ -76,7 +76,7 @@ class CoverageListenerTrait
         $cache = $r->getValue();
         $cache = array_replace_recursive($cache, array(
             \get_class($test) => array(
-                'covers' => array($sutFqcn),
+                'covers' => \is_array($sutFqcn) ? $sutFqcn : array($sutFqcn),
             ),
         ));
         $r->setValue($testClass, $cache);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...
| License       | MIT
| Doc PR        | 

Phpunit handle multiple covers annotation:
```
/**
 * @covers ClassOne
 * @covers ClassTwo
 */
```

The coverage solver was only allowed to return `ClassOne` or `ClassTwo` since it was transformed to `[ClassName]`. Returning `[ClassOne, ClassTwo]` was transform to [[ClassOne, ClassTwo]]` which was creating an error with phpunit. This PR fixed this case.