### PR TITLE
[ErrorHandler] Forward \Throwable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -174,10 +174,8 @@ class Application extends BaseApplication
             if ($bundle instanceof Bundle) {
                 try {
                     $bundle->registerCommands($this);
-                } catch (\Exception $e) {
-                    $this->registrationErrors[] = $e;
                 } catch (\Throwable $e) {
-                    $this->registrationErrors[] = new FatalThrowableError($e);
+                    $this->registrationErrors[] = $e;
                 }
             }
         }
@@ -192,10 +190,8 @@ class Application extends BaseApplication
                 if (!isset($lazyCommandIds[$id])) {
                     try {
                         $this->add($container->get($id));
-                    } catch (\Exception $e) {
-                        $this->registrationErrors[] = $e;
                     } catch (\Throwable $e) {
-                        $this->registrationErrors[] = new FatalThrowableError($e);
+                        $this->registrationErrors[] = $e;
                     }
                 }
             }
@@ -211,6 +207,10 @@ class Application extends BaseApplication
         (new SymfonyStyle($input, $output))->warning('Some commands could not be registered:');
 
         foreach ($this->registrationErrors as $error) {
+            if (!$error instanceof \Exception) {
+                $error = new FatalThrowableError($error);
+            }
+
             $this->doRenderException($error, $output);
         }
     }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -127,7 +127,7 @@ class Application implements ResetInterface
             $output = new ConsoleOutput();
         }
 
-        $renderException = function ($e) use ($output) {
+        $renderException = function (\Throwable $e) use ($output) {
             if (!$e instanceof \Exception) {
                 $e = class_exists(FatalThrowableError::class) ? new FatalThrowableError($e) : (class_exists(LegacyFatalThrowableError::class) ? new LegacyFatalThrowableError($e) : new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine()));
             }

--- a/src/Symfony/Component/ErrorHandler/Exception/FatalThrowableError.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FatalThrowableError.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\ErrorHandler\Exception;
 
+use Symfony\Component\ErrorHandler\ThrowableUtils;
+
 /**
  * Fatal Throwable Error.
  *
@@ -24,18 +26,10 @@ class FatalThrowableError extends FatalErrorException
     {
         $this->originalClassName = \get_class($e);
 
-        if ($e instanceof \ParseError) {
-            $severity = E_PARSE;
-        } elseif ($e instanceof \TypeError) {
-            $severity = E_RECOVERABLE_ERROR;
-        } else {
-            $severity = E_ERROR;
-        }
-
         \ErrorException::__construct(
             $e->getMessage(),
             $e->getCode(),
-            $severity,
+            ThrowableUtils::getSeverity($e),
             $e->getFile(),
             $e->getLine(),
             $e->getPrevious()

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -382,18 +382,19 @@ class ErrorHandlerTest extends TestCase
         restore_error_handler();
     }
 
-    public function testHandleException()
+    /**
+     * @dataProvider handleExceptionProvider
+     */
+    public function testHandleException(string $expectedMessage, \Throwable $exception)
     {
         try {
             $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
             $handler = ErrorHandler::register();
 
-            $exception = new \Exception('foo');
-
-            $logArgCheck = function ($level, $message, $context) {
-                $this->assertSame('Uncaught Exception: foo', $message);
+            $logArgCheck = function ($level, $message, $context) use ($expectedMessage, $exception) {
+                $this->assertSame($expectedMessage, $message);
                 $this->assertArrayHasKey('exception', $context);
-                $this->assertInstanceOf(\Exception::class, $context['exception']);
+                $this->assertInstanceOf(\get_class($exception), $context['exception']);
             };
 
             $logger
@@ -407,7 +408,7 @@ class ErrorHandlerTest extends TestCase
             try {
                 $handler->handleException($exception);
                 $this->fail('Exception expected');
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $this->assertSame($exception, $e);
             }
 
@@ -420,6 +421,15 @@ class ErrorHandlerTest extends TestCase
             restore_error_handler();
             restore_exception_handler();
         }
+    }
+
+    public function handleExceptionProvider(): array
+    {
+        return [
+            ['Uncaught Exception: foo', new \Exception('foo')],
+            ['Uncaught Error: bar', new \Error('bar')],
+            ['Uncaught ccc', new \ErrorException('ccc')],
+        ];
     }
 
     public function testBootstrappingLogger()

--- a/src/Symfony/Component/ErrorHandler/ThrowableUtils.php
+++ b/src/Symfony/Component/ErrorHandler/ThrowableUtils.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ErrorHandler;
+
+/**
+ * @internal
+ */
+class ThrowableUtils
+{
+    public static function getSeverity(\Throwable $throwable): int
+    {
+        if ($throwable instanceof \ErrorException) {
+            return $throwable->getSeverity();
+        }
+
+        if ($throwable instanceof \ParseError) {
+            return E_PARSE;
+        }
+
+        if ($throwable instanceof \TypeError) {
+            return E_RECOVERABLE_ERROR;
+        }
+
+        return E_ERROR;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\ErrorHandler\ErrorHandler;
+use Symfony\Component\ErrorHandler\Exception\FatalThrowableError;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
@@ -42,7 +43,7 @@ class DebugHandlersListener implements EventSubscriberInterface
     private $hasTerminatedWithException;
 
     /**
-     * @param callable|null                 $exceptionHandler A handler that will be called on Exception
+     * @param callable|null                 $exceptionHandler A handler that must support \Throwable instances that will be called on Exception
      * @param array|int                     $levels           An array map of E_* to LogLevel::* or an integer bit field of E_* constants
      * @param int|null                      $throwAt          Thrown errors in a bit field of E_* constants, or null to keep the current value
      * @param bool                          $scream           Enables/disables screaming mode, where even silenced errors are logged
@@ -106,10 +107,15 @@ class DebugHandlersListener implements EventSubscriberInterface
                 if (method_exists($kernel = $event->getKernel(), 'terminateWithException')) {
                     $request = $event->getRequest();
                     $hasRun = &$this->hasTerminatedWithException;
-                    $this->exceptionHandler = static function (\Exception $e) use ($kernel, $request, &$hasRun) {
+                    $this->exceptionHandler = static function (\Throwable $e) use ($kernel, $request, &$hasRun) {
                         if ($hasRun) {
                             throw $e;
                         }
+
+                        if (!$e instanceof \Exception) {
+                            $e = new FatalThrowableError($e);
+                        }
+
                         $hasRun = true;
                         $kernel->terminateWithException($e, $request);
                     };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/32605
| License       | MIT
| Doc PR        | -

The goal of this PR is that `ErrorHandler::handleException()` handles `\Throwable` directly and forwards it  without altering it.