### PR TITLE
Make HttpClientTestCase compatible with PHPUnit8

### DIFF
--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -26,7 +26,7 @@ abstract class HttpClientTestCase extends TestCase
 {
     private static $server;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         TestHttpServer::start();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32844
| License       | MIT
| Doc PR        | NA

the abstract class `HttpClientTestCase` may be extends by end user and execute by both PHPUnit 8 and bellow. Adding a return typehint on it will force all users extending it to add it too and would be a BC Break.

Note. I don't know how to trigger a deprecation here and help user to add it.