### PR TITLE
[Lock] remove un-needed implements interface

### DIFF
--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -16,7 +16,6 @@ use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockStorageException;
 use Symfony\Component\Lock\Key;
-use Symfony\Component\Lock\PersistingStoreInterface;
 
 /**
  * FlockStore is a PersistingStoreInterface implementation using the FileSystem flock.
@@ -28,7 +27,7 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  * @author Romain Neutron <imprec@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class FlockStore implements PersistingStoreInterface, BlockingStoreInterface
+class FlockStore implements BlockingStoreInterface
 {
     private $lockPath;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | null
| License       | MIT
| Doc PR        | not needed

following symfony/symfony#32555 it does not look necessary to implement both `PersistingStoreInterface` and `BlockingStoreInterface`