### PR TITLE
Revert "bug #33092 [DependencyInjection] Improve an exception message"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
@@ -29,12 +29,9 @@ class ResolveClassPass implements CompilerPassInterface
             if ($definition->isSynthetic() || null !== $definition->getClass()) {
                 continue;
             }
-            if (preg_match('/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)) {
+            if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)) {
                 if ($definition instanceof ChildDefinition && !class_exists($id)) {
                     throw new InvalidArgumentException(sprintf('Service definition "%s" has a parent but no class, and its name looks like a FQCN. Either the class is missing or you want to inherit it from the parent service. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.', $id));
-                }
-                if ('\\' === $id[0]) {
-                    throw new InvalidArgumentException(sprintf('Service definition "%s" has no class, and its name looks like a FQCN but it starts with a backslash; remove the leading backslash.', $id));
                 }
                 $definition->setClass($id);
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 
 class ResolveClassPassTest extends TestCase
@@ -57,17 +56,6 @@ class ResolveClassPassTest extends TestCase
         yield [\stdClass::class];
         yield ['bar'];
         yield ['\DateTime'];
-    }
-
-    public function testWontResolveClassFromClassIdWithLeadingBackslash()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Service definition "\App\Some\Service" has no class, and its name looks like a FQCN but it starts with a backslash; remove the leading backslash.');
-
-        $container = new ContainerBuilder();
-        $container->register('\App\Some\Service');
-
-        (new ResolveClassPass())->process($container);
     }
 
     public function testNonFqcnChildDefinition()

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1288,8 +1288,8 @@ class ContainerBuilderTest extends TestCase
 
     public function testNoClassFromNamespaceClassIdWithLeadingSlash()
     {
-        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Service definition "\Symfony\Component\DependencyInjection\Tests\FooClass" has no class, and its name looks like a FQCN but it starts with a backslash; remove the leading backslash.');
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('The definition for "\Symfony\Component\DependencyInjection\Tests\FooClass" has no class attribute, and appears to reference a class or interface. Please specify the class attribute explicitly or remove the leading backslash by renaming the service to "Symfony\Component\DependencyInjection\Tests\FooClass" to get rid of this error.');
         $container = new ContainerBuilder();
 
         $container->register('\\'.FooClass::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As reminded by @ro0NL in https://github.com/symfony/symfony/pull/33092#issuecomment-520138148, it looks like we forgot that `CheckDefinitionValidityPass` already checks and suggests for leading slashes.

Why didn't you get the exception from `CheckDefinitionValidityPass` @fabpot?