### PR TITLE
Remove deprecated assertContains

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -46,8 +46,8 @@ class DeprecationTest extends TestCase
     public function testItCanBeConvertedToAString()
     {
         $deprecation = new Deprecation('💩', $this->debugBacktrace(), __FILE__);
-        $this->assertContains('💩', $deprecation->toString());
-        $this->assertContains(__FUNCTION__, $deprecation->toString());
+        $this->assertStringContainsString('💩', $deprecation->toString());
+        $this->assertStringContainsString(__FUNCTION__, $deprecation->toString());
     }
 
     public function testItRulesOutFilesOutsideVendorsAsIndirect()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
@@ -45,7 +45,7 @@ class CachePoolDeleteCommandTest extends TestCase
         $tester = $this->getCommandTester($this->getKernel());
         $tester->execute(['pool' => 'foo', 'key' => 'bar']);
 
-        $this->assertContains('[OK] Cache item "bar" was successfully deleted.', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Cache item "bar" was successfully deleted.', $tester->getDisplay());
     }
 
     public function testCommandWithInValidKey()
@@ -62,7 +62,7 @@ class CachePoolDeleteCommandTest extends TestCase
         $tester = $this->getCommandTester($this->getKernel());
         $tester->execute(['pool' => 'foo', 'key' => 'bar']);
 
-        $this->assertContains('[NOTE] Cache item "bar" does not exist in cache pool "foo".', $tester->getDisplay());
+        $this->assertStringContainsString('[NOTE] Cache item "bar" does not exist in cache pool "foo".', $tester->getDisplay());
     }
 
     public function testCommandDeleteFailed()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
@@ -69,7 +69,7 @@ EOF;
         );
 
         $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
-        $this->assertContains('[OK] All 0 XLIFF files contain valid syntax', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] All 0 XLIFF files contain valid syntax', trim($tester->getDisplay()));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -226,7 +226,7 @@ class ApplicationTest extends TestCase
         $this->assertSame(0, $tester->getStatusCode());
         $display = explode('Lists commands', $tester->getDisplay());
 
-        $this->assertContains(trim('[WARNING] Some commands could not be registered:'), trim($display[1]));
+        $this->assertStringContainsString(trim('[WARNING] Some commands could not be registered:'), trim($display[1]));
     }
 
     public function testSuggestingPackagesWithExactMatch()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
@@ -31,8 +31,8 @@ class CachePoolListCommandTest extends AbstractWebTestCase
         $tester->execute([]);
 
         $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:list exits with 0 in case of success');
-        $this->assertContains('cache.app', $tester->getDisplay());
-        $this->assertContains('cache.system', $tester->getDisplay());
+        $this->assertStringContainsString('cache.app', $tester->getDisplay());
+        $this->assertStringContainsString('cache.system', $tester->getDisplay());
     }
 
     public function testEmptyList()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -71,7 +71,7 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         $tester = $this->createCommandTester();
         $tester->execute(['name' => 'FrameworkBundle']);
 
-        $this->assertContains("cookie_httponly: '%env(bool:COOKIE_HTTPONLY)%'", $tester->getDisplay());
+        $this->assertStringContainsString("cookie_httponly: '%env(bool:COOKIE_HTTPONLY)%'", $tester->getDisplay());
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -61,8 +61,8 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
         $this->assertNotContains('private_alias', $tester->getDisplay());
 
         $tester->run(['command' => 'debug:container']);
