### PR TITLE
[HttpFoundation] reintroduce set trusted header name in request

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * passing arguments to `Request::isMethodSafe()` is deprecated.
  * `ApacheRequest` is deprecated, use the `Request` class instead.
+ * added `setTrustedHeaderName()` method to the `Request` class.
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -611,6 +611,23 @@ class Request
     }
 
     /**
+     * Sets the name for trusted headers.
+     *
+     * @param int    $type  A bit field like Request::HEADER_*, to set which headers to trust from your proxies
+     * @param string $value The header name
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function setTrustedHeaderName(int $type, string $value): void
+    {
+        if (!isset(self::$trustedHeaders[$type])) {
+            throw new \InvalidArgumentException(sprintf('Unable to set the trusted header name for type "%s".', $type));
+        }
+
+        self::$trustedHeaders[$type] = $value;
+    }
+
+    /**
      * Gets the list of trusted host patterns.
      *
      * @return array An array of trusted host patterns

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2325,6 +2325,20 @@ class RequestTest extends TestCase
 
         $this->assertSame(80, $request->getPort());
     }
+
+    public function testSetTrustedHeaderName()
+    {
+        $request = Request::create('http://example.com/');
+        $request->server->set('REMOTE_ADDR', '1.1.1.1');
+        $request->headers->set('X_CUSTOM_FORWARDED_PORT', '8888');
+
+        $this->assertSame(80, $request->getPort());
+
+        $request::setTrustedHeaderName(Request::HEADER_X_FORWARDED_PORT, 'X_CUSTOM_FORWARDED_PORT');
+        Request::setTrustedProxies(['1.1.1.1'], Request::HEADER_X_FORWARDED_PORT);
+
+        $this->assertSame(8888, $request->getPort());
+    }
 }
 
 class RequestContentProxy extends Request


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26333   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | TODO <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

I think it could be great to reintroduce in a simple way the ability to support custom header names .

Indeed, not everyone can use "standard" header name (see https://github.com/fideloper/TrustedProxy/issues/108 for instance).
Some people start using workaround like https://github.com/jdavidbakr/CloudfrontProxies.

I personally need it for some Drupal sites.