### PR TITLE
[Mime][FormDataPart] Add support of multidimensional fields in constructor 

### DIFF
--- a/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
+++ b/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
@@ -58,11 +58,17 @@ final class FormDataPart extends AbstractMultipartPart
     private function prepareFields(array $fields): array
     {
         $values = [];
-        array_walk_recursive($fields, function ($item, $key) use (&$values) {
-            if (!\is_array($item)) {
-                $values[] = $this->preparePart($key, $item);
+        $prepare = function ($item, $key, $root = null) use (&$values, &$prepare) {
+            if (\is_array($item)) {
+                array_walk($item, $prepare, $root ?: $key);
+
+                return;
             }
-        });
+
+            $values[] = $this->preparePart($root ?: $key, $item);
+        };
+
+        array_walk($fields, $prepare);
 
         return $values;
     }

--- a/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
@@ -18,6 +18,45 @@ use Symfony\Component\Mime\Part\TextPart;
 
 class FormDataPartTest extends TestCase
 {
+    public function testConstructorWithMultidimensionalParams()
+    {
+        $r = new \ReflectionProperty(TextPart::class, 'encoding');
+        $r->setAccessible(true);
+
+        $b = new TextPart('content');
+        $c = DataPart::fromPath($file = __DIR__.'/../../Fixtures/mimetypes/test.gif');
+        $f = new FormDataPart([
+            'foo' => [
+                $content =
+                    'very very long content that will not be cut even if the length i way more than 76 characters, ok?',
+                $content,
+            ],
+            'bar' => [
+                clone $b,
+                clone $b,
+            ],
+            'baz' => [
+                clone $c,
+                clone $c,
+            ],
+        ]);
+
+        $t = new TextPart($content, 'utf-8', 'plain', '8bit');
+        $t->setDisposition('form-data');
+        $t->setName('foo');
+        $t->getHeaders()->setMaxLineLength(PHP_INT_MAX);
+        $b->setDisposition('form-data');
+        $b->setName('bar');
+        $b->getHeaders()->setMaxLineLength(PHP_INT_MAX);
+        $r->setValue($b, '8bit');
+        $c->setDisposition('form-data');
+        $c->setName('baz');
+        $c->getHeaders()->setMaxLineLength(PHP_INT_MAX);
+        $r->setValue($c, '8bit');
+
+        $this->assertEquals([$t, $t, $b, $b, $c, $c], $f->getParts());
+    }
+
     public function testConstructor()
     {
         $r = new \ReflectionProperty(TextPart::class, 'encoding');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #33063    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | 

Add support of multidimensional fields in FormDataPart. 
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
