### PR TITLE
[Routing] Deprecate RouteCollectionBuilder

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -1,0 +1,13 @@
+UPGRADE FROM 5.0 to 5.1
+=======================
+
+FrameworkBundle
+---------------
+
+ * Marked `MicroKernelTrait::configureRoutes()` as `@internal` and `@final`.
+ * Deprecated not overriding `MicroKernelTrait::configureRouting()`.
+
+Routing
+-------
+
+ * Deprecated `RouteCollectionBuilder` in favor of `RoutingConfigurator`.

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -1,0 +1,13 @@
+UPGRADE FROM 5.x to 6.0
+=======================
+
+FrameworkBundle
+---------------
+
+ * Removed `MicroKernelTrait::configureRoutes()`.
+ * Made `MicroKernelTrait::configureRouting()` abstract.
+
+Routing
+-------
+
+ * Removed `RouteCollectionBuilder`.

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Marked `MicroKernelTrait::configureRoutes()` as `@internal` and `@final`.
+ * Deprecated not overriding `MicroKernelTrait::configureRouting()`.
+
 5.0.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -19,6 +19,18 @@ use Symfony\Component\HttpFoundation\Request;
 
 class MicroKernelTraitTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation Adding routes via the "Symfony\Bundle\FrameworkBundle\Tests\Kernel\MicroKernelWithConfigureRoutes:configureRoutes()" method is deprecated since Symfony 5.1 and will have no effect in 6.0; use "configureRouting()" instead.
+     * @expectedDeprecation Not overriding the "Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait::configureRouting()" method is deprecated since Symfony 5.1 and will trigger a fatal error in 6.0.
+     */
+    public function testConfigureRoutingDeprecated()
+    {
+        $kernel = new MicroKernelWithConfigureRoutes('test', false);
+        $kernel->boot();
+        $kernel->handle(Request::create('/'));
+    }
+
     public function test()
     {
         $kernel = new ConcreteMicroKernel('test', false);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelWithConfigureRoutes.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelWithConfigureRoutes.php
@@ -16,36 +16,15 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
-class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
+class MicroKernelWithConfigureRoutes extends Kernel
 {
     use MicroKernelTrait;
 
     private $cacheDir;
-
-    public function onKernelException(ExceptionEvent $event)
-    {
-        if ($event->getException() instanceof Danger) {
-            $event->setResponse(Response::create('It\'s dangerous to go alone. Take this ⚔'));
-        }
-    }
-
-    public function halloweenAction()
-    {
-        return new Response('halloween');
-    }
-
-    public function dangerousAction()
-    {
-        throw new Danger();
-    }
 
     public function registerBundles(): iterable
     {
@@ -56,7 +35,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
 
     public function getCacheDir(): string
     {
-        return $this->cacheDir = sys_get_temp_dir().'/sf_micro_kernel';
+        return $this->cacheDir = sys_get_temp_dir().'/sf_micro_kernel_with_configured_routes';
     }
 
     public function getLogDir(): string
@@ -80,10 +59,9 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
         $fs->remove($this->cacheDir);
     }
 
-    protected function configureRouting(RoutingConfigurator $routes): void
+    protected function configureRoutes(RouteCollectionBuilder $routes)
     {
-        $routes->add('halloween', '/')->controller('kernel::halloweenAction');
-        $routes->add('danger', '/danger')->controller('kernel::dangerousAction');
+        $routes->add('/', 'kernel::halloweenAction');
     }
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
@@ -92,22 +70,5 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
         $c->loadFromExtension('framework', [
             'secret' => '$ecret',
         ]);
-
-        $c->setParameter('halloween', 'Have a great day!');
-        $c->register('halloween', 'stdClass')->setPublic(true);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            KernelEvents::EXCEPTION => 'onKernelException',
-        ];
-    }
-}
-
-class Danger extends \RuntimeException
-{
 }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -27,7 +27,7 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "^4.4|^5.0",
         "symfony/finder": "^4.4|^5.0",
-        "symfony/routing": "^5.0"
+        "symfony/routing": "^5.1"
     },
     "require-dev": {
         "doctrine/annotations": "~1.7",

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Deprecated `RouteCollectionBuilder` in favor of `RoutingConfigurator`.
+ * Added support for a generic loader to `RoutingConfigurator`.
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -19,6 +19,8 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  * Helps add and import routes into a RouteCollection.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
+ *
+ * @deprecated since Symfony 5.1, use RoutingConfigurator instead
  */
 class RouteCollectionBuilder
 {

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -19,6 +19,9 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
+/**
+ * @group legacy
+ */
 class RouteCollectionBuilderTest extends TestCase
 {
     public function testImport()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #32240 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/12688
| Recipe PR | https://github.com/symfony/recipes/pull/690 

A lot to be done here after the implementation is accepted:
- [x] finish deprecations in the MicroKernelTrait
- [x] deprecate the class
- [x] mention in the CHANGELOG file
- [x] mention in the UPGRADE file
- [x] mark tests as legacy
- [x] add a doc PR
- [x] update the recipe

Ping @Tobion , @nicolas-grekas .