### PR TITLE
[Ldap] remove wrongly added legacy group from test

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Ldap\Tests\Security\User;
+namespace Symfony\Component\Ldap\Tests\Security;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Ldap\Adapter\CollectionInterface;
@@ -21,7 +21,6 @@ use Symfony\Component\Ldap\Security\LdapUser;
 use Symfony\Component\Ldap\Security\LdapUserProvider;
 
 /**
- * @group legacy
  * @requires extension ldap
  */
 class LdapUserProviderTest extends TestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This was missed to be removed when tests from the legacy implementation
where copied from the Security component.
