### PR TITLE
[Translation] Highlight invalid translation status

### DIFF
--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -167,8 +167,9 @@ function printTable($translations, $verboseOutput)
     $longestLocaleNameLength = max(array_map('strlen', array_keys($translations)));
 
     foreach ($translations as $locale => $translation) {
-        $isTranslationCompleted = $translation['translated'] === $translation['total'];
-        if ($isTranslationCompleted) {
+        if ($translation['translated'] > $translation['total']) {
+            textColorRed();
+        } elseif ($translation['translated'] === $translation['total']) {
             textColorGreen();
         }
 
@@ -192,6 +193,11 @@ function printTable($translations, $verboseOutput)
 function textColorGreen()
 {
     echo "\033[32m";
+}
+
+function textColorRed()
+{
+    echo "\033[31m";
 }
 
 function textColorNormal()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Highlights translation locales with overflow in red, which is currently the case in 4.3 :)
