### PR TITLE
Use assertStringContainsString when needed

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -197,12 +197,12 @@ class ConsoleHandlerTest extends TestCase
 
         $event = new ConsoleCommandEvent(new Command('foo'), $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock(), $output);
         $dispatcher->dispatch(ConsoleEvents::COMMAND, $event);
-        $this->assertContains('Before command message.', $out = $output->fetch());
-        $this->assertContains('After command message.', $out);
+        $this->assertStringContainsString('Before command message.', $out = $output->fetch());
+        $this->assertStringContainsString('After command message.', $out);
 
         $event = new ConsoleTerminateEvent(new Command('foo'), $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock(), $output, 0);
         $dispatcher->dispatch(ConsoleEvents::TERMINATE, $event);
-        $this->assertContains('Before terminate message.', $out = $output->fetch());
-        $this->assertContains('After terminate message.', $out);
+        $this->assertStringContainsString('Before terminate message.', $out = $output->fetch());
+        $this->assertStringContainsString('After terminate message.', $out);
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -33,14 +33,14 @@ class CoverageListenerTest extends TestCase
 
         exec("$php $phpunit -c $dir/phpunit-without-listener.xml.dist $dir/tests/ --coverage-text 2> /dev/null", $output);
         $output = implode("\n", $output);
-        $this->assertContains('FooCov', $output);
+        $this->assertStringContainsString('FooCov', $output);
 
         exec("$php $phpunit -c $dir/phpunit-with-listener.xml.dist $dir/tests/ --coverage-text 2> /dev/null", $output);
         $output = implode("\n", $output);
-        $this->assertNotContains('FooCov', $output);
-        $this->assertContains("SutNotFoundTest::test\nCould not find the tested class.", $output);
-        $this->assertNotContains("CoversTest::test\nCould not find the tested class.", $output);
-        $this->assertNotContains("CoversDefaultClassTest::test\nCould not find the tested class.", $output);
-        $this->assertNotContains("CoversNothingTest::test\nCould not find the tested class.", $output);
+        $this->assertStringNotContainsString('FooCov', $output);
+        $this->assertStringContainsString("SutNotFoundTest::test\nCould not find the tested class.", $output);
+        $this->assertStringNotContainsString("CoversTest::test\nCould not find the tested class.", $output);
+        $this->assertStringNotContainsString("CoversDefaultClassTest::test\nCould not find the tested class.", $output);
+        $this->assertStringNotContainsString("CoversNothingTest::test\nCould not find the tested class.", $output);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -26,7 +26,7 @@ class DebugCommandTest extends TestCase
         $ret = $tester->execute([], ['decorated' => false]);
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('Functions', trim($tester->getDisplay()));
+        $this->assertStringContainsString('Functions', trim($tester->getDisplay()));
     }
 
     public function testLineSeparatorInLoaderPaths()
@@ -59,7 +59,7 @@ Loader Paths
 TXT;
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains($loaderPaths, trim($tester->getDisplay(true)));
+        $this->assertStringContainsString($loaderPaths, trim($tester->getDisplay(true)));
     }
 
     public function testWithGlobals()
@@ -70,7 +70,7 @@ TXT;
 
         $display = $tester->getDisplay();
 
-        $this->assertContains(json_encode($message), $display);
+        $this->assertStringContainsString(json_encode($message), $display);
     }
 
     public function testWithGlobalsJson()

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -31,7 +31,7 @@ class LintCommandTest extends TestCase
         $ret = $tester->execute(['filename' => [$filename]], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]);
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('OK in', trim($tester->getDisplay()));
+        $this->assertStringContainsString('OK in', trim($tester->getDisplay()));
     }
 
     public function testLintIncorrectFile()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -27,7 +27,7 @@ class RouterDebugCommandTest extends TestCase
         $ret = $tester->execute(['name' => null], ['decorated' => false]);
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('Name   Method   Scheme   Host   Path', $tester->getDisplay());
+        $this->assertStringContainsString('Name   Method   Scheme   Host   Path', $tester->getDisplay());
     }
 
     public function testDebugSingleRoute()
@@ -36,7 +36,7 @@ class RouterDebugCommandTest extends TestCase
         $ret = $tester->execute(['name' => 'foo'], ['decorated' => false]);
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('Route Name   | foo', $tester->getDisplay());
+        $this->assertStringContainsString('Route Name   | foo', $tester->getDisplay());
     }
 
     public function testDebugInvalidRoute()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -29,7 +29,7 @@ class RouterMatchCommandTest extends TestCase
         $ret = $tester->execute(['path_info' => '/foo', 'foo'], ['decorated' => false]);
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('Route Name   | foo', $tester->getDisplay());
+        $this->assertStringContainsString('Route Name   | foo', $tester->getDisplay());
     }
 
     public function testWithNotMatchPath()
@@ -38,7 +38,7 @@ class RouterMatchCommandTest extends TestCase
         $ret = $tester->execute(['path_info' => '/test', 'foo'], ['decorated' => false]);
 
         $this->assertEquals(1, $ret, 'Returns 1 in case of failure');
