### PR TITLE
[PHPUnitBridge] Fix deprecation filter by regex

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -145,7 +145,7 @@ class Configuration
     {
         parse_str($serializedConfiguration, $normalizedConfiguration);
         foreach (array_keys($normalizedConfiguration) as $key) {
-            if (!\in_array($key, ['max', 'disabled', 'verbose'], true)) {
+            if (!\in_array($key, ['max', 'disabled', 'verbose', 'regex'], true)) {
                 throw new \InvalidArgumentException(sprintf('Unknown configuration option "%s"', $key));
             }
         }
@@ -161,7 +161,7 @@ class Configuration
 
         return new self(
             isset($normalizedConfiguration['max']) ? $normalizedConfiguration['max'] : [],
-            '',
+            isset($normalizedConfiguration['regex']) ? $normalizedConfiguration['regex'] : '',
             $verboseOutput
         );
     }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
@@ -175,6 +175,14 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($configuration->shouldDisplayStackTrace('interesting'));
     }
 
+    public function testItCanTellWhetherToDisplayAStackTraceFromRegExOption()
+    {
+        $configuration = Configuration::fromUrlEncodedString('regex=/^interesting/');
+
+        $this->assertFalse($configuration->shouldDisplayStackTrace('uninteresting'));
+        $this->assertTrue($configuration->shouldDisplayStackTrace('interesting'));
+    }
+
     public function testItCanBeDisabled()
     {
         $configuration = Configuration::fromUrlEncodedString('disabled');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
| License       | MIT
| Doc PR        | NA

From the documentation https://symfony.com/doc/current/components/phpunit_bridge.html#display-the-full-stack-trace we can filter deprecations by using a regex
```bash
SYMFONY_DEPRECATIONS_HELPER='regex=/.*/' SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1 SYMFONY_PHPUNIT_VERSION=8 ./phpunit src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
```

but this option does not works and triggers

```
1) Symfony\Component\Form\Tests\ChoiceList\Factory\PropertyAccessDecoratorTest::testCreateFromChoicesPropertyPathWithCallableString                                                                                                                          
InvalidArgumentException: Unknown configuration option "regex"
```

This PR adds the configuration option `regex`. 

Ping @greg0ire