### PR TITLE
[Form] Fix inconsistencies

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -172,13 +172,13 @@ class ArrayChoiceList implements ChoiceListInterface
     /**
      * Flattens an array into the given output variables.
      *
-     * @param array    $choices          The array to flatten
-     * @param callable $value            The callable for generating choice values
-     * @param array    $choicesByValues  The flattened choices indexed by the
-     *                                   corresponding values
-     * @param array    $keysByValues     The original keys indexed by the
-     *                                   corresponding values
-     * @param array    $structuredValues The values indexed by the original keys
+     * @param array      $choices          The array to flatten
+     * @param callable   $value            The callable for generating choice values
+     * @param array|null $choicesByValues  The flattened choices indexed by the
+     *                                     corresponding values
+     * @param array|null $keysByValues     The original keys indexed by the
+     *                                     corresponding values
+     * @param array|null $structuredValues The values indexed by the original keys
      *
      * @internal
      */

--- a/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
@@ -32,8 +32,7 @@ interface ChoiceListFactoryInterface
      * Null may be passed when the choice list contains the empty value.
      *
      * @param iterable      $choices The choices
-     * @param callable|null $value   The callable generating the choice
-     *                               values
+     * @param callable|null $value   The callable generating the choice values
      *
      * @return ChoiceListInterface The choice list
      */
@@ -46,9 +45,7 @@ interface ChoiceListFactoryInterface
      * The callable receives the choice as only argument.
      * Null may be passed when the choice list contains the empty value.
      *
-     * @param ChoiceLoaderInterface $loader The choice loader
-     * @param callable|null         $value  The callable generating the choice
-     *                                      values
+     * @param callable|null $value The callable generating the choice values
      *
      * @return ChoiceListInterface The choice list
      */
@@ -80,7 +77,6 @@ interface ChoiceListFactoryInterface
      * match the keys of the choices. The values should be arrays of HTML
      * attributes that should be added to the respective choice.
      *
-     * @param ChoiceListInterface $list             The choice list
      * @param array|callable|null $preferredChoices The preferred choices
      * @param callable|null       $label            The callable generating the
      *                                              choice labels

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -30,10 +30,10 @@ class ChoiceView
     /**
      * Creates a new choice view.
      *
-     * @param mixed  $data  The original choice
-     * @param string $value The view representation of the choice
-     * @param string $label The label displayed to humans
-     * @param array  $attr  Additional attributes for the HTML tag
+     * @param mixed        $data  The original choice
+     * @param string       $value The view representation of the choice
+     * @param string|false $label The label displayed to humans; pass false to discard the label
+     * @param array        $attr  Additional attributes for the HTML tag
      */
     public function __construct($data, $value, $label, array $attr = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

- ~~Use `@inheritdoc` in `Button` and `ButtonBuilder` where the method does satisfy the contract.~~
- ~~Add `This method should not be invoked` in all unsupported methods in `Button` and `ButtonBuilder` for consistency.~~
- ~~Fix the misused `idempotent` term in implementations of the `getFormConfig` method. It is wrong in the sense that the method does not always return the same result. You can `setAttribute` for instance and `getFormConfig` will return a different config object.~~
- ~~Add `if ($this->locked)` checks in the supported mutators.~~
- ~~Fix the arguments contract in the `ChoiceListFactoryInterface` — now it supports `PropertyPathInterface` explicitly. The downside of it — breaking LSP in the `DefaultChoiceListFactory`.~~
- Fix the `$label` phpdoc of the `ChoiceView` (arised in https://github.com/symfony/symfony/pull/32237).
- Use `PropertyPathInterface` instead of `PropertyPath` in `PropertyAccessDecorator` of the choice factory.
- Fix `ArrayChoiceList::flatten` type hints.

These changes are debatable, so feel free to correct me if I am wrong at some point.

Ping @xabbuh , @HeahDude , @yceruto , @nicolas-grekas 