### PR TITLE
[Serializer] added the ability to pass \ArrayObject to context.callbacks

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -169,8 +169,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
 
         if (isset($this->defaultContext[self::CALLBACKS])) {
-            if (!\is_array($this->defaultContext[self::CALLBACKS])) {
-                throw new InvalidArgumentException(sprintf('The "%s" default context option must be an array of callables.', self::CALLBACKS));
+            if (!\is_array($this->defaultContext[self::CALLBACKS]) && !$this->defaultContext[self::CALLBACKS] instanceof \ArrayObject) {
+                throw new InvalidArgumentException(sprintf('The "%s" default context option must be an array or an \ArrayObject of callables.', self::CALLBACKS));
             }
 
             foreach ($this->defaultContext[self::CALLBACKS] as $attribute => $callback) {
@@ -230,7 +230,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      *
      * @throws InvalidArgumentException if a non-callable callback is set
      */
-    public function setCallbacks(array $callbacks)
+    public function setCallbacks($callbacks)
     {
         @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the "callbacks" key of the context instead.', __METHOD__), E_USER_DEPRECATED);
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -144,8 +144,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         if (isset($context[self::CALLBACKS])) {
-            if (!\is_array($context[self::CALLBACKS])) {
-                throw new InvalidArgumentException(sprintf('The "%s" context option must be an array of callables.', self::CALLBACKS));
+            if (!\is_array($context[self::CALLBACKS]) && !$context[self::CALLBACKS] instanceof \ArrayObject) {
+                throw new InvalidArgumentException(sprintf('The "%s" context option must be an array or an \ArrayObject of callables.', self::CALLBACKS));
             }
 
             foreach ($context[self::CALLBACKS] as $attribute => $callback) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
@@ -103,6 +103,23 @@ trait CallbacksTestTrait
                 [new CallbacksObject(), new CallbacksObject()],
                 ['bar' => 2],
             ],
+            'Callbacks as ArrayObject' => [
+                new class() extends \ArrayObject {
+                    public function offsetExists($index)
+                    {
+                        return true;
+                    }
+
+                    public function offsetGet($index)
+                    {
+                        return function () use ($index) {
+                            return $index;
+                        };
+                    }
+                },
+                'baz',
+                ['bar' => 'bar'],
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#12135

Callbacks system isn't much flexible as sometimes needed, so I decided to allow using ArrayObject here and now it's possible to add more flexible callback reactions since \ArrayObject can be extended and return callbacks dynamically
