### PR TITLE
[DataCollector] Don't change data type on DataCollector

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -205,7 +205,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
     public function lateCollect()
     {
-        $this->data = $this->cloneVar($this->data);
+        $this->data = $this->cloneVar($this->data, true);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -83,7 +83,7 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertFalse($collector->isImpersonated());
         $this->assertNull($collector->getImpersonatorUser());
         $this->assertNull($collector->getImpersonationExitPath());
-        $this->assertSame('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', $collector->getTokenClass()->getValue());
+        $this->assertSame('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', (string) $collector->getTokenClass());
         $this->assertTrue($collector->supportsRoleHierarchy());
         $this->assertSame($normalizedRoles, $collector->getRoles()->getValue(true));
         $this->assertSame($inheritedRoles, $collector->getInheritedRoles()->getValue(true));

--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -63,7 +63,7 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
 
     public function lateCollect()
     {
-        $this->data = $this->cloneVar($this->data);
+        $this->data = $this->cloneVar($this->data, true);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -238,7 +238,9 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
             }
         }
 
-        return serialize($this->cloneVar($this->data));
+        $this->data = $this->cloneVar($this->data, true);
+
+        return serialize($this->data);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -103,7 +103,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
 
     public function lateCollect()
     {
-        $this->data = $this->cloneVar($this->data);
+        $this->data = $this->cloneVar($this->data, true);
     }
 
     public function getApplicationName()

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -60,10 +60,11 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
      * the VarDumper component.
      *
      * @param mixed $var
+     * @param bool  $keepType
      *
      * @return Data
      */
-    protected function cloneVar($var)
+    protected function cloneVar($var, $keepType = false)
     {
         if ($var instanceof Data) {
             return $var;
@@ -86,7 +87,17 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
             return $this->valueExporter->exportValue($var);
         }
 
-        return $this->cloner->cloneVar($var);
+        if (!$keepType) {
+            return $this->cloner->cloneVar($var);
+        }
+
+        foreach ($var as $k => &$v) {
+            if (\is_array($v) || is_a($v, \Serializable::class)) {
+                $v = $this->cloner->cloneVar($v);
+            }
+        }
+
+        return $var;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -63,7 +63,7 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
             $this->setCalledListeners($this->dispatcher->getCalledListeners());
             $this->setNotCalledListeners($this->dispatcher->getNotCalledListeners());
         }
-        $this->data = $this->cloneVar($this->data);
+        $this->data = $this->cloneVar($this->data, true);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -68,7 +68,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
             $this->data = $this->computeErrorsCount($containerDeprecationLogs);
             $this->data['compiler_logs'] = $this->getContainerCompilerLogs();
             $this->data['logs'] = $this->sanitizeLogs(array_merge($this->logger->getLogs(), $containerDeprecationLogs));
-            $this->data = $this->cloneVar($this->data);
+            $this->data = $this->cloneVar($this->data, true);
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -154,7 +154,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
 
     public function lateCollect()
     {
-        $this->data = $this->cloneVar($this->data);
+        $this->data = $this->cloneVar($this->data, true);
     }
 
     public function reset()

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -42,7 +42,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
         $this->data['locale'] = $this->translator->getLocale();
         $this->data['fallback_locales'] = $this->translator->getFallbackLocales();
 
-        $this->data = $this->cloneVar($this->data);
+        $this->data = $this->cloneVar($this->data, true);
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Cloner/Stub.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Stub.php
@@ -39,7 +39,7 @@ class Stub
     public $position = 0;
     public $attr = [];
 
-    private static $defaultProperties = [];
+    protected static $defaultProperties = [];
 
     /**
      * @internal


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

~~I'm not sure that this is the best solution but it corrects the typing problem of the `getData` function that does not return an `array` but a `Symfony\Component\VarDumper\Cloner\Data` instance~~

~~Tell me if this is not good~~