-        $this->assertContains('None of the routes match the path "/test"', $tester->getDisplay());
+        $this->assertStringContainsString('None of the routes match the path "/test"', $tester->getDisplay());
     }
 
     /**
@@ -56,7 +56,7 @@ class RouterMatchCommandTest extends TestCase
 
         $tester->execute(['path_info' => '/']);
 
-        $this->assertContains('None of the routes match the path "/"', $tester->getDisplay());
+        $this->assertStringContainsString('None of the routes match the path "/"', $tester->getDisplay());
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -239,7 +239,7 @@ class TranslationDebugCommandTest extends TestCase
         $tester = new CommandTester($application->find('debug:translation'));
         $tester->execute(['locale' => 'en']);
 
-        $this->assertContains('No defined or extracted', $tester->getDisplay());
+        $this->assertStringContainsString('No defined or extracted', $tester->getDisplay());
     }
 
     private function getBundle($path)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -231,7 +231,7 @@ class TranslationUpdateCommandTest extends TestCase
         $tester = new CommandTester($application->find('translation:update'));
         $tester->execute(['locale' => 'en']);
 
-        $this->assertContains('You must choose one of --force or --dump-messages', $tester->getDisplay());
+        $this->assertStringContainsString('You must choose one of --force or --dump-messages', $tester->getDisplay());
     }
 
     private function getBundle($path)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -41,7 +41,7 @@ class YamlLintCommandTest extends TestCase
         );
 
         $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
-        $this->assertContains('OK', trim($tester->getDisplay()));
+        $this->assertStringContainsString('OK', trim($tester->getDisplay()));
     }
 
     public function testLintIncorrectFile()
@@ -55,7 +55,7 @@ bar';
         $tester->execute(['filename' => $filename], ['decorated' => false]);
 
         $this->assertEquals(1, $tester->getStatusCode(), 'Returns 1 in case of error');
-        $this->assertContains('Unable to parse at line 3 (near "bar").', trim($tester->getDisplay()));
+        $this->assertStringContainsString('Unable to parse at line 3 (near "bar").', trim($tester->getDisplay()));
     }
 
     public function testLintFileNotReadable()
@@ -106,7 +106,7 @@ EOF;
         );
 
         $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
-        $this->assertContains('[OK] All 0 YAML files contain valid syntax', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] All 0 YAML files contain valid syntax', trim($tester->getDisplay()));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -160,9 +160,9 @@ class ApplicationTest extends TestCase
         $output = $tester->getDisplay();
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertContains('Some commands could not be registered:', $output);
-        $this->assertContains('throwing', $output);
-        $this->assertContains('fine', $output);
+        $this->assertStringContainsString('Some commands could not be registered:', $output);
+        $this->assertStringContainsString('throwing', $output);
+        $this->assertStringContainsString('fine', $output);
     }
 
     public function testRegistrationErrorsAreDisplayedOnCommandNotFound()
@@ -188,8 +188,8 @@ class ApplicationTest extends TestCase
         $output = $tester->getDisplay();
 
         $this->assertSame(1, $tester->getStatusCode());
-        $this->assertContains('Some commands could not be registered:', $output);
-        $this->assertContains('Command "fine" is not defined.', $output);
+        $this->assertStringContainsString('Some commands could not be registered:', $output);
+        $this->assertStringContainsString('Command "fine" is not defined.', $output);
     }
 
     private function getKernel(array $bundles, $useDispatcher = false)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -127,9 +127,9 @@ class ControllerNameParserTest extends TestCase
 
             if (false === $suggestedBundleName) {
                 // make sure we don't have a suggestion
-                $this->assertNotContains('Did you mean', $e->getMessage());
+                $this->assertStringNotContainsString('Did you mean', $e->getMessage());
             } else {
-                $this->assertContains(sprintf('Did you mean "%s"', $suggestedBundleName), $e->getMessage());
+                $this->assertStringContainsString(sprintf('Did you mean "%s"', $suggestedBundleName), $e->getMessage());
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -186,8 +186,8 @@ abstract class ControllerTraitTest extends TestCase
         if ($response->headers->get('content-type')) {
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
-        $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
-        $this->assertContains(basename(__FILE__), $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(basename(__FILE__), $response->headers->get('content-disposition'));
     }
 
     public function testFileAsInline()
@@ -202,8 +202,8 @@ abstract class ControllerTraitTest extends TestCase
         if ($response->headers->get('content-type')) {
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
-        $this->assertContains(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
-        $this->assertContains(basename(__FILE__), $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(basename(__FILE__), $response->headers->get('content-disposition'));
     }
 
     public function testFileWithOwnFileName()
@@ -219,8 +219,8 @@ abstract class ControllerTraitTest extends TestCase
         if ($response->headers->get('content-type')) {
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
-        $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
-        $this->assertContains($fileName, $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
+        $this->assertStringContainsString($fileName, $response->headers->get('content-disposition'));
     }
 
     public function testFileWithOwnFileNameAsInline()
@@ -236,8 +236,8 @@ abstract class ControllerTraitTest extends TestCase
         if ($response->headers->get('content-type')) {
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
-        $this->assertContains(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
-        $this->assertContains($fileName, $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
+        $this->assertStringContainsString($fileName, $response->headers->get('content-disposition'));
     }
 
     public function testFileFromPath()
@@ -252,8 +252,8 @@ abstract class ControllerTraitTest extends TestCase
         if ($response->headers->get('content-type')) {
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
-        $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
-        $this->assertContains(basename(__FILE__), $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(basename(__FILE__), $response->headers->get('content-disposition'));
     }
 
     public function testFileFromPathWithCustomizedFileName()
@@ -268,8 +268,8 @@ abstract class ControllerTraitTest extends TestCase
         if ($response->headers->get('content-type')) {
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
-        $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
-        $this->assertContains('test.php', $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
+        $this->assertStringContainsString('test.php', $response->headers->get('content-disposition'));
     }
 
     public function testFileWhichDoesNotExist()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -824,9 +824,9 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertSame('addYamlMappings', $calls[4][0]);
         $this->assertCount(3, $calls[4][1][0]);
-        $this->assertContains('foo.yml', $calls[4][1][0][0]);
-        $this->assertContains('validation.yml', $calls[4][1][0][1]);
-        $this->assertContains('validation.yaml', $calls[4][1][0][2]);
+        $this->assertStringContainsString('foo.yml', $calls[4][1][0][0]);
+        $this->assertStringContainsString('validation.yml', $calls[4][1][0][1]);
+        $this->assertStringContainsString('validation.yaml', $calls[4][1][0][2]);
     }
 
     public function testFormsCanBeEnabledWithoutCsrfProtection()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -31,8 +31,8 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $tester->execute(['pools' => ['cache.private_pool']], ['decorated' => false]);
 
         $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
-        $this->assertContains('Clearing cache pool: cache.private_pool', $tester->getDisplay());
-        $this->assertContains('[OK] Cache was successfully cleared.', $tester->getDisplay());
+        $this->assertStringContainsString('Clearing cache pool: cache.private_pool', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
 
     public function testClearPublicPool()
@@ -41,8 +41,8 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $tester->execute(['pools' => ['cache.public_pool']], ['decorated' => false]);
 
         $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
-        $this->assertContains('Clearing cache pool: cache.public_pool', $tester->getDisplay());
-        $this->assertContains('[OK] Cache was successfully cleared.', $tester->getDisplay());
+        $this->assertStringContainsString('Clearing cache pool: cache.public_pool', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
 
     public function testClearPoolWithCustomClearer()
@@ -51,8 +51,8 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $tester->execute(['pools' => ['cache.pool_with_clearer']], ['decorated' => false]);
 
         $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
-        $this->assertContains('Clearing cache pool: cache.pool_with_clearer', $tester->getDisplay());
-        $this->assertContains('[OK] Cache was successfully cleared.', $tester->getDisplay());
+        $this->assertStringContainsString('Clearing cache pool: cache.pool_with_clearer', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
 
     public function testCallClearer()
@@ -61,8 +61,8 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $tester->execute(['pools' => ['cache.app_clearer']], ['decorated' => false]);
 
         $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
-        $this->assertContains('Calling cache clearer: cache.app_clearer', $tester->getDisplay());
-        $this->assertContains('[OK] Cache was successfully cleared.', $tester->getDisplay());
+        $this->assertStringContainsString('Calling cache clearer: cache.app_clearer', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
 
     public function testClearUnexistingPool()
@@ -86,7 +86,7 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
 
         $tester->execute(['pools' => []]);
 
-        $this->assertContains('Cache was successfully cleared', $tester->getDisplay());
+        $this->assertStringContainsString('Cache was successfully cleared', $tester->getDisplay());
     }
 
     private function createCommandTester()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -36,7 +36,7 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         $ret = $tester->execute(['name' => 'TestBundle']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('custom: foo', $tester->getDisplay());
+        $this->assertStringContainsString('custom: foo', $tester->getDisplay());
     }
 
     public function testDumpBundleOption()
@@ -45,7 +45,7 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         $ret = $tester->execute(['name' => 'TestBundle', 'path' => 'custom']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('foo', $tester->getDisplay());
+        $this->assertStringContainsString('foo', $tester->getDisplay());
     }
 
     public function testParametersValuesAreResolved()
@@ -54,8 +54,8 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         $ret = $tester->execute(['name' => 'framework']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains("locale: '%env(LOCALE)%'", $tester->getDisplay());
-        $this->assertContains('secret: test', $tester->getDisplay());
+        $this->assertStringContainsString("locale: '%env(LOCALE)%'", $tester->getDisplay());
+        $this->assertStringContainsString('secret: test', $tester->getDisplay());
     }
 
     public function testDumpUndefinedBundleOption()
@@ -63,7 +63,7 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         $tester = $this->createCommandTester();
         $tester->execute(['name' => 'TestBundle', 'path' => 'foo']);
 
-        $this->assertContains('Unable to find configuration for "test.foo"', $tester->getDisplay());
+        $this->assertStringContainsString('Unable to find configuration for "test.foo"', $tester->getDisplay());
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -36,8 +36,8 @@ class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
         $ret = $tester->execute(['name' => 'TestBundle']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('test:', $tester->getDisplay());
-        $this->assertContains('    custom:', $tester->getDisplay());
+        $this->assertStringContainsString('test:', $tester->getDisplay());
+        $this->assertStringContainsString('    custom:', $tester->getDisplay());
     }
 
     public function testDumpAtPath()
@@ -70,7 +70,7 @@ EOL
         ]);
 
         $this->assertSame(1, $ret);
-        $this->assertContains('[ERROR] The "path" option is only available for the "yaml" format.', $tester->getDisplay());
+        $this->assertStringContainsString('[ERROR] The "path" option is only available for the "yaml" format.', $tester->getDisplay());
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -44,7 +44,7 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:container']);
 
-        $this->assertContains('public', $tester->getDisplay());
+        $this->assertStringContainsString('public', $tester->getDisplay());
     }
 
     public function testPrivateAlias()
@@ -56,11 +56,11 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:container', '--show-private' => true]);
-        $this->assertContains('public', $tester->getDisplay());
-        $this->assertContains('private_alias', $tester->getDisplay());
+        $this->assertStringContainsString('public', $tester->getDisplay());
+        $this->assertStringContainsString('private_alias', $tester->getDisplay());
 
         $tester->run(['command' => 'debug:container']);
-        $this->assertContains('public', $tester->getDisplay());
-        $this->assertNotContains('private_alias', $tester->getDisplay());
+        $this->assertStringContainsString('public', $tester->getDisplay());
+        $this->assertStringNotContainsString('private_alias', $tester->getDisplay());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -29,8 +29,8 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:autowiring']);
 
-        $this->assertContains('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
-        $this->assertContains('alias to http_kernel', $tester->getDisplay());
+        $this->assertStringContainsString('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
+        $this->assertStringContainsString('alias to http_kernel', $tester->getDisplay());
     }
 
     public function testSearchArgument()
@@ -43,8 +43,8 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:autowiring', 'search' => 'kern']);
 
-        $this->assertContains('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
-        $this->assertNotContains('Symfony\Component\Routing\RouterInterface', $tester->getDisplay());
+        $this->assertStringContainsString('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
+        $this->assertStringNotContainsString('Symfony\Component\Routing\RouterInterface', $tester->getDisplay());
     }
 
     public function testSearchNoResults()
@@ -57,7 +57,7 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:autowiring', 'search' => 'foo_fake'], ['capture_stderr_separately' => true]);
 
-        $this->assertContains('No autowirable classes or interfaces found matching "foo_fake"', $tester->getErrorOutput());
+        $this->assertStringContainsString('No autowirable classes or interfaces found matching "foo_fake"', $tester->getErrorOutput());
         $this->assertEquals(1, $tester->getStatusCode());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -27,23 +27,23 @@ class SessionTest extends AbstractWebTestCase
 
         // no session
         $crawler = $client->request('GET', '/session');
-        $this->assertContains('You are new here and gave no name.', $crawler->text());
+        $this->assertStringContainsString('You are new here and gave no name.', $crawler->text());
 
         // remember name
         $crawler = $client->request('GET', '/session/drak');
-        $this->assertContains('Hello drak, nice to meet you.', $crawler->text());
+        $this->assertStringContainsString('Hello drak, nice to meet you.', $crawler->text());
 
         // prove remembered name
         $crawler = $client->request('GET', '/session');
-        $this->assertContains('Welcome back drak, nice to meet you.', $crawler->text());
+        $this->assertStringContainsString('Welcome back drak, nice to meet you.', $crawler->text());
 
         // clear session
         $crawler = $client->request('GET', '/session_logout');
-        $this->assertContains('Session cleared.', $crawler->text());
+        $this->assertStringContainsString('Session cleared.', $crawler->text());
 
         // prove cleared session
         $crawler = $client->request('GET', '/session');
-        $this->assertContains('You are new here and gave no name.', $crawler->text());
+        $this->assertStringContainsString('You are new here and gave no name.', $crawler->text());
     }
 
     /**
@@ -62,11 +62,11 @@ class SessionTest extends AbstractWebTestCase
         $crawler = $client->request('GET', '/session_setflash/Hello%20world.');
 
         // check flash displays on redirect
-        $this->assertContains('Hello world.', $client->followRedirect()->text());
+        $this->assertStringContainsString('Hello world.', $client->followRedirect()->text());
 
         // check flash is gone
         $crawler = $client->request('GET', '/session_showflash');
-        $this->assertContains('No flash was set.', $crawler->text());
+        $this->assertStringContainsString('No flash was set.', $crawler->text());
     }
 
     /**
@@ -91,39 +91,39 @@ class SessionTest extends AbstractWebTestCase
 
         // new session, so no name set.
         $crawler1 = $client1->request('GET', '/session');
-        $this->assertContains('You are new here and gave no name.', $crawler1->text());
+        $this->assertStringContainsString('You are new here and gave no name.', $crawler1->text());
 
         // set name of client1
         $crawler1 = $client1->request('GET', '/session/client1');
-        $this->assertContains('Hello client1, nice to meet you.', $crawler1->text());
+        $this->assertStringContainsString('Hello client1, nice to meet you.', $crawler1->text());
 
         // no session for client2
         $crawler2 = $client2->request('GET', '/session');
-        $this->assertContains('You are new here and gave no name.', $crawler2->text());
+        $this->assertStringContainsString('You are new here and gave no name.', $crawler2->text());
 
         // remember name client2
         $crawler2 = $client2->request('GET', '/session/client2');
-        $this->assertContains('Hello client2, nice to meet you.', $crawler2->text());
+        $this->assertStringContainsString('Hello client2, nice to meet you.', $crawler2->text());
 
         // prove remembered name of client1
         $crawler1 = $client1->request('GET', '/session');
-        $this->assertContains('Welcome back client1, nice to meet you.', $crawler1->text());
+        $this->assertStringContainsString('Welcome back client1, nice to meet you.', $crawler1->text());
 
         // prove remembered name of client2
         $crawler2 = $client2->request('GET', '/session');
-        $this->assertContains('Welcome back client2, nice to meet you.', $crawler2->text());
+        $this->assertStringContainsString('Welcome back client2, nice to meet you.', $crawler2->text());
 
         // clear client1
         $crawler1 = $client1->request('GET', '/session_logout');
-        $this->assertContains('Session cleared.', $crawler1->text());
+        $this->assertStringContainsString('Session cleared.', $crawler1->text());
 
         // prove client1 data is cleared
         $crawler1 = $client1->request('GET', '/session');
-        $this->assertContains('You are new here and gave no name.', $crawler1->text());
+        $this->assertStringContainsString('You are new here and gave no name.', $crawler1->text());
 
         // prove remembered name of client2 remains untouched.
         $crawler2 = $client2->request('GET', '/session');
-        $this->assertContains('Welcome back client2, nice to meet you.', $crawler2->text());
+        $this->assertStringContainsString('Welcome back client2, nice to meet you.', $crawler2->text());
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
@@ -69,7 +69,7 @@ class TemplateLocatorTest extends TestCase
             $locator->locate($template);
             $this->fail('->locate() should throw an exception when the file is not found.');
         } catch (\InvalidArgumentException $e) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 $errorMessage,
                 $e->getMessage(),
                 'TemplateLocator exception should propagate the FileLocator exception message'

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
@@ -30,12 +30,12 @@ class CsrfFormLoginTest extends AbstractWebTestCase
         $crawler = $client->followRedirect();
 
         $text = $crawler->text();
-        $this->assertContains('Hello johannes!', $text);
-        $this->assertContains('You\'re browsing to path "/profile".', $text);
+        $this->assertStringContainsString('Hello johannes!', $text);
+        $this->assertStringContainsString('You\'re browsing to path "/profile".', $text);
 
         $logoutLinks = $crawler->selectLink('Log out')->links();
         $this->assertCount(2, $logoutLinks);
-        $this->assertContains('_csrf_token=', $logoutLinks[0]->getUri());
+        $this->assertStringContainsString('_csrf_token=', $logoutLinks[0]->getUri());
         $this->assertSame($logoutLinks[0]->getUri(), $logoutLinks[1]->getUri());
 
         $client->click($logoutLinks[0]);
@@ -57,7 +57,7 @@ class CsrfFormLoginTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/login');
 
         $text = $client->followRedirect()->text();
-        $this->assertContains('Invalid CSRF token.', $text);
+        $this->assertStringContainsString('Invalid CSRF token.', $text);
     }
 
     /**
@@ -76,8 +76,8 @@ class CsrfFormLoginTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/foo');
 
         $text = $client->followRedirect()->text();
-        $this->assertContains('Hello johannes!', $text);
-        $this->assertContains('You\'re browsing to path "/foo".', $text);
+        $this->assertStringContainsString('Hello johannes!', $text);
+        $this->assertStringContainsString('You\'re browsing to path "/foo".', $text);
     }
 
     /**
@@ -97,8 +97,8 @@ class CsrfFormLoginTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/protected-resource');
 
         $text = $client->followRedirect()->text();
-        $this->assertContains('Hello johannes!', $text);
-        $this->assertContains('You\'re browsing to path "/protected-resource".', $text);
+        $this->assertStringContainsString('Hello johannes!', $text);
+        $this->assertStringContainsString('You\'re browsing to path "/protected-resource".', $text);
     }
 
     public function getConfigs()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -28,8 +28,8 @@ class FormLoginTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/profile');
 
         $text = $client->followRedirect()->text();
-        $this->assertContains('Hello johannes!', $text);
-        $this->assertContains('You\'re browsing to path "/profile".', $text);
+        $this->assertStringContainsString('Hello johannes!', $text);
+        $this->assertStringContainsString('You\'re browsing to path "/profile".', $text);
     }
 
     /**
@@ -49,8 +49,8 @@ class FormLoginTest extends AbstractWebTestCase
         $crawler = $client->followRedirect();
         $text = $crawler->text();
 
-        $this->assertContains('Hello johannes!', $text);
-        $this->assertContains('You\'re browsing to path "/profile".', $text);
+        $this->assertStringContainsString('Hello johannes!', $text);
+        $this->assertStringContainsString('You\'re browsing to path "/profile".', $text);
 
         $logoutLinks = $crawler->selectLink('Log out')->links();
         $this->assertCount(6, $logoutLinks);
@@ -81,8 +81,8 @@ class FormLoginTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/foo');
 
         $text = $client->followRedirect()->text();
-        $this->assertContains('Hello johannes!', $text);
-        $this->assertContains('You\'re browsing to path "/foo".', $text);
+        $this->assertStringContainsString('Hello johannes!', $text);
+        $this->assertStringContainsString('You\'re browsing to path "/foo".', $text);
     }
 
     /**
@@ -102,8 +102,8 @@ class FormLoginTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/protected_resource');
 
         $text = $client->followRedirect()->text();
-        $this->assertContains('Hello johannes!', $text);
-        $this->assertContains('You\'re browsing to path "/protected_resource".', $text);
+        $this->assertStringContainsString('Hello johannes!', $text);
+        $this->assertStringContainsString('You\'re browsing to path "/protected_resource".', $text);
     }
 
     public function getConfigs()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -49,7 +49,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
             'command' => 'security:encode-password',
         ], ['interactive' => false]);
 
-        $this->assertContains('[ERROR] The password must not be empty.', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringContainsString('[ERROR] The password must not be empty.', $this->passwordEncoderCommandTester->getDisplay());
         $this->assertEquals($statusCode, 1);
     }
 
@@ -62,7 +62,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
         ], ['interactive' => false]);
 
         $output = $this->passwordEncoderCommandTester->getDisplay();
-        $this->assertContains('Password encoding succeeded', $output);
+        $this->assertStringContainsString('Password encoding succeeded', $output);
 
         $encoder = new BCryptPasswordEncoder(17);
         preg_match('# Encoded password\s{1,}([\w+\/$.]+={0,2})\s+#', $output, $matches);
@@ -83,7 +83,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
         ], ['interactive' => false]);
 
         $output = $this->passwordEncoderCommandTester->getDisplay();
-        $this->assertContains('Password encoding succeeded', $output);
+        $this->assertStringContainsString('Password encoding succeeded', $output);
 
         $encoder = new Argon2iPasswordEncoder();
         preg_match('#  Encoded password\s+(\$argon2id?\$[\w,=\$+\/]+={0,2})\s+#', $output, $matches);
@@ -100,7 +100,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
         ], ['interactive' => false]);
 
         $output = $this->passwordEncoderCommandTester->getDisplay();
-        $this->assertContains('Password encoding succeeded', $output);
+        $this->assertStringContainsString('Password encoding succeeded', $output);
 
         $encoder = new Pbkdf2PasswordEncoder('sha512', true, 1000);
         preg_match('# Encoded password\s{1,}([\w+\/]+={0,2})\s+#', $output, $matches);
@@ -119,9 +119,9 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
             ], ['interactive' => false]
         );
 
-        $this->assertContains('Password encoding succeeded', $this->passwordEncoderCommandTester->getDisplay());
-        $this->assertContains(' Encoded password   p@ssw0rd', $this->passwordEncoderCommandTester->getDisplay());
-        $this->assertContains(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringContainsString('Password encoding succeeded', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringContainsString(' Encoded password   p@ssw0rd', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringContainsString(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
     }
 
     public function testEncodePasswordEmptySaltOutput()
@@ -133,9 +133,9 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
             '--empty-salt' => true,
         ]);
 
-        $this->assertContains('Password encoding succeeded', $this->passwordEncoderCommandTester->getDisplay());
-        $this->assertContains(' Encoded password   p@ssw0rd', $this->passwordEncoderCommandTester->getDisplay());
-        $this->assertNotContains(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringContainsString('Password encoding succeeded', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringContainsString(' Encoded password   p@ssw0rd', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
     }
 
     public function testEncodePasswordBcryptOutput()
@@ -146,7 +146,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
             'user-class' => 'Custom\Class\Bcrypt\User',
         ], ['interactive' => false]);
 
-        $this->assertNotContains(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
     }
 
     public function testEncodePasswordArgon2iOutput()
@@ -162,7 +162,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
             'user-class' => 'Custom\Class\Argon2i\User',
         ], ['interactive' => false]);
 
-        $this->assertNotContains(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
     }
 
     public function testEncodePasswordNoConfigForGivenUserClass()
@@ -185,7 +185,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
             'password' => 'password',
         ], ['decorated' => false]);
 
-        $this->assertContains(<<<EOTXT
+        $this->assertStringContainsString(<<<EOTXT
  For which user class would you like to encode a password? [Custom\Class\Bcrypt\User]:
   [0] Custom\Class\Bcrypt\User
   [1] Custom\Class\Pbkdf2\User
@@ -202,7 +202,7 @@ EOTXT
             'password' => 'password',
         ], ['interactive' => false]);
 
-        $this->assertContains('Encoder used       Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringContainsString('Encoder used       Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder', $this->passwordEncoderCommandTester->getDisplay());
     }
 
     public function testThrowsExceptionOnNoConfiguredEncoders()
@@ -240,7 +240,7 @@ EOTXT
             'password' => 'password',
         ], ['interactive' => false]);
 
-        $this->assertContains('Encoder used       Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder', $tester->getDisplay());
+        $this->assertStringContainsString('Encoder used       Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder', $tester->getDisplay());
     }
 
     protected function setUp()

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -27,7 +27,7 @@ class NoTemplatingEntryTest extends TestCase
 
         $container = $kernel->getContainer();
         $content = $container->get('twig')->render('index.html.twig');
-        $this->assertContains('{ a: b }', $content);
+        $this->assertStringContainsString('{ a: b }', $content);
     }
 
     protected function setUp()

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -24,28 +24,28 @@ class XmlUtilsTest extends TestCase
             XmlUtils::loadFile($fixtures.'invalid.xml');
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertContains('ERROR 77', $e->getMessage());
+            $this->assertStringContainsString('ERROR 77', $e->getMessage());
         }
 
         try {
             XmlUtils::loadFile($fixtures.'document_type.xml');
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertContains('Document types are not allowed', $e->getMessage());
+            $this->assertStringContainsString('Document types are not allowed', $e->getMessage());
         }
 
         try {
             XmlUtils::loadFile($fixtures.'invalid_schema.xml', $fixtures.'schema.xsd');
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertContains('ERROR 1845', $e->getMessage());
+            $this->assertStringContainsString('ERROR 1845', $e->getMessage());
         }
 
         try {
             XmlUtils::loadFile($fixtures.'invalid_schema.xml', 'invalid_callback_or_file');
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertContains('XSD file or callable', $e->getMessage());
+            $this->assertStringContainsString('XSD file or callable', $e->getMessage());
         }
 
         $mock = $this->getMockBuilder(__NAMESPACE__.'\Validator')->getMock();

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -183,7 +183,7 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['test']);
-        $this->assertContains('It works!', $tester->getDisplay(true));
+        $this->assertStringContainsString('It works!', $tester->getDisplay(true));
     }
 
     public function testAdd()
@@ -705,7 +705,7 @@ class ApplicationTest extends TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception1.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exception');
 
         $tester->run(['command' => 'foo'], ['decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE, 'capture_stderr_separately' => true]);
-        $this->assertContains('Exception trace', $tester->getErrorOutput(), '->renderException() renders a pretty exception with a stack trace when verbosity is verbose');
+        $this->assertStringContainsString('Exception trace', $tester->getErrorOutput(), '->renderException() renders a pretty exception with a stack trace when verbosity is verbose');
 
         $tester->run(['command' => 'list', '--foo' => true], ['decorated' => false, 'capture_stderr_separately' => true]);
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception2.txt', $tester->getErrorOutput(true), '->renderException() renders the command synopsis when an exception occurs in the context of a command');
@@ -806,7 +806,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foo'], ['decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE]);
 
-        $this->assertContains(sprintf('() at %s:', __FILE__), $tester->getDisplay());
+        $this->assertStringContainsString(sprintf('() at %s:', __FILE__), $tester->getDisplay());
     }
 
     public function testRun()
@@ -1231,7 +1231,7 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foo']);
-        $this->assertContains('before.foo.error.after.', $tester->getDisplay());
+        $this->assertStringContainsString('before.foo.error.after.', $tester->getDisplay());
     }
 
     public function testRunDispatchesAllEventsWithExceptionInListener()
@@ -1251,7 +1251,7 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foo']);
-        $this->assertContains('before.error.after.', $tester->getDisplay());
+        $this->assertStringContainsString('before.error.after.', $tester->getDisplay());
     }
 
     /**
@@ -1302,7 +1302,7 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foo']);
-        $this->assertContains('before.error.silenced.after.', $tester->getDisplay());
+        $this->assertStringContainsString('before.error.silenced.after.', $tester->getDisplay());
         $this->assertEquals(ConsoleCommandEvent::RETURN_CODE_DISABLED, $tester->getStatusCode());
     }
 
@@ -1321,7 +1321,7 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'unknown']);
-        $this->assertContains('silenced command not found', $tester->getDisplay());
+        $this->assertStringContainsString('silenced command not found', $tester->getDisplay());
         $this->assertEquals(1, $tester->getStatusCode());
     }
 
@@ -1348,8 +1348,8 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foo']);
-        $this->assertContains('before.caught.error.after.', $tester->getDisplay());
-        $this->assertContains('replaced in caught.', $tester->getDisplay());
+        $this->assertStringContainsString('before.caught.error.after.', $tester->getDisplay());
+        $this->assertStringContainsString('replaced in caught.', $tester->getDisplay());
     }
 
     /**
@@ -1396,7 +1396,7 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'dym']);
-        $this->assertContains('before.dym.error.after.', $tester->getDisplay(), 'The PHP Error did not dispached events');
+        $this->assertStringContainsString('before.dym.error.after.', $tester->getDisplay(), 'The PHP Error did not dispached events');
     }
 
     /**
@@ -1416,7 +1416,7 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'dym']);
-        $this->assertContains('before.dym.error.after.', $tester->getDisplay(), 'The PHP Error did not dispached events');
+        $this->assertStringContainsString('before.dym.error.after.', $tester->getDisplay(), 'The PHP Error did not dispached events');
     }
 
     /**
@@ -1451,7 +1451,7 @@ class ApplicationTest extends TestCase
 
         $tester = new ApplicationTester($application);
         $exitCode = $tester->run(['command' => 'foo']);
-        $this->assertContains('before.after.', $tester->getDisplay());
+        $this->assertStringContainsString('before.after.', $tester->getDisplay());
         $this->assertEquals(ConsoleCommandEvent::RETURN_CODE_DISABLED, $exitCode);
     }
 
@@ -1579,10 +1579,10 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
 
         $tester->run([]);
-        $this->assertContains('called', $tester->getDisplay());
+        $this->assertStringContainsString('called', $tester->getDisplay());
 
         $tester->run(['--help' => true]);
-        $this->assertContains('The foo:bar command', $tester->getDisplay());
+        $this->assertStringContainsString('The foo:bar command', $tester->getDisplay());
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -154,20 +154,20 @@ class CommandTest extends TestCase
     {
         $command = new \TestCommand();
         $command->setHelp('The %command.name% command does... Example: php %command.full_name%.');
-        $this->assertContains('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly');
-        $this->assertNotContains('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name%');
+        $this->assertStringContainsString('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly');
+        $this->assertStringNotContainsString('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name%');
 
         $command = new \TestCommand();
         $command->setHelp('');
-        $this->assertContains('description', $command->getProcessedHelp(), '->getProcessedHelp() falls back to the description');
+        $this->assertStringContainsString('description', $command->getProcessedHelp(), '->getProcessedHelp() falls back to the description');
 
         $command = new \TestCommand();
         $command->setHelp('The %command.name% command does... Example: php %command.full_name%.');
         $application = new Application();
         $application->add($command);
         $application->setDefaultCommand('namespace:name', true);
-        $this->assertContains('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly in single command applications');
-        $this->assertNotContains('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name% in single command applications');
+        $this->assertStringContainsString('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly in single command applications');
+        $this->assertStringNotContainsString('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name% in single command applications');
     }
 
     public function testGetSetAliases()

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -25,9 +25,9 @@ class HelpCommandTest extends TestCase
         $command->setApplication(new Application());
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command_name' => 'li'], ['decorated' => false]);
-        $this->assertContains('list [options] [--] [<namespace>]', $commandTester->getDisplay(), '->execute() returns a text help for the given command alias');
-        $this->assertContains('format=FORMAT', $commandTester->getDisplay(), '->execute() returns a text help for the given command alias');
-        $this->assertContains('raw', $commandTester->getDisplay(), '->execute() returns a text help for the given command alias');
+        $this->assertStringContainsString('list [options] [--] [<namespace>]', $commandTester->getDisplay(), '->execute() returns a text help for the given command alias');
+        $this->assertStringContainsString('format=FORMAT', $commandTester->getDisplay(), '->execute() returns a text help for the given command alias');
+        $this->assertStringContainsString('raw', $commandTester->getDisplay(), '->execute() returns a text help for the given command alias');
     }
 
     public function testExecuteForCommand()
@@ -36,9 +36,9 @@ class HelpCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $command->setCommand(new ListCommand());
         $commandTester->execute([], ['decorated' => false]);
-        $this->assertContains('list [options] [--] [<namespace>]', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
-        $this->assertContains('format=FORMAT', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
-        $this->assertContains('raw', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertStringContainsString('list [options] [--] [<namespace>]', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertStringContainsString('format=FORMAT', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertStringContainsString('raw', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
     }
 
     public function testExecuteForCommandWithXmlOption()
@@ -47,7 +47,7 @@ class HelpCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $command->setCommand(new ListCommand());
         $commandTester->execute(['--format' => 'xml']);
-        $this->assertContains('<command', $commandTester->getDisplay(), '->execute() returns an XML help text if --xml is passed');
+        $this->assertStringContainsString('<command', $commandTester->getDisplay(), '->execute() returns an XML help text if --xml is passed');
     }
 
     public function testExecuteForApplicationCommand()
@@ -55,9 +55,9 @@ class HelpCommandTest extends TestCase
         $application = new Application();
         $commandTester = new CommandTester($application->get('help'));
         $commandTester->execute(['command_name' => 'list']);
-        $this->assertContains('list [options] [--] [<namespace>]', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
-        $this->assertContains('format=FORMAT', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
-        $this->assertContains('raw', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertStringContainsString('list [options] [--] [<namespace>]', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertStringContainsString('format=FORMAT', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertStringContainsString('raw', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
     }
 
     public function testExecuteForApplicationCommandWithXmlOption()
@@ -65,7 +65,7 @@ class HelpCommandTest extends TestCase
         $application = new Application();
         $commandTester = new CommandTester($application->get('help'));
         $commandTester->execute(['command_name' => 'list', '--format' => 'xml']);
-        $this->assertContains('list [--raw] [--format FORMAT] [--] [&lt;namespace&gt;]', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
-        $this->assertContains('<command', $commandTester->getDisplay(), '->execute() returns an XML help text if --format=xml is passed');
+        $this->assertStringContainsString('list [--raw] [--format FORMAT] [--] [&lt;namespace&gt;]', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertStringContainsString('<command', $commandTester->getDisplay(), '->execute() returns an XML help text if --format=xml is passed');
     }
 }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
@@ -86,7 +86,7 @@ class OutputFormatterStyleTest extends TestCase
             $this->fail('->setOption() throws an \InvalidArgumentException when the option does not exist in the available options');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->setOption() throws an \InvalidArgumentException when the option does not exist in the available options');
-            $this->assertContains('Invalid option specified: "foo"', $e->getMessage(), '->setOption() throws an \InvalidArgumentException when the option does not exist in the available options');
+            $this->assertStringContainsString('Invalid option specified: "foo"', $e->getMessage(), '->setOption() throws an \InvalidArgumentException when the option does not exist in the available options');
         }
 
         try {
@@ -94,7 +94,7 @@ class OutputFormatterStyleTest extends TestCase
             $this->fail('->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
-            $this->assertContains('Invalid option specified: "foo"', $e->getMessage(), '->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
+            $this->assertStringContainsString('Invalid option specified: "foo"', $e->getMessage(), '->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
         }
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -68,7 +68,7 @@ class HelperSetTest extends TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->get() throws InvalidArgumentException when helper not found');
             $this->assertInstanceOf('Symfony\Component\Console\Exception\ExceptionInterface', $e, '->get() throws domain specific exception when helper not found');
-            $this->assertContains('The helper "foo" is not defined.', $e->getMessage(), '->get() throws InvalidArgumentException when helper not found');
+            $this->assertStringContainsString('The helper "foo" is not defined.', $e->getMessage(), '->get() throws InvalidArgumentException when helper not found');
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -53,7 +53,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
 
         rewind($output->getStream());
         $stream = stream_get_contents($output->getStream());
-        $this->assertContains('Input "Fabien" is not a superhero!', $stream);
+        $this->assertStringContainsString('Input "Fabien" is not a superhero!', $stream);
 
         try {
             $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, '1');
@@ -616,7 +616,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
 
         rewind($output->getStream());
         $stream = stream_get_contents($output->getStream());
-        $this->assertContains('Input "Fabien" is not a superhero!', $stream);
+        $this->assertStringContainsString('Input "Fabien" is not a superhero!', $stream);
 
         try {
             $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, '1');

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -161,6 +161,6 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
     {
         rewind($output->getStream());
         $stream = stream_get_contents($output->getStream());
-        $this->assertContains($expected, $stream);
+        $this->assertStringContainsString($expected, $stream);
     }
 }

--- a/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
@@ -267,7 +267,7 @@ class FlattenExceptionTest extends TestCase
 
         $flattened = FlattenException::create($exception);
         $trace = $flattened->getTrace();
-        $this->assertContains('*DEEP NESTED ARRAY*', serialize($trace));
+        $this->assertStringContainsString('*DEEP NESTED ARRAY*', serialize($trace));
     }
 
     public function testTooBigArray()
@@ -291,8 +291,8 @@ class FlattenExceptionTest extends TestCase
 
         $serializeTrace = serialize($trace);
 
-        $this->assertContains('*SKIPPED over 10000 entries*', $serializeTrace);
-        $this->assertNotContains('*value1*', $serializeTrace);
+        $this->assertStringContainsString('*SKIPPED over 10000 entries*', $serializeTrace);
+        $this->assertStringNotContainsString('*value1*', $serializeTrace);
     }
 
     private function createException($foo)

--- a/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
@@ -39,8 +39,8 @@ class ExceptionHandlerTest extends TestCase
         $handler->sendPhpResponse(new \RuntimeException('Foo'));
         $response = ob_get_clean();
 
-        $this->assertContains('Whoops, looks like something went wrong.', $response);
-        $this->assertNotContains('<div class="trace trace-as-html">', $response);
+        $this->assertStringContainsString('Whoops, looks like something went wrong.', $response);
+        $this->assertStringNotContainsString('<div class="trace trace-as-html">', $response);
 
         $handler = new ExceptionHandler(true);
 
@@ -48,8 +48,8 @@ class ExceptionHandlerTest extends TestCase
         $handler->sendPhpResponse(new \RuntimeException('Foo'));
         $response = ob_get_clean();
 
-        $this->assertContains('Whoops, looks like something went wrong.', $response);
-        $this->assertContains('<div class="trace trace-as-html">', $response);
+        $this->assertStringContainsString('Whoops, looks like something went wrong.', $response);
+        $this->assertStringContainsString('<div class="trace trace-as-html">', $response);
     }
 
     public function testStatusCode()
@@ -60,7 +60,7 @@ class ExceptionHandlerTest extends TestCase
         $handler->sendPhpResponse(new NotFoundHttpException('Foo'));
         $response = ob_get_clean();
 
-        $this->assertContains('Sorry, the page you are looking for could not be found.', $response);
+        $this->assertStringContainsString('Sorry, the page you are looking for could not be found.', $response);
 
         $expectedHeaders = [
             ['HTTP/1.0 404', true, null],
@@ -157,7 +157,7 @@ class ExceptionHandlerTest extends TestCase
 
     private function assertThatTheExceptionWasOutput($content, $expectedClass, $expectedTitle, $expectedMessage)
     {
-        $this->assertContains(sprintf('<span class="exception_title"><abbr title="%s">%s</abbr></span>', $expectedClass, $expectedTitle), $content);
-        $this->assertContains(sprintf('<p class="break-long-words trace-message">%s</p>', $expectedMessage), $content);
+        $this->assertStringContainsString(sprintf('<span class="exception_title"><abbr title="%s">%s</abbr></span>', $expectedClass, $expectedTitle), $content);
+        $this->assertStringContainsString(sprintf('<p class="break-long-words trace-message">%s</p>', $expectedMessage), $content);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -438,7 +438,7 @@ class XmlFileLoaderTest extends TestCase
 
             $e = $e->getPrevious();
             $this->assertInstanceOf('InvalidArgumentException', $e, '->load() throws an InvalidArgumentException if the configuration does not validate the XSD');
-            $this->assertContains('The attribute \'bar\' is not allowed', $e->getMessage(), '->load() throws an InvalidArgumentException if the configuration does not validate the XSD');
+            $this->assertStringContainsString('The attribute \'bar\' is not allowed', $e->getMessage(), '->load() throws an InvalidArgumentException if the configuration does not validate the XSD');
         }
 
         // non-registered extension
@@ -478,7 +478,7 @@ class XmlFileLoaderTest extends TestCase
 
             $e = $e->getPrevious();
             $this->assertInstanceOf('InvalidArgumentException', $e, '->load() throws an InvalidArgumentException if the configuration does not validate the XSD');
-            $this->assertContains('The attribute \'bar\' is not allowed', $e->getMessage(), '->load() throws an InvalidArgumentException if the configuration does not validate the XSD');
+            $this->assertStringContainsString('The attribute \'bar\' is not allowed', $e->getMessage(), '->load() throws an InvalidArgumentException if the configuration does not validate the XSD');
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -41,7 +41,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
 
         $this->assertCount(1, $placeholderForVariable);
         $this->assertIsString($placeholder);
-        $this->assertContains($envVariableName, $placeholder);
+        $this->assertStringContainsString($envVariableName, $placeholder);
     }
 
     public function testMergeWhereFirstBagIsEmptyWillWork()
@@ -64,7 +64,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
 
         $this->assertCount(1, $placeholderForVariable);
         $this->assertIsString($placeholder);
-        $this->assertContains($envVariableName, $placeholder);
+        $this->assertStringContainsString($envVariableName, $placeholder);
     }
 
     public function testMergeWherePlaceholderOnlyExistsInSecond()

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -917,7 +917,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         $html = $this->renderWidget($form->createView());
 
         // compare plain HTML to check the whitespace
-        $this->assertContains('<div id="form" class="foobar" data-foo="bar">', $html);
+        $this->assertStringContainsString('<div id="form" class="foobar" data-foo="bar">', $html);
     }
 
     public function testWidgetContainerAttributeNameRepeatedIfTrue()
@@ -929,6 +929,6 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         $html = $this->renderWidget($form->createView());
 
         // foo="foo"
-        $this->assertContains('<div id="form" foo="foo">', $html);
+        $this->assertStringContainsString('<div id="form" foo="foo">', $html);
     }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2395,7 +2395,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $html = $this->renderWidget($form->createView());
 
-        $this->assertNotContains('foo="', $html);
+        $this->assertStringNotContainsString('foo="', $html);
     }
 
     public function testButtonAttributes()
@@ -2431,7 +2431,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $html = $this->renderWidget($form->createView());
 
-        $this->assertNotContains('foo="', $html);
+        $this->assertStringNotContainsString('foo="', $html);
     }
 
     public function testTextareaWithWhitespaceOnlyContentRetainsValue()
@@ -2440,7 +2440,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $html = $this->renderWidget($form->createView());
 
-        $this->assertContains('>  </textarea>', $html);
+        $this->assertStringContainsString('>  </textarea>', $html);
     }
 
     public function testTextareaWithWhitespaceOnlyContentRetainsValueWhenRenderingForm()
@@ -2451,7 +2451,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $html = $this->renderForm($form->createView());
 
-        $this->assertContains('>  </textarea>', $html);
+        $this->assertStringContainsString('>  </textarea>', $html);
     }
 
     public function testWidgetContainerAttributeHiddenIfFalse()
@@ -2463,7 +2463,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $html = $this->renderWidget($form->createView());
 
         // no foo
-        $this->assertNotContains('foo="', $html);
+        $this->assertStringNotContainsString('foo="', $html);
     }
 
     public function testTranslatedAttributes()

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -519,7 +519,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
         $html = $this->renderWidget($form->createView());
 
         // compare plain HTML to check the whitespace
-        $this->assertContains('<table id="form" class="foobar" data-foo="bar">', $html);
+        $this->assertStringContainsString('<table id="form" class="foobar" data-foo="bar">', $html);
     }
 
     public function testWidgetContainerAttributeNameRepeatedIfTrue()
@@ -531,6 +531,6 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
         $html = $this->renderWidget($form->createView());
 
         // foo="foo"
-        $this->assertContains('<table id="form" foo="foo">', $html);
+        $this->assertStringContainsString('<table id="form" foo="foo">', $html);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -27,7 +27,7 @@ class DebugCommandTest extends TestCase
         $ret = $tester->execute([], ['decorated' => false]);
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('Built-in form types', $tester->getDisplay());
+        $this->assertStringContainsString('Built-in form types', $tester->getDisplay());
     }
 
     public function testDebugSingleFormType()
@@ -36,7 +36,7 @@ class DebugCommandTest extends TestCase
         $ret = $tester->execute(['class' => 'FormType'], ['decorated' => false]);
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")', $tester->getDisplay());
+        $this->assertStringContainsString('Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")', $tester->getDisplay());
     }
 
     public function testDebugFormTypeOption()
@@ -45,7 +45,7 @@ class DebugCommandTest extends TestCase
         $ret = $tester->execute(['class' => 'FormType', 'option' => 'method'], ['decorated' => false]);
 
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('Symfony\Component\Form\Extension\Core\Type\FormType (method)', $tester->getDisplay());
+        $this->assertStringContainsString('Symfony\Component\Form\Extension\Core\Type\FormType (method)', $tester->getDisplay());
     }
 
     public function testDebugSingleFormTypeNotFound()

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -261,7 +261,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->expectOutputString('');
         $response->sendContent();
 
-        $this->assertContains('README.md', $response->headers->get('X-Sendfile'));
+        $this->assertStringContainsString('README.md', $response->headers->get('X-Sendfile'));
     }
 
     public function provideXSendfileFiles()

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1631,14 +1631,14 @@ class RequestTest extends TestCase
 
         $asString = (string) $request;
 
-        $this->assertContains('Accept-Language: zh, en-us; q=0.8, en; q=0.6', $asString);
-        $this->assertContains('Cookie: Foo=Bar', $asString);
+        $this->assertStringContainsString('Accept-Language: zh, en-us; q=0.8, en; q=0.6', $asString);
+        $this->assertStringContainsString('Cookie: Foo=Bar', $asString);
 
         $request->cookies->set('Another', 'Cookie');
 
         $asString = (string) $request;
 
-        $this->assertContains('Cookie: Foo=Bar; Another=Cookie', $asString);
+        $this->assertStringContainsString('Cookie: Foo=Bar; Another=Cookie', $asString);
     }
 
     public function testIsMethod()

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -582,7 +582,7 @@ class ResponseTest extends ResponseTestCase
             $this->fail('->setCache() throws an InvalidArgumentException if an option is not supported');
         } catch (\Exception $e) {
             $this->assertInstanceOf('InvalidArgumentException', $e, '->setCache() throws an InvalidArgumentException if an option is not supported');
-            $this->assertContains('"wrong option"', $e->getMessage());
+            $this->assertStringContainsString('"wrong option"', $e->getMessage());
         }
 
         $options = ['etag' => '"whatever"'];
@@ -635,7 +635,7 @@ class ResponseTest extends ResponseTestCase
         ob_start();
         $response->sendContent();
         $string = ob_get_clean();
-        $this->assertContains('test response rendering', $string);
+        $this->assertStringContainsString('test response rendering', $string);
     }
 
     public function testSetPublic()

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -204,7 +204,7 @@ class RouterListenerTest extends TestCase
         $request = Request::create('http://localhost/');
         $response = $kernel->handle($request);
         $this->assertSame(404, $response->getStatusCode());
-        $this->assertContains('Welcome', $response->getContent());
+        $this->assertStringContainsString('Welcome', $response->getContent());
     }
 
     public function testRequestWithBadHost()

--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -20,9 +20,9 @@ class UriSignerTest extends TestCase
     {
         $signer = new UriSigner('foobar');
 
-        $this->assertContains('?_hash=', $signer->sign('http://example.com/foo'));
-        $this->assertContains('?_hash=', $signer->sign('http://example.com/foo?foo=bar'));
-        $this->assertContains('&foo=', $signer->sign('http://example.com/foo?foo=bar'));
+        $this->assertStringContainsString('?_hash=', $signer->sign('http://example.com/foo'));
+        $this->assertStringContainsString('?_hash=', $signer->sign('http://example.com/foo?foo=bar'));
+        $this->assertStringContainsString('&foo=', $signer->sign('http://example.com/foo?foo=bar'));
     }
 
     public function testCheck()

--- a/src/Symfony/Component/Process/Tests/PhpProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpProcessTest.php
@@ -38,10 +38,10 @@ PHP
         $commandLine = $process->getCommandLine();
 
         $process->start();
-        $this->assertContains($commandLine, $process->getCommandLine(), '::getCommandLine() returns the command line of PHP after start');
+        $this->assertStringContainsString($commandLine, $process->getCommandLine(), '::getCommandLine() returns the command line of PHP after start');
 
         $process->wait();
-        $this->assertContains($commandLine, $process->getCommandLine(), '::getCommandLine() returns the command line of PHP after wait');
+        $this->assertStringContainsString($commandLine, $process->getCommandLine(), '::getCommandLine() returns the command line of PHP after wait');
 
         $this->assertSame(PHP_VERSION.\PHP_SAPI, $process->getOutput());
     }

--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -79,7 +79,7 @@ class ProcessBuilderTest extends TestCase
 
         $proc = $pb->getProcess();
 
-        $this->assertContains('second', $proc->getCommandLine());
+        $this->assertStringContainsString('second', $proc->getCommandLine());
     }
 
     public function testPrefixIsPrependedToAllGeneratedProcess()

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -48,7 +48,7 @@ bar';
         $ret = $tester->execute(['filename' => $filename], ['decorated' => false]);
 
         $this->assertEquals(1, $ret, 'Returns 1 in case of error');
-        $this->assertContains('Unable to parse at line 3 (near "bar").', trim($tester->getDisplay()));
+        $this->assertStringContainsString('Unable to parse at line 3 (near "bar").', trim($tester->getDisplay()));
     }
 
     public function testConstantAsKey()

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -132,7 +132,7 @@ class InlineTest extends TestCase
             }
 
             $this->assertEquals('1.2', Inline::dump(1.2));
-            $this->assertContains('fr', strtolower(setlocale(LC_NUMERIC, 0)));
+            $this->assertStringContainsStringIgnoringCase('fr', setlocale(LC_NUMERIC, 0));
         } finally {
             setlocale(LC_NUMERIC, $locale);
         }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -58,7 +58,7 @@ class ParserTest extends TestCase
             restore_error_handler();
 
             $this->assertCount(1, $deprecations);
-            $this->assertContains(true !== $deprecated ? $deprecated : 'Using the comma as a group separator for floats is deprecated since Symfony 3.2 and will be removed in 4.0 on line 1.', $deprecations[0]);
+            $this->assertStringContainsString(true !== $deprecated ? $deprecated : 'Using the comma as a group separator for floats is deprecated since Symfony 3.2 and will be removed in 4.0 on line 1.', $deprecations[0]);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

This PR replaces deprecated assertContains to comparre string by the dedicated method `assertStringContainsString`