### PR TITLE
[DependencyInjection] Detect circular references when using configurator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -125,12 +125,12 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass implements Repe
         $this->byConstructor = $isRoot || $byConstructor;
         $this->processValue($value->getFactory());
         $this->processValue($value->getArguments());
+        $this->processValue($value->getConfigurator());
         $this->byConstructor = $byConstructor;
 
         if (!$this->onlyConstructorArguments) {
             $this->processValue($value->getProperties());
             $this->processValue($value->getMethodCalls());
-            $this->processValue($value->getConfigurator());
         }
         $this->lazy = $lazy;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
@@ -85,6 +85,22 @@ class CheckCircularReferencesPassTest extends TestCase
         $this->process($container);
     }
 
+    public function testProcessDetectsIndirectCircularReferenceWithConfigurator()
+    {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');
+        $container = new ContainerBuilder();
+
+        $container->register('a')->addArgument(new Reference('b'));
+
+        $container
+            ->register('b', 'stdClass')
+            ->setConfigurator([new Reference('c'), 'getInstance']);
+
+        $container->register('c')->addArgument(new Reference('a'));
+
+        $this->process($container);
+    }
+
     public function testDeepCircularReference()
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32959
| License       | MIT
| Doc PR        | N/A

Detect circular references when using a configurator.
