### PR TITLE
[Messenger][DX] Display real handler if handler is wrapped

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -70,6 +70,7 @@ class MessengerPass implements CompilerPassInterface
     {
         $definitions = [];
         $handlersByBusAndMessage = [];
+        $handlerToOriginalServiceIdMapping = [];
 
         foreach ($container->findTaggedServiceIds($this->handlerTag, true) as $serviceId => $tags) {
             foreach ($tags as $tag) {
@@ -140,6 +141,8 @@ class MessengerPass implements CompilerPassInterface
                         $definitionId = $serviceId;
                     }
 
+                    $handlerToOriginalServiceIdMapping[$definitionId] = $serviceId;
+
                     foreach ($buses as $handlerBus) {
                         $handlersByBusAndMessage[$handlerBus][$message][$priority][] = [$definitionId, $options];
                     }
@@ -188,6 +191,12 @@ class MessengerPass implements CompilerPassInterface
             foreach ($busIds as $bus) {
                 if (!isset($debugCommandMapping[$bus])) {
                     $debugCommandMapping[$bus] = [];
+                }
+
+                foreach ($debugCommandMapping[$bus] as $message => $handlers) {
+                    foreach ($handlers as $key => $handler) {
+                        $debugCommandMapping[$bus][$message][$key][0] = $handlerToOriginalServiceIdMapping[$handler[0]];
+                    }
                 }
             }
             $container->getDefinition('console.command.messenger_debug')->replaceArgument(0, $debugCommandMapping);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Execute:

```
bin/console debug:messenger
```

Before:

<img width="718" alt="Bildschirmfoto 2019-08-11 um 15 35 10" src="https://user-images.githubusercontent.com/470138/62834539-5faaa280-bc4e-11e9-99d6-a7e98822108c.png">

After:

<img width="673" alt="Bildschirmfoto 2019-08-11 um 15 34 27" src="https://user-images.githubusercontent.com/470138/62834540-646f5680-bc4e-11e9-9aa7-c5fb5219204c.png">