### PR TITLE
[Messenger][DX] Add middlewares section in debug:messenger command

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineClearEntityManagerMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineClearEntityManagerMiddleware.php
@@ -13,6 +13,8 @@ namespace Symfony\Bridge\Doctrine\Messenger;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\DescriptionAwareMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareDescription;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
 /**
@@ -20,7 +22,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
  *
  * @author Konstantin Myakshin <molodchick@gmail.com>
  */
-class DoctrineClearEntityManagerMiddleware extends AbstractDoctrineMiddleware
+class DoctrineClearEntityManagerMiddleware extends AbstractDoctrineMiddleware implements DescriptionAwareMiddleware
 {
     protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
     {
@@ -29,5 +31,10 @@ class DoctrineClearEntityManagerMiddleware extends AbstractDoctrineMiddleware
         } finally {
             $entityManager->clear();
         }
+    }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::after('Clear Doctrine entity manager');
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
@@ -13,6 +13,8 @@ namespace Symfony\Bridge\Doctrine\Messenger;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\DescriptionAwareMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareDescription;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
 /**
@@ -20,7 +22,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
  *
  * @author Fuong <insidestyles@gmail.com>
  */
-class DoctrineCloseConnectionMiddleware extends AbstractDoctrineMiddleware
+class DoctrineCloseConnectionMiddleware extends AbstractDoctrineMiddleware implements DescriptionAwareMiddleware
 {
     protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
     {
@@ -31,5 +33,10 @@ class DoctrineCloseConnectionMiddleware extends AbstractDoctrineMiddleware
         } finally {
             $connection->close();
         }
+    }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::after('Close Doctrine connection');
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
@@ -13,6 +13,8 @@ namespace Symfony\Bridge\Doctrine\Messenger;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\DescriptionAwareMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareDescription;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
 /**
@@ -20,7 +22,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
  *
  * @author Fuong <insidestyles@gmail.com>
  */
-class DoctrinePingConnectionMiddleware extends AbstractDoctrineMiddleware
+class DoctrinePingConnectionMiddleware extends AbstractDoctrineMiddleware implements DescriptionAwareMiddleware
 {
     protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
     {
@@ -36,5 +38,10 @@ class DoctrinePingConnectionMiddleware extends AbstractDoctrineMiddleware
         }
 
         return $stack->next()->handle($envelope, $stack);
+    }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::before('Ping Doctrine connection');
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
@@ -14,6 +14,8 @@ namespace Symfony\Bridge\Doctrine\Messenger;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Middleware\DescriptionAwareMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareDescription;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 
@@ -22,7 +24,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class DoctrineTransactionMiddleware extends AbstractDoctrineMiddleware
+class DoctrineTransactionMiddleware extends AbstractDoctrineMiddleware implements DescriptionAwareMiddleware
 {
     protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
     {
@@ -44,5 +46,10 @@ class DoctrineTransactionMiddleware extends AbstractDoctrineMiddleware
 
             throw $exception;
         }
+    }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::around('Start Doctrine transaction', 'Commit/rollback Doctrine transaction');
     }
 }

--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -81,11 +81,11 @@ EOF
             $io->section($bus);
 
             $this->describeMessages($handlersByMessage, $bus, $io);
-            // describe middlewares
+            $this->describeMiddlewares([], $bus, $io);
         }
     }
 
-    private function describeMessages($handlersByMessage, $bus, SymfonyStyle $io): void
+    private function describeMessages($handlersByMessage, string $bus, SymfonyStyle $io): void
     {
         $tableRows = [];
         foreach ($handlersByMessage as $message => $handlers) {
@@ -109,7 +109,7 @@ EOF
     /**
      * @param MiddlewareInterface[] $middlewares
      */
-    private function describeMiddlewares(array $middlewares): void
+    private function describeMiddlewares(array $middlewares, string $bus, SymfonyStyle $io): void
     {
         $before = $after = [];
         foreach ($middlewares as $middleware) {
@@ -122,11 +122,10 @@ EOF
             }
         }
 
-        $after = array_reverse($after);
-
-        foreach (array_merge($before, $after) as $line) {
-            // ...
-        }
+        $lines = array_merge($before, array_reverse($after));
+        $io->text('The following middlewares are registered:');
+        $io->newLine();
+        $io->listing($lines);
     }
 
     private function formatConditions(array $options): string

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -317,5 +317,16 @@ class MessengerPass implements CompilerPassInterface
         }
 
         $container->getDefinition($busId)->replaceArgument(0, new IteratorArgument($middlewareReferences));
