### PR TITLE
[HttpClient] use "idle" instead of "inactivity" when telling about the timeout option

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1348,7 +1348,7 @@ class Configuration implements ConfigurationInterface
                                     ->info('A comma separated list of hosts that do not require a proxy to be reached.')
                                 ->end()
                                 ->floatNode('timeout')
-                                    ->info('Defaults to "default_socket_timeout" ini parameter.')
+                                    ->info('The idle timeout, defaults to the "default_socket_timeout" ini parameter.')
                                 ->end()
                                 ->scalarNode('bindto')
                                     ->info('A network interface name, IP address, a host name or a UNIX socket to bind to.')

--- a/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
@@ -30,7 +30,7 @@ class ErrorChunk implements ChunkInterface
     {
         $this->offset = $offset;
         $this->error = $error;
-        $this->errorMessage = null !== $error ? $error->getMessage() : 'Reading from the response stream reached the inactivity timeout.';
+        $this->errorMessage = null !== $error ? $error->getMessage() : 'Reading from the response stream reached the idle timeout.';
     }
 
     /**

--- a/src/Symfony/Contracts/HttpClient/ChunkInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ChunkInterface.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 interface ChunkInterface
 {
     /**
-     * Tells when the inactivity timeout has been reached.
+     * Tells when the idle timeout has been reached.
      *
      * @throws TransportExceptionInterface on a network error
      */
@@ -36,21 +36,21 @@ interface ChunkInterface
     /**
      * Tells when headers just arrived.
      *
-     * @throws TransportExceptionInterface on a network error or when the inactivity timeout is reached
+     * @throws TransportExceptionInterface on a network error or when the idle timeout is reached
      */
     public function isFirst(): bool;
 
     /**
      * Tells when the body just completed.
      *
-     * @throws TransportExceptionInterface on a network error or when the inactivity timeout is reached
+     * @throws TransportExceptionInterface on a network error or when the idle timeout is reached
      */
     public function isLast(): bool;
 
     /**
      * Returns the content of the response chunk.
      *
-     * @throws TransportExceptionInterface on a network error or when the inactivity timeout is reached
+     * @throws TransportExceptionInterface on a network error or when the idle timeout is reached
      */
     public function getContent(): string;
 

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -52,7 +52,7 @@ interface HttpClientInterface
         'resolve' => [],        // string[] - a map of host to IP address that SHOULD replace DNS resolution
         'proxy' => null,        // string - by default, the proxy-related env vars handled by curl SHOULD be honored
         'no_proxy' => null,     // string - a comma separated list of hosts that do not require a proxy to be reached
-        'timeout' => null,      // float - the inactivity timeout - defaults to ini_get('default_socket_timeout')
+        'timeout' => null,      // float - the idle timeout - defaults to ini_get('default_socket_timeout')
         'bindto' => '0',        // string - the interface or the local socket to bind to
         'verify_peer' => true,  // see https://php.net/context.ssl for the following options
         'verify_host' => true,
@@ -85,7 +85,7 @@ interface HttpClientInterface
      * Yields responses chunk by chunk as they complete.
      *
      * @param ResponseInterface|ResponseInterface[]|iterable $responses One or more responses created by the current HTTP client
-     * @param float|null                                     $timeout   The inactivity timeout before exiting the iterator
+     * @param float|null                                     $timeout   The idle timeout before yielding timeout chunks
      */
     public function stream($responses, float $timeout = null): ResponseStreamInterface;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I feel like this might be easier to understand.
This is also the word I used in the doc.