### PR TITLE
[5.0] set return type declartion to `self` instead of `object` when the type is `$this`

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
@@ -63,7 +63,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function setSubject(string $subject): object
+    public function setSubject(string $subject): self
     {
         $this->message->subject($subject);
 
@@ -78,7 +78,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function setReturnPath(string $address): object
+    public function setReturnPath(string $address): self
     {
         $this->message->returnPath($address);
 
@@ -93,7 +93,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addFrom(string $address, string $name = null): object
+    public function addFrom(string $address, string $name = null): self
     {
         $this->message->addFrom($name ? new NamedAddress($address, $name) : new Address($address));
 
@@ -111,7 +111,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addReplyTo(string $address): object
+    public function addReplyTo(string $address): self
     {
         $this->message->addReplyTo($address);
 
@@ -129,7 +129,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addTo(string $address, string $name = null): object
+    public function addTo(string $address, string $name = null): self
     {
         $this->message->addTo($name ? new NamedAddress($address, $name) : new Address($address));
 
@@ -147,7 +147,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addCc(string $address, string $name = null): object
+    public function addCc(string $address, string $name = null): self
     {
         $this->message->addCc($name ? new NamedAddress($address, $name) : new Address($address));
 
@@ -165,7 +165,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addBcc(string $address, string $name = null): object
+    public function addBcc(string $address, string $name = null): self
     {
         $this->message->addBcc($name ? new NamedAddress($address, $name) : new Address($address));
 
@@ -183,7 +183,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function setPriority(int $priority): object
+    public function setPriority(int $priority): self
     {
         $this->message->setPriority($priority);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -42,7 +42,7 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
      *
      * @throws InvalidArgumentException when an invalid tag name or attribute is provided
      */
-    final public function tag(string $name, array $attributes = []): object
+    final public function tag(string $name, array $attributes = []): self
     {
         if ('' === $name) {
             throw new InvalidArgumentException('The tag name in "_defaults" must be a non-empty string.');

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
@@ -32,7 +32,7 @@ class ParametersConfigurator extends AbstractConfigurator
      *
      * @return $this
      */
-    final public function set(string $name, $value): object
+    final public function set(string $name, $value): self
     {
         $this->container->setParameter($name, static::processValue($value, true));
 
@@ -44,7 +44,7 @@ class ParametersConfigurator extends AbstractConfigurator
      *
      * @return $this
      */
-    final public function __invoke(string $name, $value): object
+    final public function __invoke(string $name, $value): self
     {
         return $this->set($name, $value);
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
@@ -75,7 +75,7 @@ class PrototypeConfigurator extends AbstractServiceConfigurator
      *
      * @return $this
      */
-    final public function exclude($excludes): object
+    final public function exclude($excludes): self
     {
         $this->excludes = (array) $excludes;
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ReferenceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ReferenceConfigurator.php
@@ -32,7 +32,7 @@ class ReferenceConfigurator extends AbstractConfigurator
     /**
      * @return $this
      */
-    final public function ignoreOnInvalid(): object
+    final public function ignoreOnInvalid(): self
     {
         $this->invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
 
@@ -42,7 +42,7 @@ class ReferenceConfigurator extends AbstractConfigurator
     /**
      * @return $this
      */
-    final public function nullOnInvalid(): object
+    final public function nullOnInvalid(): self
     {
         $this->invalidBehavior = ContainerInterface::NULL_ON_INVALID_REFERENCE;
 
@@ -52,7 +52,7 @@ class ReferenceConfigurator extends AbstractConfigurator
     /**
      * @return $this
      */
-    final public function ignoreOnUninitialized(): object
+    final public function ignoreOnUninitialized(): self
     {
         $this->invalidBehavior = ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE;
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AbstractTrait.php
@@ -19,7 +19,7 @@ trait AbstractTrait
      *
      * @return $this
      */
-    final public function abstract(bool $abstract = true): object
+    final public function abstract(bool $abstract = true): self
     {
         $this->definition->setAbstract($abstract);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ArgumentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ArgumentTrait.php
@@ -20,7 +20,7 @@ trait ArgumentTrait
      *
      * @return $this
      */
-    final public function args(array $arguments): object
+    final public function args(array $arguments): self
     {
         $this->definition->setArguments(static::processValue($arguments, true));
 
@@ -35,7 +35,7 @@ trait ArgumentTrait
      *
      * @return $this
      */
-    final public function arg($key, $value): object
+    final public function arg($key, $value): self
     {
         $this->definition->setArgument($key, static::processValue($value, true));
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutoconfigureTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutoconfigureTrait.php
@@ -23,7 +23,7 @@ trait AutoconfigureTrait
      *
      * @throws InvalidArgumentException when a parent is already set
      */
-    final public function autoconfigure(bool $autoconfigured = true): object
+    final public function autoconfigure(bool $autoconfigured = true): self
     {
         if ($autoconfigured && $this->definition instanceof ChildDefinition) {
             throw new InvalidArgumentException(sprintf('The service "%s" cannot have a "parent" and also have "autoconfigure". Try disabling autoconfiguration for the service.', $this->id));

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutowireTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutowireTrait.php
@@ -18,7 +18,7 @@ trait AutowireTrait
      *
      * @return $this
      */
-    final public function autowire(bool $autowired = true): object
+    final public function autowire(bool $autowired = true): self
     {
         $this->definition->setAutowired($autowired);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
@@ -31,7 +31,7 @@ trait BindTrait
      *
      * @return $this
      */
-    final public function bind(string $nameOrFqcn, $valueOrRef): object
+    final public function bind(string $nameOrFqcn, $valueOrRef): self
     {
         $valueOrRef = static::processValue($valueOrRef, true);
         if (!preg_match('/^(?:(?:array|bool|float|int|string)[ \t]*+)?\$/', $nameOrFqcn) && !$valueOrRef instanceof Reference) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/CallTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/CallTrait.php
@@ -25,7 +25,7 @@ trait CallTrait
      *
      * @throws InvalidArgumentException on empty $method param
      */
-    final public function call(string $method, array $arguments = []): object
+    final public function call(string $method, array $arguments = []): self
     {
         $this->definition->addMethodCall($method, static::processValue($arguments, true));
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ClassTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ClassTrait.php
@@ -18,7 +18,7 @@ trait ClassTrait
      *
      * @return $this
      */
-    final public function class(?string $class): object
+    final public function class(?string $class): self
     {
         $this->definition->setClass($class);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
@@ -20,7 +20,7 @@ trait ConfiguratorTrait
      *
      * @return $this
      */
-    final public function configurator($configurator): object
+    final public function configurator($configurator): self
     {
         $this->definition->setConfigurator(static::processValue($configurator, true));
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DecorateTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DecorateTrait.php
@@ -26,7 +26,7 @@ trait DecorateTrait
      *
      * @throws InvalidArgumentException in case the decorated service id and the new decorated service id are equals
      */
-    final public function decorate(?string $id, ?string $renamedId = null, int $priority = 0): object
+    final public function decorate(?string $id, ?string $renamedId = null, int $priority = 0): self
     {
         $this->definition->setDecoratedService($id, $renamedId, $priority);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DeprecateTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DeprecateTrait.php
@@ -24,7 +24,7 @@ trait DeprecateTrait
      *
      * @throws InvalidArgumentException when the message template is invalid
      */
-    final public function deprecate(string $template = null): object
+    final public function deprecate(string $template = null): self
     {
         $this->definition->setDeprecated(true, $template);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
@@ -22,7 +22,7 @@ trait FactoryTrait
      *
      * @return $this
      */
-    final public function factory($factory): object
+    final public function factory($factory): self
     {
         if (\is_string($factory) && 1 === substr_count($factory, ':')) {
             $factoryParts = explode(':', $factory);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FileTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FileTrait.php
@@ -18,7 +18,7 @@ trait FileTrait
      *
      * @return $this
      */
-    final public function file(string $file): object
+    final public function file(string $file): self
     {
         $this->definition->setFile($file);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/LazyTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/LazyTrait.php
@@ -20,7 +20,7 @@ trait LazyTrait
      *
      * @return $this
      */
-    final public function lazy($lazy = true): object
+    final public function lazy($lazy = true): self
     {
         $this->definition->setLazy((bool) $lazy);
         if (\is_string($lazy)) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
@@ -23,7 +23,7 @@ trait ParentTrait
      *
      * @throws InvalidArgumentException when parent cannot be set
      */
-    final public function parent(string $parent): object
+    final public function parent(string $parent): self
     {
         if (!$this->allowParent) {
             throw new InvalidArgumentException(sprintf('A parent cannot be defined when either "_instanceof" or "_defaults" are also defined for service prototype "%s".', $this->id));

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PublicTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PublicTrait.php
@@ -16,7 +16,7 @@ trait PublicTrait
     /**
      * @return $this
      */
-    final public function public(): object
+    final public function public(): self
     {
         $this->definition->setPublic(true);
 
@@ -26,7 +26,7 @@ trait PublicTrait
     /**
      * @return $this
      */
-    final public function private(): object
+    final public function private(): self
     {
         $this->definition->setPublic(false);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ShareTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ShareTrait.php
@@ -18,7 +18,7 @@ trait ShareTrait
      *
      * @return $this
      */
-    final public function share(bool $shared = true): object
+    final public function share(bool $shared = true): self
     {
         $this->definition->setShared($shared);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/SyntheticTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/SyntheticTrait.php
@@ -19,7 +19,7 @@ trait SyntheticTrait
      *
      * @return $this
      */
-    final public function synthetic(bool $synthetic = true): object
+    final public function synthetic(bool $synthetic = true): self
     {
         $this->definition->setSynthetic($synthetic);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
@@ -20,7 +20,7 @@ trait TagTrait
      *
      * @return $this
      */
-    final public function tag(string $name, array $attributes = []): object
+    final public function tag(string $name, array $attributes = []): self
     {
         if (!\is_string($name) || '' === $name) {
             throw new InvalidArgumentException(sprintf('The tag name for service "%s" must be a non-empty string.', $this->id));

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -418,7 +418,7 @@ class Response
      *
      * @final
      */
-    public function setProtocolVersion(string $version): object
+    public function setProtocolVersion(string $version): self
     {
         $this->version = $version;
 
@@ -447,7 +447,7 @@ class Response
      *
      * @final
      */
-    public function setStatusCode(int $code, $text = null): object
+    public function setStatusCode(int $code, $text = null): self
     {
         $this->statusCode = $code;
         if ($this->isInvalid()) {
@@ -488,7 +488,7 @@ class Response
      *
      * @final
      */
-    public function setCharset(string $charset): object
+    public function setCharset(string $charset): self
     {
         $this->charset = $charset;
 
@@ -569,7 +569,7 @@ class Response
      *
      * @final
      */
-    public function setPrivate(): object
+    public function setPrivate(): self
     {
         $this->headers->removeCacheControlDirective('public');
         $this->headers->addCacheControlDirective('private');
@@ -586,7 +586,7 @@ class Response
      *
      * @final
      */
-    public function setPublic(): object
+    public function setPublic(): self
     {
         $this->headers->addCacheControlDirective('public');
         $this->headers->removeCacheControlDirective('private');
@@ -601,7 +601,7 @@ class Response
      *
      * @final
      */
-    public function setImmutable(bool $immutable = true): object
+    public function setImmutable(bool $immutable = true): self
     {
         if ($immutable) {
             $this->headers->addCacheControlDirective('immutable');
@@ -656,7 +656,7 @@ class Response
      *
      * @final
      */
-    public function setDate(\DateTimeInterface $date): object
+    public function setDate(\DateTimeInterface $date): self
     {
         if ($date instanceof \DateTime) {
             $date = \DateTimeImmutable::createFromMutable($date);
@@ -721,7 +721,7 @@ class Response
      *
      * @final
      */
-    public function setExpires(\DateTimeInterface $date = null): object
+    public function setExpires(\DateTimeInterface $date = null): self
     {
         if (null === $date) {
             $this->headers->remove('Expires');
@@ -774,7 +774,7 @@ class Response
      *
      * @final
      */
-    public function setMaxAge(int $value): object
+    public function setMaxAge(int $value): self
     {
         $this->headers->addCacheControlDirective('max-age', $value);
 
@@ -790,7 +790,7 @@ class Response
      *
      * @final
      */
-    public function setSharedMaxAge(int $value): object
+    public function setSharedMaxAge(int $value): self
     {
         $this->setPublic();
         $this->headers->addCacheControlDirective('s-maxage', $value);
@@ -824,7 +824,7 @@ class Response
      *
      * @final
      */
-    public function setTtl(int $seconds): object
+    public function setTtl(int $seconds): self
     {
         $this->setSharedMaxAge($this->getAge() + $seconds);
 
@@ -840,7 +840,7 @@ class Response
      *
      * @final
      */
-    public function setClientTtl(int $seconds): object
+    public function setClientTtl(int $seconds): self
     {
         $this->setMaxAge($this->getAge() + $seconds);
 
@@ -868,7 +868,7 @@ class Response
      *
      * @final
      */
-    public function setLastModified(\DateTimeInterface $date = null): object
+    public function setLastModified(\DateTimeInterface $date = null): self
     {
         if (null === $date) {
             $this->headers->remove('Last-Modified');
@@ -906,7 +906,7 @@ class Response
      *
      * @final
      */
-    public function setEtag(string $etag = null, bool $weak = false): object
+    public function setEtag(string $etag = null, bool $weak = false): self
     {
         if (null === $etag) {
             $this->headers->remove('Etag');
@@ -932,7 +932,7 @@ class Response
      *
      * @final
      */
-    public function setCache(array $options): object
+    public function setCache(array $options): self
     {
         if ($diff = array_diff(array_keys($options), ['etag', 'last_modified', 'max_age', 's_maxage', 'private', 'public', 'immutable'])) {
             throw new \InvalidArgumentException(sprintf('Response does not support the following options: "%s".', implode('", "', $diff)));
@@ -989,7 +989,7 @@ class Response
      *
      * @final
      */
-    public function setNotModified(): object
+    public function setNotModified(): self
     {
         $this->setStatusCode(304);
         $this->setContent(null);
@@ -1041,7 +1041,7 @@ class Response
      *
      * @final
      */
-    public function setVary($headers, bool $replace = true): object
+    public function setVary($headers, bool $replace = true): self
     {
         $this->headers->set('Vary', $headers, $replace);
 

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -64,7 +64,7 @@ final class Headers
      *
      * @return $this
      */
-    public function addMailboxListHeader(string $name, array $addresses): object
+    public function addMailboxListHeader(string $name, array $addresses): self
     {
         return $this->add(new MailboxListHeader($name, Address::createArray($addresses)));
     }
@@ -74,7 +74,7 @@ final class Headers
      *
      * @return $this
      */
-    public function addMailboxHeader(string $name, $address): object
+    public function addMailboxHeader(string $name, $address): self
     {
         return $this->add(new MailboxHeader($name, Address::create($address)));
     }
@@ -84,7 +84,7 @@ final class Headers
      *
      * @return $this
      */
-    public function addIdHeader(string $name, $ids): object
+    public function addIdHeader(string $name, $ids): self
     {
         return $this->add(new IdentificationHeader($name, $ids));
     }
@@ -94,7 +94,7 @@ final class Headers
      *
      * @return $this
      */
-    public function addPathHeader(string $name, $path): object
+    public function addPathHeader(string $name, $path): self
     {
         return $this->add(new PathHeader($name, $path instanceof Address ? $path : new Address($path)));
     }
@@ -102,7 +102,7 @@ final class Headers
     /**
      * @return $this
      */
-    public function addDateHeader(string $name, \DateTimeInterface $dateTime): object
+    public function addDateHeader(string $name, \DateTimeInterface $dateTime): self
     {
         return $this->add(new DateHeader($name, $dateTime));
     }
@@ -110,7 +110,7 @@ final class Headers
     /**
      * @return $this
      */
-    public function addTextHeader(string $name, string $value): object
+    public function addTextHeader(string $name, string $value): self
     {
         return $this->add(new UnstructuredHeader($name, $value));
     }
@@ -118,7 +118,7 @@ final class Headers
     /**
      * @return $this
      */
-    public function addParameterizedHeader(string $name, string $value, array $params = []): object
+    public function addParameterizedHeader(string $name, string $value, array $params = []): self
     {
         return $this->add(new ParameterizedHeader($name, $value, $params));
     }
@@ -131,7 +131,7 @@ final class Headers
     /**
      * @return $this
      */
-    public function add(HeaderInterface $header): object
+    public function add(HeaderInterface $header): self
     {
         static $map = [
             'date' => DateHeader::class,

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -246,7 +246,7 @@ class Process implements \IteratorAggregate
      *
      * @final
      */
-    public function mustRun(callable $callback = null, array $env = []): object
+    public function mustRun(callable $callback = null, array $env = []): self
     {
         if (0 !== $this->run($callback, $env)) {
             throw new ProcessFailedException($this);
@@ -370,7 +370,7 @@ class Process implements \IteratorAggregate
      *
      * @final
      */
-    public function restart(callable $callback = null, array $env = []): object
+    public function restart(callable $callback = null, array $env = []): self
     {
         if ($this->isRunning()) {
             throw new RuntimeException('Process is already running');

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -60,7 +60,7 @@ class CollectionConfigurator
      *
      * @return $this
      */
-    final public function prefix($prefix): object
+    final public function prefix($prefix): self
     {
         if (\is_array($prefix)) {
             if (null === $this->parentPrefixes) {

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -41,7 +41,7 @@ class ImportConfigurator
      *
      * @return $this
      */
-    final public function prefix($prefix, bool $trailingSlashOnRoot = true): object
+    final public function prefix($prefix, bool $trailingSlashOnRoot = true): self
     {
         if (!\is_array($prefix)) {
             $this->route->addPrefix($prefix);
@@ -84,7 +84,7 @@ class ImportConfigurator
      *
      * @return $this
      */
-    final public function namePrefix(string $namePrefix): object
+    final public function namePrefix(string $namePrefix): self
     {
         $this->route->addNamePrefix($namePrefix);
 

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -26,7 +26,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function defaults(array $defaults): object
+    final public function defaults(array $defaults): self
     {
         $this->route->addDefaults($defaults);
 
@@ -38,7 +38,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function requirements(array $requirements): object
+    final public function requirements(array $requirements): self
     {
         $this->route->addRequirements($requirements);
 
@@ -50,7 +50,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function options(array $options): object
+    final public function options(array $options): self
     {
         $this->route->addOptions($options);
 
@@ -62,7 +62,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function utf8(bool $utf8 = true): object
+    final public function utf8(bool $utf8 = true): self
     {
         $this->route->addOptions(['utf8' => $utf8]);
 
@@ -74,7 +74,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function condition(string $condition): object
+    final public function condition(string $condition): self
     {
         $this->route->setCondition($condition);
 
@@ -86,7 +86,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function host(string $pattern): object
+    final public function host(string $pattern): self
     {
         $this->route->setHost($pattern);
 
@@ -101,7 +101,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function schemes(array $schemes): object
+    final public function schemes(array $schemes): self
     {
         $this->route->setSchemes($schemes);
 
@@ -116,7 +116,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function methods(array $methods): object
+    final public function methods(array $methods): self
     {
         $this->route->setMethods($methods);
 
@@ -130,7 +130,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function controller($controller): object
+    final public function controller($controller): self
     {
         $this->route->addDefaults(['_controller' => $controller]);
 
@@ -142,7 +142,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function locale(string $locale): object
+    final public function locale(string $locale): self
     {
         $this->route->addDefaults(['_locale' => $locale]);
 
@@ -154,7 +154,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function format(string $format): object
+    final public function format(string $format): self
     {
         $this->route->addDefaults(['_format' => $format]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no  
| Deprecations? | no 
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32179
| License       | MIT

please see : https://github.com/symfony/symfony/pull/31996#discussion_r294063966