### PR TITLE
Fix deprecations on 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ matrix:
           env: deps=high
         - php: 7.3
           env: deps=low
+        - php: 7.4snapshot
+    allow_failures:
+    - php: 7.4snapshot
     fast_finish: true
 
 cache:

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
@@ -1,21 +1,21 @@
 <?php
 
-class SunnyInterface_1eff735 implements \ProxyManager\Proxy\VirtualProxyInterface, \Symfony\Bridge\ProxyManager\Tests\LazyProxy\PhpDumper\DummyInterface, \Symfony\Bridge\ProxyManager\Tests\LazyProxy\PhpDumper\SunnyInterface
+class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \Symfony\Bridge\ProxyManager\Tests\LazyProxy\PhpDumper\DummyInterface, \Symfony\Bridge\ProxyManager\Tests\LazyProxy\PhpDumper\SunnyInterface
 {
 
-    private $valueHolder1eff735 = null;
+    private $valueHolder%s = null;
 
-    private $initializer1eff735 = null;
+    private $initializer%s = null;
 
-    private static $publicProperties1eff735 = [
-        
+    private static $publicProperties%s = [
+%S
     ];
 
     public function dummy()
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, 'dummy', array(), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, 'dummy', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        if ($this->valueHolder1eff735 === $returnValue = $this->valueHolder1eff735->dummy()) {
+        if ($this->valueHolder%s === $returnValue = $this->valueHolder%s->dummy()) {
             $returnValue = $this;
         }
 
@@ -24,9 +24,9 @@ class SunnyInterface_1eff735 implements \ProxyManager\Proxy\VirtualProxyInterfac
 
     public function & dummyRef()
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, 'dummyRef', array(), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, 'dummyRef', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        if ($this->valueHolder1eff735 === $returnValue = &$this->valueHolder1eff735->dummyRef()) {
+        if ($this->valueHolder%s === $returnValue = &$this->valueHolder%s->dummyRef()) {
             $returnValue = $this;
         }
 
@@ -35,9 +35,9 @@ class SunnyInterface_1eff735 implements \ProxyManager\Proxy\VirtualProxyInterfac
 
     public function sunny()
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, 'sunny', array(), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, 'sunny', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        if ($this->valueHolder1eff735 === $returnValue = $this->valueHolder1eff735->sunny()) {
+        if ($this->valueHolder%s === $returnValue = $this->valueHolder%s->sunny()) {
             $returnValue = $this;
         }
 
@@ -49,9 +49,9 @@ class SunnyInterface_1eff735 implements \ProxyManager\Proxy\VirtualProxyInterfac
         static $reflection;
 
         $reflection = $reflection ?? new \ReflectionClass(__CLASS__);
-        $instance = $reflection->newInstanceWithoutConstructor();
+        $instance%w= $reflection->newInstanceWithoutConstructor();
 
-        $instance->initializer1eff735 = $initializer;
+        $instance->initializer%s = $initializer;
 
         return $instance;
     }
@@ -60,21 +60,21 @@ class SunnyInterface_1eff735 implements \ProxyManager\Proxy\VirtualProxyInterfac
     {
         static $reflection;
 
-        if (! $this->valueHolder1eff735) {
+        if (! $this->valueHolder%s) {
             $reflection = $reflection ?? new \ReflectionClass(__CLASS__);
-            $this->valueHolder1eff735 = $reflection->newInstanceWithoutConstructor();
+            $this->valueHolder%s = $reflection->newInstanceWithoutConstructor();
         }
     }
 
     public function & __get($name)
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, '__get', ['name' => $name], $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, '__get', ['name' => $name], $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        if (isset(self::$publicProperties1eff735[$name])) {
-            return $this->valueHolder1eff735->$name;
+        if (isset(self::$publicProperties%s[$name])) {
+            return $this->valueHolder%s->$name;
         }
 
-        $targetObject = $this->valueHolder1eff735;
+        $targetObject = $this->valueHolder%s;
 
         $backtrace = debug_backtrace(false);
         trigger_error(
@@ -92,27 +92,27 @@ class SunnyInterface_1eff735 implements \ProxyManager\Proxy\VirtualProxyInterfac
 
     public function __set($name, $value)
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, '__set', array('name' => $name, 'value' => $value), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, '__set', array('name' => $name, 'value' => $value), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        $targetObject = $this->valueHolder1eff735;
+        $targetObject = $this->valueHolder%s;
 
         return $targetObject->$name = $value;
     }
 
     public function __isset($name)
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, '__isset', array('name' => $name), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, '__isset', array('name' => $name), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        $targetObject = $this->valueHolder1eff735;
+        $targetObject = $this->valueHolder%s;
 
         return isset($targetObject->$name);
     }
 
     public function __unset($name)
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, '__unset', array('name' => $name), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, '__unset', array('name' => $name), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        $targetObject = $this->valueHolder1eff735;
+        $targetObject = $this->valueHolder%s;
 
         unset($targetObject->$name);
 return;
@@ -120,45 +120,45 @@ return;
 
     public function __clone()
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, '__clone', array(), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, '__clone', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        $this->valueHolder1eff735 = clone $this->valueHolder1eff735;
+        $this->valueHolder%s = clone $this->valueHolder%s;
     }
 
     public function __sleep()
     {
-        $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, '__sleep', array(), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, '__sleep', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        return array('valueHolder1eff735');
+        return array('valueHolder%s');
     }
 
     public function __wakeup()
     {
     }
 
-    public function setProxyInitializer(\Closure $initializer = null)
+    public function setProxyInitializer(\Closure $initializer = null)%S
     {
-        $this->initializer1eff735 = $initializer;
+        $this->initializer%s = $initializer;
     }
 
-    public function getProxyInitializer()
+    public function getProxyInitializer()%S
     {
-        return $this->initializer1eff735;
+        return $this->initializer%s;
     }
 
     public function initializeProxy() : bool
     {
-        return $this->initializer1eff735 && ($this->initializer1eff735->__invoke($valueHolder1eff735, $this, 'initializeProxy', array(), $this->initializer1eff735) || 1) && $this->valueHolder1eff735 = $valueHolder1eff735;
+        return $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, 'initializeProxy', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
     }
 
     public function isProxyInitialized() : bool
     {
-        return null !== $this->valueHolder1eff735;
+        return null !== $this->valueHolder%s;
     }
 
-    public function getWrappedValueHolderValue()
+    public function getWrappedValueHolderValue()%S
     {
-        return $this->valueHolder1eff735;
+        return $this->valueHolder%s;
     }
 
 

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -168,12 +168,12 @@ return new class
 EOPHP;
 
         $implem = preg_replace('#\n    /\*\*.*?\*/#s', '', $implem);
-        $implem = str_replace('getWrappedValueHolderValue() : ?object', 'getWrappedValueHolderValue()', $implem);
         $implem = str_replace("array(\n        \n    );", "[\n        \n    ];", $implem);
-        $this->assertStringEqualsFile(__DIR__.'/Fixtures/proxy-implem.php', $implem);
+
+        $this->assertStringMatchesFormatFile(__DIR__.'/Fixtures/proxy-implem.php', $implem);
         $this->assertStringEqualsFile(__DIR__.'/Fixtures/proxy-factory.php', $factory);
 
-        require_once __DIR__.'/Fixtures/proxy-implem.php';
+        eval(preg_replace('/^<\?php/', '', $implem));
         $factory = require __DIR__.'/Fixtures/proxy-factory.php';
 
         $foo = $factory->getFooService();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -57,8 +57,8 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:container', '--show-hidden' => true]);
-        $this->assertNotContains('public', $tester->getDisplay());
-        $this->assertNotContains('private_alias', $tester->getDisplay());
+        $this->assertStringNotContainsString('public', $tester->getDisplay());
+        $this->assertStringNotContainsString('private_alias', $tester->getDisplay());
 
         $tester->run(['command' => 'debug:container']);
         $this->assertStringContainsString('public', $tester->getDisplay());
@@ -77,7 +77,7 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
 
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:container', 'name' => $validServiceId]);
-        $this->assertNotContains('No services found', $tester->getDisplay());
+        $this->assertStringNotContainsString('No services found', $tester->getDisplay());
     }
 
     public function testDescribeEnvVars()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -227,7 +227,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
             'user-class' => 'Custom\Class\Sodium\User',
         ], ['interactive' => false]);
 
-        $this->assertNotContains(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
     }
 
     public function testEncodePasswordNoConfigForGivenUserClass()

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Cache\IntegrationTests\CachePoolTest;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Warning;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\CacheItem;
@@ -120,7 +121,7 @@ abstract class AdapterTestCase extends CachePoolTest
             CacheItem::METADATA_EXPIRY => 9.5 + time(),
             CacheItem::METADATA_CTIME => 1000,
         ];
