### PR TITLE
Added correct plural for box -> boxes

### DIFF
--- a/src/Symfony/Component/Inflector/Inflector.php
+++ b/src/Symfony/Component/Inflector/Inflector.php
@@ -284,6 +284,9 @@ final class Inflector
         // indices (index)
         ['xedni', 5, false, true, ['indicies', 'indexes']],
 
+        // boxes (box)
+        ['xo', 2, false, true, 'oxes'],
+
         // indexes (index), matrixes (matrix)
         ['x', 1, true, false, ['cies', 'xes']],
 

--- a/src/Symfony/Component/Inflector/Tests/InflectorTest.php
+++ b/src/Symfony/Component/Inflector/Tests/InflectorTest.php
@@ -180,7 +180,7 @@ class InflectorTest extends TestCase
             ['batch', 'batches'],
             ['beau', ['beaus', 'beaux']],
             ['bee', 'bees'],
-            ['box', ['bocies', 'boxes']],
+            ['box', 'boxes'],
             ['boy', 'boys'],
             ['bureau', ['bureaus', 'bureaux']],
             ['bus', 'buses'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

The Inflector component's old test asserted that a valid plural for box is 'bocies', but a quick look at the dictionary (https://www.merriam-webster.com/dictionary/box) assures this is not actually the case. This pull request fixes that pluralization.