### PR TITLE
[Form] use a choice label normalizer instead of violating ChoiceListFactoryInterface::createView

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -124,7 +124,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         if (null === $label) {
             // If the labels are null, use the original choice key by default
             $label = (string) $key;
-        } elseif (false !== $label) {
+        } else {
             // If "choice_label" is set to false and "expanded" is true, the value false
             // should be passed on to the "label" option of the checkboxes/radio buttons
             $dynamicLabel = \call_user_func($label, $choice, $key, $value);

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -312,6 +312,16 @@ class ChoiceType extends AbstractType
             return $choiceTranslationDomain;
         };
 
+        $choiceLabelNormalizer = function (Options $options, $choiceLabel) {
+            if (false === $choiceLabel) {
+                return function () {
+                    return false;
+                };
+            }
+
+            return $choiceLabel;
+        };
+
         $resolver->setDefaults([
             'multiple' => false,
             'expanded' => false,
@@ -339,6 +349,7 @@ class ChoiceType extends AbstractType
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);
         $resolver->setNormalizer('choice_translation_domain', $choiceTranslationDomainNormalizer);
         $resolver->setNormalizer('choices_as_values', $choicesAsValuesNormalizer);
+        $resolver->setNormalizer('choice_label', $choiceLabelNormalizer);
 
         $resolver->setAllowedTypes('choices', ['null', 'array', '\Traversable']);
         $resolver->setAllowedTypes('choice_translation_domain', ['null', 'bool', 'string']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Continuation of #32935 which offers a slightly different implementation of #17798 
This way, `'choice_label' => false` does not need to be passed to `\Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface::createView` which violates `@param callable|null       $label`. So we can add a real callable type in #32237