### PR TITLE
Disable typehint patch on PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
     global:
         - MIN_PHP=7.1.3
         - SYMFONY_PROCESS_PHP_TEST_BINARY=~/.phpenv/shims/php
-        - SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1
         - MESSENGER_AMQP_DSN=amqp://localhost/%2f/messages
         - MESSENGER_REDIS_DSN=redis://127.0.0.1:7001/messages
 

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -20,7 +20,7 @@ class ContainerAwareEventManagerTest extends TestCase
     private $container;
     private $evm;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->evm = new ContainerAwareEventManager($this->container);

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -26,7 +26,7 @@ class DoctrineExtensionTest extends TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
@@ -73,7 +73,7 @@ class DoctrineChoiceLoaderTest extends TestCase
      */
     private $obj3;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface')->getMock();
         $this->om = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')->getMock();

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
@@ -25,7 +25,7 @@ class CollectionToArrayTransformerTest extends TestCase
      */
     private $transformer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->transformer = new CollectionToArrayTransformer();
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/EventListener/MergeDoctrineCollectionListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/EventListener/MergeDoctrineCollectionListenerTest.php
@@ -28,7 +28,7 @@ class MergeDoctrineCollectionListenerTest extends TestCase
     private $factory;
     private $form;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->collection = new ArrayCollection(['test']);
         $this->dispatcher = new EventDispatcher();
@@ -37,7 +37,7 @@ class MergeDoctrineCollectionListenerTest extends TestCase
             ->getForm();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->collection = null;
         $this->dispatcher = null;

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -50,7 +50,7 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
         ];
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->em = DoctrineTestHelper::createTestEntityManager();
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -60,7 +60,7 @@ class EntityTypeTest extends BaseTypeTest
 
     protected static $supportedFeatureSetVersion = 304;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->em = DoctrineTestHelper::createTestEntityManager();
         $this->emRegistry = $this->createRegistryMock('default', $this->em);
@@ -90,7 +90,7 @@ class EntityTypeTest extends BaseTypeTest
         }
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
@@ -17,7 +17,7 @@ use Symfony\Bridge\ProxyManager\Tests\LazyProxy\Dumper\PhpDumperTest;
 
 class ManagerRegistryTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists('PHPUnit_Framework_TestCase')) {
             self::markTestSkipped('proxy-manager-bridge is not yet compatible with namespaced phpunit versions.');

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -58,7 +58,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     protected $repositoryFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repositoryFactory = new TestRepositoryFactory();
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
@@ -21,12 +21,12 @@ use Symfony\Bridge\PhpUnit\ClockMock;
  */
 class ClockMockTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         ClockMock::register(__CLASS__);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         ClockMock::withClockMock(1234567890.125);
     }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\PhpUnit\DnsMock;
 
 class DnsMockTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         DnsMock::withMockedHosts(array());
     }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
@@ -30,7 +30,7 @@ class RuntimeInstantiatorTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->instantiator = new RuntimeInstantiator();
     }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -32,7 +32,7 @@ class ProxyDumperTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dumper = new ProxyDumper();
     }

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -15,7 +15,7 @@ class AppVariableTest extends TestCase
      */
     protected $appVariable;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->appVariable = new AppVariable();
     }

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -93,12 +93,12 @@ class LintCommandTest extends TestCase
         return $filename;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->files = [];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
@@ -33,7 +33,7 @@ class FormExtensionBootstrap3HorizontalLayoutTest extends AbstractBootstrap3Hori
      */
     private $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -29,7 +29,7 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTest
      */
     private $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
@@ -35,7 +35,7 @@ class FormExtensionBootstrap4HorizontalLayoutTest extends AbstractBootstrap4Hori
 
     private $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -33,7 +33,7 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTest
      */
     private $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -33,7 +33,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
 
     protected static $supportedFeatureSetVersion = 403;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -32,7 +32,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
 
     protected static $supportedFeatureSetVersion = 403;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WebLinkExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WebLinkExtensionTest.php
