### PR TITLE
[HttpClient] Improve timeouts errors messages

### DIFF
--- a/src/Symfony/Component/HttpClient/Chunk/TimeoutChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/TimeoutChunk.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Chunk;
+
+use Symfony\Component\HttpClient\Exception\TransportException;
+
+/**
+ * @internal
+ */
+class TimeoutChunk extends ErrorChunk
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(int $offset, string $url, float $seconds)
+    {
+        parent::__construct($offset, TransportException::readTimeoutReached($url, $seconds));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTimeout(): bool
+    {
+        $this->didThrow = true;
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpClient/Exception/TransportException.php
+++ b/src/Symfony/Component/HttpClient/Exception/TransportException.php
@@ -18,4 +18,13 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
  */
 final class TransportException extends \RuntimeException implements TransportExceptionInterface
 {
+    public static function connectionTimeoutReached(string $url, float $seconds): self
+    {
+        return new self(sprintf('Failed connecting to "%s". The idle timeout was reached after %s second%s.', $url, $seconds, $seconds > 1 ? 's' : ''));
+    }
+
+    public static function readTimeoutReached(string $url, float $seconds): self
+    {
+        return new self(sprintf('Failed reading the complete response stream from "%s". The idle timeout was reached after %s second%s.', $url, $seconds, $seconds > 1 ? 's' : ''));
+    }
 }

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\HttpClient\Response;
 
-use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
+use Symfony\Component\HttpClient\Chunk\TimeoutChunk;
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\ClientState;
@@ -28,6 +28,8 @@ class MockResponse implements ResponseInterface
     use ResponseTrait {
         doDestruct as public __destruct;
     }
+
+    public const DEFAULT_TIMEOUT_VALUE = 1;
 
     private $body;
     private $requestOptions = [];
@@ -278,7 +280,7 @@ class MockResponse implements ResponseInterface
             foreach ($body as $chunk) {
                 if ('' === $chunk = (string) $chunk) {
                     // simulate a timeout
-                    $response->body[] = new ErrorChunk($offset);
+                    $response->body[] = new TimeoutChunk($offset, $response->info['url'], $response->timeout ?? $response->requestOptions['timeout'] ?? self::DEFAULT_TIMEOUT_VALUE);
                 } else {
                     $response->body[] = $chunk;
                     $offset += \strlen($chunk);

--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpClient\Chunk\DataChunk;
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Chunk\LastChunk;
+use Symfony\Component\HttpClient\Chunk\TimeoutChunk;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\HttpClient\Exception\RedirectionException;
@@ -308,7 +309,8 @@ trait ResponseTrait
                         unset($responses[$j]);
                         continue;
                     } elseif ($isTimeout) {
-                        $multi->handlesActivity[$j] = [new ErrorChunk($response->offset)];
+                        $info = $response->getInfo();
+                        $multi->handlesActivity[$j] = [new TimeoutChunk($response->offset, $info['url'], $timeoutMax)];
                     } else {
                         continue;
                     }

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -107,7 +107,7 @@ class MockHttpClientTest extends HttpClientTestCase
                 $mock = $this->getMockBuilder(ResponseInterface::class)->getMock();
                 $mock->expects($this->any())
                     ->method('getHeaders')
-                    ->willThrowException(new TransportException('Timeout'));
+                    ->willThrowException(TransportException::readTimeoutReached('http://localhost:8057/timeout-header', 0.1));
 
                 $responses[] = $mock;
                 break;
@@ -115,7 +115,7 @@ class MockHttpClientTest extends HttpClientTestCase
             case 'testResolve':
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);
-                $responses[] = new MockResponse((function () { throw new \Exception('Fake connection timeout'); yield ''; })(), ['response_headers' => $headers]);
+                $responses[] = new MockResponse((function () { throw TransportException::connectionTimeoutReached('http://symfony.com:8057/', 3); yield ''; })(), ['response_headers' => $headers]);
                 break;
 
             case 'testTimeoutOnStream':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The goal is to have common better messages to help users to understand timeouts errors (idle on connect / read) (+ max duration once it's merged).
Having the same message between inner transports also looks coherent with the spirit of the component that is to not leak the inner implementations.
It could be done on 4.3.