### PR TITLE
Use PHPUnit 8.3 on Travis when possible

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -8,8 +8,8 @@ if (!file_exists(__DIR__.'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
     exit(1);
 }
 if (!getenv('SYMFONY_PHPUNIT_VERSION')) {
-    if (\PHP_VERSION_ID >= 70400) {
-        putenv('SYMFONY_PHPUNIT_VERSION=8.2');
+    if (\PHP_VERSION_ID >= 70200) {
+        putenv('SYMFONY_PHPUNIT_VERSION=8.3');
     } elseif (\PHP_VERSION_ID >= 70000) {
         putenv('SYMFONY_PHPUNIT_VERSION=6.5');
     }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/asset": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
-        "symfony/form": "^3.4.23|^4.2.4",
+        "symfony/form": "^3.4.31|^4.3.4",
         "symfony/http-foundation": "^3.3.11|~4.0",
         "symfony/http-kernel": "~3.2|~4.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -41,7 +41,7 @@
         "symfony/workflow": "~3.3|~4.0"
     },
     "conflict": {
-        "symfony/form": "<3.4.13|>=4.0,<4.0.13|>=4.1,<4.1.2",
+        "symfony/form": "<3.4.31|>=4.0,<4.3.4",
         "symfony/console": "<3.4"
     },
     "suggest": {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -25,7 +25,7 @@
         "symfony/debug": "~2.8|~3.0|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/http-foundation": "^3.3.11|~4.0",
-        "symfony/http-kernel": "~3.4|~4.0",
+        "symfony/http-kernel": "^3.4.31|^4.3.4",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

We just achieved running PHPUnit 8.2 on PHP 7.4, let's ensure it continues running by using it on a primary job.