### PR TITLE
[Routing] Add a warning about the getRouteCollection() method

### DIFF
--- a/src/Symfony/Component/Routing/RouterInterface.php
+++ b/src/Symfony/Component/Routing/RouterInterface.php
@@ -26,6 +26,9 @@ interface RouterInterface extends UrlMatcherInterface, UrlGeneratorInterface
     /**
      * Gets the RouteCollection instance associated with this Router.
      *
+     * WARNING: This method should never be used at runtime as it is SLOW.
+     *          You might use it in a cache warmer though.
+     *
      * @return RouteCollection A RouteCollection instance
      */
     public function getRouteCollection();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

In #19274, we tried to deprecate `RouterInterface::getRouteCollection()`, but failed at doing so. I propose to add a warning about why one should never use it at runtime as a first step.
