### PR TITLE
Fix unitialized variable in DeprecationErrorHandler

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -48,7 +48,6 @@ class DeprecationErrorHandler
         }
 
         $UtilPrefix = class_exists('PHPUnit_Util_ErrorHandler') ? 'PHPUnit_Util_' : 'PHPUnit\Util\\';
-        self::$isAtLeastPhpUnit83 = method_exists('PHPUnit\Util\ErrorHandler', '__invoke');
 
         $getMode = function () use ($mode) {
             static $memoizedMode = false;
@@ -304,6 +303,9 @@ class DeprecationErrorHandler
      */
     public static function getPhpUnitErrorHandler()
     {
+        if (!isset(self::$isAtLeastPhpUnit83)) {
+            self::$isAtLeastPhpUnit83 = class_exists(ErrorHandler::class) && method_exists(ErrorHandler::class, '__invoke');
+        }
         if (!self::$isAtLeastPhpUnit83) {
             return (class_exists('PHPUnit_Util_ErrorHandler', false) ? 'PHPUnit_Util_' : 'PHPUnit\Util\\').'ErrorHandler::handleError';
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In some case the variable `isAtLeastPhpUnit83` were not initialized (see https://github.com/symfony/symfony/pull/33079/files#r312406060).
This PR initialize it when needed.