### PR TITLE
Disable PHPUnit result cache on the CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,7 @@ init:
     - SET "SYMFONY_REQUIRE=>=3.4"
     - SET ANSICON=121x90 (121x90)
     - SET SYMFONY_PHPUNIT_VERSION=4.8
+    - SET SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE=1
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
         - MIN_PHP=5.5.9
         - SYMFONY_PROCESS_PHP_TEST_BINARY=~/.phpenv/versions/5.6/bin/php
         - SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1
+        - SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE=1
 
 matrix:
     include:

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -133,6 +133,14 @@ EOPHP
 global $argv, $argc;
 $argv = isset($_SERVER['argv']) ? $_SERVER['argv'] : array();
 $argc = isset($_SERVER['argc']) ? $_SERVER['argc'] : 0;
+
+if ($PHPUNIT_VERSION < 8.0) {
+    $argv = array_filter($argv, function ($v) use (&$argc) { if ('--do-not-cache-result' !== $v) return true; --$argc; });
+} elseif (filter_var(getenv('SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE'), FILTER_VALIDATE_BOOLEAN)) {
+    $argv[] = '--do-not-cache-result';
+    ++$argc;
+}
+
 $components = array();
 $cmd = array_map('escapeshellarg', $argv);
 $exit = 0;

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -280,9 +280,9 @@ abstract class BaseNode implements NodeInterface
     /**
      * Normalizes the value before any other normalization is applied.
      *
-     * @param $value
+     * @param mixed $value
      *
-     * @return The normalized array value
+     * @return mixed The normalized array value
      */
     protected function preNormalize($value)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

We don't need it and disabling it works around the segfault on 4.3