### PR TITLE
[Intl] Support DateTimeInterface in IntlDateFormatter::format

### DIFF
--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -176,7 +176,7 @@ class IntlDateFormatter
     /**
      * Format the date/time value (timestamp) as a string.
      *
-     * @param int|\DateTime $timestamp The timestamp to format
+     * @param int|\DateTimeInterface $timestamp The timestamp to format
      *
      * @return string|bool The formatted value or false if formatting failed
      *
@@ -195,7 +195,7 @@ class IntlDateFormatter
 
         // behave like the intl extension
         $argumentError = null;
-        if (!\is_int($timestamp) && !$timestamp instanceof \DateTime) {
+        if (!\is_int($timestamp) && !$timestamp instanceof \DateTimeInterface) {
             $argumentError = sprintf('datefmt_format: string \'%s\' is not numeric, which would be required for it to be a valid date', $timestamp);
         }
 
@@ -207,7 +207,7 @@ class IntlDateFormatter
             return false;
         }
 
-        if ($timestamp instanceof \DateTime) {
+        if ($timestamp instanceof \DateTimeInterface) {
             $timestamp = $timestamp->getTimestamp();
         }
 

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -76,6 +76,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     public function formatProvider()
     {
         $dateTime = new \DateTime('@0');
+        $dateTimeImmutable = new \DateTimeImmutable('@0');
 
         $formatData = [
             /* general */
@@ -250,6 +251,12 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $formatData[] = ['h:mm a', $dateTime, '12:00 AM'];
         $formatData[] = ['yyyyy.MMMM.dd hh:mm aaa', $dateTime, '01970.January.01 12:00 AM'];
 
+        /* general, DateTimeImmutable */
+        $formatData[] = ['y-M-d', $dateTimeImmutable, '1970-1-1'];
+        $formatData[] = ["EEE, MMM d, ''yy", $dateTimeImmutable, "Thu, Jan 1, '70"];
+        $formatData[] = ['h:mm a', $dateTimeImmutable, '12:00 AM'];
+        $formatData[] = ['yyyyy.MMMM.dd hh:mm aaa', $dateTimeImmutable, '01970.January.01 12:00 AM'];
+
         if (IcuVersion::compare(Intl::getIcuVersion(), '59.1', '>=', 1)) {
             // Before ICU 59.1 GMT was used instead of UTC
             $formatData[] = ["yyyy.MM.dd 'at' HH:mm:ss zzz", 0, '1970.01.01 at 00:00:00 UTC'];
@@ -272,6 +279,8 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
 
         $this->assertSame('1970.01.01 at 00:00:00 GMT', $gmtFormatter->format(new \DateTime('@0')));
         $this->assertSame('1970.01.01 at 00:00:00 UTC', $utcFormatter->format(new \DateTime('@0')));
+        $this->assertSame('1970.01.01 at 00:00:00 GMT', $gmtFormatter->format(new \DateTimeImmutable('@0')));
+        $this->assertSame('1970.01.01 at 00:00:00 UTC', $utcFormatter->format(new \DateTimeImmutable('@0')));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32898
| License       | MIT
| Doc PR        | N/A

Add support for `DateTimeInterface` to `IntlDateFormatter::format` which is supported since PHP 7.1.5.

Since this component supports PHP from 7.1.3, should version checks be added, to only support DateTimeInterface if PHP is >= 7.1.5 or should the minimum required PHP version bumped to 7.1.5?