-        $this->assertEquals($expected, $item->getMetadata(), 'Item metadata should embed expiry and ctime.', .6);
+        $this->assertEqualsWithDelta($expected, $item->getMetadata(), .6, 'Item metadata should embed expiry and ctime.');
     }
 
     public function testDefaultLifeTime()
@@ -251,6 +252,15 @@ abstract class AdapterTestCase extends CachePoolTest
         $cache->prune();
         $this->assertFalse($this->isPruned($cache, 'foo'));
         $this->assertTrue($this->isPruned($cache, 'qux'));
+    }
+
+    public function testSavingObject()
+    {
+        if (\PHP_VERSION_ID >= 70400) {
+            throw new Warning('PHP 7.4 breaks this test, see https://bugs.php.net/78351.');
+        }
+
+        parent::testSavingObject();
     }
 }
 

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeDefinitionTest.php
@@ -14,26 +14,25 @@ namespace Symfony\Component\Config\Tests\Definition\Builder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
-use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
 
 class NodeDefinitionTest extends TestCase
 {
-    public function testDefaultPathSeparatorIsDot()
-    {
-        $node = $this->getMockForAbstractClass(NodeDefinition::class, ['foo']);
-
-        $this->assertAttributeSame('.', 'pathSeparator', $node);
-    }
-
     public function testSetPathSeparatorChangesChildren()
     {
-        $node = new ArrayNodeDefinition('foo');
-        $scalar = new ScalarNodeDefinition('bar');
-        $node->append($scalar);
+        $parentNode = new ArrayNodeDefinition('name');
+        $childNode = $this->createMock(NodeDefinition::class);
 
-        $node->setPathSeparator('/');
+        $childNode
+            ->expects($this->once())
+            ->method('setPathSeparator')
+            ->with('/');
+        $childNode
+            ->expects($this->once())
+            ->method('setParent')
+            ->with($parentNode)
+            ->willReturn($childNode);
+        $parentNode->append($childNode);
 
-        $this->assertAttributeSame('/', 'pathSeparator', $node);
-        $this->assertAttributeSame('/', 'pathSeparator', $scalar);
+        $parentNode->setPathSeparator('/');
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -142,6 +142,10 @@ class FileLoaderTest extends TestCase
 
     public function testRegisterClassesWithExcludeAsArray()
     {
+        if (\PHP_VERSION_ID >= 70400) {
+            throw new Warning('PHP 7.4 breaks this test, see https://bugs.php.net/78351.');
+        }
+
         $container = new ContainerBuilder();
         $container->setParameter('sub_dir', 'Sub');
         $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -51,11 +51,11 @@ class CountryTypeTest extends BaseTypeTest
             ->createView()->vars['choices'];
 
         // Don't check objects for identity
-        $this->assertContains(new ChoiceView('DE', 'DE', 'Німеччина'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('GB', 'GB', 'Велика Британія'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('US', 'US', 'Сполучені Штати'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('FR', 'FR', 'Франція'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('MY', 'MY', 'Малайзія'), $choices, '', false, false);
+        $this->assertContainsEquals(new ChoiceView('DE', 'DE', 'Німеччина'), $choices);
+        $this->assertContainsEquals(new ChoiceView('GB', 'GB', 'Велика Британія'), $choices);
+        $this->assertContainsEquals(new ChoiceView('US', 'US', 'Сполучені Штати'), $choices);
+        $this->assertContainsEquals(new ChoiceView('FR', 'FR', 'Франція'), $choices);
+        $this->assertContainsEquals(new ChoiceView('MY', 'MY', 'Малайзія'), $choices);
     }
 
     public function testUnknownCountryIsNotIncluded()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -48,9 +48,9 @@ class CurrencyTypeTest extends BaseTypeTest
             ->createView()->vars['choices'];
 
         // Don't check objects for identity
-        $this->assertContains(new ChoiceView('EUR', 'EUR', 'євро'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('USD', 'USD', 'долар США'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('SIT', 'SIT', 'словенський толар'), $choices, '', false, false);
+        $this->assertContainsEquals(new ChoiceView('EUR', 'EUR', 'євро'), $choices);
+        $this->assertContainsEquals(new ChoiceView('USD', 'USD', 'долар США'), $choices);
+        $this->assertContainsEquals(new ChoiceView('SIT', 'SIT', 'словенський толар'), $choices);
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -50,10 +50,10 @@ class LanguageTypeTest extends BaseTypeTest
             ->createView()->vars['choices'];
 
         // Don't check objects for identity
-        $this->assertContains(new ChoiceView('en', 'en', 'англійська'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('en_US', 'en_US', 'англійська (США)'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('fr', 'fr', 'французька'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('my', 'my', 'бірманська'), $choices, '', false, false);
+        $this->assertContainsEquals(new ChoiceView('en', 'en', 'англійська'), $choices);
+        $this->assertContainsEquals(new ChoiceView('en_US', 'en_US', 'англійська (США)'), $choices);
+        $this->assertContainsEquals(new ChoiceView('fr', 'fr', 'французька'), $choices);
+        $this->assertContainsEquals(new ChoiceView('my', 'my', 'бірманська'), $choices);
     }
 
     public function testMultipleLanguagesIsNotIncluded()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -48,9 +48,9 @@ class LocaleTypeTest extends BaseTypeTest
             ->createView()->vars['choices'];
 
         // Don't check objects for identity
-        $this->assertContains(new ChoiceView('en', 'en', 'англійська'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'англійська (Велика Британія)'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'китайська (традиційна, Макао, О.А.Р Китаю)'), $choices, '', false, false);
+        $this->assertContainsEquals(new ChoiceView('en', 'en', 'англійська'), $choices);
+        $this->assertContainsEquals(new ChoiceView('en_GB', 'en_GB', 'англійська (Велика Британія)'), $choices);
+        $this->assertContainsEquals(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'китайська (традиційна, Макао, О.А.Р Китаю)'), $choices);
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)

--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
@@ -31,19 +31,19 @@ class AbstractTransportTest extends TestCase
 
         $start = time();
         $transport->send($message, $envelope);
-        $this->assertEquals(0, time() - $start, '', 1);
+        $this->assertEqualsWithDelta(0, time() - $start, 1);
         $transport->send($message, $envelope);
-        $this->assertEquals(5, time() - $start, '', 1);
+        $this->assertEqualsWithDelta(5, time() - $start, 1);
         $transport->send($message, $envelope);
-        $this->assertEquals(10, time() - $start, '', 1);
+        $this->assertEqualsWithDelta(10, time() - $start, 1);
         $transport->send($message, $envelope);
-        $this->assertEquals(15, time() - $start, '', 1);
+        $this->assertEqualsWithDelta(15, time() - $start, 1);
 
         $start = time();
         $transport->setMaxPerSecond(-3);
         $transport->send($message, $envelope);
-        $this->assertEquals(0, time() - $start, '', 1);
+        $this->assertEqualsWithDelta(0, time() - $start, 1);
         $transport->send($message, $envelope);
-        $this->assertEquals(0, time() - $start, '', 1);
+        $this->assertEqualsWithDelta(0, time() - $start, 1);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
@@ -22,7 +22,7 @@ class HandlersLocatorTest extends TestCase
 {
     public function testItYieldsHandlerDescriptors()
     {
-        $handler = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $handler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
         $locator = new HandlersLocator([
             DummyMessage::class => [$handler],
         ]);
@@ -32,13 +32,13 @@ class HandlersLocatorTest extends TestCase
 
     public function testItReturnsOnlyHandlersMatchingTransport()
     {
-        $firstHandler = $this->createPartialMock(\stdClass::class, ['__invoke']);
-        $secondHandler = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $firstHandler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $secondHandler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
 
         $locator = new HandlersLocator([
             DummyMessage::class => [
                 $first = new HandlerDescriptor($firstHandler, ['alias' => 'one']),
-                new HandlerDescriptor($this->createPartialMock(\stdClass::class, ['__invoke']), ['from_transport' => 'ignored', 'alias' => 'two']),
+                new HandlerDescriptor($this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']), ['from_transport' => 'ignored', 'alias' => 'two']),
                 $second = new HandlerDescriptor($secondHandler, ['from_transport' => 'transportName', 'alias' => 'three']),
             ],
         ]);
@@ -49,5 +49,12 @@ class HandlersLocatorTest extends TestCase
         ], iterator_to_array($locator->getHandlers(
             new Envelope(new DummyMessage('Body'), [new ReceivedStamp('transportName')])
         )));
+    }
+}
+
+class HandlersLocatorTestCallable
+{
+    public function __invoke()
+    {
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/ActivationMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/ActivationMiddlewareTest.php
@@ -42,7 +42,7 @@ class ActivationMiddlewareTest extends MiddlewareTestCase
         $message = new DummyMessage('Hello');
         $envelope = new Envelope($message);
 
-        $activated = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $activated = $this->createPartialMock(ActivationMiddlewareTestCallable::class, ['__invoke']);
         $activated->expects($this->once())->method('__invoke')->with($envelope)->willReturn(true);
 
         $stack = $this->getStackMock(false);
@@ -66,5 +66,12 @@ class ActivationMiddlewareTest extends MiddlewareTestCase
         $decorator = new ActivationMiddleware($middleware, false);
 
         $decorator->handle($envelope, $this->getStackMock());
+    }
+}
+
+class ActivationMiddlewareTestCallable
+{
+    public function __invoke()
+    {
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -28,7 +28,7 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $message = new DummyMessage('Hey');
         $envelope = new Envelope($message);
 
-        $handler = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $handler = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
 
         $middleware = new HandleMessageMiddleware(new HandlersLocator([
             DummyMessage::class => [$handler],
@@ -62,15 +62,15 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
 
     public function itAddsHandledStampsProvider()
     {
-        $first = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $first = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
         $first->method('__invoke')->willReturn('first result');
         $firstClass = \get_class($first);
 
-        $second = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $second = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
         $second->method('__invoke')->willReturn(null);
         $secondClass = \get_class($second);
 
-        $failing = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $failing = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
         $failing->method('__invoke')->will($this->throwException(new \Exception('handler failed.')));
 
         yield 'A stamp is added' => [
@@ -127,5 +127,12 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $middleware = new HandleMessageMiddleware(new HandlersLocator([]), true);
 
         $this->assertInstanceOf(Envelope::class, $middleware->handle(new Envelope(new DummyMessage('Hey')), new StackMiddleware()));
+    }
+}
+
+class HandleMessageMiddlewareTestCallable
+{
+    public function __invoke()
+    {
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineSenderTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineSenderTest.php
@@ -28,7 +28,7 @@ class DoctrineSenderTest extends TestCase
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'])->willReturn(15);
+        $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'])->willReturn('15');
 
         $serializer = $this->createMock(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturnOnConsecutiveCalls($encoded);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -27,7 +27,7 @@ class PhpSerializerTest extends TestCase
         $envelope = new Envelope(new DummyMessage('Hello'));
 
         $encoded = $serializer->encode($envelope);
-        $this->assertNotContains("\0", $encoded['body'], 'Does not contain the binary characters');
+        $this->assertStringNotContainsString("\0", $encoded['body'], 'Does not contain the binary characters');
         $this->assertEquals($envelope, $serializer->decode($encoded));
     }
 
@@ -74,7 +74,7 @@ class PhpSerializerTest extends TestCase
         ]);
 
         $encoded = $serializer->encode($envelope);
-        $this->assertNotContains('DummyPhpSerializerNonSendableStamp', $encoded['body']);
+        $this->assertStringNotContainsString('DummyPhpSerializerNonSendableStamp', $encoded['body']);
     }
 }
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -205,7 +205,7 @@ class SerializerTest extends TestCase
         ]);
 
         $encoded = $serializer->encode($envelope);
-        $this->assertNotContains('DummySymfonySerializerNonSendableStamp', print_r($encoded['headers'], true));
+        $this->assertStringNotContainsString('DummySymfonySerializerNonSendableStamp', print_r($encoded['headers'], true));
     }
 }
 class DummySymfonySerializerNonSendableStamp implements NonSendableStampInterface

--- a/src/Symfony/Component/Messenger/Transport/Sync/SyncTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/Sync/SyncTransport.php
@@ -58,7 +58,7 @@ class SyncTransport implements TransportInterface
     {
         /** @var SentStamp|null $sentStamp */
         $sentStamp = $envelope->last(SentStamp::class);
-        $alias = null === $sentStamp ? 'sync' : $sentStamp->getSenderAlias() ?: $sentStamp->getSenderClass();
+        $alias = null === $sentStamp ? 'sync' : ($sentStamp->getSenderAlias() ?: $sentStamp->getSenderClass());
 
         $envelope = $envelope->with(new ReceivedStamp($alias));
 

--- a/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
@@ -466,6 +466,8 @@ Symfony\Component\VarDumper\Cloner\Data Object
                             [position] => 1
                             [attr] => Array
                                 (
+                                    [file] => %s
+                                    [line] => 5
                                 )
 
                         )

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarExporter\Tests;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Warning;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 use Symfony\Component\VarExporter\Internal\Registry;
 use Symfony\Component\VarExporter\VarExporter;
@@ -75,6 +76,13 @@ class VarExporterTest extends TestCase
      */
     public function testExport(string $testName, $value, bool $staticValueExpected = false)
     {
+        if (\PHP_VERSION_ID >= 70400 && 'datetime' === $testName) {
+            throw new Warning('PHP 7.4 breaks this test, see https://bugs.php.net/78383.');
+        }
+        if (\PHP_VERSION_ID >= 70400 && \in_array($testName, ['spl-object-storage', 'array-object-custom', 'array-iterator', 'array-object', 'final-array-iterator'])) {
+            throw new Warning('PHP 7.4 breaks this test.');
+        }
+
         $dumpedValue = $this->getDump($value);
         $isStaticValue = true;
         $marshalledValue = VarExporter::export($value, $isStaticValue);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

Fix deprecations in branch 4.3
note: remaining deprecation `assertStringContainsString` will be fixed in #32977

* [ ] fix tests in branch 3.4 in #32981