+
+        //FIXME: add argument to console command
+        if ($container->hasDefinition('console.command.messenger_debug')) {
+            $debugCommandMapping = $handlersByBusAndMessage;
+            foreach ($busIds as $bus) {
+                if (!isset($debugCommandMapping[$bus])) {
+                    $debugCommandMapping[$bus] = [];
+                }
+            }
+            $container->getDefinition('console.command.messenger_debug')->replaceArgument(0, $debugCommandMapping);
+        }
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/AddBusNameStampMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/AddBusNameStampMiddleware.php
@@ -37,4 +37,9 @@ class AddBusNameStampMiddleware implements MiddlewareInterface
 
         return $stack->next()->handle($envelope, $stack);
     }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::before('Add bus name');
+    }
 }

--- a/src/Symfony/Component/Messenger/Middleware/DescriptionAwareMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DescriptionAwareMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+/**
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ */
+interface DescriptionAwareMiddleware
+{
+    public function getDescription(): MiddlewareDescription;
+}

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class HandleMessageMiddleware implements MiddlewareInterface
+class HandleMessageMiddleware implements MiddlewareInterface, DescriptionAwareMiddleware
 {
     use LoggerAwareTrait;
 
@@ -91,5 +91,10 @@ class HandleMessageMiddleware implements MiddlewareInterface
             });
 
         return \count($some) > 0;
+    }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::before('Call message handler');
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/MiddlewareDescription.php
+++ b/src/Symfony/Component/Messenger/Middleware/MiddlewareDescription.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+/**
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ */
+final class MiddlewareDescription
+{
+    private $before;
+    private $after;
+
+    public static function before(string $before): self
+    {
+        $self = new self();
+        $self->before = $before;
+
+        return $self;
+    }
+
+    public static function after(string $after): self
+    {
+        $self = new self();
+        $self->after = $after;
+
+        return $self;
+    }
+
+    public static function around(string $before, string $after): self
+    {
+        $self = new self();
+        $self->before = $before;
+        $self->after = $after;
+
+        return $self;
+    }
+
+    public function getBefore(): ?string
+    {
+        return $this->before;
+    }
+
+    public function getAfter(): ?string
+    {
+        return $this->after;
+    }
+
+    private function __construct()
+    {
+        // no-op
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  * @author Samuel Roze <samuel.roze@gmail.com>
  * @author Tobias Schultze <http://tobion.de>
  */
-class SendMessageMiddleware implements MiddlewareInterface
+class SendMessageMiddleware implements MiddlewareInterface, DescriptionAwareMiddleware
 {
     use LoggerAwareTrait;
 
@@ -80,6 +80,11 @@ class SendMessageMiddleware implements MiddlewareInterface
 
         // message should only be sent and not be handled by the next middleware
         return $envelope;
+    }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::before('Send message to transport');
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
@@ -19,7 +19,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
-class TraceableMiddleware implements MiddlewareInterface
+class TraceableMiddleware implements MiddlewareInterface, DescriptionAwareMiddleware
 {
     private $stopwatch;
     private $busName;
@@ -44,6 +44,11 @@ class TraceableMiddleware implements MiddlewareInterface
         } finally {
             $stack->stop();
         }
+    }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::around('Star collecting profiler data', 'Finish collecting profiler data');
     }
 }
 

--- a/src/Symfony/Component/Messenger/Middleware/ValidationMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ValidationMiddleware.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ValidationMiddleware implements MiddlewareInterface
+class ValidationMiddleware implements MiddlewareInterface, DescriptionAwareMiddleware
 {
     private $validator;
 
@@ -46,5 +46,10 @@ class ValidationMiddleware implements MiddlewareInterface
         }
 
         return $stack->next()->handle($envelope, $stack);
+    }
+
+    public function getDescription(): MiddlewareDescription
+    {
+        return MiddlewareDescription::before('Validate message');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not yet
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Register all needed middlewares in right order it is not trivial deal. I propose improve it by optionally providing `MiddlewareDescription` that describes what this middleware do and when it should be activated. For example for my setup

```yaml
framework:
    messenger:
        default_bus: messenger.bus.commands
        buses:
            messenger.bus.commands:
                default_middleware: false
                middleware:
                    - App\Common\Infrastructure\Messenger\ProcessMonologHandlersMiddleware
                    - validation
                    - App\Common\Infrastructure\Messenger\DoctrineClearEntityManagerMiddleware
                    - App\Common\Infrastructure\Messenger\DispatchDomainEventsMiddleware
                    - doctrine_ping_connection
                    - doctrine_transaction
                    - send_message
                    - handle_message
```

It would display something like:

```
0. start collecting profiler data
1. process monolog handlers
2. perform validation
3. ping doctrine connection
4. conditionally start wrapped middleware
4.1. start doctrine transaction
5. send message to transpot
6. handle message
7. commit doctrine transaction
8. dispatch domain events
9. clear entity manager
10. close doctrine connection
11. finish collecting profiler data
```

PR in early state, I want to collect feedback about idea. Also it should solve some issues described in #32436.