### PR TITLE
Fix inheritance when using SetUpTearDownTrait

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV5.php
@@ -21,6 +21,8 @@ trait SetUpTearDownTraitForV5
      */
     public static function setUpBeforeClass()
     {
+        parent::setUpBeforeClass();
+
         self::doSetUpBeforeClass();
     }
 
@@ -30,6 +32,8 @@ trait SetUpTearDownTraitForV5
     public static function tearDownAfterClass()
     {
         self::doTearDownAfterClass();
+
+        parent::doTearDownAfterClass();
     }
 
     /**
@@ -37,6 +41,8 @@ trait SetUpTearDownTraitForV5
      */
     protected function setUp()
     {
+        parent::setUp();
+
         self::doSetUp();
     }
 
@@ -46,6 +52,8 @@ trait SetUpTearDownTraitForV5
     protected function tearDown()
     {
         self::doTearDown();
+
+        parent::tearDown();
     }
 
     private static function doSetUpBeforeClass()

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV8.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV8.php
@@ -18,22 +18,30 @@ trait SetUpTearDownTraitForV8
 {
     public static function setUpBeforeClass(): void
     {
+        parent::setUpBeforeClass();
+
         self::doSetUpBeforeClass();
     }
 
     public static function tearDownAfterClass(): void
     {
         self::doTearDownAfterClass();
+
+        parent::tearDownAfterClass();
     }
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         self::doSetUp();
     }
 
     protected function tearDown(): void
     {
         self::doTearDown();
+
+        parent::doTearDown();
     }
 
     private static function doSetUpBeforeClass(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When using the `SetUpTearDownTrait` polyfill, the various `setUp` and `tearDown` methods don't call their parents, which makes it impossible to use the trait when having test cases inherit from each other and each adding their own functionality in `setUp` or `tearDown`.

I'm aware that this makes the trait unusable when used outside of a `PHPUnit\Framework\TestCase` class, but then I'm not aware where else this specific polyfill should be used. 🤷‍♂️