### PR TITLE
Use assertEqualsWithDelta when needed

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -119,7 +119,7 @@ class CookieTest extends TestCase
         $cookie = new Cookie('foo', 'bar', $value);
         $expire = strtotime($value);
 
-        $this->assertEquals($expire, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date', 1);
+        $this->assertEqualsWithDelta($expire, $cookie->getExpiresTime(), 1, '->getExpiresTime() returns the expire date');
     }
 
     public function testGetDomain()

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -806,7 +806,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
     {
         $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
         $parsedValue = $formatter->parse($value, NumberFormatter::TYPE_DOUBLE);
-        $this->assertEquals($expectedValue, $parsedValue, '', 0.001);
+        $this->assertEqualsWithDelta($expectedValue, $parsedValue, 0.001);
     }
 
     public function parseTypeDoubleProvider()

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -73,7 +73,7 @@ class StopwatchEventTest extends TestCase
         $event->start();
         usleep(200000);
         $event->stop();
-        $this->assertEquals(200, $event->getDuration(), '', self::DELTA);
+        $this->assertEqualsWithDelta(200, $event->getDuration(), self::DELTA);
 
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
@@ -83,7 +83,7 @@ class StopwatchEventTest extends TestCase
         $event->start();
         usleep(100000);
         $event->stop();
-        $this->assertEquals(200, $event->getDuration(), '', self::DELTA);
+        $this->assertEqualsWithDelta(200, $event->getDuration(), self::DELTA);
     }
 
     public function testDurationBeforeStop()
@@ -91,7 +91,7 @@ class StopwatchEventTest extends TestCase
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
         usleep(200000);
-        $this->assertEquals(200, $event->getDuration(), '', self::DELTA);
+        $this->assertEqualsWithDelta(200, $event->getDuration(), self::DELTA);
 
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
@@ -100,7 +100,7 @@ class StopwatchEventTest extends TestCase
         usleep(50000);
         $event->start();
         usleep(100000);
-        $this->assertEquals(100, $event->getDuration(), '', self::DELTA);
+        $this->assertEqualsWithDelta(100, $event->getDuration(), self::DELTA);
     }
 
     public function testStopWithoutStart()
@@ -132,7 +132,7 @@ class StopwatchEventTest extends TestCase
         $event->start();
         usleep(100000);
         $event->ensureStopped();
-        $this->assertEquals(300, $event->getDuration(), '', self::DELTA);
+        $this->assertEqualsWithDelta(300, $event->getDuration(), self::DELTA);
     }
 
     public function testStartTime()
@@ -149,7 +149,7 @@ class StopwatchEventTest extends TestCase
         $event->start();
         usleep(100000);
         $event->stop();
-        $this->assertEquals(0, $event->getStartTime(), '', self::DELTA);
+        $this->assertEqualsWithDelta(0, $event->getStartTime(), self::DELTA);
     }
 
     public function testInvalidOriginThrowsAnException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

This PR replaces deprecated paramèter `$delta` of methods `assertEquals` by the dedicated method `assertEqualsWithDelta`