### PR TITLE
Add compatibility trait for PHPUnit constraint classes

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ConstraintTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/ConstraintTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use ReflectionClass;
+
+$r = new ReflectionClass(Constraint::class);
+if (\PHP_VERSION_ID < 70000 || !$r->getMethod('matches')->hasReturnType()) {
+    trait ConstraintTrait
+    {
+        use Legacy\ConstraintTraitForV6;
+    }
+} else {
+    trait ConstraintTrait
+    {
+        use Legacy\ConstraintTraitForV7;
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV6.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+use SebastianBergmann\Exporter\Exporter;
+
+/**
+ * @internal
+ */
+trait ConstraintTraitForV6
+{
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return $this->doCount();
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->doToString();
+    }
+
+    /**
+     * @param mixed $other
+     *
+     * @return string
+     */
+    protected function additionalFailureDescription($other)
+    {
+        return $this->doAdditionalFailureDescription($other);
+    }
+
+    /**
+     * @return Exporter
+     */
+    protected function exporter()
+    {
+        return $this->exporter;
+    }
+
+    /**
+     * @param mixed $other
+     *
+     * @return string
+     */
+    protected function failureDescription($other)
+    {
+        return $this->doFailureDescription($other);
+    }
+
+    /**
+     * @param mixed $other
+     *
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        return $this->doMatches($other);
+    }
+
+    private function doAdditionalFailureDescription($other)
+    {
+        return '';
+    }
+
+    private function doCount()
+    {
+        return 1;
+    }
+
+    private function doFailureDescription($other)
+    {
+        return $this->exporter()->export($other).' '.$this->toString();
+    }
+
+    private function doMatches($other)
+    {
+        return false;
+    }
+
+    private function doToString()
+    {
+        return '';
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV7.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+/**
+ * @internal
+ */
+trait ConstraintTraitForV7
+{
+    public function count(): int
+    {
+        return $this->doCount();
+    }
+
+    public function toString(): string
+    {
+        return $this->doToString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        return $this->doAdditionalFailureDescription($other);
+    }
+
+    protected function failureDescription($other): string
+    {
+        return $this->doFailureDescription($other);
+    }
+
+    protected function matches($other): bool
+    {
+        return $this->doMatches($other);
+    }
+
+    private function doAdditionalFailureDescription($other): string
+    {
+        return '';
+    }
+
+    private function doCount(): int
+    {
+        return 1;
+    }
+
+    private function doFailureDescription($other): string
+    {
+        return $this->exporter()->export($other).' '.$this->toString();
+    }
+
+    private function doMatches($other): bool
+    {
+        return false;
+    }
+
+    private function doToString(): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Similar to the SetUpTearDownTrait, this trait removes the pain of dealing with method signature changes. The `PHPUnit\Framework\Constraint\Constraint` class added return type hints in PHPUnit 7 which this trait will take care of.