### PR TITLE
setting $container=null shouldn't be in try block

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -631,8 +631,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             });
         }
 
+        $container = null;
         try {
-            $container = null;
             $container = $this->buildContainer();
             $container->compile();
         } finally {


### PR DESCRIPTION
it feels like it's overwritten immediately, and unlike java php try does not confine variable scope

just one-line code style fix

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT


<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
