### PR TITLE
[Config] Add handling for ignored keys in ArrayNode::mergeValues.

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -396,7 +396,12 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
             }
 
             if (!isset($this->children[$k])) {
-                throw new \RuntimeException('merge() expects a normalized config array.');
+                if (!$this->ignoreExtraKeys || $this->removeExtraKeys) {
+                    throw new \RuntimeException('merge() expects a normalized config array.');
+                }
+
+                $leftSide[$k] = $v;
+                continue;
             }
 
             $leftSide[$k] = $this->children[$k]->merge($leftSide[$k], $v);

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -255,4 +255,66 @@ class ArrayNodeTest extends TestCase
         restore_error_handler();
         $this->assertTrue($deprecationTriggered, '->finalize() should trigger if the deprecated node is set');
     }
+
+    /**
+     * @dataProvider getDataWithIncludedExtraKeys
+     */
+    public function testMergeWithoutIgnoringExtraKeys($prenormalizeds, $merged)
+    {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('merge() expects a normalized config array.');
+        $node = new ArrayNode('root');
+        $node->addChild(new ScalarNode('foo'));
+        $node->addChild(new ScalarNode('bar'));
+        $node->setIgnoreExtraKeys(false);
+
+        $r = new \ReflectionMethod($node, 'mergeValues');
+        $r->setAccessible(true);
+
+        $r->invoke($node, ...$prenormalizeds);
+    }
+
+    /**
+     * @dataProvider getDataWithIncludedExtraKeys
+     */
+    public function testMergeWithIgnoringAndRemovingExtraKeys($prenormalizeds, $merged)
+    {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('merge() expects a normalized config array.');
+        $node = new ArrayNode('root');
+        $node->addChild(new ScalarNode('foo'));
+        $node->addChild(new ScalarNode('bar'));
+        $node->setIgnoreExtraKeys(true);
+
+        $r = new \ReflectionMethod($node, 'mergeValues');
+        $r->setAccessible(true);
+
+        $r->invoke($node, ...$prenormalizeds);
+    }
+
+    /**
+     * @dataProvider getDataWithIncludedExtraKeys
+     */
+    public function testMergeWithIgnoringExtraKeys($prenormalizeds, $merged)
+    {
+        $node = new ArrayNode('root');
+        $node->addChild(new ScalarNode('foo'));
+        $node->addChild(new ScalarNode('bar'));
+        $node->setIgnoreExtraKeys(true, false);
+
+        $r = new \ReflectionMethod($node, 'mergeValues');
+        $r->setAccessible(true);
+
+        $this->assertEquals($merged, $r->invoke($node, ...$prenormalizeds));
+    }
+
+    public function getDataWithIncludedExtraKeys()
+    {
+        return [
+            [
+                [['foo' => 'bar', 'baz' => 'not foo'], ['bar' => 'baz', 'baz' => 'foo']],
+                ['foo' => 'bar', 'bar' => 'baz', 'baz' => 'foo'],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33101 
| License       | MIT
| Doc PR        | N/A

Fix case where normalized data accepting and keeping ignored keys is rejected during merge.