### PR TITLE
[HttpKernel] Lower EOL date

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,7 +73,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     const EXTRA_VERSION = 'DEV';
 
     const END_OF_MAINTENANCE = '07/2020';
-    const END_OF_LIFE = '01/2021';
+    const END_OF_LIFE = '07/2020';
 
     public function __construct(string $environment, bool $debug)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This PR implements the changes described in https://symfony.com/blog/symfony-maintenance-changes-for-standard-releases:

> Symfony 5.0 will be the first release to implement the change: EOM and EOL dates will be July 2020.