### PR TITLE
[Console] add missing conflict rule

### DIFF
--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -42,6 +42,7 @@
     "conflict": {
         "symfony/dependency-injection": "<3.4",
         "symfony/event-dispatcher": "<4.3|>=5",
+        "symfony/lock": "<4.4",
         "symfony/process": "<3.3"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The LockableTrait uses the LockFactory introduced in Symfony 4.4.
