### PR TITLE
[PHPUnit Bridge] Avoid registering listener twice

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV5.php
@@ -23,8 +23,6 @@ class CommandForV5 extends \PHPUnit_TextUI_Command
      */
     protected function createRunner()
     {
-        $listener = new SymfonyTestsListenerForV5();
-
         $this->arguments['listeners'] = isset($this->arguments['listeners']) ? $this->arguments['listeners'] : array();
 
         $registeredLocally = false;
@@ -37,8 +35,21 @@ class CommandForV5 extends \PHPUnit_TextUI_Command
             }
         }
 
+        if (isset($this->arguments['configuration'])) {
+            $configuration = $this->arguments['configuration'];
+            if (!$configuration instanceof \PHPUnit_Util_Configuration) {
+                $configuration = \PHPUnit_Util_Configuration::getInstance($this->arguments['configuration']);
+            }
+            foreach ($configuration->getListenerConfiguration() as $registeredListener) {
+                if ('Symfony\Bridge\PhpUnit\SymfonyTestsListener' === ltrim($registeredListener['class'], '\\')) {
+                    $registeredLocally = true;
+                    break;
+                }
+            }
+        }
+
         if (!$registeredLocally) {
-            $this->arguments['listeners'][] = $listener;
+            $this->arguments['listeners'][] = new SymfonyTestsListenerForV5();
         }
 
         return parent::createRunner();


### PR DESCRIPTION
The listener can be registered via configuration by the user. In that
case, we do not want to add it again to the list of listeners.
Closes #31649

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a