### PR TITLE
[4.3] Update UPGRADE guide of 4.3 for EventDispatcher

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -54,7 +54,36 @@ Dotenv
 EventDispatcher
 ---------------
 
- * The signature of the `EventDispatcherInterface::dispatch()` method should be updated to `dispatch($event, string $eventName = null)`, not doing so is deprecated
+ * The signature of the `EventDispatcherInterface::dispatch()` method has been updated, consider using the new signature `dispatch($event, string $eventName = null)` instead of the old signature `dispatch($eventName, $event)` that is deprecated
+
+   You have to swap arguments when calling `dispatch()`:
+
+   Before:
+   ```php
+   $this->eventDispatcher->dispatch(Events::My_EVENT, $event);
+   ```
+
+   After:
+   ```php
+   $this->eventDispatcher->dispatch($event, Events::My_EVENT);
+   ```
+
+   If your bundle or package needs to provide compatibility with the previous way of using the dispatcher, you can use `Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy::decorate()` to ease upgrades:
+
+   Before:
+   ```php
+   public function __construct(EventDispatcherInterface $eventDispatcher) {
+       $this->eventDispatcher = $eventDispatcher;
+   }   
+   ```
+
+   After:
+   ```php
+   public function __construct(EventDispatcherInterface $eventDispatcher) {   
+       $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
+   }
+   ```
+ 
  * The `Event` class has been deprecated, use `Symfony\Contracts\EventDispatcher\Event` instead
 
 Filesystem


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

I updated `UPGRADE-4.3.md` to ease upgrading `EventDispatcher` to 4.3, related changes were introduced in https://github.com/symfony/symfony/pull/28920

This code is used in Symfony: https://github.com/symfony/symfony/blob/f8302262714674e3efbd775c9b107294d89fb77e/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php#L49

Thanks to @nicolas-grekas for the hint: https://github.com/symfony/symfony/commit/75369dabb8af73b0d0ad7f206d85c08cf39117f8#r34480203