### PR TITLE
[Security\Http] Drop some useless param phpdoc annotations

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -109,8 +109,7 @@ class SwitchUserListener implements ListenerInterface
     /**
      * Attempts to switch to another user.
      *
-     * @param Request $request  A Request instance
-     * @param string  $username
+     * @param string $username
      *
      * @return TokenInterface|null The new TokenInterface if successfully switched, null otherwise
      *

--- a/src/Symfony/Component/Security/Http/ParameterBagUtils.php
+++ b/src/Symfony/Component/Security/Http/ParameterBagUtils.php
@@ -29,8 +29,7 @@ final class ParameterBagUtils
      *
      * Paths like foo[bar] will be evaluated to find deeper items in nested data structures.
      *
-     * @param ParameterBag $parameters The parameter bag
-     * @param string       $path       The key
+     * @param string $path The key
      *
      * @return mixed
      *
@@ -64,8 +63,7 @@ final class ParameterBagUtils
      *
      * Paths like foo[bar] will be evaluated to find deeper items in nested data structures.
      *
-     * @param Request $request The request
-     * @param string  $path    The key
+     * @param string $path The key
      *
      * @return mixed
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

#32314 is removing some `@param` annotations in favor of scalar typehints, this removes the ones which were already useless on 3.4 (compound typehints).