### PR TITLE
[Yaml] PHP-8: Uncaught TypeError: abs() expects parameter 1 to be int or float, string given

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -715,7 +715,7 @@ class Parser
         if (self::preg_match('/^(?:'.self::TAG_PATTERN.' +)?'.self::BLOCK_SCALAR_HEADER_PATTERN.'$/', $value, $matches)) {
             $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : '';
 
-            $data = $this->parseBlockScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs($modifiers));
+            $data = $this->parseBlockScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs((int) $modifiers));
 
             if ('' !== $matches['tag']) {
                 if ('!!binary' === $matches['tag']) {

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2307,6 +2307,48 @@ YAML;
 
         $this->assertSame(['parameters' => 'abc'], $this->parser->parse($yaml));
     }
+
+    public function testParseValueWithModifiers()
+    {
+        $yaml = <<<YAML
+parameters:
+    abc: |+5 # plus five spaces indent
+         one
+         two
+         three
+         four
+         five
+YAML;
+        $this->assertSame(
+            [
+                'parameters' => [
+                    'abc' => implode("\n", ['one', 'two', 'three', 'four', 'five']),
+                ],
+            ],
+            $this->parser->parse($yaml)
+        );
+    }
+
+    public function testParseValueWithNegativeModifiers()
+    {
+        $yaml = <<<YAML
+parameters:
+    abc: |-3 # minus
+       one
+       two
+       three
+       four
+       five
+YAML;
+        $this->assertSame(
+            [
+                'parameters' => [
+                    'abc' => implode("\n", ['one', 'two', 'three', 'four', 'five']),
+                ],
+            ],
+            $this->parser->parse($yaml)
+        );
+    }
 }
 
 class B


### PR DESCRIPTION
[Yaml] PHP-8: Uncaught TypeError: abs() expects parameter 1 to be int or float, string given

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| License       | MIT

In additional for PR: https://github.com/symfony/symfony/pull/32862