### PR TITLE
Clarify VoterInterface with multiple attributes

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -30,6 +30,9 @@ interface VoterInterface
      * This method must return one of the following constants:
      * ACCESS_GRANTED, ACCESS_DENIED, or ACCESS_ABSTAIN.
      *
+     * If more than one attribute is passed, the voter must grant access if access is granted to any of
+     * the given attributes.
+     *
      * @param TokenInterface $token      A TokenInterface instance
      * @param mixed          $subject    The subject to secure
      * @param array          $attributes An array of attributes associated with the method being invoked


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

According to the `Voter` [source code](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php#L41), passing multiple attributes to `vote()` acts as an `OR`, i.e. grant access if *any* of the attributes is granted.

It looks like this is not documented, neither in the source code nor in the docs.