### PR TITLE
[Yaml] Allow parsing of unindented closing quotation mark

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -925,7 +925,7 @@ class Parser
     {
         $trimmedLine = trim($this->currentLine, ' ');
 
-        return strlen($trimmedLine) == 1 && '' !== $trimmedLine && ("'" === $trimmedLine[0] || '"' === $trimmedLine[0]);
+        return 1 == \strlen($trimmedLine) && '' !== $trimmedLine && ("'" === $trimmedLine[0] || '"' === $trimmedLine[0]);
     }
 
     private function isCurrentLineLastLineInDocument(): bool

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -529,8 +529,8 @@ class Parser
             do {
                 $EOF = false;
 
-                // empty and comment-like lines do not influence the indentation depth
-                if ($this->isCurrentLineEmpty() || $this->isCurrentLineComment()) {
+                // empty, quotation mark only, and comment-like lines do not influence the indentation depth
+                if ($this->isCurrentLineEmpty() || $this->isCurrentLineComment() || $this->isCurrentLineQuotationOnly()) {
                     $EOF = !$this->moveToNextLine();
 
                     if (!$EOF) {
@@ -557,7 +557,7 @@ class Parser
         $data = [];
         if ($this->getCurrentLineIndentation() >= $newIndent) {
             $data[] = substr($this->currentLine, $newIndent);
-        } elseif ($this->isCurrentLineEmpty() || $this->isCurrentLineComment()) {
+        } elseif ($this->isCurrentLineEmpty() || $this->isCurrentLineComment() || $this->isCurrentLineQuotationOnly()) {
             $data[] = $this->currentLine;
         } else {
             $this->moveToPreviousLine();
@@ -590,7 +590,7 @@ class Parser
 
             if ($indent >= $newIndent) {
                 $data[] = substr($this->currentLine, $newIndent);
-            } elseif ($this->isCurrentLineComment()) {
+            } elseif ($this->isCurrentLineComment() || $this->isCurrentLineQuotationOnly()) {
                 $data[] = $this->currentLine;
             } elseif (0 == $indent) {
                 $this->moveToPreviousLine();
@@ -914,6 +914,18 @@ class Parser
         $ltrimmedLine = ltrim($this->currentLine, ' ');
 
         return '' !== $ltrimmedLine && '#' === $ltrimmedLine[0];
+    }
+
+    /**
+     * Returns true if the current line contains quotation mark only.
+     *
+     * @return bool Returns true if the current line contains quotation mark only, false otherwise
+     */
+    private function isCurrentLineQuotationOnly(): bool
+    {
+        $trimmedLine = trim($this->currentLine, ' ');
+
+        return strlen($trimmedLine) == 1 && '' !== $trimmedLine && ("'" === $trimmedLine[0] || '"' === $trimmedLine[0]);
     }
 
     private function isCurrentLineLastLineInDocument(): bool

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2150,6 +2150,38 @@ YAML;
             $this->parser->parse($yaml)
         );
     }
+
+    public function testParseValueWithUnindentedClosingQuotation()
+    {
+        $expected = ['foo' => ['bar' => 'baz ']];
+
+        // unindented closing single quote
+        $yaml = <<<YAML
+---
+foo:
+    bar: 'baz
+'
+YAML;
+        $this->assertSame($expected, $this->parser->parse($yaml));
+
+        // unindented closing double quote
+        $yaml = <<<YAML
+---
+foo:
+    bar: "baz
+"
+YAML;
+        $this->assertSame($expected, $this->parser->parse($yaml));
+
+        // correctly-indented closing double quote
+        $yaml = <<<YAML
+---
+foo:
+    bar: "baz
+    "
+YAML;
+        $this->assertSame($expected, $this->parser->parse($yaml));
+    }
 }
 
 class B


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33082
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

Unindented quotation marks are not parsed correctly by the parser. Online parsers accepts values/strings with unindented quotation marks as valid yaml.

```php
$yaml = <<<YAML
---
foo:
  bar: 'baz

'
YAML;
dump($this->parser->parse($yaml));
```

**Before fix**
```
Symfony\Component\Yaml\Exception\ParseException: Malformed inline YAML string: 'baz at line 4.
```

**After fix**
```
array:1 [
  "foo" => array:1 [
    "bar" => "baz\n"
  ]
]
```
