### PR TITLE
Ignore ErrorHandler DebugClassLoaderTest class in PHP-CS-Fixer config

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -52,6 +52,7 @@ return PhpCsFixer\Config::create()
             ->notPath('Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php')
             // explicit trigger_error tests
             ->notPath('Symfony/Component/Debug/Tests/DebugClassLoaderTest.php')
+            ->notPath('Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php')
             // invalid annotations on purpose
             ->notPath('Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php')
     )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

It must be ignored like the `Debug` one.