### PR TITLE
[Yaml] Removed unused $nullAsTilde property

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -33,7 +33,6 @@ class Inline
     private static $objectSupport = false;
     private static $objectForMap = false;
     private static $constantSupport = false;
-    private static $nullAsTilde = false;
 
     /**
      * @param int         $flags
@@ -46,7 +45,6 @@ class Inline
         self::$objectSupport = (bool) (Yaml::PARSE_OBJECT & $flags);
         self::$objectForMap = (bool) (Yaml::PARSE_OBJECT_FOR_MAP & $flags);
         self::$constantSupport = (bool) (Yaml::PARSE_CONSTANT & $flags);
-        self::$nullAsTilde = (bool) (Yaml::DUMP_NULL_AS_TILDE & $flags);
         self::$parsedFilename = $parsedFilename;
 
         if (null !== $parsedLineNumber) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

#32669 added a new private property `$nullAsTilde`, but that property was never used, so this PR removes the unused property