### PR TITLE
[ProxyManagerBridge] Polyfill for unmaintained version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,8 @@
             "Symfony\\Component\\": "src/Symfony/Component/"
         },
         "classmap": [
-            "src/Symfony/Component/Intl/Resources/stubs"
+            "src/Symfony/Component/Intl/Resources/stubs",
+            "src/Symfony/Bridge/ProxyManager/Legacy/ProxiedMethodReturnExpression.php"
         ],
         "exclude-from-classmap": [
             "**/Tests/"

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -112,6 +112,10 @@ EOF;
             );
         }
 
+        if (version_compare(self::getProxyManagerVersion(), '2.5', '<')) {
+            $code = str_replace(' \Closure::bind(function ', ' \Closure::bind(static function ', $code);
+        }
+
         return $code;
     }
 

--- a/src/Symfony/Bridge/ProxyManager/Legacy/ProxiedMethodReturnExpression.php
+++ b/src/Symfony/Bridge/ProxyManager/Legacy/ProxiedMethodReturnExpression.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ProxyManager\Generator\Util;
+
+use Composer\Autoload\ClassLoader;
+use ProxyManager\Version;
+
+if (class_exists(Version::class) && version_compare(\defined(Version::class.'::VERSION') ? Version::VERSION : Version::getVersion(), '2.5', '<')) {
+    /**
+     * Utility class to generate return expressions in method, given a method signature.
+     *
+     * This is required since return expressions may be forbidden by the method signature (void).
+     *
+     * @author Marco Pivetta <ocramius@gmail.com>
+     * @license MIT
+     *
+     * @see https://github.com/Ocramius/ProxyManager
+     */
+    final class ProxiedMethodReturnExpression
+    {
+        public static function generate(string $returnedValueExpression, ?\ReflectionMethod $originalMethod): string
+        {
+            $originalReturnType = null === $originalMethod ? null : $originalMethod->getReturnType();
+
+            $originalReturnTypeName = null === $originalReturnType ? null : $originalReturnType->getName();
+
+            if ('void' === $originalReturnTypeName) {
+                return $returnedValueExpression.";\nreturn;";
+            }
+
+            return 'return '.$returnedValueExpression.';';
+        }
+    }
+} else {
+    // Fallback to the original class by unregistering this file from composer class loader
+    $getComposerClassLoader = static function ($functionLoader) use (&$getComposerClassLoader) {
+        if (\is_array($functionLoader)) {
+            $functionLoader = $functionLoader[0];
+        }
+        if (!\is_object($functionLoader)) {
+            return;
+        }
+        if ($functionLoader instanceof ClassLoader) {
+            return $functionLoader;
+        }
+        if ($functionLoader instanceof \Symfony\Component\Debug\DebugClassLoader) {
+            return $getComposerClassLoader($functionLoader->getClassLoader());
+        }
+        if ($functionLoader instanceof \Symfony\Component\ErrorHandler\DebugClassLoader) {
+            return $getComposerClassLoader($functionLoader->getClassLoader());
+        }
+    };
+
+    $classLoader = null;
+    $functions = spl_autoload_functions();
+    while (null === $classLoader && $functions) {
+        $classLoader = $getComposerClassLoader(array_shift($functions));
+    }
+    $getComposerClassLoader = null;
+
+    if (null !== $classLoader) {
+        $classLoader->addClassMap([ProxiedMethodReturnExpression::class => null]);
+        $classLoader->loadClass(ProxiedMethodReturnExpression::class);
+    }
+}

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\ProxyManager\Tests\LazyProxy\PhpDumper;
 
 use PHPUnit\Framework\TestCase;
+use ProxyManager\Version;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -61,6 +62,20 @@ class ProxyDumperTest extends TestCase
                 .'\Symfony\Bridge\ProxyManager\Tests\LazyProxy\PhpDumper\ProxyDumperTest%a',
             $code
         );
+    }
+
+    public function testStaticBinding()
+    {
+        if (!class_exists(Version::class) || version_compare(\defined(Version::class.'::VERSION') ? Version::VERSION : Version::getVersion(), '2.1', '<')) {
+            $this->markTestSkipped('ProxyManager prior to version 2.1 does not support static binding');
+        }
+
+        $definition = new Definition(__CLASS__);
+        $definition->setLazy(true);
+
+        $code = $this->dumper->getProxyCode($definition);
+
+        $this->assertStringContainsString('\Closure::bind(static function (\PHPUnit\Framework\TestCase $instance) {', $code);
     }
 
     public function testDeterministicProxyCode()

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -25,6 +25,7 @@
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\ProxyManager\\": "" },
+        "classmap": [ "Legacy/ProxiedMethodReturnExpression.php" ],
         "exclude-from-classmap": [
             "/Tests/"
         ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

The current implementation of proxy-manager triggers a PHP 7.4 deprecation `ReflectionType::__toString`, and the patch won't be applied to a version prior to 2.5 (see https://github.com/Ocramius/ProxyManager/pull/484) will older version of proxy-manager (2.1 to 2.4 are also compatible with php 7.4). 

This PR fixes the implementation of `ProxiedMethodReturnExpression` for version prior to 2.5