@@ -32,7 +32,7 @@ class WebLinkExtensionTest extends TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->request = new Request();
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -28,7 +28,7 @@ class WorkflowExtensionTest extends TestCase
     private $extension;
     private $t1;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!class_exists(Workflow::class)) {
             $this->markTestSkipped('The Workflow component is needed to run tests for this extension.');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -17,7 +17,7 @@ class AnnotationsCacheWarmerTest extends TestCase
 {
     private $cacheDir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cacheDir = sys_get_temp_dir().'/'.uniqid();
         $fs = new Filesystem();
@@ -25,7 +25,7 @@ class AnnotationsCacheWarmerTest extends TestCase
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $fs = new Filesystem();
         $fs->remove($this->cacheDir);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
@@ -38,7 +38,7 @@ class TemplatePathsCacheWarmerTest extends TestCase
 
     private $tmpDir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->templateFinder = $this
             ->getMockBuilder(TemplateFinderInterface::class)
@@ -59,7 +59,7 @@ class TemplatePathsCacheWarmerTest extends TestCase
         $this->filesystem->mkdir($this->tmpDir);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->filesystem->remove($this->tmpDir);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -28,14 +28,14 @@ class CacheClearCommandTest extends TestCase
     /** @var Filesystem */
     private $fs;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fs = new Filesystem();
         $this->kernel = new TestAppKernel('test', true);
         $this->fs->mkdir($this->kernel->getProjectDir());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->fs->remove($this->kernel->getProjectDir());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -127,7 +127,7 @@ class TranslationDebugCommandTest extends TestCase
         $tester->execute(['locale' => 'en', 'bundle' => 'dir']);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fs = new Filesystem();
         $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
@@ -135,7 +135,7 @@ class TranslationDebugCommandTest extends TestCase
         $this->fs->mkdir($this->translationDir.'/templates');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->fs->remove($this->translationDir);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -105,7 +105,7 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertRegExp('/Translation files were successfully updated./', $tester->getDisplay());
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fs = new Filesystem();
         $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf_translation', true);
@@ -113,7 +113,7 @@ class TranslationUpdateCommandTest extends TestCase
         $this->fs->mkdir($this->translationDir.'/templates');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->fs->remove($this->translationDir);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -181,13 +181,13 @@ EOF;
         return $application;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         @mkdir(sys_get_temp_dir().'/yml-lint-test');
         $this->files = [];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -15,12 +15,12 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\TextDescriptor;
 
 class TextDescriptorTest extends AbstractDescriptorTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         putenv('COLUMNS=121');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv('COLUMNS');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -23,7 +23,7 @@ class ControllerNameParserTest extends TestCase
 {
     protected $loader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loader = new ClassLoader();
         $this->loader->add('TestBundle', __DIR__.'/../Fixtures');
@@ -31,7 +31,7 @@ class ControllerNameParserTest extends TestCase
         $this->loader->register();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->loader->unregister();
         $this->loader = null;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
@@ -26,7 +26,7 @@ class CachePoolPassTest extends TestCase
 {
     private $cachePoolPass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cachePoolPass = new CachePoolPass();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/DataCollectorTranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/DataCollectorTranslatorPassTest.php
@@ -22,7 +22,7 @@ class DataCollectorTranslatorPassTest extends TestCase
     private $container;
     private $dataCollectorTranslatorPass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->dataCollectorTranslatorPass = new DataCollectorTranslatorPass();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
@@ -25,7 +25,7 @@ class WorkflowGuardListenerPassTest extends TestCase
     private $container;
     private $compilerPass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->compilerPass = new WorkflowGuardListenerPass();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
@@ -22,12 +22,12 @@ abstract class AbstractWebTestCase extends BaseWebTestCase
         self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         static::deleteTmpDir();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         static::deleteTmpDir();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class CachePoolClearCommandTest extends AbstractWebTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel(['test_case' => 'CachePoolClear', 'root_config' => 'config.yml']);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -23,7 +23,7 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
 {
     private $application;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $kernel = static::createKernel(['test_case' => 'ConfigDump', 'root_config' => 'config.yml']);
         $this->application = new Application($kernel);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -23,7 +23,7 @@ class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
 {
     private $application;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $kernel = static::createKernel(['test_case' => 'ConfigDump', 'root_config' => 'config.yml']);
         $this->application = new Application($kernel);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
@@ -23,7 +23,7 @@ class GlobalVariablesTest extends TestCase
     private $container;
     private $globals;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->globals = new GlobalVariables($this->container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
@@ -24,7 +24,7 @@ class AssetsHelperTest extends TestCase
 {
     private $helper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $fooPackage = new Package(new StaticVersionStrategy('42', '%s?v=%s'));
         $barPackage = new Package(new StaticVersionStrategy('22', '%s?%s'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -55,7 +55,7 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
         ]);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->engine = null;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -100,7 +100,7 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
         ]);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->engine = null;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/RequestHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/RequestHelperTest.php
@@ -23,7 +23,7 @@ class RequestHelperTest extends TestCase
 {
     protected $requestStack;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->requestStack = new RequestStack();
         $request = new Request();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/SessionHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/SessionHelperTest.php
@@ -25,7 +25,7 @@ class SessionHelperTest extends TestCase
 {
     protected $requestStack;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $request = new Request();
 
@@ -39,7 +39,7 @@ class SessionHelperTest extends TestCase
         $this->requestStack->push($request);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->requestStack = null;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateFilenameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateFilenameParserTest.php
@@ -22,12 +22,12 @@ class TemplateFilenameParserTest extends TestCase
 {
     protected $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = new TemplateFilenameParser();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->parser = null;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -23,7 +23,7 @@ class TemplateNameParserTest extends TestCase
 {
     protected $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel
@@ -40,7 +40,7 @@ class TemplateNameParserTest extends TestCase
         $this->parser = new TemplateNameParser($kernel);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->parser = null;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -24,13 +24,13 @@ class TranslatorTest extends TestCase
 {
     protected $tmpDir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/sf_translation';
         $this->deleteTmpDir();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->deleteTmpDir();
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
@@ -22,12 +22,12 @@ abstract class AbstractWebTestCase extends BaseWebTestCase
         self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         static::deleteTmpDir();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         static::deleteTmpDir();
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -286,7 +286,7 @@ EOTXT
         ], ['interactive' => false]);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         putenv('COLUMNS='.(119 + \strlen(PHP_EOL)));
         $kernel = $this->createKernel(['test_case' => 'PasswordEncode']);
@@ -299,7 +299,7 @@ EOTXT
         $this->passwordEncoderCommandTester = new CommandTester($passwordEncoderCommand);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->passwordEncoderCommandTester = null;
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -31,7 +31,7 @@ class TwigLoaderPassTest extends TestCase
      */
     private $pass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ContainerBuilder();
         $this->builder->register('twig');

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
@@ -47,12 +47,12 @@ class CacheWarmingTest extends TestCase
         $this->assertFileExists($kernel->getCacheDir().'/twig');
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->deleteTempDir();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->deleteTempDir();
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -30,12 +30,12 @@ class NoTemplatingEntryTest extends TestCase
         $this->assertStringContainsString('{ a: b }', $content);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->deleteTempDir();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->deleteTempDir();
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -46,7 +46,7 @@ class WebProfilerExtensionTest extends TestCase
         self::assertEquals([], $errors, $message);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -73,7 +73,7 @@ class WebProfilerExtensionTest extends TestCase
         $this->container->addCompilerPass(new RegisterListenersPass());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -38,7 +38,7 @@ class TemplateManagerTest extends TestCase
      */
     protected $templateManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -28,7 +28,7 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
         return new RedisAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
@@ -39,7 +39,7 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$redis = null;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\Cache\CallbackInterface;
 
 abstract class AdapterTestCase extends CachePoolTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/FilesystemAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/FilesystemAdapterTest.php
@@ -24,7 +24,7 @@ class FilesystemAdapterTest extends AdapterTestCase
         return new FilesystemAdapter('', $defaultLifetime);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::rmdir(sys_get_temp_dir().'/symfony-cache');
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -23,7 +23,7 @@ class MemcachedAdapterTest extends AdapterTestCase
 
     protected static $client;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!MemcachedAdapter::isSupported()) {
             self::markTestSkipped('Extension memcached >=2.2.0 required.');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -23,7 +23,7 @@ class PdoAdapterTest extends AdapterTestCase
 
     protected static $dbFile;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
@@ -35,7 +35,7 @@ class PdoAdapterTest extends AdapterTestCase
         $pool->createTable();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
@@ -24,7 +24,7 @@ class PdoDbalAdapterTest extends AdapterTestCase
 
     protected static $dbFile;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
@@ -35,7 +35,7 @@ class PdoDbalAdapterTest extends AdapterTestCase
         $pool = new PdoAdapter(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]));
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -58,12 +58,12 @@ class PhpArrayAdapterTest extends AdapterTestCase
 
     protected static $file;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$file = sys_get_temp_dir().'/symfony-cache/php-array-adapter-test.php';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (file_exists(sys_get_temp_dir().'/symfony-cache')) {
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
@@ -30,12 +30,12 @@ class PhpArrayAdapterWithFallbackTest extends AdapterTestCase
 
     protected static $file;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$file = sys_get_temp_dir().'/symfony-cache/php-array-adapter-test.php';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (file_exists(sys_get_temp_dir().'/symfony-cache')) {
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
@@ -28,7 +28,7 @@ class PhpFilesAdapterTest extends AdapterTestCase
         return new PhpFilesAdapter('sf-cache');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 class PredisAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setupBeforeClass();
         self::$redis = new \Predis\Client(['host' => getenv('REDIS_HOST')]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
@@ -13,13 +13,13 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 class PredisClusterAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setupBeforeClass();
         self::$redis = new \Predis\Client([['host' => getenv('REDIS_HOST')]]);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$redis = null;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
             self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
@@ -24,7 +24,7 @@ class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
         self::$redis = RedisAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['class' => \Predis\Client::class, 'redis_cluster' => true]);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$redis = null;
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Cache\Traits\RedisProxy;
 
 class RedisAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setupBeforeClass();
         self::$redis = AbstractAdapter::createConnection('redis://'.getenv('REDIS_HOST'), ['lazy' => true]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 class RedisArrayAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setupBeforeClass();
         if (!class_exists('RedisArray')) {

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Cache\Traits\RedisClusterProxy;
 
 class RedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists('RedisCluster')) {
             self::markTestSkipped('The RedisCluster class is required.');

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -29,7 +29,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         return new TagAwareAdapter(new FilesystemAdapter('', $defaultLifetime));
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -31,7 +31,7 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
         return new RedisCache(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
@@ -42,7 +42,7 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$redis = null;
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/CacheTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/CacheTestCase.php
@@ -17,7 +17,7 @@ use Symfony\Component\Cache\PruneableInterface;
 
 abstract class CacheTestCase extends SimpleCacheTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -27,7 +27,7 @@ class MemcachedCacheTest extends CacheTestCase
 
     protected static $client;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!MemcachedCache::isSupported()) {
             self::markTestSkipped('Extension memcached >=2.2.0 required.');

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
@@ -24,7 +24,7 @@ class PdoCacheTest extends CacheTestCase
 
     protected static $dbFile;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
@@ -36,7 +36,7 @@ class PdoCacheTest extends CacheTestCase
         $pool->createTable();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
@@ -25,7 +25,7 @@ class PdoDbalCacheTest extends CacheTestCase
 
     protected static $dbFile;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
@@ -37,7 +37,7 @@ class PdoDbalCacheTest extends CacheTestCase
         $pool->createTable();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$dbFile);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
@@ -50,12 +50,12 @@ class PhpArrayCacheTest extends CacheTestCase
 
     protected static $file;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$file = sys_get_temp_dir().'/symfony-cache/php-array-adapter-test.php';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (file_exists(sys_get_temp_dir().'/symfony-cache')) {
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWithFallbackTest.php
@@ -37,12 +37,12 @@ class PhpArrayCacheWithFallbackTest extends CacheTestCase
 
     protected static $file;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$file = sys_get_temp_dir().'/symfony-cache/php-array-adapter-test.php';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (file_exists(sys_get_temp_dir().'/symfony-cache')) {
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisArrayCacheTest.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Cache\Tests\Simple;
  */
 class RedisArrayCacheTest extends AbstractRedisCacheTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setupBeforeClass();
         if (!class_exists('RedisArray')) {

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Cache\Simple\RedisCache;
  */
 class RedisCacheTest extends AbstractRedisCacheTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setupBeforeClass();
         self::$redis = RedisCache::createConnection('redis://'.getenv('REDIS_HOST'));

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisClusterCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisClusterCacheTest.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Cache\Tests\Simple;
  */
 class RedisClusterCacheTest extends AbstractRedisCacheTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists('RedisCluster')) {
             self::markTestSkipped('The RedisCluster class is required.');

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -19,12 +19,12 @@ class ConfigCacheTest extends TestCase
 {
     private $cacheFile = null;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'config_');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $files = [$this->cacheFile, $this->cacheFile.'.meta'];
 

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -18,7 +18,7 @@ class DirectoryResourceTest extends TestCase
 {
     protected $directory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->directory = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'symfonyDirectoryIterator';
         if (!file_exists($this->directory)) {
@@ -27,7 +27,7 @@ class DirectoryResourceTest extends TestCase
         touch($this->directory.'/tmp.xml');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (!is_dir($this->directory)) {
             return;

--- a/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
@@ -20,14 +20,14 @@ class FileExistenceResourceTest extends TestCase
     protected $file;
     protected $time;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->file = realpath(sys_get_temp_dir()).'/tmp.xml';
         $this->time = time();
         $this->resource = new FileExistenceResource($this->file);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (file_exists($this->file)) {
             unlink($this->file);

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -20,7 +20,7 @@ class FileResourceTest extends TestCase
     protected $file;
     protected $time;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->file = sys_get_temp_dir().'/tmp.xml';
         $this->time = time();
@@ -28,7 +28,7 @@ class FileResourceTest extends TestCase
         $this->resource = new FileResource($this->file);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (!file_exists($this->file)) {
             return;

--- a/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Resource\GlobResource;
 
 class GlobResourceTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $dir = \dirname(__DIR__).'/Fixtures';
         @rmdir($dir.'/TmpGlob');

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -20,12 +20,12 @@ class ResourceCheckerConfigCacheTest extends TestCase
 {
     private $cacheFile = null;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cacheFile = tempnam(sys_get_temp_dir(), 'config_');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $files = [$this->cacheFile, "{$this->cacheFile}.meta"];
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -43,12 +43,12 @@ class ApplicationTest extends TestCase
 
     private $colSize;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->colSize = getenv('COLUMNS');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
         putenv('SHELL_VERBOSITY');
@@ -56,7 +56,7 @@ class ApplicationTest extends TestCase
         unset($_SERVER['SHELL_VERBOSITY']);
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/Fixtures/');
         require_once self::$fixturesPath.'/FooCommand.php';

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -28,7 +28,7 @@ class CommandTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = __DIR__.'/../Fixtures/';
         require_once self::$fixturesPath.'/TestCommand.php';

--- a/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
@@ -21,7 +21,7 @@ class LockableTraitTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = __DIR__.'/../Fixtures/';
         require_once self::$fixturesPath.'/FooLockCommand.php';

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -25,13 +25,13 @@ class ProgressBarTest extends TestCase
 {
     private $colSize;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->colSize = getenv('COLUMNS');
         putenv('COLUMNS=120');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
     }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -24,12 +24,12 @@ class TableTest extends TestCase
 {
     protected $stream;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->stream = fopen('php://memory', 'r+');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         fclose($this->stream);
         $this->stream = null;

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -25,7 +25,7 @@ class InputDefinitionTest extends TestCase
     protected $foo1;
     protected $foo2;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixtures = __DIR__.'/../Fixtures/';
     }

--- a/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
@@ -19,12 +19,12 @@ class StreamOutputTest extends TestCase
 {
     protected $stream;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->stream = fopen('php://memory', 'a', false);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->stream = null;
     }

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -28,7 +28,7 @@ class SymfonyStyleTest extends TestCase
     protected $tester;
     private $colSize;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->colSize = getenv('COLUMNS');
         putenv('COLUMNS=121');
@@ -36,7 +36,7 @@ class SymfonyStyleTest extends TestCase
         $this->tester = new CommandTester($this->command);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
         $this->command = null;

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -19,13 +19,13 @@ class TerminalTest extends TestCase
     private $colSize;
     private $lineSize;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->colSize = getenv('COLUMNS');
         $this->lineSize = getenv('LINES');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
         putenv($this->lineSize ? 'LINES' : 'LINES='.$this->lineSize);

--- a/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
@@ -23,7 +23,7 @@ class ApplicationTesterTest extends TestCase
     protected $application;
     protected $tester;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->application = new Application();
         $this->application->setAutoExit(false);
@@ -38,7 +38,7 @@ class ApplicationTesterTest extends TestCase
         $this->tester->run(['command' => 'foo', 'foo' => 'bar'], ['interactive' => false, 'decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE]);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->application = null;
         $this->tester = null;

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -27,7 +27,7 @@ class CommandTesterTest extends TestCase
     protected $command;
     protected $tester;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->command = new Command('foo');
         $this->command->addArgument('command');
@@ -38,7 +38,7 @@ class CommandTesterTest extends TestCase
         $this->tester->execute(['foo' => 'bar'], ['interactive' => false, 'decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE]);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->command = null;
         $this->tester = null;

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -23,7 +23,7 @@ class DebugClassLoaderTest extends TestCase
 
     private $loader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->errorReporting = error_reporting(E_ALL);
         $this->loader = new ClassLoader();
@@ -31,7 +31,7 @@ class DebugClassLoaderTest extends TestCase
         DebugClassLoader::enable();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         DebugClassLoader::disable();
         spl_autoload_unregister([$this->loader, 'loadClass']);

--- a/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ExceptionHandlerTest.php
@@ -21,12 +21,12 @@ require_once __DIR__.'/HeaderMock.php';
 
 class ExceptionHandlerTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         testHeader();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         testHeader();
     }

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Debug\FatalErrorHandler\ClassNotFoundFatalErrorHandler;
 
 class ClassNotFoundFatalErrorHandlerTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         foreach (spl_autoload_functions() as $function) {
             if (!\is_array($function)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ExtensionCompilerPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ExtensionCompilerPassTest.php
@@ -25,7 +25,7 @@ class ExtensionCompilerPassTest extends TestCase
     private $container;
     private $pass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->pass = new ExtensionCompilerPass();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -21,7 +21,7 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
     private $container;
     private $fooDefinition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->compilerPass = new ResolveParameterPlaceHoldersPass();
         $this->container = $this->createContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
@@ -29,7 +29,7 @@ class ContainerParametersResourceCheckerTest extends TestCase
     /** @var ContainerInterface */
     private $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->resource = new ContainerParametersResource(['locales' => ['fr', 'en'], 'default_locale' => 'fr']);
         $this->container = $this->getMockBuilder(ContainerInterface::class)->getMock();

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceTest.php
@@ -19,7 +19,7 @@ class ContainerParametersResourceTest extends TestCase
     /** @var ContainerParametersResource */
     private $resource;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->resource = new ContainerParametersResource(['locales' => ['fr', 'en'], 'default_locale' => 'fr']);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
@@ -19,7 +19,7 @@ class CrossCheckTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = __DIR__.'/Fixtures/';
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
@@ -21,7 +21,7 @@ class GraphvizDumperTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = __DIR__.'/../Fixtures/';
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -48,7 +48,7 @@ class PhpDumperTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -25,7 +25,7 @@ class XmlDumperTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -28,7 +28,7 @@ class YamlDumperTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
@@ -27,12 +27,12 @@ class DirectoryLoaderTest extends TestCase
     private $container;
     private $loader;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $locator = new FileLocator(self::$fixturesPath);
         $this->container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -37,7 +37,7 @@ class FileLoaderTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
@@ -21,7 +21,7 @@ class IniFileLoaderTest extends TestCase
     protected $container;
     protected $loader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->loader = new IniFileLoader($this->container, new FileLocator(realpath(__DIR__.'/../Fixtures/').'/ini'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/LoaderResolverTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/LoaderResolverTest.php
@@ -28,7 +28,7 @@ class LoaderResolverTest extends TestCase
     /** @var LoaderResolver */
     private $resolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -38,7 +38,7 @@ class XmlFileLoaderTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
         require_once self::$fixturesPath.'/includes/foo.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -39,7 +39,7 @@ class YamlFileLoaderTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
         require_once self::$fixturesPath.'/includes/foo.php';

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\DomCrawler\FormFieldRegistry;
 
 class FormTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         // Ensure that the private helper class FormFieldRegistry is loaded
         class_exists('Symfony\\Component\\DomCrawler\\Form');

--- a/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
@@ -28,7 +28,7 @@ class EventTest extends TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->event = new Event();
     }
@@ -37,7 +37,7 @@ class EventTest extends TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->event = null;
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -29,7 +29,7 @@ class GenericEventTest extends TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->subject = new \stdClass();
         $this->event = new GenericEvent($this->subject, ['name' => 'Event']);
@@ -38,7 +38,7 @@ class GenericEventTest extends TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->subject = null;
         $this->event = null;

--- a/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
@@ -31,7 +31,7 @@ class ImmutableEventDispatcherTest extends TestCase
      */
     private $dispatcher;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->innerDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->dispatcher = new ImmutableEventDispatcher($this->innerDispatcher);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -23,7 +23,7 @@ class LexerTest extends TestCase
      */
     private $lexer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->lexer = new Lexer();
     }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -40,7 +40,7 @@ class FilesystemTestCase extends TestCase
      */
     private static $symlinkOnWindows = null;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
             self::$linkOnWindows = true;
@@ -69,7 +69,7 @@ class FilesystemTestCase extends TestCase
         }
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->umask = umask(0);
         $this->filesystem = new Filesystem();
@@ -78,7 +78,7 @@ class FilesystemTestCase extends TestCase
         $this->workspace = realpath($this->workspace);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (!empty($this->longPathNamesWindows)) {
             foreach ($this->longPathNamesWindows as $path) {

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -16,7 +16,7 @@ abstract class RealIteratorTestCase extends IteratorTestCase
     protected static $tmpDir;
     protected static $files;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$tmpDir = realpath(sys_get_temp_dir()).\DIRECTORY_SEPARATOR.'symfony_finder';
 
@@ -69,7 +69,7 @@ abstract class RealIteratorTestCase extends IteratorTestCase
         touch(self::toAbsolute('test.php'), strtotime('2005-10-15'));
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         $paths = new \RecursiveIteratorIterator(
              new \RecursiveDirectoryIterator(self::$tmpDir, \RecursiveDirectoryIterator::SKIP_DOTS),

--- a/src/Symfony/Component/Form/Tests/AbstractFormTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractFormTest.php
@@ -34,14 +34,14 @@ abstract class AbstractFormTest extends TestCase
      */
     protected $form;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
         $this->form = $this->createForm();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->dispatcher = null;
         $this->factory = null;

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -25,7 +25,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     protected $csrfTokenManager;
     protected $testableFeatures = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!\extension_loaded('intl')) {
             $this->markTestSkipped('Extension intl is required.');
@@ -45,7 +45,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         ];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->csrfTokenManager = null;
 

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -40,7 +40,7 @@ abstract class AbstractRequestHandlerTest extends TestCase
 
     protected $serverParams;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->serverParams = $this->getMockBuilder('Symfony\Component\Form\Util\ServerParams')->setMethods(['getNormalizedIniPostMaxSize', 'getContentLength'])->getMock();
         $this->requestHandler = $this->getRequestHandler();

--- a/src/Symfony/Component/Form/Tests/ButtonTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonTest.php
@@ -24,7 +24,7 @@ class ButtonTest extends TestCase
 
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTest.php
@@ -103,7 +103,7 @@ abstract class AbstractChoiceListTest extends TestCase
      */
     protected $key4;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -20,7 +20,7 @@ class ArrayChoiceListTest extends AbstractChoiceListTest
 {
     private $object;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->object = new \stdClass();
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -30,7 +30,7 @@ class CachingFactoryDecoratorTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->decoratedFactory = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface')->getMock();
         $this->factory = new CachingFactoryDecorator($this->decoratedFactory);

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -89,7 +89,7 @@ class DefaultChoiceListFactoryTest extends TestCase
             : new DefaultChoiceListFactoryTest_Castable('Group 2');
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->obj1 = (object) ['label' => 'A', 'index' => 'w', 'value' => 'a', 'preferred' => false, 'group' => 'Group 1', 'attr' => []];
         $this->obj2 = (object) ['label' => 'B', 'index' => 'x', 'value' => 'b', 'preferred' => true, 'group' => 'Group 1', 'attr' => ['attr1' => 'value1']];

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
@@ -31,7 +31,7 @@ class PropertyAccessDecoratorTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->decoratedFactory = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface')->getMock();
         $this->factory = new PropertyAccessDecorator($this->decoratedFactory);

--- a/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
@@ -37,7 +37,7 @@ class LazyChoiceListTest extends TestCase
 
     private $value;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loadedList = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
         $this->loader = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
@@ -45,7 +45,7 @@ class CallbackChoiceLoaderTest extends TestCase
      */
     private static $lazyChoiceList;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$loader = new CallbackChoiceLoader(function () {
             return self::$choices;
@@ -91,7 +91,7 @@ class CallbackChoiceLoaderTest extends TestCase
         );
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$loader = null;
         self::$value = null;

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/JsonDescriptorTest.php
@@ -15,12 +15,12 @@ use Symfony\Component\Form\Console\Descriptor\JsonDescriptor;
 
 class JsonDescriptorTest extends AbstractDescriptorTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         putenv('COLUMNS=121');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv('COLUMNS');
     }

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -15,12 +15,12 @@ use Symfony\Component\Form\Console\Descriptor\TextDescriptor;
 
 class TextDescriptorTest extends AbstractDescriptorTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         putenv('COLUMNS=121');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv('COLUMNS');
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -38,7 +38,7 @@ class PropertyPathMapperTest extends TestCase
      */
     private $propertyAccessor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
@@ -18,7 +18,7 @@ class ArrayToPartsTransformerTest extends TestCase
 {
     private $transformer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->transformer = new ArrayToPartsTransformer([
             'first' => ['a', 'b', 'c'],
@@ -26,7 +26,7 @@ class ArrayToPartsTransformerTest extends TestCase
         ]);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->transformer = null;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -23,12 +23,12 @@ class BooleanToStringTransformerTest extends TestCase
      */
     protected $transformer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->transformer = new BooleanToStringTransformer(self::TRUE_VALUE);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->transformer = null;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoiceToValueTransformerTest.php
@@ -20,7 +20,7 @@ class ChoiceToValueTransformerTest extends TestCase
     protected $transformer;
     protected $transformerWithNull;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $list = new ArrayChoiceList(['', false, 'X', true]);
         $listWithNull = new ArrayChoiceList(['', false, 'X', null]);
@@ -29,7 +29,7 @@ class ChoiceToValueTransformerTest extends TestCase
         $this->transformerWithNull = new ChoiceToValueTransformer($listWithNull);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->transformer = null;
         $this->transformerWithNull = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoicesToValuesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ChoicesToValuesTransformerTest.php
@@ -20,7 +20,7 @@ class ChoicesToValuesTransformerTest extends TestCase
     protected $transformer;
     protected $transformerWithNull;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $list = new ArrayChoiceList(['', false, 'X']);
         $listWithNull = new ArrayChoiceList(['', false, 'X', null]);
@@ -29,7 +29,7 @@ class ChoicesToValuesTransformerTest extends TestCase
         $this->transformerWithNull = new ChoicesToValuesTransformer($listWithNull);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->transformer = null;
         $this->transformerWithNull = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -23,7 +23,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
     protected $dateTime;
     protected $dateTimeWithoutSeconds;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -36,7 +36,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
         $this->dateTimeWithoutSeconds = new \DateTime('2010-02-03 04:05:00 UTC');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->dateTime = null;
         $this->dateTimeWithoutSeconds = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -22,7 +22,7 @@ class DateTimeToRfc3339TransformerTest extends TestCase
     protected $dateTime;
     protected $dateTimeWithoutSeconds;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -30,7 +30,7 @@ class DateTimeToRfc3339TransformerTest extends TestCase
         $this->dateTimeWithoutSeconds = new \DateTime('2010-02-03 04:05:00 UTC');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->dateTime = null;
         $this->dateTimeWithoutSeconds = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -19,13 +19,13 @@ class IntegerToLocalizedStringTransformerTest extends TestCase
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         \Locale::setDefault($this->defaultLocale);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -19,12 +19,12 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 {
     private $previousLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->previousLocale = setlocale(LC_ALL, '0');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         setlocale(LC_ALL, $this->previousLocale);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -19,13 +19,13 @@ class NumberToLocalizedStringTransformerTest extends TestCase
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         \Locale::setDefault($this->defaultLocale);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -19,13 +19,13 @@ class PercentToLocalizedStringTransformerTest extends TestCase
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         \Locale::setDefault($this->defaultLocale);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -18,12 +18,12 @@ class ValueToDuplicatesTransformerTest extends TestCase
 {
     private $transformer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->transformer = new ValueToDuplicatesTransformer(['a', 'b', 'c']);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->transformer = null;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
@@ -19,12 +19,12 @@ abstract class MergeCollectionListenerTest extends TestCase
 {
     protected $form;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->form = $this->getForm('axes');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->form = null;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -26,7 +26,7 @@ class ResizeFormListenerTest extends TestCase
     private $factory;
     private $form;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = (new FormFactoryBuilder())->getFormFactory();
         $this->form = $this->getBuilder()
@@ -35,7 +35,7 @@ class ResizeFormListenerTest extends TestCase
             ->getForm();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->factory = null;
         $this->form = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -60,7 +60,7 @@ class ChoiceTypeTest extends BaseTypeTest
         ],
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -73,7 +73,7 @@ class ChoiceTypeTest extends BaseTypeTest
         ];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -19,7 +19,7 @@ class CountryTypeTest extends BaseTypeTest
 {
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CountryType';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -19,7 +19,7 @@ class CurrencyTypeTest extends BaseTypeTest
 {
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CurrencyType';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -17,7 +17,7 @@ class DateTimeTypeTest extends BaseTypeTest
 {
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\DateTimeType';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         \Locale::setDefault('en');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -22,14 +22,14 @@ class DateTypeTest extends BaseTypeTest
     private $defaultTimezone;
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->defaultTimezone = date_default_timezone_get();
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         date_default_timezone_set($this->defaultTimezone);
         \Locale::setDefault($this->defaultLocale);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -17,7 +17,7 @@ class IntegerTypeTest extends BaseTypeTest
 {
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\IntegerType';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -19,7 +19,7 @@ class LanguageTypeTest extends BaseTypeTest
 {
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\LanguageType';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -19,7 +19,7 @@ class LocaleTypeTest extends BaseTypeTest
 {
     const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\LocaleType';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireIntl($this, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -19,7 +19,7 @@ class MoneyTypeTest extends BaseTypeTest
 
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // we test against different locales, so we need the full
         // implementation
@@ -30,7 +30,7 @@ class MoneyTypeTest extends BaseTypeTest
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -19,7 +19,7 @@ class NumberTypeTest extends BaseTypeTest
 
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -30,7 +30,7 @@ class NumberTypeTest extends BaseTypeTest
         \Locale::setDefault('de_DE');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -22,7 +22,7 @@ class RepeatedTypeTest extends BaseTypeTest
      */
     protected $form;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -27,7 +27,7 @@ class CsrfValidationListenerTest extends TestCase
     protected $tokenManager;
     protected $form;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
         $this->factory = (new FormFactoryBuilder())->getFormFactory();
@@ -37,7 +37,7 @@ class CsrfValidationListenerTest extends TestCase
             ->getForm();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->dispatcher = null;
         $this->factory = null;

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -43,7 +43,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
      */
     protected $translator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tokenManager = $this->getMockBuilder(CsrfTokenManagerInterface::class)->getMock();
         $this->translator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
@@ -51,7 +51,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->tokenManager = null;
         $this->translator = null;

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/DataCollectorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/DataCollectorExtensionTest.php
@@ -27,7 +27,7 @@ class DataCollectorExtensionTest extends TestCase
      */
     private $dataCollector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dataCollector = $this->getMockBuilder('Symfony\Component\Form\Extension\DataCollector\FormDataCollectorInterface')->getMock();
         $this->extension = new DataCollectorExtension($this->dataCollector);

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -65,7 +65,7 @@ class FormDataCollectorTest extends TestCase
      */
     private $childView;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dataExtractor = $this->getMockBuilder('Symfony\Component\Form\Extension\DataCollector\FormDataExtractorInterface')->getMock();
         $this->dataCollector = new FormDataCollector($this->dataExtractor);

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -45,7 +45,7 @@ class FormDataExtractorTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dataExtractor = new FormDataExtractor();
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/Type/DataCollectorTypeExtensionTest.php
@@ -27,7 +27,7 @@ class DataCollectorTypeExtensionTest extends TestCase
      */
     private $dataCollector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dataCollector = $this->getMockBuilder('Symfony\Component\Form\Extension\DataCollector\FormDataCollectorInterface')->getMock();
         $this->extension = new DataCollectorTypeExtension($this->dataCollector);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -48,7 +48,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
         $this->factory = (new FormFactoryBuilder())->getFormFactory();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -58,7 +58,7 @@ class ValidationListenerTest extends TestCase
 
     private $params;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
         $this->factory = (new FormFactoryBuilder())->getFormFactory();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorTypeGuesserTest.php
@@ -51,7 +51,7 @@ class ValidatorTypeGuesserTest extends TestCase
      */
     private $metadataFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->metadata = new ClassMetadata(self::TEST_CLASS);
         $this->metadataFactory = new FakeMetadataFactory();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -61,7 +61,7 @@ class ViolationMapperTest extends TestCase
      */
     private $params;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
         $this->mapper = new ViolationMapper();

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -24,14 +24,14 @@ class FormBuilderTest extends TestCase
     private $factory;
     private $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
         $this->builder = new FormBuilder('name', null, $this->dispatcher, $this->factory);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->dispatcher = null;
         $this->factory = null;

--- a/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryBuilderTest.php
@@ -21,7 +21,7 @@ class FormFactoryBuilderTest extends TestCase
     private $guesser;
     private $type;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $factory = new \ReflectionClass('Symfony\Component\Form\FormFactory');
         $this->registry = $factory->getProperty('registry');

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -49,7 +49,7 @@ class FormFactoryTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->guesser1 = $this->getMockBuilder('Symfony\Component\Form\FormTypeGuesserInterface')->getMock();
         $this->guesser2 = $this->getMockBuilder('Symfony\Component\Form\FormTypeGuesserInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -62,7 +62,7 @@ class FormRegistryTest extends TestCase
      */
     private $extension2;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->resolvedTypeFactory = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeFactory')->getMock();
         $this->guesser1 = $this->getMockBuilder('Symfony\Component\Form\FormTypeGuesserInterface')->getMock();

--- a/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
@@ -20,12 +20,12 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
 {
     private static $serverBackup;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$serverBackup = $_SERVER;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +38,7 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
         ];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -70,7 +70,7 @@ class ResolvedFormTypeTest extends TestCase
      */
     private $resolvedType;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->factory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -355,7 +355,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         return new BinaryFileResponse(__DIR__.'/../README.md', 200, ['Content-Type' => 'application/octet-stream']);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         $path = __DIR__.'/../Fixtures/to_delete';
         if (file_exists($path)) {

--- a/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
@@ -78,7 +78,7 @@ class MimeTypeTest extends TestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         $path = __DIR__.'/../Fixtures/to_delete';
         if (file_exists($path)) {

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class UploadedFileTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!ini_get('file_uploads')) {
             $this->markTestSkipped('file_uploads is disabled in php.ini');

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -160,12 +160,12 @@ class FileBagTest extends TestCase
         return $tempFile;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         mkdir(sys_get_temp_dir().'/form_test', 0777, true);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach (glob(sys_get_temp_dir().'/form_test/*') as $file) {
             unlink($file);

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class RequestTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Request::setTrustedProxies([], -1);
         Request::setTrustedHosts([]);

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
@@ -20,7 +20,7 @@ class ResponseFunctionalTest extends TestCase
 {
     private static $server;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $spec = [
             1 => ['file', '/dev/null', 'w'],
@@ -32,7 +32,7 @@ class ResponseFunctionalTest extends TestCase
         sleep(1);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (self::$server) {
             proc_terminate(self::$server);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/AttributeBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/AttributeBagTest.php
@@ -28,7 +28,7 @@ class AttributeBagTest extends TestCase
      */
     private $bag;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->array = [
             'hello' => 'world',
@@ -49,7 +49,7 @@ class AttributeBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->bag = null;
         $this->array = [];

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/NamespacedAttributeBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/NamespacedAttributeBagTest.php
@@ -28,7 +28,7 @@ class NamespacedAttributeBagTest extends TestCase
      */
     private $bag;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->array = [
             'hello' => 'world',
@@ -49,7 +49,7 @@ class NamespacedAttributeBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->bag = null;
         $this->array = [];

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
@@ -28,7 +28,7 @@ class AutoExpireFlashBagTest extends TestCase
 
     protected $array = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->bag = new FlashBag();
@@ -36,7 +36,7 @@ class AutoExpireFlashBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->bag = null;
         parent::tearDown();

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -28,7 +28,7 @@ class FlashBagTest extends TestCase
 
     protected $array = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->bag = new FlashBag();
@@ -36,7 +36,7 @@ class FlashBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->bag = null;
         parent::tearDown();

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -37,13 +37,13 @@ class SessionTest extends TestCase
      */
     protected $session;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->storage = new MockArraySessionStorage();
         $this->session = new Session($this->storage, new AttributeBag(), new FlashBag());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->storage = null;
         $this->session = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
@@ -37,7 +37,7 @@ abstract class AbstractRedisSessionHandlerTestCase extends TestCase
      */
     abstract protected function createRedisClient(string $host);
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ abstract class AbstractRedisSessionHandlerTestCase extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->redisClient = null;
         $this->storage = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
@@ -17,7 +17,7 @@ class AbstractSessionHandlerTest extends TestCase
 {
     private static $server;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $spec = [
             1 => ['file', '/dev/null', 'w'],
@@ -29,7 +29,7 @@ class AbstractSessionHandlerTest extends TestCase
         sleep(1);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (self::$server) {
             proc_terminate(self::$server);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -30,7 +30,7 @@ class MemcachedSessionHandlerTest extends TestCase
 
     protected $memcached;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -45,7 +45,7 @@ class MemcachedSessionHandlerTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->memcached = null;
         $this->storage = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -29,7 +29,7 @@ class MongoDbSessionHandlerTest extends TestCase
     private $storage;
     public $options;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -22,7 +22,7 @@ class PdoSessionHandlerTest extends TestCase
 {
     private $dbFile;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // make sure the temporary database file is deleted when it has been created (even when a test fails)
         if ($this->dbFile) {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MetadataBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MetadataBagTest.php
@@ -28,7 +28,7 @@ class MetadataBagTest extends TestCase
 
     protected $array = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->bag = new MetadataBag();
@@ -36,7 +36,7 @@ class MetadataBagTest extends TestCase
         $this->bag->initialize($this->array);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->array = [];
         $this->bag = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
@@ -40,7 +40,7 @@ class MockArraySessionStorageTest extends TestCase
 
     private $data;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->attributes = new AttributeBag();
         $this->flashes = new FlashBag();
@@ -56,7 +56,7 @@ class MockArraySessionStorageTest extends TestCase
         $this->storage->setSessionData($this->data);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->data = null;
         $this->flashes = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -33,13 +33,13 @@ class MockFileSessionStorageTest extends TestCase
      */
     protected $storage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->sessionDir = sys_get_temp_dir().'/sftest';
         $this->storage = $this->getStorage();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->sessionDir = null;
         $this->storage = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -33,7 +33,7 @@ class NativeSessionStorageTest extends TestCase
 {
     private $savePath;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->iniSet('session.save_handler', 'files');
         $this->iniSet('session.save_path', $this->savePath = sys_get_temp_dir().'/sftest');
@@ -42,7 +42,7 @@ class NativeSessionStorageTest extends TestCase
         }
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         session_write_close();
         array_map('unlink', glob($this->savePath.'/*'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -29,7 +29,7 @@ class PhpBridgeSessionStorageTest extends TestCase
 {
     private $savePath;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->iniSet('session.save_handler', 'files');
         $this->iniSet('session.save_path', $this->savePath = sys_get_temp_dir().'/sftest');
@@ -38,7 +38,7 @@ class PhpBridgeSessionStorageTest extends TestCase
         }
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         session_write_close();
         array_map('unlink', glob($this->savePath.'/*'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -27,12 +27,12 @@ class AbstractProxyTest extends TestCase
      */
     protected $proxy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->proxy = $this->getMockForAbstractClass(AbstractProxy::class);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->proxy = null;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -34,13 +34,13 @@ class SessionHandlerProxyTest extends TestCase
      */
     private $proxy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mock = $this->getMockBuilder('SessionHandlerInterface')->getMock();
         $this->proxy = new SessionHandlerProxy($this->mock);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->mock = null;
         $this->proxy = null;

--- a/src/Symfony/Component/HttpKernel/Tests/CacheClearer/ChainCacheClearerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheClearer/ChainCacheClearerTest.php
@@ -18,12 +18,12 @@ class ChainCacheClearerTest extends TestCase
 {
     protected static $cacheDir;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$cacheDir = tempnam(sys_get_temp_dir(), 'sf_cache_clearer_dir');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$cacheDir);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
@@ -18,12 +18,12 @@ class CacheWarmerAggregateTest extends TestCase
 {
     protected static $cacheDir;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$cacheDir = tempnam(sys_get_temp_dir(), 'sf_cache_warmer_dir');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$cacheDir);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
@@ -18,12 +18,12 @@ class CacheWarmerTest extends TestCase
 {
     protected static $cacheFile;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$cacheFile = tempnam(sys_get_temp_dir(), 'sf_cache_warmer_dir');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$cacheFile);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -30,7 +30,7 @@ class ArgumentResolverTest extends TestCase
     /** @var ArgumentResolver */
     private static $resolver;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $factory = new ArgumentMetadataFactory();
 

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -26,7 +26,7 @@ class ArgumentMetadataFactoryTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new ArgumentMetadataFactory();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ServicesResetterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ServicesResetterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\ResettableService;
 
 class ServicesResetterTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         ResettableService::$counter = 0;
         ClearableService::$counter = 0;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
@@ -29,12 +29,12 @@ class AddRequestFormatsListenerTest extends TestCase
      */
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = new AddRequestFormatsListener(['csv' => ['text/csv', 'text/plain']]);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->listener = null;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -23,7 +23,7 @@ class LocaleListenerTest extends TestCase
 {
     private $requestStack;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->disableOriginalConstructor()->getMock();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
@@ -26,7 +26,7 @@ class ResponseListenerTest extends TestCase
 
     private $kernel;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
         $listener = new ResponseListener('UTF-8');
@@ -35,7 +35,7 @@ class ResponseListenerTest extends TestCase
         $this->kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->dispatcher = null;
         $this->kernel = null;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -31,7 +31,7 @@ class RouterListenerTest extends TestCase
 {
     private $requestStack;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->disableOriginalConstructor()->getMock();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -40,7 +40,7 @@ class TestSessionListenerTest extends TestCase
      */
     private $session;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\EventListener\AbstractTestSessionListener');
         $this->session = $this->getSession();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
@@ -28,7 +28,7 @@ class TranslatorListenerTest extends TestCase
     private $translator;
     private $requestStack;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->translator = $this->getMockBuilder(LocaleAwareInterface::class)->getMock();
         $this->requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ValidateRequestListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ValidateRequestListenerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class ValidateRequestListenerTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Request::setTrustedProxies([], -1);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -23,7 +23,7 @@ class FragmentHandlerTest extends TestCase
 {
     private $requestStack;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->requestStack = $this->getMockBuilder('Symfony\\Component\\HttpFoundation\\RequestStack')
             ->disableOriginalConstructor()

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -35,7 +35,7 @@ class HttpCacheTestCase extends TestCase
      */
     protected $store;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->kernel = null;
 
@@ -53,7 +53,7 @@ class HttpCacheTestCase extends TestCase
         $this->clearDirectory(sys_get_temp_dir().'/http_cache');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->cache) {
             $this->cache->getStore()->cleanup();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -26,7 +26,7 @@ class StoreTest extends TestCase
      */
     protected $store;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->request = Request::create('/');
         $this->response = new Response('hello world', 200, []);
@@ -36,7 +36,7 @@ class StoreTest extends TestCase
         $this->store = new Store(sys_get_temp_dir().'/http_cache');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->store = null;
         $this->request = null;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SubRequestHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SubRequestHandlerTest.php
@@ -21,12 +21,12 @@ class SubRequestHandlerTest extends TestCase
 {
     private static $globalState;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::$globalState = $this->getGlobalState();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Request::setTrustedProxies(self::$globalState[0], self::$globalState[1]);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\ResettableService;
 
 class KernelTest extends TestCase
 {
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         $fs = new Filesystem();
         $fs->remove(__DIR__.'/Fixtures/var');

--- a/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
@@ -32,13 +32,13 @@ class LoggerTest extends TestCase
      */
     private $tmpFile;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tmpFile = tempnam(sys_get_temp_dir(), 'log');
         $this->logger = new Logger(LogLevel::DEBUG, $this->tmpFile);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (!@unlink($this->tmpFile)) {
             file_put_contents($this->tmpFile, '');

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -20,7 +20,7 @@ class FileProfilerStorageTest extends TestCase
     private $tmpDir;
     private $storage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/sf_profiler_file_storage';
         if (is_dir($this->tmpDir)) {
@@ -30,7 +30,7 @@ class FileProfilerStorageTest extends TestCase
         $this->storage->purge();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         self::cleanDir();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -82,7 +82,7 @@ class ProfilerTest extends TestCase
         $this->assertCount(0, $profiler->find(null, null, null, null, null, null, '204'));
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tmp = tempnam(sys_get_temp_dir(), 'sf_profiler');
         if (file_exists($this->tmp)) {
@@ -93,7 +93,7 @@ class ProfilerTest extends TestCase
         $this->storage->purge();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (null !== $this->storage) {
             $this->storage->purge();

--- a/src/Symfony/Component/Intl/Tests/Collator/Verification/CollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/Verification/CollatorTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class CollatorTest extends AbstractCollatorTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -62,7 +62,7 @@ class BundleEntryReaderTest extends TestCase
         'Foo' => 'Bar',
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->readerImpl = $this->getMockBuilder('Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReaderInterface')->getMock();
         $this->reader = new BundleEntryReader($this->readerImpl);

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
@@ -25,7 +25,7 @@ class IntlBundleReaderTest extends TestCase
      */
     private $reader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->reader = new IntlBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
@@ -24,7 +24,7 @@ class JsonBundleReaderTest extends TestCase
      */
     private $reader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->reader = new JsonBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
@@ -24,7 +24,7 @@ class PhpBundleReaderTest extends TestCase
      */
     private $reader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->reader = new PhpBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
@@ -32,7 +32,7 @@ class JsonBundleWriterTest extends TestCase
      */
     private $filesystem;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->writer = new JsonBundleWriter();
         $this->directory = sys_get_temp_dir().'/JsonBundleWriterTest/'.mt_rand(1000, 9999);
@@ -41,7 +41,7 @@ class JsonBundleWriterTest extends TestCase
         $this->filesystem->mkdir($this->directory);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->filesystem->remove($this->directory);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/PhpBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/PhpBundleWriterTest.php
@@ -32,7 +32,7 @@ class PhpBundleWriterTest extends TestCase
      */
     private $filesystem;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->writer = new PhpBundleWriter();
         $this->directory = sys_get_temp_dir().'/PhpBundleWriterTest/'.mt_rand(1000, 9999);
@@ -41,7 +41,7 @@ class PhpBundleWriterTest extends TestCase
         $this->filesystem->mkdir($this->directory);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->filesystem->remove($this->directory);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/TextBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/TextBundleWriterTest.php
@@ -34,7 +34,7 @@ class TextBundleWriterTest extends TestCase
      */
     private $filesystem;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->writer = new TextBundleWriter();
         $this->directory = sys_get_temp_dir().'/TextBundleWriterTest/'.mt_rand(1000, 9999);
@@ -43,7 +43,7 @@ class TextBundleWriterTest extends TestCase
         $this->filesystem->mkdir($this->directory);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->filesystem->remove($this->directory);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
@@ -593,7 +593,7 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
     protected $dataProvider;
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -605,7 +605,7 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
@@ -703,7 +703,7 @@ abstract class AbstractDataProviderTest extends TestCase
 
     private static $rootLocales;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         \Locale::setDefault('en');
         Locale::setDefaultFallback('en');

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLanguageDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLanguageDataProviderTest.php
@@ -832,7 +832,7 @@ abstract class AbstractLanguageDataProviderTest extends AbstractDataProviderTest
     protected $dataProvider;
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -844,7 +844,7 @@ abstract class AbstractLanguageDataProviderTest extends AbstractDataProviderTest
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLocaleDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLocaleDataProviderTest.php
@@ -27,7 +27,7 @@ abstract class AbstractLocaleDataProviderTest extends AbstractDataProviderTest
     protected $dataProvider;
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -39,7 +39,7 @@ abstract class AbstractLocaleDataProviderTest extends AbstractDataProviderTest
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         \Locale::setDefault($this->defaultLocale);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractRegionDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractRegionDataProviderTest.php
@@ -281,7 +281,7 @@ abstract class AbstractRegionDataProviderTest extends AbstractDataProviderTest
     protected $dataProvider;
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -293,7 +293,7 @@ abstract class AbstractRegionDataProviderTest extends AbstractDataProviderTest
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractScriptDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractScriptDataProviderTest.php
@@ -221,7 +221,7 @@ abstract class AbstractScriptDataProviderTest extends AbstractDataProviderTest
     protected $dataProvider;
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -233,7 +233,7 @@ abstract class AbstractScriptDataProviderTest extends AbstractDataProviderTest
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Intl/Tests/Data/Util/LocaleScannerTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Util/LocaleScannerTest.php
@@ -32,7 +32,7 @@ class LocaleScannerTest extends TestCase
      */
     private $scanner;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->directory = sys_get_temp_dir().'/LocaleScannerTest/'.mt_rand(1000, 9999);
         $this->filesystem = new Filesystem();
@@ -62,7 +62,7 @@ class LocaleScannerTest extends TestCase
         file_put_contents($this->directory.'/fr_child.txt', 'en_GB{%%Parent{"fr"}}');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->filesystem->remove($this->directory);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Util/RingBufferTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Util/RingBufferTest.php
@@ -24,7 +24,7 @@ class RingBufferTest extends TestCase
      */
     private $buffer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->buffer = new RingBuffer(2);
     }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -26,7 +26,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -34,7 +34,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         \Locale::setDefault('en');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Intl/Tests/Globals/Verification/IntlGlobalsTest.php
+++ b/src/Symfony/Component/Intl/Tests/Globals/Verification/IntlGlobalsTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class IntlGlobalsTest extends AbstractIntlGlobalsTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Intl/Tests/IntlTest.php
+++ b/src/Symfony/Component/Intl/Tests/IntlTest.php
@@ -18,14 +18,14 @@ class IntlTest extends TestCase
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Intl/Tests/Locale/Verification/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/Verification/LocaleTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class LocaleTest extends AbstractLocaleTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireFullIntl($this, false);
 

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
  */
 class NumberFormatterTest extends AbstractNumberFormatterTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         IntlTestHelper::requireFullIntl($this, '55.1');
 

--- a/src/Symfony/Component/Intl/Tests/ResourceBundleTestCase.php
+++ b/src/Symfony/Component/Intl/Tests/ResourceBundleTestCase.php
@@ -696,7 +696,7 @@ abstract class ResourceBundleTestCase extends TestCase
 
     private static $rootLocales;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         Locale::setDefault('en');
         Locale::setDefaultFallback('en');

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
@@ -27,7 +27,7 @@ class LdapManagerTest extends LdapTestCase
     /** @var Adapter */
     private $adapter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->adapter = new Adapter($this->getLdapConfig());
         $this->adapter->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -26,7 +26,7 @@ class LdapTest extends TestCase
     /** @var Ldap */
     private $ldap;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->adapter = $this->getMockBuilder(AdapterInterface::class)->getMock();
         $this->ldap = new Ldap($this->adapter);

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -59,7 +59,7 @@ class CombinedStoreTest extends AbstractStoreTest
     /** @var CombinedStore */
     private $store;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->strategy = $this->getMockBuilder(StrategyInterface::class)->getMock();
         $this->store1 = $this->getMockBuilder(StoreInterface::class)->getMock();

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -22,7 +22,7 @@ class MemcachedStoreTest extends AbstractStoreTest
 {
     use ExpiringStoreTestTrait;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $memcached = new \Memcached();
         $memcached->addServer(getenv('MEMCACHED_HOST'), 11211);

--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Lock\Tests\Store;
  */
 class PredisStoreTest extends AbstractRedisStoreTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $redis = new \Predis\Client('tcp://'.getenv('REDIS_HOST').':6379');
         try {

--- a/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Lock\Tests\Store;
  */
 class RedisArrayStoreTest extends AbstractRedisStoreTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists('RedisArray')) {
             self::markTestSkipped('The RedisArray class is required.');

--- a/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Lock\Tests\Store;
  */
 class RedisClusterStoreTest extends AbstractRedisStoreTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists('RedisCluster')) {
             self::markTestSkipped('The RedisCluster class is required.');

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Lock\Tests\Store;
  */
 class RedisStoreTest extends AbstractRedisStoreTest
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
             $e = error_get_last();

--- a/src/Symfony/Component/Lock/Tests/Strategy/ConsensusStrategyTest.php
+++ b/src/Symfony/Component/Lock/Tests/Strategy/ConsensusStrategyTest.php
@@ -22,7 +22,7 @@ class ConsensusStrategyTest extends TestCase
     /** @var ConsensusStrategy */
     private $strategy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->strategy = new ConsensusStrategy();
     }

--- a/src/Symfony/Component/Lock/Tests/Strategy/UnanimousStrategyTest.php
+++ b/src/Symfony/Component/Lock/Tests/Strategy/UnanimousStrategyTest.php
@@ -22,7 +22,7 @@ class UnanimousStrategyTest extends TestCase
     /** @var UnanimousStrategy */
     private $strategy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->strategy = new UnanimousStrategy();
     }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -24,7 +24,7 @@ class OptionsResolverTest extends TestCase
      */
     private $resolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->resolver = new OptionsResolver();
     }

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -21,7 +21,7 @@ class ExecutableFinderTest extends TestCase
 {
     private $path;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->path) {
             // Restore path if it was changed.

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -29,7 +29,7 @@ class ProcessTest extends TestCase
     private static $process;
     private static $sigchild;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $phpBin = new PhpExecutableFinder();
         self::$phpBin = getenv('SYMFONY_PROCESS_PHP_TEST_BINARY') ?: ('phpdbg' === \PHP_SAPI ? 'php' : $phpBin->find());
@@ -39,7 +39,7 @@ class ProcessTest extends TestCase
         self::$sigchild = false !== strpos(ob_get_clean(), '--enable-sigchild');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (self::$process) {
             self::$process->stop(0);

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
@@ -22,7 +22,7 @@ abstract class PropertyAccessorArrayAccessTest extends TestCase
      */
     protected $propertyAccessor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->propertyAccessor = new PropertyAccessor();
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
@@ -23,12 +23,12 @@ class PropertyAccessorBuilderTest extends TestCase
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new PropertyAccessorBuilder();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->builder = null;
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -34,7 +34,7 @@ class PropertyAccessorTest extends TestCase
      */
     private $propertyAccessor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->propertyAccessor = new PropertyAccessor();
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
@@ -27,7 +27,7 @@ class PropertyPathBuilderTest extends TestCase
      */
     private $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new PropertyPathBuilder(new PropertyPath(self::PREFIX));
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/AbstractPropertyInfoExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/AbstractPropertyInfoExtractorTest.php
@@ -28,7 +28,7 @@ class AbstractPropertyInfoExtractorTest extends TestCase
      */
     protected $propertyInfo;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $extractors = [new NullExtractor(), new DummyExtractor()];
         $this->propertyInfo = new PropertyInfoExtractor($extractors, $extractors, $extractors, $extractors, $extractors);

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -26,7 +26,7 @@ class PhpDocExtractorTest extends TestCase
      */
     private $extractor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->extractor = new PhpDocExtractor();
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -31,7 +31,7 @@ class ReflectionExtractorTest extends TestCase
      */
     private $extractor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->extractor = new ReflectionExtractor();
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -27,7 +27,7 @@ class SerializerExtractorTest extends TestCase
      */
     private $extractor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $this->extractor = new SerializerExtractor($classMetadataFactory);

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor;
  */
 class PropertyInfoCacheExtractorTest extends AbstractPropertyInfoExtractorTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -43,7 +43,7 @@ class PhpGeneratorDumperTest extends TestCase
      */
     private $largeTestTmpFilepath;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -55,7 +55,7 @@ class PhpGeneratorDumperTest extends TestCase
         @unlink($this->largeTestTmpFilepath);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -45,7 +45,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
      */
     private $loader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $reader = new AnnotationReader();
         $this->loader = new class($reader) extends AnnotationClassLoader {

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -19,7 +19,7 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
     protected $loader;
     protected $reader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -20,7 +20,7 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
     protected $loader;
     protected $reader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/DirectoryLoaderTest.php
@@ -23,7 +23,7 @@ class DirectoryLoaderTest extends AbstractAnnotationLoaderTest
     private $loader;
     private $reader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -34,7 +34,7 @@ class PhpMatcherDumperTest extends TestCase
      */
     private $dumpPath;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -42,7 +42,7 @@ class PhpMatcherDumperTest extends TestCase
         $this->dumpPath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'php_matcher.'.$this->matcherClass.'.php';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -22,7 +22,7 @@ class RouterTest extends TestCase
 
     private $loader = null;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
         $this->router = new Router($this->loader, 'routing.yml');

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -23,7 +23,7 @@ class AuthorizationCheckerTest extends TestCase
     private $authorizationChecker;
     private $tokenStorage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
         $this->accessDecisionManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock();

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -20,7 +20,7 @@ class VoterTest extends TestCase
 {
     protected $token;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
     }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
@@ -23,7 +23,7 @@ class Argon2iPasswordEncoderTest extends TestCase
 {
     const PASSWORD = 'password';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!Argon2iPasswordEncoder::isSupported()) {
             $this->markTestSkipped('Argon2i algorithm is not supported.');

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
@@ -46,7 +46,7 @@ abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
         return new UserPasswordValidator($this->tokenStorage, $this->encoderFactory);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $user = $this->createUser();
         $this->tokenStorage = $this->createTokenStorage($user);

--- a/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
@@ -210,12 +210,12 @@ class CsrfTokenManagerTest extends TestCase
         ];
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $_SERVER['HTTPS'] = 'on';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php
@@ -33,17 +33,17 @@ class UriSafeTokenGeneratorTest extends TestCase
      */
     private $generator;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$bytes = base64_decode('aMf+Tct/RLn2WQ==');
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->generator = new UriSafeTokenGenerator(self::ENTROPY);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->generator = null;
     }

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
@@ -29,7 +29,7 @@ class NativeSessionTokenStorageTest extends TestCase
      */
     private $storage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $_SESSION = [];
 

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
@@ -33,7 +33,7 @@ class SessionTokenStorageTest extends TestCase
      */
     private $storage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->session = new Session(new MockArraySessionStorage());
         $this->storage = new SessionTokenStorage($this->session, self::SESSION_NAMESPACE);

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -75,7 +75,7 @@ class FormLoginAuthenticatorTest extends TestCase
         $this->assertEquals(self::LOGIN_URL, $failureResponse->getTargetUrl());
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->requestWithoutSession = new Request([], [], [], [], [], []);
         $this->requestWithSession = new Request([], [], [], [], [], []);

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -260,7 +260,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $listener($this->event);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager')
             ->disableOriginalConstructor()
@@ -285,7 +285,7 @@ class GuardAuthenticationListenerTest extends TestCase
         $this->rememberMeServices = $this->getMockBuilder('Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface')->getMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->authenticationManager = null;
         $this->guardAuthenticatorHandler = null;

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -153,7 +153,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $handler->authenticateWithToken($this->token, $this->request, 'some_provider_key');
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
         $this->dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
@@ -163,7 +163,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $this->guardAuthenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->tokenStorage = null;
         $this->dispatcher = null;

--- a/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
@@ -165,7 +165,7 @@ class GuardAuthenticationProviderTest extends TestCase
         $provider->authenticate($token);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();
         $this->userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
@@ -174,7 +174,7 @@ class GuardAuthenticationProviderTest extends TestCase
             ->getMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->userProvider = null;
         $this->userChecker = null;

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -26,7 +26,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     private $session;
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->httpKernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $this->httpUtils = $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -36,7 +36,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
 
     private $response;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->successHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface')->getMock();
         $this->failureHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -97,7 +97,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $listener($this->event);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager')
             ->disableOriginalConstructor()
@@ -120,7 +120,7 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $this->token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->authenticationManager = null;
         $this->dispatcher = null;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -39,7 +39,7 @@ class SwitchUserListenerTest extends TestCase
 
     private $event;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tokenStorage = new TokenStorage();
         $this->userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Logout/CsrfTokenClearingLogoutHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/CsrfTokenClearingLogoutHandlerTest.php
@@ -25,7 +25,7 @@ class CsrfTokenClearingLogoutHandlerTest extends TestCase
     private $csrfTokenStorage;
     private $csrfTokenClearingLogoutHandler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->session = new Session(new MockArraySessionStorage());
         $this->csrfTokenStorage = new SessionTokenStorage($this->session, 'foo');

--- a/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
@@ -29,7 +29,7 @@ class LogoutUrlGeneratorTest extends TestCase
     /** @var LogoutUrlGenerator */
     private $generator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $request = $this->getMockBuilder(Request::class)->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
 class PersistentTokenBasedRememberMeServicesTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         try {
             random_bytes(1);

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -24,7 +24,7 @@ class ChainDecoderTest extends TestCase
     private $decoder1;
     private $decoder2;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->decoder1 = $this
             ->getMockBuilder('Symfony\Component\Serializer\Encoder\DecoderInterface')

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -26,7 +26,7 @@ class ChainEncoderTest extends TestCase
     private $encoder1;
     private $encoder2;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->encoder1 = $this
             ->getMockBuilder('Symfony\Component\Serializer\Encoder\EncoderInterface')

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -24,7 +24,7 @@ class CsvEncoderTest extends TestCase
      */
     private $encoder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->encoder = new CsvEncoder();
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonDecodeTest.php
@@ -20,7 +20,7 @@ class JsonDecodeTest extends TestCase
     /** @var \Symfony\Component\Serializer\Encoder\JsonDecode */
     private $decode;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->decode = new JsonDecode();
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncodeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncodeTest.php
@@ -19,7 +19,7 @@ class JsonEncodeTest extends TestCase
 {
     private $encode;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->encode = new JsonEncode();
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
@@ -21,7 +21,7 @@ class JsonEncoderTest extends TestCase
     private $encoder;
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->encoder = new JsonEncoder();
         $this->serializer = new Serializer([new CustomNormalizer()], ['json' => new JsonEncoder()]);

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -30,7 +30,7 @@ class XmlEncoderTest extends TestCase
 
     private $exampleDateTimeString = '2017-02-19T15:16:08+0300';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->encoder = new XmlEncoder();
         $serializer = new Serializer([new CustomNormalizer()], ['xml' => new XmlEncoder()]);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -32,7 +32,7 @@ class AnnotationLoaderTest extends TestCase
      */
     private $loader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loader = new AnnotationLoader(new AnnotationReader());
     }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -35,7 +35,7 @@ class XmlFileLoaderTest extends TestCase
      */
     private $metadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loader = new XmlFileLoader(__DIR__.'/../../Fixtures/serialization.xml');
         $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -35,7 +35,7 @@ class YamlFileLoaderTest extends TestCase
      */
     private $metadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loader = new YamlFileLoader(__DIR__.'/../../Fixtures/serialization.yml');
         $this->metadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -35,7 +35,7 @@ class AbstractNormalizerTest extends TestCase
      */
     private $classMetadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $loader = $this->getMockBuilder('Symfony\Component\Serializer\Mapping\Loader\LoaderChain')->setConstructorArgs([[]])->getMock();
         $this->classMetadata = $this->getMockBuilder('Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory')->setConstructorArgs([$loader])->getMock();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -28,7 +28,7 @@ class ArrayDenormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->serializer = $this->getMockBuilder('Symfony\Component\Serializer\Serializer')->getMock();
         $this->denormalizer = new ArrayDenormalizer();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/CustomNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/CustomNormalizerTest.php
@@ -23,7 +23,7 @@ class CustomNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->normalizer = new CustomNormalizer();
         $this->normalizer->setSerializer(new Serializer());

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
@@ -29,7 +29,7 @@ class DataUriNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->normalizer = new DataUriNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
@@ -15,7 +15,7 @@ class DateIntervalNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->normalizer = new DateIntervalNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -24,7 +24,7 @@ class DateTimeNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->normalizer = new DateTimeNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -61,7 +61,7 @@ class GetSetMethodNormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->createNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
@@ -33,7 +33,7 @@ class JsonSerializableNormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->createNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -71,7 +71,7 @@ class ObjectNormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->createNormalizer();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -62,7 +62,7 @@ class PropertyNormalizerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->createNormalizer();
     }

--- a/src/Symfony/Component/Templating/Tests/Loader/ChainLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/ChainLoaderTest.php
@@ -21,7 +21,7 @@ class ChainLoaderTest extends TestCase
     protected $loader1;
     protected $loader2;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $fixturesPath = realpath(__DIR__.'/../Fixtures/');
         $this->loader1 = new FilesystemLoader($fixturesPath.'/null/%name%');

--- a/src/Symfony/Component/Templating/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/FilesystemLoaderTest.php
@@ -19,7 +19,7 @@ class FilesystemLoaderTest extends TestCase
 {
     protected static $fixturesPath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -24,12 +24,12 @@ class PhpEngineTest extends TestCase
 {
     protected $loader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loader = new ProjectTemplateLoader();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->loader = null;
     }

--- a/src/Symfony/Component/Templating/Tests/TemplateNameParserTest.php
+++ b/src/Symfony/Component/Templating/Tests/TemplateNameParserTest.php
@@ -19,12 +19,12 @@ class TemplateNameParserTest extends TestCase
 {
     protected $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = new TemplateNameParser();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->parser = null;
     }

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Translation\DataCollectorTranslator;
 
 class TranslationDataCollectorTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!class_exists('Symfony\Component\HttpKernel\DataCollector\DataCollector')) {
             $this->markTestSkipped('The "DataCollector" is not available');

--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -18,14 +18,14 @@ class IdentityTranslatorTest extends TranslatorTest
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Translation/Tests/Loader/LocalizedTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/LocalizedTestCase.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class LocalizedTestCase extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!\extension_loaded('intl')) {
             $this->markTestSkipped('Extension intl is required.');

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -23,13 +23,13 @@ class TranslatorCacheTest extends TestCase
 {
     protected $tmpDir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/sf_translation';
         $this->deleteTmpDir();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->deleteTmpDir();
     }

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -19,12 +19,12 @@ class ConstraintViolationListTest extends TestCase
 {
     protected $list;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->list = new ConstraintViolationList();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->list = null;
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -20,14 +20,14 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -20,14 +20,14 @@ class CurrencyValidatorTest extends ConstraintValidatorTestCase
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -27,7 +27,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         return new FileValidator();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -36,7 +36,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         fwrite($this->file, ' ', 1);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -39,7 +39,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         return new ImageValidator();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -20,14 +20,14 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
 {
     private $defaultLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->defaultLocale = \Locale::getDefault();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -172,7 +172,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
         return static::$file;
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (static::$file) {
             fclose(static::$file);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
 
 class DoctrineCacheTest extends AbstractCacheTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cache = new DoctrineCache(new ArrayCache());
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/Psr6CacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/Psr6CacheTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
  */
 class Psr6CacheTest extends AbstractCacheTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cache = new Psr6Cache(new ArrayAdapter());
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -28,12 +28,12 @@ class ClassMetadataTest extends TestCase
 
     protected $metadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->metadata = new ClassMetadata(self::CLASSNAME);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->metadata = null;
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -20,12 +20,12 @@ class StaticMethodLoaderTest extends TestCase
 {
     private $errorLevel;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->errorLevel = error_reporting();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         error_reporting($this->errorLevel);
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/MemberMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/MemberMetadataTest.php
@@ -22,7 +22,7 @@ class MemberMetadataTest extends TestCase
 {
     protected $metadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->metadata = new TestMemberMetadata(
             'Symfony\Component\Validator\Tests\Fixtures\Entity',
@@ -31,7 +31,7 @@ class MemberMetadataTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->metadata = null;
     }

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
@@ -43,7 +43,7 @@ abstract class AbstractTest extends AbstractValidatorTest
      */
     abstract protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = []);
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
@@ -47,7 +47,7 @@ abstract class AbstractValidatorTest extends TestCase
      */
     public $referenceMetadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->metadataFactory = new FakeMetadataFactory();
         $this->metadata = new ClassMetadata(self::ENTITY_CLASS);
@@ -56,7 +56,7 @@ abstract class AbstractValidatorTest extends TestCase
         $this->metadataFactory->addMetadata($this->referenceMetadata);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->metadataFactory = null;
         $this->metadata = null;

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -23,12 +23,12 @@ class ValidatorBuilderTest extends TestCase
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ValidatorBuilder();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->builder = null;
     }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -28,7 +28,7 @@ class ExceptionCasterTest extends TestCase
         return new \Exception(''.$msg);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         ExceptionCaster::$srcContext = 1;
         ExceptionCaster::$traceArgs = true;

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -24,13 +24,13 @@ class XmlReaderCasterTest extends TestCase
     /** @var \XmlReader */
     private $reader;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->reader = new \XmlReader();
         $this->reader->open(__DIR__.'/../Fixtures/xml_reader.xml');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->reader->close();
     }

--- a/src/Symfony/Component/WebLink/Tests/HttpHeaderSerializerTest.php
+++ b/src/Symfony/Component/WebLink/Tests/HttpHeaderSerializerTest.php
@@ -22,7 +22,7 @@ class HttpHeaderSerializerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->serializer = new HttpHeaderSerializer();
     }

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -13,7 +13,7 @@ class GraphvizDumperTest extends TestCase
 
     private $dumper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dumper = new GraphvizDumper();
     }

--- a/src/Symfony/Component/Workflow/Tests/Dumper/StateMachineGraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/StateMachineGraphvizDumperTest.php
@@ -13,7 +13,7 @@ class StateMachineGraphvizDumperTest extends TestCase
 
     private $dumper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dumper = new StateMachineGraphvizDumper();
     }

--- a/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
@@ -24,7 +24,7 @@ class GuardListenerTest extends TestCase
     private $listener;
     private $configuration;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configuration = [
             'test_is_granted' => 'is_granted("something")',
@@ -44,7 +44,7 @@ class GuardListenerTest extends TestCase
         $this->listener = new GuardListener($this->configuration, $expressionLanguage, $tokenStorage, $this->authenticationChecker, $trustResolver, null, $this->validator);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->authenticationChecker = null;
         $this->validator = null;

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -15,7 +15,7 @@ class RegistryTest extends TestCase
 {
     private $registry;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->registry = new Registry();
 
@@ -24,7 +24,7 @@ class RegistryTest extends TestCase
         $this->registry->addWorkflow(new Workflow(new Definition([], []), $this->getMockBuilder(MarkingStoreInterface::class)->getMock(), $this->getMockBuilder(EventDispatcherInterface::class)->getMock(), 'workflow3'), $this->createWorkflowSupportStrategy(Subject2::class));
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->registry = null;
     }

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -125,13 +125,13 @@ YAML;
         return new CommandTester($command);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->files = [];
         @mkdir(sys_get_temp_dir().'/framework-yml-lint-test');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -38,14 +38,14 @@ class DumperTest extends TestCase
         ],
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = new Parser();
         $this->dumper = new Dumper();
         $this->path = __DIR__.'/Fixtures';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->parser = null;
         $this->dumper = null;

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class InlineTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         Inline::initialize(0, 0);
     }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -21,12 +21,12 @@ class ParserTest extends TestCase
     /** @var Parser */
     protected $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = new Parser();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->parser = null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

This PR removes the `SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT` patch and adds a `: void` typehint on `setup` and `tearDown` methods in order to be compatible with PHPUnit 8