-        $this->assertContains('public', $tester->getDisplay());
-        $this->assertContains('private_alias', $tester->getDisplay());
+        $this->assertStringContainsString('public', $tester->getDisplay());
+        $this->assertStringContainsString('private_alias', $tester->getDisplay());
     }
 
     /**
@@ -130,7 +130,7 @@ TXT
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:container', '--env-var' => 'js'], ['decorated' => false]);
 
-        $this->assertContains(file_get_contents(__DIR__.'/Fixtures/describe_env_vars.txt'), $tester->getDisplay(true));
+        $this->assertStringContainsString(file_get_contents(__DIR__.'/Fixtures/describe_env_vars.txt'), $tester->getDisplay(true));
     }
 
     public function provideIgnoreBackslashWhenFindingService()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -56,7 +56,7 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:autowiring', 'search' => 'HttpKernelHttpKernelInterface']);
-        $this->assertContains('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
+        $this->assertStringContainsString('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
     }
 
     public function testSearchNoResults()
@@ -83,7 +83,7 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:autowiring', 'search' => 'redirect']);
 
-        $this->assertContains(' more concrete service would be displayed when adding the "--all" option.', $tester->getDisplay());
+        $this->assertStringContainsString(' more concrete service would be displayed when adding the "--all" option.', $tester->getDisplay());
     }
 
     public function testSearchNotAliasedServiceWithAll()
@@ -95,6 +95,6 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:autowiring', 'search' => 'redirect', '--all' => true]);
-        $this->assertContains('Pro-tip: use interfaces in your type-hints instead of classes to benefit from the dependency inversion principle.', $tester->getDisplay());
+        $this->assertStringContainsString('Pro-tip: use interfaces in your type-hints instead of classes to benefit from the dependency inversion principle.', $tester->getDisplay());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -34,9 +34,9 @@ class RouterDebugCommandTest extends AbstractWebTestCase
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('routerdebug_test', $display);
-        $this->assertContains('/test', $display);
-        $this->assertContains('/session', $display);
+        $this->assertStringContainsString('routerdebug_test', $display);
+        $this->assertStringContainsString('/test', $display);
+        $this->assertStringContainsString('/session', $display);
     }
 
     public function testDumpOneRoute()
@@ -45,8 +45,8 @@ class RouterDebugCommandTest extends AbstractWebTestCase
         $ret = $tester->execute(['name' => 'routerdebug_session_welcome']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('routerdebug_session_welcome', $tester->getDisplay());
-        $this->assertContains('/session', $tester->getDisplay());
+        $this->assertStringContainsString('routerdebug_session_welcome', $tester->getDisplay());
+        $this->assertStringContainsString('/session', $tester->getDisplay());
     }
 
     public function testSearchMultipleRoutes()
@@ -56,9 +56,9 @@ class RouterDebugCommandTest extends AbstractWebTestCase
         $ret = $tester->execute(['name' => 'routerdebug'], ['interactive' => true]);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('Select one of the matching routes:', $tester->getDisplay());
-        $this->assertContains('routerdebug_test', $tester->getDisplay());
-        $this->assertContains('/test', $tester->getDisplay());
+        $this->assertStringContainsString('Select one of the matching routes:', $tester->getDisplay());
+        $this->assertStringContainsString('routerdebug_test', $tester->getDisplay());
+        $this->assertStringContainsString('/test', $tester->getDisplay());
     }
 
     public function testSearchWithThrow()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TranslationDebugCommandTest.php
@@ -33,13 +33,13 @@ class TranslationDebugCommandTest extends AbstractWebTestCase
         $ret = $tester->execute(['locale' => 'en']);
 
         $this->assertSame(0, $ret, 'Returns 0 in case of success');
-        $this->assertContains('missing    messages     hello_from_construct_arg_service', $tester->getDisplay());
-        $this->assertContains('missing    messages     hello_from_subscriber_service', $tester->getDisplay());
-        $this->assertContains('missing    messages     hello_from_property_service', $tester->getDisplay());
-        $this->assertContains('missing    messages     hello_from_method_calls_service', $tester->getDisplay());
-        $this->assertContains('missing    messages     hello_from_controller', $tester->getDisplay());
-        $this->assertContains('unused     validators   This value should be blank.', $tester->getDisplay());
-        $this->assertContains('unused     security     Invalid CSRF token.', $tester->getDisplay());
+        $this->assertStringContainsString('missing    messages     hello_from_construct_arg_service', $tester->getDisplay());
+        $this->assertStringContainsString('missing    messages     hello_from_subscriber_service', $tester->getDisplay());
+        $this->assertStringContainsString('missing    messages     hello_from_property_service', $tester->getDisplay());
+        $this->assertStringContainsString('missing    messages     hello_from_method_calls_service', $tester->getDisplay());
+        $this->assertStringContainsString('missing    messages     hello_from_controller', $tester->getDisplay());
+        $this->assertStringContainsString('unused     validators   This value should be blank.', $tester->getDisplay());
+        $this->assertStringContainsString('unused     security     Invalid CSRF token.', $tester->getDisplay());
     }
 
     private function createCommandTester(): CommandTester

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -109,7 +109,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
         ], ['interactive' => false]);
 
         $output = $this->passwordEncoderCommandTester->getDisplay();
-        $this->assertContains('Password encoding succeeded', $output);
+        $this->assertStringContainsString('Password encoding succeeded', $output);
 
         $encoder = new NativePasswordEncoder();
         preg_match('# Encoded password\s{1,}([\w+\/$.,=]+={0,2})\s+#', $output, $matches);
@@ -130,7 +130,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
         ], ['interactive' => false]);
 
         $output = $this->passwordEncoderCommandTester->getDisplay();
-        $this->assertContains('Password encoding succeeded', $output);
+        $this->assertStringContainsString('Password encoding succeeded', $output);
 
         preg_match('#  Encoded password\s+(\$?\$[\w,=\$+\/]+={0,2})\s+#', $output, $matches);
         $hash = $matches[1];

--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -159,9 +159,9 @@ class HttpBrowserTest extends AbstractBrowserTest
             ->expects($this->once())
             ->method('request')
             ->with('POST', 'http://example.com/', $this->callback(function ($options) {
-                $this->assertContains('Content-Type: multipart/form-data', implode('', $options['headers']));
+                $this->assertStringContainsString('Content-Type: multipart/form-data', implode('', $options['headers']));
                 $this->assertInstanceOf('\Generator', $options['body']);
-                $this->assertContains('my_file', implode('', iterator_to_array($options['body'])));
+                $this->assertStringContainsString('my_file', implode('', iterator_to_array($options['body'])));
 
                 return true;
             }))

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -506,9 +506,9 @@ class ApplicationTest extends TestCase
         $tester->setInputs(['y']);
         $tester->run(['command' => 'foos'], ['decorated' => false]);
         $display = trim($tester->getDisplay(true));
-        $this->assertContains('Command "foos" is not defined', $display);
-        $this->assertContains('Do you want to run "foo" instead?  (yes/no) [no]:', $display);
-        $this->assertContains('called', $display);
+        $this->assertStringContainsString('Command "foos" is not defined', $display);
+        $this->assertStringContainsString('Do you want to run "foo" instead?  (yes/no) [no]:', $display);
+        $this->assertStringContainsString('called', $display);
     }
 
     public function testDontRunAlternativeCommandName()
@@ -521,8 +521,8 @@ class ApplicationTest extends TestCase
         $exitCode = $tester->run(['command' => 'foos'], ['decorated' => false]);
         $this->assertSame(1, $exitCode);
         $display = trim($tester->getDisplay(true));
-        $this->assertContains('Command "foos" is not defined', $display);
-        $this->assertContains('Do you want to run "foo" instead?  (yes/no) [no]:', $display);
+        $this->assertStringContainsString('Command "foos" is not defined', $display);
+        $this->assertStringContainsString('Do you want to run "foo" instead?  (yes/no) [no]:', $display);
     }
 
     public function provideInvalidCommandNamesSingle()
@@ -854,7 +854,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
 
         $tester->run(['command' => 'foo'], ['decorated' => false]);
-        $this->assertContains('[InvalidArgumentException@anonymous]', $tester->getDisplay(true));
+        $this->assertStringContainsString('[InvalidArgumentException@anonymous]', $tester->getDisplay(true));
 
         $application = new Application();
         $application->setAutoExit(false);
@@ -865,7 +865,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
 
         $tester->run(['command' => 'foo'], ['decorated' => false]);
-        $this->assertContains('Dummy type "@anonymous" is invalid.', $tester->getDisplay(true));
+        $this->assertStringContainsString('Dummy type "@anonymous" is invalid.', $tester->getDisplay(true));
     }
 
     public function testRenderExceptionStackTraceContainsRootException()
@@ -879,7 +879,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
 
         $tester->run(['command' => 'foo'], ['decorated' => false]);
-        $this->assertContains('[InvalidArgumentException@anonymous]', $tester->getDisplay(true));
+        $this->assertStringContainsString('[InvalidArgumentException@anonymous]', $tester->getDisplay(true));
 
         $application = new Application();
         $application->setAutoExit(false);

--- a/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
@@ -58,7 +58,7 @@ content="0;url=data:text/html;base64,PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaXB0Pg"
         $handler->sendPhpResponse(new \RuntimeException($htmlWithXss));
         $response = ob_get_clean();
 
-        $this->assertContains(sprintf('<h1 class="break-long-words exception-message">%s</h1>', htmlspecialchars($htmlWithXss, ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8')), $response);
+        $this->assertStringContainsString(sprintf('<h1 class="break-long-words exception-message">%s</h1>', htmlspecialchars($htmlWithXss, ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8')), $response);
     }
 
     public function testStatusCode()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CustomExpressionLanguageFunctionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CustomExpressionLanguageFunctionTest.php
@@ -31,6 +31,6 @@ class CustomExpressionLanguageFunctionTest extends TestCase
         $dump = new PhpDumper($container);
         $dumped = $dump->dump();
 
-        $this->assertContains('strtolower("foobar")', $dumped);
+        $this->assertStringContainsString('strtolower("foobar")', $dumped);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -72,7 +72,7 @@ TXT
         $tester->execute(['class' => 'DateTime'], ['decorated' => false, 'interactive' => false]);
 
         $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
-        $this->assertContains('Symfony\Component\Form\Extension\Core\Type\DateTimeType (Block prefix: "datetime")', $tester->getDisplay());
+        $this->assertStringContainsString('Symfony\Component\Form\Extension\Core\Type\DateTimeType (Block prefix: "datetime")', $tester->getDisplay());
     }
 
     public function testDebugFormTypeOption()

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsRedirectedTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsRedirectedTest.php
@@ -29,7 +29,7 @@ class ResponseIsRedirectedTest extends TestCase
         try {
             $constraint->evaluate(new Response());
         } catch (ExpectationFailedException $e) {
-            $this->assertContains("Failed asserting that the Response is redirected.\nHTTP/1.0 200 OK", TestFailure::exceptionToString($e));
+            $this->assertStringContainsString("Failed asserting that the Response is redirected.\nHTTP/1.0 200 OK", TestFailure::exceptionToString($e));
 
             return;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsSuccessfulTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsSuccessfulTest.php
@@ -29,7 +29,7 @@ class ResponseIsSuccessfulTest extends TestCase
         try {
             $constraint->evaluate(new Response('', 404));
         } catch (ExpectationFailedException $e) {
-            $this->assertContains("Failed asserting that the Response is successful.\nHTTP/1.0 404 Not Found", TestFailure::exceptionToString($e));
+            $this->assertStringContainsString("Failed asserting that the Response is successful.\nHTTP/1.0 404 Not Found", TestFailure::exceptionToString($e));
 
             return;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseStatusCodeSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseStatusCodeSameTest.php
@@ -31,7 +31,7 @@ class ResponseStatusCodeSameTest extends TestCase
         try {
             $constraint->evaluate(new Response('', 404));
         } catch (ExpectationFailedException $e) {
-            $this->assertContains("Failed asserting that the Response status code is 200.\nHTTP/1.0 404 Not Found", TestFailure::exceptionToString($e));
+            $this->assertStringContainsString("Failed asserting that the Response status code is 200.\nHTTP/1.0 404 Not Found", TestFailure::exceptionToString($e));
 
             return;
         }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -218,7 +218,7 @@ class HttpKernelTest extends TestCase
 
             // `file` index the array starting at 0, and __FILE__ starts at 1
             $line = file($first['file'])[$first['line'] - 2];
-            $this->assertContains('// call controller', $line);
+            $this->assertStringContainsString('// call controller', $line);
         }
     }
 

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
@@ -188,7 +188,7 @@ class LdapManagerTest extends LdapTestCase
         $newEntry = $result[0];
         $originalCN = $entry->getAttribute('cn')[0];
 
-        $this->assertContains($originalCN, $newEntry->getAttribute('cn'));
+        $this->assertStringContainsString($originalCN, $newEntry->getAttribute('cn'));
 
         $entryManager->rename($newEntry, 'cn='.$originalCN);
 
@@ -357,6 +357,6 @@ class LdapManagerTest extends LdapTestCase
 
         $result = $this->executeSearchQuery(1);
         $movedEntry = $result[0];
-        $this->assertContains('ou=Ldap', $movedEntry->getDn());
+        $this->assertStringContainsString('ou=Ldap', $movedEntry->getDn());
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -244,7 +244,7 @@ class TransportTest extends TestCase
         $this->assertInstanceOf(Amazon\Smtp\SesTransport::class, $transport);
         $this->assertEquals('u$er', $transport->getUsername());
         $this->assertEquals('pa$s', $transport->getPassword());
-        $this->assertContains('.sun.', $transport->getStream()->getHost());
+        $this->assertStringContainsString('.sun.', $transport->getStream()->getHost());
         $this->assertProperties($transport, $dispatcher, $logger);
 
         $client = $this->createMock(HttpClientInterface::class);

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -62,7 +62,7 @@ class ConsumeMessagesCommandTest extends TestCase
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertContains('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 
     public function testRunWithBusOption()
@@ -95,7 +95,7 @@ class ConsumeMessagesCommandTest extends TestCase
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertContains('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 
     public function testBasicRunWithBusLocator()
@@ -127,7 +127,7 @@ class ConsumeMessagesCommandTest extends TestCase
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertContains('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 
     public function testRunWithBusOptionAndBusLocator()
@@ -160,6 +160,6 @@ class ConsumeMessagesCommandTest extends TestCase
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertContains('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
+        $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -32,6 +32,6 @@ class FailedMessagesRemoveCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute(['id' => 20, '--force' => true]);
 
-        $this->assertContains('Message removed.', $tester->getDisplay());
+        $this->assertStringContainsString('Message removed.', $tester->getDisplay());
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -44,6 +44,6 @@ class FailedMessagesRetryCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute(['id' => [10, 12]]);
 
-        $this->assertContains('[OK]', $tester->getDisplay());
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -45,7 +45,7 @@ class FailedMessagesShowCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute(['id' => 15]);
 
-        $this->assertContains(sprintf(<<<EOF
+        $this->assertStringContainsString(sprintf(<<<EOF
  ------------- --------------------- 
   Class         stdClass             
   Message Id    15                   

--- a/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
@@ -42,8 +42,8 @@ class SetupTransportsCommandTest extends TestCase
         $tester->execute([]);
         $display = $tester->getDisplay();
 
-        $this->assertContains('The "amqp" transport was setup successfully.', $display);
-        $this->assertContains('The "other_transport" transport does not support setup.', $display);
+        $this->assertStringContainsString('The "amqp" transport was setup successfully.', $display);
+        $this->assertStringContainsString('The "other_transport" transport does not support setup.', $display);
     }
 
     public function testReceiverNameArgument()
@@ -66,7 +66,7 @@ class SetupTransportsCommandTest extends TestCase
         $tester->execute(['transport' => 'amqp']);
         $display = $tester->getDisplay();
 
-        $this->assertContains('The "amqp" transport was setup successfully.', $display);
+        $this->assertStringContainsString('The "amqp" transport was setup successfully.', $display);
     }
 
     public function testReceiverNameArgumentNotFound()

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -330,7 +330,7 @@ class EmailTest extends TestCase
         $this->assertCount(2, $parts = $related[0]->getParts());
         $this->assertInstanceOf(AlternativePart::class, $parts[0]);
         $generatedHtml = $parts[0]->getParts()[1];
-        $this->assertContains('cid:'.$parts[1]->getContentId(), $generatedHtml->getBody());
+        $this->assertStringContainsString('cid:'.$parts[1]->getContentId(), $generatedHtml->getBody());
 
         $content = 'html content <img src="cid:test.gif">';
         $r = fopen('php://memory', 'r+', false);

--- a/src/Symfony/Component/Mime/Tests/Part/MessagePartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/MessagePartTest.php
@@ -23,9 +23,9 @@ class MessagePartTest extends TestCase
     public function testConstructor()
     {
         $p = new MessagePart((new Email())->from('fabien@symfony.com')->text('content'));
-        $this->assertContains('content', $p->getBody());
-        $this->assertContains('content', $p->bodyToString());
-        $this->assertContains('content', implode('', iterator_to_array($p->bodyToIterable())));
+        $this->assertStringContainsString('content', $p->getBody());
+        $this->assertStringContainsString('content', $p->bodyToString());
+        $this->assertStringContainsString('content', implode('', iterator_to_array($p->bodyToIterable())));
         $this->assertEquals('message', $p->getMediaType());
         $this->assertEquals('rfc822', $p->getMediaSubType());
     }

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -37,7 +37,7 @@ class XliffLintCommandTest extends TestCase
         );
 
         $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
-        $this->assertContains('OK', trim($tester->getDisplay()));
+        $this->assertStringContainsString('OK', trim($tester->getDisplay()));
     }
 
     public function testLintCorrectFiles()
@@ -52,7 +52,7 @@ class XliffLintCommandTest extends TestCase
         );
 
         $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
-        $this->assertContains('OK', trim($tester->getDisplay()));
+        $this->assertStringContainsString('OK', trim($tester->getDisplay()));
     }
 
     /**
@@ -69,7 +69,7 @@ class XliffLintCommandTest extends TestCase
         );
 
         $this->assertEquals($mustFail ? 1 : 0, $tester->getStatusCode());
-        $this->assertContains($mustFail ? '[WARNING] 0 XLIFF files have valid syntax and 1 contain errors.' : '[OK] All 1 XLIFF files contain valid syntax.', $tester->getDisplay());
+        $this->assertStringContainsString($mustFail ? '[WARNING] 0 XLIFF files have valid syntax and 1 contain errors.' : '[OK] All 1 XLIFF files contain valid syntax.', $tester->getDisplay());
     }
 
     public function testLintIncorrectXmlSyntax()
@@ -80,7 +80,7 @@ class XliffLintCommandTest extends TestCase
         $tester->execute(['filename' => $filename], ['decorated' => false]);
 
         $this->assertEquals(1, $tester->getStatusCode(), 'Returns 1 in case of error');
-        $this->assertContains('Opening and ending tag mismatch: target line 6 and source', trim($tester->getDisplay()));
+        $this->assertStringContainsString('Opening and ending tag mismatch: target line 6 and source', trim($tester->getDisplay()));
     }
 
     public function testLintIncorrectTargetLanguage()
@@ -91,7 +91,7 @@ class XliffLintCommandTest extends TestCase
         $tester->execute(['filename' => $filename], ['decorated' => false]);
 
         $this->assertEquals(1, $tester->getStatusCode(), 'Returns 1 in case of error');
-        $this->assertContains('There is a mismatch between the language included in the file name ("messages.en.xlf") and the "es" value used in the "target-language" attribute of the file.', trim($tester->getDisplay()));
+        $this->assertStringContainsString('There is a mismatch between the language included in the file name ("messages.en.xlf") and the "es" value used in the "target-language" attribute of the file.', trim($tester->getDisplay()));
     }
 
     public function testLintTargetLanguageIsCaseInsensitive()
@@ -102,7 +102,7 @@ class XliffLintCommandTest extends TestCase
         $tester->execute(['filename' => $filename], ['decorated' => false]);
 
         $this->assertEquals(0, $tester->getStatusCode());
-        $this->assertContains('[OK] All 1 XLIFF files contain valid syntax.', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] All 1 XLIFF files contain valid syntax.', trim($tester->getDisplay()));
     }
 
     public function testLintFileNotReadable()

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -446,7 +446,7 @@ abstract class HttpClientTestCase extends TestCase
 
         $body = $response->toArray();
 
-        $this->assertContains('json', $body['content-type']);
+        $this->assertStringContainsString('json', $body['content-type']);
         unset($body['content-type']);
         $this->assertSame(['foo' => 'bar', 'REQUEST_METHOD' => 'POST'], $body);
     }
@@ -705,11 +705,11 @@ abstract class HttpClientTestCase extends TestCase
         $headers = $response->getHeaders();
 
         $this->assertSame(['Accept-Encoding'], $headers['vary']);
-        $this->assertContains('gzip', $headers['content-encoding'][0]);
+        $this->assertStringContainsString('gzip', $headers['content-encoding'][0]);
 
         $body = $response->toArray();
 
-        $this->assertContains('gzip', $body['HTTP_ACCEPT_ENCODING']);
+        $this->assertStringContainsString('gzip', $body['HTTP_ACCEPT_ENCODING']);
     }
 
     public function testBaseUri()
@@ -757,7 +757,7 @@ abstract class HttpClientTestCase extends TestCase
         $headers = $response->getHeaders();
 
         $this->assertSame(['Accept-Encoding'], $headers['vary']);
-        $this->assertContains('gzip', $headers['content-encoding'][0]);
+        $this->assertStringContainsString('gzip', $headers['content-encoding'][0]);
 
         $body = $response->getContent();
         $this->assertSame("\x1F", $body[0]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | symfony

This PR replaces `assertContains()` with `assertStringContainsString()`. 
