### PR TITLE
[HttpClient] Declare `$active` first to prevent weird issue

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -290,6 +290,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
             throw new \TypeError(sprintf('%s() expects parameter 1 to be an iterable of CurlResponse objects, %s given.', __METHOD__, \is_object($responses) ? \get_class($responses) : \gettype($responses)));
         }
 
+        $active = 0;
         while (CURLM_CALL_MULTI_PERFORM === curl_multi_exec($this->multi->handle, $active));
 
         return new ResponseStream(CurlResponse::stream($responses, $timeout));
@@ -302,6 +303,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
             curl_multi_setopt($this->multi->handle, CURLMOPT_PUSHFUNCTION, null);
         }
 
+        $active = 0;
         while (CURLM_CALL_MULTI_PERFORM === curl_multi_exec($this->multi->handle, $active));
 
         foreach ($this->multi->openHandles as $ch) {

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -255,6 +255,7 @@ final class CurlResponse implements ResponseInterface
 
         try {
             self::$performing = true;
+            $active = 0;
             while (CURLM_CALL_MULTI_PERFORM === curl_multi_exec($multi->handle, $active));
 
             while ($info = curl_multi_info_read($multi->handle)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | -    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32833    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | no

In some undefined cases we can have the following error while using the WebTestCase/CurlHttpClient in PHPUnit:
![Sélection_999(101)](https://user-images.githubusercontent.com/2103975/62543336-0ad9e700-b85e-11e9-8b7f-d5b49e1d2d0d.png)

This is really weird because `$active` is a reference and so it does not need to be declared before, but doing that fixes the issue. (https://github.com/symfony/symfony/issues/32833#issuecomment-518658222)

I can't add tests because we were not able to reproduce the issue...