### PR TITLE
[cs-fixer] Use PhpUnit native assertions in filsystem checks

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,7 +9,7 @@ return PhpCsFixer\Config::create()
         '@Symfony' => true,
         '@Symfony:risky' => true,
         '@PHPUnit75Migration:risky' => true,
-        'php_unit_dedicate_assert' => ['target' => '3.5'],
+        'php_unit_dedicate_assert' => ['target' => '5.6'],
         'phpdoc_no_empty_return' => false, // triggers almost always false positive
         'array_syntax' => ['syntax' => 'short'],
         'fopen_flags' => false,

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -153,7 +153,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->copy($sourceFilePath, $targetFilePath);
 
-        $this->assertTrue(is_dir($targetFileDirectory));
+        $this->assertDirectoryExists($targetFileDirectory);
         $this->assertFileExists($targetFilePath);
         $this->assertStringEqualsFile($targetFilePath, 'SOURCE FILE');
     }
@@ -185,7 +185,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->mkdir($directory);
 
-        $this->assertTrue(is_dir($directory));
+        $this->assertDirectoryExists($directory);
     }
 
     public function testMkdirCreatesDirectoriesFromArray()
@@ -197,9 +197,9 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->mkdir($directories);
 
-        $this->assertTrue(is_dir($basePath.'1'));
-        $this->assertTrue(is_dir($basePath.'2'));
-        $this->assertTrue(is_dir($basePath.'3'));
+        $this->assertDirectoryExists($basePath.'1');
+        $this->assertDirectoryExists($basePath.'2');
+        $this->assertDirectoryExists($basePath.'3');
     }
 
     public function testMkdirCreatesDirectoriesFromTraversableObject()
@@ -211,9 +211,9 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->mkdir($directories);
 
-        $this->assertTrue(is_dir($basePath.'1'));
-        $this->assertTrue(is_dir($basePath.'2'));
-        $this->assertTrue(is_dir($basePath.'3'));
+        $this->assertDirectoryExists($basePath.'1');
+        $this->assertDirectoryExists($basePath.'2');
+        $this->assertDirectoryExists($basePath.'3');
     }
 
     public function testMkdirCreatesDirectoriesFails()
@@ -347,7 +347,7 @@ class FilesystemTest extends FilesystemTestCase
 
         // create symlink to dir using trailing forward slash
         $this->filesystem->symlink($basePath.'dir/', $basePath.'dir-link');
-        $this->assertTrue(is_dir($basePath.'dir-link'));
+        $this->assertDirectoryExists($basePath.'dir-link');
 
         // create symlink to nonexistent dir
         rmdir($basePath.'dir');
@@ -825,7 +825,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->assertFalse(is_link($link));
         $this->assertFalse(is_file($link));
-        $this->assertFalse(is_dir($link));
+        $this->assertDirectoryNotExists($link);
     }
 
     public function testSymlinkIsOverwrittenIfPointsToDifferentTarget()
@@ -1170,8 +1170,8 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->mirror($sourcePath, $targetPath);
 
-        $this->assertTrue(is_dir($targetPath));
-        $this->assertTrue(is_dir($targetPath.'directory'));
+        $this->assertDirectoryExists($targetPath);
+        $this->assertDirectoryExists($targetPath.'directory');
         $this->assertFileEquals($file1, $targetPath.'directory'.\DIRECTORY_SEPARATOR.'file1');
         $this->assertFileEquals($file2, $targetPath.'file2');
 
@@ -1204,7 +1204,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->mirror($sourcePath, $targetPath);
 
-        $this->assertTrue(is_dir($targetPath));
+        $this->assertDirectoryExists($targetPath);
 
         $this->filesystem->remove($sourcePath);
     }
@@ -1223,7 +1223,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->mirror($sourcePath, $targetPath);
 
-        $this->assertTrue(is_dir($targetPath));
+        $this->assertDirectoryExists($targetPath);
         $this->assertFileEquals($sourcePath.'file1', $targetPath.'link1');
         $this->assertTrue(is_link($targetPath.\DIRECTORY_SEPARATOR.'link1'));
     }
@@ -1243,7 +1243,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->mirror($sourcePath, $targetPath);
 
-        $this->assertTrue(is_dir($targetPath));
+        $this->assertDirectoryExists($targetPath);
         $this->assertFileEquals($sourcePath.'/nested/file1.txt', $targetPath.'link1/file1.txt');
         $this->assertTrue(is_link($targetPath.\DIRECTORY_SEPARATOR.'link1'));
     }
@@ -1267,7 +1267,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->mirror($sourcePath, $targetPath);
 
-        $this->assertTrue(is_dir($targetPath));
+        $this->assertDirectoryExists($targetPath);
         $this->assertFileEquals($sourcePath.'/nested/file1.txt', $targetPath.'link1/file1.txt');
         $this->assertTrue(is_link($targetPath.\DIRECTORY_SEPARATOR.'link1'));
         $this->assertEquals('\\' === \DIRECTORY_SEPARATOR ? realpath($sourcePath.'\nested') : 'nested', readlink($targetPath.\DIRECTORY_SEPARATOR.'link1'));
@@ -1290,7 +1290,7 @@ class FilesystemTest extends FilesystemTestCase
 
         chdir($oldPath);
 
-        $this->assertTrue(is_dir($targetPath));
+        $this->assertDirectoryExists($targetPath);
         $this->assertFileExists($targetPath.'source');
         $this->assertFileExists($targetPath.'target');
     }
@@ -1315,7 +1315,7 @@ class FilesystemTest extends FilesystemTestCase
 
         chdir($oldPath);
 
-        $this->assertTrue(is_dir($targetPath));
+        $this->assertDirectoryExists($targetPath);
         $this->assertFileExists($targetPath.'source');
         $this->assertFileNotExists($targetPath.'target');
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -43,7 +43,7 @@ class NativeFileSessionHandlerTest extends TestCase
     {
         $handler = new NativeFileSessionHandler($savePath);
         $this->assertEquals($expectedSavePath, ini_get('session.save_path'));
-        $this->assertTrue(is_dir(realpath($path)));
+        $this->assertDirectoryExists(realpath($path));
 
         rmdir($path);
     }

--- a/src/Symfony/Component/Intl/Tests/IntlTest.php
+++ b/src/Symfony/Component/Intl/Tests/IntlTest.php
@@ -61,7 +61,7 @@ class IntlTest extends TestCase
 
     public function testGetDataDirectoryReturnsThePathToIcuData()
     {
-        $this->assertTrue(is_dir(Intl::getDataDirectory()));
+        $this->assertDirectoryExists(Intl::getDataDirectory());
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/Util/GitRepositoryTest.php
+++ b/src/Symfony/Component/Intl/Tests/Util/GitRepositoryTest.php
@@ -51,7 +51,7 @@ class GitRepositoryTest extends TestCase
         $git = GitRepository::download(self::REPO_URL, $this->targetDir);
 
         $this->assertInstanceOf(GitRepository::class, $git);
-        $this->assertTrue(is_dir($this->targetDir.'/.git'));
+        $this->assertDirectoryExists($this->targetDir.'/.git');
         $this->assertSame($this->targetDir, $git->getPath());
         $this->assertSame(self::REPO_URL, $git->getUrl());
         $this->assertRegExp('#^[0-9a-z]{40}$#', $git->getLastCommitHash());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
| License       | MIT
| Doc PR        | NA

This PR change the minimal value of PhpUnit introduced in #32885 in branche 3.4.
Note: `5.6` is the highest value at the time.