### PR TITLE
Deprecate traits ForwardCompatTestTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/ForwardCompatTestTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ForwardCompatTestTrait.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use PHPUnit\Framework\TestCase;
 
+@trigger_error(sprintf('The "%s" trait is deprecated since Symfony 4.3, typehint methods "setUp" and "tearDown" with ": void" instead.', ForwardCompatTestTrait::class), E_USER_DEPRECATED);
+
 // Auto-adapt to PHPUnit 8 that added a `void` return-type to the setUp/tearDown methods
 
 if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {

--- a/src/Symfony/Component/Form/Test/ForwardCompatTestTrait.php
+++ b/src/Symfony/Component/Form/Test/ForwardCompatTestTrait.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Form\Test;
 
 use PHPUnit\Framework\TestCase;
 
+@trigger_error(sprintf('The "%s" trait is deprecated since Symfony 4.3, typehint methods "setUp" and "tearDown" with ": void" instead.', ForwardCompatTestTrait::class), E_USER_DEPRECATED);
+
 // Auto-adapt to PHPUnit 8 that added a `void` return-type to the setUp/tearDown methods
 
 if ((new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {

--- a/src/Symfony/Component/Validator/Test/ForwardCompatTestTrait.php
+++ b/src/Symfony/Component/Validator/Test/ForwardCompatTestTrait.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Validator\Test;
 
 use PHPUnit\Framework\TestCase;
 
+@trigger_error(sprintf('The "%s" trait is deprecated since Symfony 4.3, typehint methods "setUp" and "tearDown" with ": void" instead.', ForwardCompatTestTrait::class), E_USER_DEPRECATED);
+
 // Auto-adapt to PHPUnit 8 that added a `void` return-type to the setUp/tearDown methods
 
 if ((new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

As symfony 4.3 is compatible with php 7.1 which supports typehint, we don't have to provide a trait that provide 2 signatures in order to be compatible with both PHPUnit 8 and bellow