### PR TITLE
[ErrorRenderer] Fix timestamp on logs view

### DIFF
--- a/src/Symfony/Component/ErrorRenderer/Resources/views/logs.html.php
+++ b/src/Symfony/Component/ErrorRenderer/Resources/views/logs.html.php
@@ -22,7 +22,7 @@
         <tr class="status-<?= $status; ?>" data-filter-level="<?= strtolower($this->escape($log['priorityName'])); ?>"<?php if ($channelIsDefined) { ?> data-filter-channel="<?= $this->escape($log['channel']); ?>"<?php } ?>
             <td class="text-small" nowrap>
                 <span class="colored text-bold"><?= $this->escape($log['priorityName']); ?></span>
-                <span class="text-muted newline"><?= (new \DateTime($log['timestamp']))->format('H:i:s'); ?></span>
+                <span class="text-muted newline"><?= date('H:i:s', $log['timestamp']); ?></span>
             </td>
             <?php if ($channelIsDefined) { ?>
             <td class="text-small text-bold nowrap">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This syntax raises a php exception :
```php
(new \DateTime($log['timestamp']))->format('H:i:s');
```

```
<br />
<b>Fatal error</b>:  Uncaught Exception: DateTime::__construct(): Failed to parse time string (1565179387) at position 7 (3): Unexpected character in [...][...]:4
Stack trace:
#0 [...][...](4): DateTime-&gt;__construct('1565179387')
#1 {main}
  thrown in <b>[...][...]</b> on line <b>4</b><br />
```