### PR TITLE
[Serializer] Fix typo in DateIntervalTest

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
@@ -89,7 +89,7 @@ class DateIntervalNormalizerTest extends TestCase
      */
     public function testDenormalizeUsingFormatPassedInContext($format, $input, $output)
     {
-        $this->assertDateIntervalEquals($this->getInterval($input), $this->normalizer->denormalize($input, \DateInterval::class, null, [DateIntervalNormalizer::FORMAT_KEY => $format]));
+        $this->assertDateIntervalEquals($this->getInterval($output), $this->normalizer->denormalize($input, \DateInterval::class, null, [DateIntervalNormalizer::FORMAT_KEY => $format]));
     }
 
     /**
@@ -97,7 +97,7 @@ class DateIntervalNormalizerTest extends TestCase
      */
     public function testDenormalizeUsingFormatPassedInConstructor($format, $input, $output)
     {
-        $this->assertDateIntervalEquals($this->getInterval($input), (new DateIntervalNormalizer($format))->denormalize($input, \DateInterval::class));
+        $this->assertDateIntervalEquals($this->getInterval($output), (new DateIntervalNormalizer($format))->denormalize($input, \DateInterval::class));
     }
 
     public function testDenormalizeExpectsString()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yers
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fix typo in test introduced in https://github.com/symfony/symfony/pull/33066/files#diff-cc998cdc60ddd99a53955a3aae10e83fL87