### PR TITLE
[PhpUnitBridge] Remove deprecated methods assertArraySubset

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
@@ -70,6 +70,6 @@ class JsonLoginTest extends AbstractWebTestCase
 
         $this->assertSame(400, $response->getStatusCode());
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
-        $this->assertArraySubset(['error' => ['code' => 400, 'message' => 'Bad Request']], json_decode($response->getContent(), true));
+        $this->assertSame(['error' => ['code' => 400, 'message' => 'Bad Request']], json_decode($response->getContent(), true));
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
@@ -54,7 +54,7 @@ class JsonSerializableNormalizerTest extends TestCase
             ->expects($this->once())
             ->method('normalize')
             ->willReturnCallback(function ($data) {
-                $this->assertArraySubset(['foo' => 'a', 'bar' => 'b', 'baz' => 'c'], $data);
+                $this->assertSame(['foo' => 'a', 'bar' => 'b', 'baz' => 'c'], array_diff_key($data, ['qux' => '']));
 
                 return 'string_object';
             })


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | 

This PR removes the 2 occurrences of assertArraySubset