### PR TITLE
[Form] type cannot be a FormTypeInterface anymore

### DIFF
--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -79,9 +79,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      *
      * This method should not be invoked.
      *
-     * @param string|FormBuilderInterface $child
-     * @param string|FormTypeInterface    $type
-     *
      * @throws BadMethodCallException
      */
     public function add($child, $type = null, array $options = [])
@@ -93,10 +90,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      * Unsupported method.
      *
      * This method should not be invoked.
-     *
-     * @param string                   $name
-     * @param string|FormTypeInterface $type
-     * @param array                    $options
      *
      * @throws BadMethodCallException
      */

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -849,8 +849,8 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
 
             $child = (string) $child;
 
-            if (null !== $type && !\is_string($type) && !$type instanceof FormTypeInterface) {
-                throw new UnexpectedTypeException($type, 'string or Symfony\Component\Form\FormTypeInterface');
+            if (null !== $type && !\is_string($type)) {
+                throw new UnexpectedTypeException($type, 'string or null');
             }
 
             // Never initialize child forms automatically

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -66,8 +66,8 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
             throw new UnexpectedTypeException($child, 'string or Symfony\Component\Form\FormBuilderInterface');
         }
 
-        if (null !== $type && !\is_string($type) && !$type instanceof FormTypeInterface) {
-            throw new UnexpectedTypeException($type, 'string or Symfony\Component\Form\FormTypeInterface');
+        if (null !== $type && !\is_string($type)) {
+            throw new UnexpectedTypeException($type, 'string or null');
         }
 
         // Add to "children" to maintain order

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -120,13 +120,6 @@ class FormBuilderTest extends TestCase
         $this->assertSame(['foo', 'bar', 'baz'], array_keys($children));
     }
 
-    public function testAddFormType()
-    {
-        $this->assertFalse($this->builder->has('foo'));
-        $this->builder->add('foo', $this->getMockBuilder('Symfony\Component\Form\FormTypeInterface')->getMock());
-        $this->assertTrue($this->builder->has('foo'));
-    }
-
     public function testRemove()
     {
         $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Found in #32237. This style of adding FormTypes has been removed in sf 3. Could also be merged in 3.4 if preferred. But there was an outdated, broken test. So 4.4 seems enough as well.
