### PR TITLE
Use namespaced Phpunit classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -209,6 +209,7 @@ install:
           git checkout -q FETCH_HEAD -- src/Symfony/Bridge/PhpUnit
           SYMFONY_VERSION=$(cat src/Symfony/Bridge/PhpUnit/composer.json | grep '^ *"dev-master". *"[1-9]' | grep -o '[0-9.]*')
           sed -i 's/"symfony\/phpunit-bridge": ".*"/"symfony\/phpunit-bridge": "'$SYMFONY_VERSION'.x@dev"/' composer.json
+          rm -rf .phpunit
       fi
 
     - |

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -201,7 +201,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
     public function testProcessThrowsExceptionForAutoconfiguredCalls()
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Autoconfigured instanceof for type "PHPUnit\Framework\TestCase" defines method calls but these are not supported and should be removed.');
+        $this->expectExceptionMessageRegExp('/Autoconfigured instanceof for type "PHPUnit[\\\\_]Framework[\\\\_]TestCase" defines method calls but these are not supported and should be removed\./');
         $container = new ContainerBuilder();
         $container->registerForAutoconfiguration(parent::class)
             ->addMethodCall('setFoo');
@@ -212,7 +212,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
     public function testProcessThrowsExceptionForArguments()
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Autoconfigured instanceof for type "PHPUnit\Framework\TestCase" defines arguments but these are not supported and should be removed.');
+        $this->expectExceptionMessageRegExp('/Autoconfigured instanceof for type "PHPUnit[\\\\_]Framework[\\\\_]TestCase" defines arguments but these are not supported and should be removed\./');
         $container = new ContainerBuilder();
         $container->registerForAutoconfiguration(parent::class)
             ->addArgument('bar');

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Config;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\ResourceCheckerInterface;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
@@ -52,15 +53,15 @@ class ContainerParametersResourceCheckerTest extends TestCase
 
     public function isFreshProvider()
     {
-        yield 'not fresh on missing parameter' => [function (\PHPUnit_Framework_MockObject_MockObject $container) {
+        yield 'not fresh on missing parameter' => [function (MockObject $container) {
             $container->method('hasParameter')->with('locales')->willReturn(false);
         }, false];
 
-        yield 'not fresh on different value' => [function (\PHPUnit_Framework_MockObject_MockObject $container) {
+        yield 'not fresh on different value' => [function (MockObject $container) {
             $container->method('getParameter')->with('locales')->willReturn(['nl', 'es']);
         }, false];
 
-        yield 'fresh on every identical parameters' => [function (\PHPUnit_Framework_MockObject_MockObject $container) {
+        yield 'fresh on every identical parameters' => [function (MockObject $container) {
             $container->expects($this->exactly(2))->method('hasParameter')->willReturn(true);
             $container->expects($this->exactly(2))->method('getParameter')
                 ->withConsecutive(

--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -20,11 +20,7 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
-        } else {
-            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
-        }
+        \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
 
         $this->addToAssertionCount(1);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPassTest.php
@@ -26,7 +26,7 @@ class RemoveEmptyControllerArgumentLocatorsPassTest extends TestCase
         $resolver = $container->register('argument_resolver.service')->addArgument([]);
 
         $container->register('stdClass', 'stdClass');
-        $container->register(parent::class, 'stdClass');
+        $container->register(TestCase::class, 'stdClass');
         $container->register('c1', RemoveTestController1::class)->addTag('controller.service_arguments');
         $container->register('c2', RemoveTestController2::class)->addTag('controller.service_arguments')
             ->addMethodCall('setTestCase', [new Reference('c1')]);

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Intl\Tests\NumberFormatter;
 
+use PHPUnit\Framework\Error\Warning;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Intl\Globals\IntlGlobals;
 use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
@@ -323,13 +324,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
      */
     public function testFormatTypeCurrency($formatter, $value)
     {
-        $exceptionCode = 'PHPUnit\Framework\Error\Warning';
-
-        if (class_exists('PHPUnit_Framework_Error_Warning')) {
-            $exceptionCode = 'PHPUnit_Framework_Error_Warning';
-        }
-
-        $this->expectException($exceptionCode);
+        $this->expectException(Warning::class);
 
         $formatter->format($value, NumberFormatter::TYPE_CURRENCY);
     }
@@ -706,13 +701,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
 
     public function testParseTypeDefault()
     {
-        $exceptionCode = 'PHPUnit\Framework\Error\Warning';
-
-        if (class_exists('PHPUnit_Framework_Error_Warning')) {
-            $exceptionCode = 'PHPUnit_Framework_Error_Warning';
-        }
-
-        $this->expectException($exceptionCode);
+        $this->expectException(Warning::class);
 
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->parse('1', NumberFormatter::TYPE_DEFAULT);
@@ -832,13 +821,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
 
     public function testParseTypeCurrency()
     {
-        $exceptionCode = 'PHPUnit\Framework\Error\Warning';
-
-        if (class_exists('PHPUnit_Framework_Error_Warning')) {
-            $exceptionCode = 'PHPUnit_Framework_Error_Warning';
-        }
-
-        $this->expectException($exceptionCode);
+        $this->expectException(Warning::class);
 
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $formatter->parse('1', NumberFormatter::TYPE_CURRENCY);

--- a/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
@@ -20,11 +20,7 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
-        } else {
-            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
-        }
+        \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
 
         $this->addToAssertionCount(1);
     }

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -20,11 +20,7 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        if (class_exists('PHPUnit_Util_XML')) {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
-        } else {
-            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
-        }
+        \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
 
         $this->addToAssertionCount(1);
     }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -45,10 +45,6 @@ class ParserTest extends TestCase
                 if (E_USER_DEPRECATED !== $type) {
                     restore_error_handler();
 
-                    if (class_exists('PHPUnit_Util_ErrorHandler')) {
-                        return \call_user_func_array('PHPUnit_Util_ErrorHandler::handleError', \func_get_args());
-                    }
-
                     return \call_user_func_array('PHPUnit\Util\ErrorHandler::handleError', \func_get_args());
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | need #32940
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

This PR simplify tests by using PhpUnit namespace introduced in #32940
It also makes compatible with PHPUnit 8 (removed class PHPUnit_Framework_MockObject_MockObject)