### PR TITLE
[Form] Deprecate passing false as $label to ChoiceListFactoryInterface

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -85,6 +85,7 @@ Form
    reference date is deprecated.
  * Using `int` or `float` as data for the `NumberType` when the `input` option is set to `string` is deprecated.
  * Overriding the methods `FormIntegrationTestCase::setUp()`, `TypeTestCase::setUp()` and `TypeTestCase::tearDown()` without the `void` return-type is deprecated.
+ * Deprecated passing `false` as `$label` to `ChoiceListFactoryInterface::createView`, pass a callable that returns false instead.
 
 FrameworkBundle
 ---------------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -215,6 +215,7 @@ Form
 
  * The `regions` option was removed from the `TimezoneType`.
  * Added support for PHPUnit 8. A `void` return-type was added to the `FormIntegrationTestCase::setUp()`, `TypeTestCase::setUp()` and `TypeTestCase::tearDown()` methods.
+ * Passing `false` as `$label` to `ChoiceListFactoryInterface::createView` now throws a `TypeError`, pass a callable that returns false instead.
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * deprecated using `int` or `float` as data for the `NumberType` when the `input` option is set to `string`
  * The type guesser guesses the HTML accept attribute when a mime type is configured in the File or Image constraint.
  * Overriding the methods `FormIntegrationTestCase::setUp()`, `TypeTestCase::setUp()` and `TypeTestCase::tearDown()` without the `void` return-type is deprecated.
+ * deprecated passing `false` as `$label` to `ChoiceListFactoryInterface::createView`, pass a callable that returns false instead
 
 4.3.0
 -----

--- a/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -116,8 +116,18 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
     /**
      * {@inheritdoc}
      */
-    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null)
+    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null/* , bool $triggerDeprecation = true */)
     {
+        $triggerDeprecation = 6 >= \func_num_args() || func_get_arg(6);
+
+        if (false === $label) {
+            if ($triggerDeprecation) {
+                @trigger_error(sprintf('Passing false as $label to %s is deprecated in Symfony 4.4 and will trigger a TypeError in 5.0, pass a callable that returns false instead.', __METHOD__), E_USER_DEPRECATED);
+            }
+
+            $label = static function () { return false; };
+        }
+
         // The input is not validated on purpose. This way, the decorated
         // factory may decide which input to accept and which not.
         $hash = self::generateHash([$list, $preferredChoices, $label, $index, $groupBy, $attr]);

--- a/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
@@ -128,8 +128,18 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
      *
      * @return ChoiceListView The choice list view
      */
-    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null)
+    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null/* , bool $triggerDeprecation = true */)
     {
+        $triggerDeprecation = 6 >= \func_num_args() || func_get_arg(6);
+
+        if (false === $label) {
+            if ($triggerDeprecation) {
+                @trigger_error(sprintf('Passing false as $label to %s is deprecated in Symfony 4.4 and will trigger a TypeError in 5.0, pass a callable that returns false instead.', __METHOD__), E_USER_DEPRECATED);
+            }
+
+            $label = static function () { return false; };
+        }
+
         $accessor = $this->propertyAccessor;
 
         if (\is_string($label)) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -410,7 +410,8 @@ class ChoiceType extends AbstractType
             $options['choice_label'],
             $options['choice_name'],
             $options['group_by'],
-            $options['choice_attr']
+            $options['choice_attr'],
+            false
         );
     }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests\ChoiceList\Factory;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Factory\CachingFactoryDecorator;
 
 /**
@@ -482,6 +483,19 @@ class CachingFactoryDecoratorTest extends TestCase
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, null, $attr1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, null, $attr2));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing false as $label to Symfony\Component\Form\ChoiceList\Factory\CachingFactoryDecorator::createView is deprecated in Symfony 4.4 and will trigger a TypeError in 5.0, pass a callable that returns false instead.
+     */
+    public function testCreateViewLabelFalseDeprecation()
+    {
+        $this->factory->createView(
+            $this->createMock(ChoiceListInterface::class),
+            null, // preferred choices
+            false // label
+        );
     }
 
     public function provideSameChoices()

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -658,6 +658,19 @@ class DefaultChoiceListFactoryTest extends TestCase
         $this->assertFlatViewWithAttr($view);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing false as $label to Symfony\Component\Form\ChoiceList\Factory\DefaultChoiceListFactory::createView is deprecated in Symfony 4.4 and will trigger a TypeError in 5.0, pass a callable that returns false instead.
+     */
+    public function testCreateViewLabelFalseDeprecation()
+    {
+        $this->factory->createView(
+            $this->list,
+            null, // preferred choices
+            false // label
+        );
+    }
+
     private function assertScalarListWithChoiceValues(ChoiceListInterface $list)
     {
         $this->assertSame(['a', 'b', 'c', 'd'], $list->getValues());

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests\ChoiceList\Factory;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
@@ -350,5 +351,18 @@ class PropertyAccessDecoratorTest extends TestCase
             null, // groups
             new PropertyPath('property')
         ));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing false as $label to Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator::createView is deprecated in Symfony 4.4 and will trigger a TypeError in 5.0, pass a callable that returns false instead.
+     */
+    public function testCreateViewLabelFalseDeprecation()
+    {
+        $this->factory->createView(
+            $this->createMock(ChoiceListInterface::class),
+            null, // preferred choices
+            false // label
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Replaces #32955 , see https://github.com/symfony/symfony/pull/32955#discussion_r310673974