### PR TITLE
[PhpUnitBridge] make the bridge act as a polyfill for newest PHPUnit features

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * made the bridge act as a polyfill for newest PHPUnit features
+ * added `SetUpTearDownTrait` to allow working around the `void` return-type added by PHPUnit 8
+
 4.3.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

It's been quite a tunnel these days with @jderusse but here we are: the phpunit-bridge is now a fully working polyfill for newest PHPUnit features. All related PRs have been merged as "minor" but they are now ready for prime time, hence this PR that I'd like to be merged as "feature", to make it part of the changelog of Symfony 4.4.

As of version 4.4, the `simple-phpunit` script will run an augmented version of PHPUnit, that will provide the newest assertions of PHPUnit 8 even if you happen to be running PHPUnit 4.8+ (because you still need to test on PHP 5.5, as Symfony does.)

The bridge currently provides polyfills for the methods that are needed to make our tests pass on PHP 7.4 with no deprecations:
- #32878 #32907 `assertString(Not)ContainsString(IgnoringCase)`, `assertEqualsWithDelta` and `assert(Not)ContainsEquals`
- #32875 `expectException*`, which replace `@expectedException*` annotations
- #32846 `assertIs*`, which replace `assertInternalType`
- #32865 `create(Partial)Mock`
- #32931 `assert(File|Directory)(Not)(Exists|IsReadable|IsWritable)`

More polyfills might be added if you need them. PRs welcome as usual.

As of #32882, when the `SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT` is set to `1`, `simple-phpunit` will also [patch](https://github.com/symfony/symfony/blob/884669b83b131df8c3c41ad6517abe8cff7903b0/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php#L149) the source of PHPUnit 8 to remove the `void` return-type on `setUp*`/`tearDown*`. This is required when the same codebase must be tested against PHP 5.5 up to 7.4+ (as does our branch 3.4). For codebases that don't want or can't run their tests with `simple-phpunit` but want to run their PHP 5.5 tests with PHPUnit 8, the bridge provides a new `SetUpTearDownTrait` that allows a [smooth transition](https://github.com/php-cache/integration-tests/blob/c59a4d2dec1e462e5f5646e5fe102f403d6b8903/src/CachePoolTest.php#L21) to it.

Along the path, we also created a new tool for our CI: it's now possible to submit a new polyfill on the current feature-branch (4.4 these days) and test it with a PR on another branch. See #32887 for the patch.

All these new features have been added to achieve PHP 7.4 support on branch 3.4. There are still many deprecations that need to be fixed, all tracked in #32844. It should be a pretty nice list of "good first issues". Thank you @luispabon, @tweichart, @Alexander1000 BTW.

A big specific thank you to @jderusse for the help!

Let's rock PHP 7.4, can't wait for your PRs, see you on #32844 :)