### PR TITLE
[Mime] Add Address::fromString

### DIFF
--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -23,6 +23,15 @@ use Symfony\Component\Mime\Exception\RfcComplianceException;
  */
 final class Address
 {
+    /**
+     * A regex that matches a structure like 'Name <email@address.com>'.
+     * It matches anything between the first < and last > as email address.
+     * This allows to use a single string to construct an Address, which can be convenient to use in
+     * config, and allows to have more readable config.
+     * This does not try to cover all edge cases for address.
+     */
+    private const FROM_STRING_PATTERN = '~(?<displayName>[^<]*)<(?<addrSpec>.*)>[^>]*~';
+
     private static $validator;
     private static $encoder;
 
@@ -99,5 +108,16 @@ final class Address
         }
 
         return $addrs;
+    }
+
+    public static function fromString(string $string): self
+    {
+        if (false === strpos($string, '<')) {
+            return new self($string, '');
+        }
+        if (!preg_match(self::FROM_STRING_PATTERN, $string, $matches)) {
+            throw new InvalidArgumentException(sprintf('Could not parse "%s" to a "%s" instance.', $string, static::class));
+        }
+        return new self($matches['addrSpec'], trim($matches['displayName'], ' \'"'));
     }
 }

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * [BC BREAK] Removed `NamedAddress` (`Address` now supports a name)
  * Added PHPUnit constraints
  * Added `AbstractPart::asDebugString()`
+ * Added `Address::fromString()`
 
 4.3.3
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33086
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/12128

This will allow to create a Address from a string such as 'Name <name@example.com>'
Example: 
```php
$address = Address::fromString("Name <name@example.com>");
```