### PR TITLE
"An instance of X" phpdocs removal

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -35,8 +35,7 @@ abstract class AbstractDoctrineExtension extends Extension
     protected $drivers = [];
 
     /**
-     * @param array            $objectManager A configured object manager
-     * @param ContainerBuilder $container     A ContainerBuilder instance
+     * @param array $objectManager A configured object manager
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -29,8 +29,7 @@ class HttpCache extends BaseHttpCache
     protected $kernel;
 
     /**
-     * @param KernelInterface $kernel   A KernelInterface instance
-     * @param string          $cacheDir The cache directory (default used if null)
+     * @param string $cacheDir The cache directory (default used if null)
      */
     public function __construct(KernelInterface $kernel, string $cacheDir = null)
     {
@@ -43,9 +42,8 @@ class HttpCache extends BaseHttpCache
     /**
      * Forwards the Request to the backend and returns the Response.
      *
-     * @param Request  $request A Request instance
-     * @param bool     $raw     Whether to catch exceptions or not
-     * @param Response $entry   A Response instance (the stale entry if present, null otherwise)
+     * @param bool     $raw   Whether to catch exceptions or not
+     * @param Response $entry A Response instance (the stale entry if present, null otherwise)
      *
      * @return Response A Response instance
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -36,12 +36,8 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
     private $paramFetcher;
 
     /**
-     * @param ContainerInterface      $container  A ContainerInterface instance
-     * @param mixed                   $resource   The main resource to load
-     * @param array                   $options    An array of options
-     * @param RequestContext          $context    The context
-     * @param ContainerInterface|null $parameters A ContainerInterface instance allowing to fetch parameters
-     * @param LoggerInterface|null    $logger
+     * @param mixed $resource The main resource to load
+     * @param array $options  An array of options
      */
     public function __construct(ContainerInterface $container, $resource, array $options = [], RequestContext $context = null, ContainerInterface $parameters = null, LoggerInterface $logger = null, string $defaultLocale = null)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -65,11 +65,9 @@ class Translator extends BaseTranslator implements WarmableInterface
      *   * debug:     Whether to enable debugging or not (false by default)
      *   * resource_files: List of translation resources available grouped by locale.
      *
-     * @param ContainerInterface        $container     A ContainerInterface instance
-     * @param MessageFormatterInterface $formatter     The message formatter
-     * @param string                    $defaultLocale
-     * @param array                     $loaderIds     An array of loader Ids
-     * @param array                     $options       An array of options
+     * @param string $defaultLocale
+     * @param array  $loaderIds     An array of loader Ids
+     * @param array  $options       An array of options
      *
      * @throws InvalidArgumentException
      */

--- a/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
+++ b/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
@@ -29,9 +29,8 @@ class TemplateIterator implements \IteratorAggregate
     private $defaultPath;
 
     /**
-     * @param KernelInterface $kernel      A KernelInterface instance
-     * @param array           $paths       Additional Twig paths to warm
-     * @param string|null     $defaultPath The directory where global templates can be stored
+     * @param array       $paths       Additional Twig paths to warm
+     * @param string|null $defaultPath The directory where global templates can be stored
      */
     public function __construct(KernelInterface $kernel, array $paths = [], string $defaultPath = null)
     {

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -36,8 +36,7 @@ class WebProfilerExtension extends Extension
     /**
      * Loads the web profiler configuration.
      *
-     * @param array            $configs   An array of configuration settings
-     * @param ContainerBuilder $container A ContainerBuilder instance
+     * @param array $configs An array of configuration settings
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -51,9 +51,7 @@ abstract class AbstractBrowser
     private $isMainRequest = true;
 
     /**
-     * @param array     $server    The server parameters (equivalent of $_SERVER)
-     * @param History   $history   A History instance to store the browser history
-     * @param CookieJar $cookieJar A CookieJar instance to store the cookies
+     * @param array $server The server parameters (equivalent of $_SERVER)
      */
     public function __construct(array $server = [], History $history = null, CookieJar $cookieJar = null)
     {
@@ -295,7 +293,6 @@ abstract class AbstractBrowser
     /**
      * Submits a form.
      *
-     * @param Form  $form             A Form instance
      * @param array $values           An array of form field values
      * @param array $serverParameters An array of server parameters
      *
@@ -683,8 +680,7 @@ abstract class AbstractBrowser
     /**
      * Makes a request from a Request object directly.
      *
-     * @param Request $request       A Request instance
-     * @param bool    $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     * @param bool $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
      *
      * @return Crawler
      */

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -132,8 +132,7 @@ class CookieJar
     /**
      * Updates the cookie jar from a Response object.
      *
-     * @param Response $response A Response object
-     * @param string   $uri      The base URL
+     * @param string $uri The base URL
      */
     public function updateFromResponse(Response $response, string $uri = null)
     {

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -52,8 +52,7 @@ final class ProgressBar
     private static $formats;
 
     /**
-     * @param OutputInterface $output An OutputInterface instance
-     * @param int             $max    Maximum steps (0 if unknown)
+     * @param int $max Maximum steps (0 if unknown)
      */
     public function __construct(OutputInterface $output, int $max = 0, float $minSecondsBetweenRedraws = 0.1)
     {

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -353,9 +353,8 @@ class QuestionHelper extends Helper
     /**
      * Gets a hidden response from user.
      *
-     * @param OutputInterface $output      An Output instance
-     * @param resource        $inputStream The handler resource
-     * @param bool            $trimmable   Is the answer trimmable
+     * @param resource $inputStream The handler resource
+     * @param bool     $trimmable   Is the answer trimmable
      *
      * @throws RuntimeException In case the fallback is deactivated and the response cannot be hidden
      */
@@ -416,9 +415,7 @@ class QuestionHelper extends Helper
     /**
      * Validates an attempt.
      *
-     * @param callable        $interviewer A callable that will ask for a question and return the result
-     * @param OutputInterface $output      An Output instance
-     * @param Question        $question    A Question instance
+     * @param callable $interviewer A callable that will ask for a question and return the result
      *
      * @return mixed The validated response
      *

--- a/src/Symfony/Component/ErrorHandler/FatalErrorHandler/FatalErrorHandlerInterface.php
+++ b/src/Symfony/Component/ErrorHandler/FatalErrorHandler/FatalErrorHandlerInterface.php
@@ -23,8 +23,7 @@ interface FatalErrorHandlerInterface
     /**
      * Attempts to convert an error into an exception.
      *
-     * @param array               $error     An array as returned by error_get_last()
-     * @param FatalErrorException $exception A FatalErrorException instance
+     * @param array $error An array as returned by error_get_last()
      *
      * @return FatalErrorException|null A FatalErrorException instance if the class is able to convert the error, null otherwise
      */

--- a/src/Symfony/Component/ExpressionLanguage/ParsedExpression.php
+++ b/src/Symfony/Component/ExpressionLanguage/ParsedExpression.php
@@ -22,10 +22,6 @@ class ParsedExpression extends Expression
 {
     private $nodes;
 
-    /**
-     * @param string $expression An expression
-     * @param Node   $nodes      A Node representing the expression
-     */
     public function __construct(string $expression, Node $nodes)
     {
         parent::__construct($expression);

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -31,11 +31,6 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     private $data = [];
     private $usageIndex = 0;
 
-    /**
-     * @param SessionStorageInterface $storage    A SessionStorageInterface instance
-     * @param AttributeBagInterface   $attributes An AttributeBagInterface instance, (defaults null for default AttributeBag)
-     * @param FlashBagInterface       $flashes    A FlashBagInterface instance (defaults null for default FlashBag)
-     */
     public function __construct(SessionStorageInterface $storage = null, AttributeBagInterface $attributes = null, FlashBagInterface $flashes = null)
     {
         $this->storage = $storage ?: new NativeSessionStorage();

--- a/src/Symfony/Component/HttpKernel/Config/FileLocator.php
+++ b/src/Symfony/Component/HttpKernel/Config/FileLocator.php
@@ -25,9 +25,8 @@ class FileLocator extends BaseFileLocator
     private $path;
 
     /**
-     * @param KernelInterface $kernel A KernelInterface instance
-     * @param string|null     $path   The path the global resource directory
-     * @param array           $paths  An array of paths where to look for resources
+     * @param string|null $path  The path the global resource directory
+     * @param array       $paths An array of paths where to look for resources
      */
     public function __construct(KernelInterface $kernel, string $path = null, array $paths = [])
     {

--- a/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
@@ -37,8 +37,7 @@ class FragmentListener implements EventSubscriberInterface
     private $fragmentPath;
 
     /**
-     * @param UriSigner $signer       A UriSigner instance
-     * @param string    $fragmentPath The path that triggers this listener
+     * @param string $fragmentPath The path that triggers this listener
      */
     public function __construct(UriSigner $signer, string $fragmentPath = '/_fragment')
     {

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -34,7 +34,6 @@ class LocaleListener implements EventSubscriberInterface
     private $requestStack;
 
     /**
-     * @param RequestStack                      $requestStack  A RequestStack instance
      * @param string                            $defaultLocale The default locale
      * @param RequestContextAwareInterface|null $router        The router
      */

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -39,11 +39,8 @@ class ProfilerListener implements EventSubscriberInterface
     protected $parents;
 
     /**
-     * @param Profiler                     $profiler           A Profiler instance
-     * @param RequestStack                 $requestStack       A RequestStack instance
-     * @param RequestMatcherInterface|null $matcher            A RequestMatcher instance
-     * @param bool                         $onlyException      True if the profiler only collects data when an exception occurs, false otherwise
-     * @param bool                         $onlyMasterRequests True if the profiler only collects data when the request is a master request, false otherwise
+     * @param bool $onlyException      True if the profiler only collects data when an exception occurs, false otherwise
+     * @param bool $onlyMasterRequests True if the profiler only collects data when the request is a master request, false otherwise
      */
     public function __construct(Profiler $profiler, RequestStack $requestStack, RequestMatcherInterface $matcher = null, bool $onlyException = false, bool $onlyMasterRequests = false)
     {

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -50,10 +50,9 @@ class RouterListener implements EventSubscriberInterface
     private $debug;
 
     /**
-     * @param UrlMatcherInterface|RequestMatcherInterface $matcher      The Url or Request matcher
-     * @param RequestStack                                $requestStack A RequestStack instance
-     * @param RequestContext|null                         $context      The RequestContext (can be null when $matcher implements RequestContextAwareInterface)
-     * @param LoggerInterface|null                        $logger       The logger
+     * @param UrlMatcherInterface|RequestMatcherInterface $matcher    The Url or Request matcher
+     * @param RequestContext|null                         $context    The RequestContext (can be null when $matcher implements RequestContextAwareInterface)
+     * @param LoggerInterface|null                        $logger     The logger
      * @param string                                      $projectDir
      * @param bool                                        $debug
      *

--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -32,7 +32,6 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
      * The "fallback" strategy when surrogate is not available should always be an
      * instance of InlineFragmentRenderer.
      *
-     * @param SurrogateInterface        $surrogate      An Surrogate instance
      * @param FragmentRendererInterface $inlineStrategy The inline strategy to use when the surrogate is not supported
      * @param UriSigner                 $signer
      */

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentRendererInterface.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentRendererInterface.php
@@ -26,7 +26,6 @@ interface FragmentRendererInterface
      * Renders a URI and returns the Response content.
      *
      * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
-     * @param Request                    $request A Request instance
      * @param array                      $options An array of options
      *
      * @return Response A Response instance

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -39,10 +39,8 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
     /**
      * Generates a fragment URI for a given controller.
      *
-     * @param ControllerReference $reference A ControllerReference instance
-     * @param Request             $request   A Request instance
-     * @param bool                $absolute  Whether to generate an absolute URL or not
-     * @param bool                $strict    Whether to allow non-scalar attributes or not
+     * @param bool $absolute Whether to generate an absolute URL or not
+     * @param bool $strict   Whether to allow non-scalar attributes or not
      *
      * @return string A fragment URI
      */

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -256,8 +256,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     /**
      * Forwards the Request to the backend without storing the Response in the cache.
      *
-     * @param Request $request A Request instance
-     * @param bool    $catch   Whether to process exceptions
+     * @param bool $catch Whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -271,8 +270,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     /**
      * Invalidates non-safe methods (like POST, PUT, and DELETE).
      *
-     * @param Request $request A Request instance
-     * @param bool    $catch   Whether to process exceptions
+     * @param bool $catch Whether to process exceptions
      *
      * @return Response A Response instance
      *
@@ -320,8 +318,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * the backend using conditional GET. When no matching cache entry is found,
      * it triggers "miss" processing.
      *
-     * @param Request $request A Request instance
-     * @param bool    $catch   Whether to process exceptions
+     * @param bool $catch Whether to process exceptions
      *
      * @return Response A Response instance
      *
@@ -366,9 +363,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * The original request is used as a template for a conditional
      * GET request with the backend.
      *
-     * @param Request  $request A Request instance
-     * @param Response $entry   A Response instance to validate
-     * @param bool     $catch   Whether to process exceptions
+     * @param bool $catch Whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -429,8 +424,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * Unconditionally fetches a fresh response from the backend and
      * stores it in the cache if is cacheable.
      *
-     * @param Request $request A Request instance
-     * @param bool    $catch   Whether to process exceptions
+     * @param bool $catch Whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -462,9 +456,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * All backend requests (cache passes, fetches, cache validations)
      * run through this method.
      *
-     * @param Request  $request A Request instance
-     * @param bool     $catch   Whether to catch exceptions or not
-     * @param Response $entry   A Response instance (the stale entry if present, null otherwise)
+     * @param bool     $catch Whether to catch exceptions or not
+     * @param Response $entry A Response instance (the stale entry if present, null otherwise)
      *
      * @return Response A Response instance
      */

--- a/src/Symfony/Component/HttpKernel/HttpCache/SurrogateInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/SurrogateInterface.php
@@ -78,10 +78,9 @@ interface SurrogateInterface
     /**
      * Handles a Surrogate from the cache.
      *
-     * @param HttpCache $cache        An HttpCache instance
-     * @param string    $uri          The main URI
-     * @param string    $alt          An alternative URI
-     * @param bool      $ignoreErrors Whether to ignore errors or not
+     * @param string $uri          The main URI
+     * @param string $alt          An alternative URI
+     * @param bool   $ignoreErrors Whether to ignore errors or not
      *
      * @return string
      *

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -109,8 +109,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      *
      * Exceptions are not caught.
      *
-     * @param Request $request A Request instance
-     * @param int     $type    The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param int $type The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
      *
      * @return Response A Response instance
      *
@@ -174,9 +173,8 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     /**
      * Filters a response object.
      *
-     * @param Response $response A Response instance
-     * @param Request  $request  An error message in case the response is not a Response object
-     * @param int      $type     The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param Request $request An error message in case the response is not a Response object
+     * @param int     $type    The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
      *
      * @return Response The filtered Response instance
      *
@@ -209,9 +207,8 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     /**
      * Handles an exception by trying to convert it to a Response.
      *
-     * @param \Exception $e       An \Exception instance
-     * @param Request    $request A Request instance
-     * @param int        $type    The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param \Exception $e    An \Exception instance
+     * @param int        $type The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
      *
      * @throws \Exception
      */

--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -34,10 +34,7 @@ class HttpKernelBrowser extends AbstractBrowser
     private $catchExceptions = true;
 
     /**
-     * @param HttpKernelInterface $kernel    An HttpKernel instance
-     * @param array               $server    The server parameters (equivalent of $_SERVER)
-     * @param History             $history   A History instance to store the browser history
-     * @param CookieJar           $cookieJar A CookieJar instance to store the cookies
+     * @param array $server The server parameters (equivalent of $_SERVER)
      */
     public function __construct(HttpKernelInterface $kernel, array $server = [], History $history = null, CookieJar $cookieJar = null)
     {

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -30,10 +30,9 @@ interface HttpKernelInterface
      * When $catch is true, the implementation must catch all exceptions
      * and do its best to convert them to a Response instance.
      *
-     * @param Request $request A Request instance
-     * @param int     $type    The type of the request
-     *                         (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
-     * @param bool    $catch   Whether to catch exceptions or not
+     * @param int  $type  The type of the request
+     *                    (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param bool $catch Whether to catch exceptions or not
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Component/Ldap/Adapter/AbstractConnection.php
+++ b/src/Symfony/Component/Ldap/Adapter/AbstractConnection.php
@@ -30,11 +30,6 @@ abstract class AbstractConnection implements ConnectionInterface
         $this->config = $resolver->resolve($config);
     }
 
-    /**
-     * Configures the adapter's options.
-     *
-     * @param OptionsResolver $resolver An OptionsResolver instance
-     */
     protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -101,10 +101,9 @@ class YamlFileLoader extends FileLoader
     /**
      * Parses a route and adds it to the RouteCollection.
      *
-     * @param RouteCollection $collection A RouteCollection instance
-     * @param string          $name       Route name
-     * @param array           $config     Route definition
-     * @param string          $path       Full path of the YAML file being processed
+     * @param string $name   Route name
+     * @param array  $config Route definition
+     * @param string $path   Full path of the YAML file being processed
      */
     protected function parseRoute(RouteCollection $collection, $name, array $config, $path)
     {
@@ -154,10 +153,9 @@ class YamlFileLoader extends FileLoader
     /**
      * Parses an import and adds the routes in the resource to the RouteCollection.
      *
-     * @param RouteCollection $collection A RouteCollection instance
-     * @param array           $config     Route definition
-     * @param string          $path       Full path of the YAML file being processed
-     * @param string          $file       Loaded file name
+     * @param array  $config Route definition
+     * @param string $path   Full path of the YAML file being processed
+     * @param string $file   Loaded file name
      */
     protected function parseImport(RouteCollection $collection, array $config, $path, $file)
     {

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -93,11 +93,8 @@ class Router implements RouterInterface, RequestMatcherInterface
     private $expressionLanguageProviders = [];
 
     /**
-     * @param LoaderInterface $loader   A LoaderInterface instance
-     * @param mixed           $resource The main resource to load
-     * @param array           $options  An array of options
-     * @param RequestContext  $context  The context
-     * @param LoggerInterface $logger   A logger instance
+     * @param mixed $resource The main resource to load
+     * @param array $options  An array of options
      */
     public function __construct(LoaderInterface $loader, $resource, array $options = [], RequestContext $context = null, LoggerInterface $logger = null, string $defaultLocale = null)
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
@@ -24,9 +24,8 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
     private $providerKey;
 
     /**
-     * @param UserCheckerInterface $userChecker An UserCheckerInterface interface
-     * @param string               $secret      A secret
-     * @param string               $providerKey A provider secret
+     * @param string $secret      A secret
+     * @param string $providerKey A provider secret
      */
     public function __construct(UserCheckerInterface $userChecker, string $secret, string $providerKey)
     {

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -23,9 +23,8 @@ interface AccessDecisionManagerInterface
     /**
      * Decides whether the access is possible or not.
      *
-     * @param TokenInterface $token      A TokenInterface instance
-     * @param array          $attributes An array of attributes associated with the method being invoked
-     * @param object         $object     The object to secure
+     * @param array  $attributes An array of attributes associated with the method being invoked
+     * @param object $object     The object to secure
      *
      * @return bool true if the access is granted, false otherwise
      */

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -30,9 +30,8 @@ interface VoterInterface
      * This method must return one of the following constants:
      * ACCESS_GRANTED, ACCESS_DENIED, or ACCESS_ABSTAIN.
      *
-     * @param TokenInterface $token      A TokenInterface instance
-     * @param mixed          $subject    The subject to secure
-     * @param array          $attributes An array of attributes associated with the method being invoked
+     * @param mixed $subject    The subject to secure
+     * @param array $attributes An array of attributes associated with the method being invoked
      *
      * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
      */

--- a/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
@@ -41,11 +41,8 @@ class GuardAuthenticationListener
     private $rememberMeServices;
 
     /**
-     * @param GuardAuthenticatorHandler         $guardHandler          The Guard handler
-     * @param AuthenticationManagerInterface    $authenticationManager An AuthenticationManagerInterface instance
-     * @param string                            $providerKey           The provider (i.e. firewall) key
-     * @param iterable|AuthenticatorInterface[] $guardAuthenticators   The authenticators, with keys that match what's passed to GuardAuthenticationProvider
-     * @param LoggerInterface                   $logger                A LoggerInterface instance
+     * @param string                            $providerKey         The provider (i.e. firewall) key
+     * @param iterable|AuthenticatorInterface[] $guardAuthenticators The authenticators, with keys that match what's passed to GuardAuthenticationProvider
      */
     public function __construct(GuardAuthenticatorHandler $guardHandler, AuthenticationManagerInterface $authenticationManager, string $providerKey, $guardAuthenticators, LoggerInterface $logger = null)
     {

--- a/src/Symfony/Component/Security/Http/AccessMap.php
+++ b/src/Symfony/Component/Security/Http/AccessMap.php
@@ -25,9 +25,8 @@ class AccessMap implements AccessMapInterface
     private $map = [];
 
     /**
-     * @param RequestMatcherInterface $requestMatcher A RequestMatcherInterface instance
-     * @param array                   $attributes     An array of attributes to pass to the access decision manager (like roles)
-     * @param string|null             $channel        The channel to enforce (http, https, or null)
+     * @param array       $attributes An array of attributes to pass to the access decision manager (like roles)
+     * @param string|null $channel    The channel to enforce (http, https, or null)
      */
     public function add(RequestMatcherInterface $requestMatcher, array $attributes = [], $channel = null)
     {

--- a/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationFailureHandler.php
@@ -22,8 +22,7 @@ class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler
     private $handler;
 
     /**
-     * @param AuthenticationFailureHandlerInterface $handler An AuthenticationFailureHandlerInterface instance
-     * @param array                                 $options Options for processing a successful authentication attempt
+     * @param array $options Options for processing a successful authentication attempt
      */
     public function __construct(AuthenticationFailureHandlerInterface $handler, array $options)
     {

--- a/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationSuccessHandler.php
@@ -22,9 +22,8 @@ class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler
     private $handler;
 
     /**
-     * @param AuthenticationSuccessHandlerInterface $handler     An AuthenticationSuccessHandlerInterface instance
-     * @param array                                 $options     Options for processing a successful authentication attempt
-     * @param string                                $providerKey The provider key
+     * @param array  $options     Options for processing a successful authentication attempt
+     * @param string $providerKey The provider key
      */
     public function __construct(AuthenticationSuccessHandlerInterface $handler, array $options, string $providerKey)
     {

--- a/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
@@ -29,10 +29,8 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
     private $httpUtils;
 
     /**
-     * @param HttpKernelInterface $kernel
-     * @param HttpUtils           $httpUtils  An HttpUtils instance
-     * @param string              $loginPath  The path to the login form
-     * @param bool                $useForward Whether to forward or redirect to the login form
+     * @param string $loginPath  The path to the login form
+     * @param bool   $useForward Whether to forward or redirect to the login form
      */
     public function __construct(HttpKernelInterface $kernel, HttpUtils $httpUtils, string $loginPath, bool $useForward = false)
     {

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -40,11 +40,8 @@ class LogoutListener
     private $csrfTokenManager;
 
     /**
-     * @param TokenStorageInterface          $tokenStorage
-     * @param HttpUtils                      $httpUtils        An HttpUtils instance
-     * @param LogoutSuccessHandlerInterface  $successHandler   A LogoutSuccessHandlerInterface instance
-     * @param array                          $options          An array of options to process a logout attempt
-     * @param CsrfTokenManagerInterface|null $csrfTokenManager A CsrfTokenManagerInterface instance
+     * @param TokenStorageInterface $tokenStorage
+     * @param array                 $options      An array of options to process a logout attempt
      */
     public function __construct(TokenStorageInterface $tokenStorage, HttpUtils $httpUtils, LogoutSuccessHandlerInterface $successHandler, array $options = [], CsrfTokenManagerInterface $csrfTokenManager = null)
     {

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -33,7 +33,6 @@ class HttpUtils
     private $secureDomainRegexp;
 
     /**
-     * @param UrlGeneratorInterface                       $urlGenerator       A UrlGeneratorInterface instance
      * @param UrlMatcherInterface|RequestMatcherInterface $urlMatcher         The URL or Request matcher
      * @param string|null                                 $domainRegexp       A regexp the target of HTTP redirections must match, scheme included
      * @param string|null                                 $secureDomainRegexp A regexp the target of HTTP redirections must match when the scheme is "https"
@@ -54,9 +53,8 @@ class HttpUtils
     /**
      * Creates a redirect Response.
      *
-     * @param Request $request A Request instance
-     * @param string  $path    A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
-     * @param int     $status  The status code
+     * @param string $path   A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
+     * @param int    $status The status code
      *
      * @return RedirectResponse A RedirectResponse instance
      */
@@ -114,8 +112,7 @@ class HttpUtils
     /**
      * Checks that a given path matches the Request.
      *
-     * @param Request $request A Request instance
-     * @param string  $path    A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
+     * @param string $path A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
      *
      * @return bool true if the path is the same as the one from the Request, false otherwise
      */
@@ -144,14 +141,13 @@ class HttpUtils
     /**
      * Generates a URI, based on the given path or absolute URL.
      *
-     * @param Request $request A Request instance
-     * @param string  $path    A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
+     * @param string $path A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
      *
      * @return string An absolute URL
      *
      * @throws \LogicException
      */
-    public function generateUri($request, $path)
+    public function generateUri(Request $request, $path)
     {
         if (0 === strpos($path, 'http') || !$path) {
             return $path;

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareTrait.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareTrait.php
@@ -23,11 +23,6 @@ trait DenormalizerAwareTrait
      */
     protected $denormalizer;
 
-    /**
-     * Sets the Denormalizer.
-     *
-     * @param DenormalizerInterface $denormalizer A DenormalizerInterface instance
-     */
     public function setDenormalizer(DenormalizerInterface $denormalizer)
     {
         $this->denormalizer = $denormalizer;

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareTrait.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareTrait.php
@@ -23,11 +23,6 @@ trait NormalizerAwareTrait
      */
     protected $normalizer;
 
-    /**
-     * Sets the normalizer.
-     *
-     * @param NormalizerInterface $normalizer A NormalizerInterface instance
-     */
     public function setNormalizer(NormalizerInterface $normalizer)
     {
         $this->normalizer = $normalizer;

--- a/src/Symfony/Component/Serializer/SerializerAwareTrait.php
+++ b/src/Symfony/Component/Serializer/SerializerAwareTrait.php
@@ -23,11 +23,6 @@ trait SerializerAwareTrait
      */
     protected $serializer;
 
-    /**
-     * Sets the serializer.
-     *
-     * @param SerializerInterface $serializer A SerializerInterface instance
-     */
     public function setSerializer(SerializerInterface $serializer)
     {
         $this->serializer = $serializer;

--- a/src/Symfony/Component/Templating/Loader/CacheLoader.php
+++ b/src/Symfony/Component/Templating/Loader/CacheLoader.php
@@ -30,8 +30,7 @@ class CacheLoader extends Loader
     protected $dir;
 
     /**
-     * @param LoaderInterface $loader A Loader instance
-     * @param string          $dir    The directory where to store the cache files
+     * @param string $dir The directory where to store the cache files
      */
     public function __construct(LoaderInterface $loader, string $dir)
     {

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -106,8 +106,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
     /**
      * Adds a Loader.
      *
-     * @param string          $format The name of the loader (@see addResource())
-     * @param LoaderInterface $loader A LoaderInterface instance
+     * @param string $format The name of the loader (@see addResource())
      */
     public function addLoader(string $format, LoaderInterface $loader)
     {

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -116,7 +116,6 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
     /**
      * Dumps a Data object.
      *
-     * @param Data                               $data   A Data object
      * @param callable|resource|string|true|null $output A line dumper callable, an opened stream, an output path or true to return the dump
      *
      * @return string|null The dump as string when $output is true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR removes all phpdocs referring to instances of X `@param X $x A X instance` (or similar).
