### PR TITLE
SCA: dropped unused mocks, duplicate import and a function alias usage

### DIFF
--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Config\Tests\Definition\Builder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\FloatNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition as NumericNodeDefinition;
 
 class NumericNodeDefinitionTest extends TestCase
 {
@@ -22,7 +21,7 @@ class NumericNodeDefinitionTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('You cannot define a min(4) as you already have a max(3)');
-        $def = new NumericNodeDefinition('foo');
+        $def = new IntegerNodeDefinition('foo');
         $def->max(3)->min(4);
     }
 
@@ -30,7 +29,7 @@ class NumericNodeDefinitionTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('You cannot define a max(2) as you already have a min(3)');
-        $node = new NumericNodeDefinition('foo');
+        $node = new IntegerNodeDefinition('foo');
         $node->min(3)->max(2);
     }
 
@@ -84,7 +83,7 @@ class NumericNodeDefinitionTest extends TestCase
     {
         $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidDefinitionException');
         $this->expectExceptionMessage('->cannotBeEmpty() is not applicable to NumericNodeDefinition.');
-        $def = new NumericNodeDefinition('foo');
+        $def = new IntegerNodeDefinition('foo');
         $def->cannotBeEmpty();
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -70,7 +70,6 @@ class ExpressionLanguageTest extends TestCase
     {
         $cacheMock = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface')->getMock();
 
-        $cacheItemMock = $this->getMockBuilder('Psr\Cache\CacheItemInterface')->getMock();
         $savedParsedExpression = null;
         $expressionLanguage = new ExpressionLanguage($cacheMock);
 

--- a/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
@@ -14,7 +14,7 @@ class LdapTestCase extends TestCase
             $this->markTestSkipped('No server is listening on LDAP_HOST:LDAP_PORT');
         }
 
-        ldap_close($h);
+        ldap_unbind($h);
 
         return [
             'host' => getenv('LDAP_HOST'),

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -85,13 +85,6 @@ class GuardAuthenticatorHandlerTest extends TestCase
      */
     public function testHandleAuthenticationClearsToken($tokenClass, $tokenProviderKey, $actualProviderKey)
     {
-        $token = $this->getMockBuilder($tokenClass)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $token->expects($this->any())
-            ->method('getProviderKey')
-            ->willReturn($tokenProviderKey);
-
         $this->tokenStorage->expects($this->never())
             ->method('setToken')
             ->with(null);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/BasicAuthenticationListenerTest.php
@@ -74,8 +74,6 @@ class BasicAuthenticationListenerTest extends TestCase
             'PHP_AUTH_PW' => 'ThePassword',
         ]);
 
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
-
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
             ->expects($this->any())

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -124,7 +124,6 @@ class AbstractRememberMeServicesTest extends TestCase
         $service = $this->getService(null, ['name' => 'foo', 'always_remember_me' => true, 'path' => null, 'domain' => null]);
         $request = new Request();
         $response = new Response();
-        $account = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $token
             ->expects($this->once())

--- a/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslationExtractorPassTest.php
+++ b/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslationExtractorPassTest.php
@@ -50,13 +50,10 @@ class TranslationExtractorPassTest extends TestCase
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
         $this->expectExceptionMessage('The alias for the tag "translation.extractor" of service "foo.id" must be set.');
-        $definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->disableOriginalConstructor()->getMock();
         $container = new ContainerBuilder();
         $container->register('translation.extractor');
         $container->register('foo.id')
             ->addTag('translation.extractor', []);
-
-        $definition->expects($this->never())->method('addMethodCall');
 
         $translationDumperPass = new TranslationExtractorPass();
         $translationDumperPass->process($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a
