### PR TITLE
[SecurityBundle] display the correct class name on the deprecated notice

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
@@ -50,7 +50,7 @@ final class WrappedListener implements ListenerInterface
         if (\is_callable($this->listener)) {
             ($this->listener)($event);
         } else {
-            @trigger_error(sprintf('Calling the "%s::handle()" method from the firewall is deprecated since Symfony 4.3, implement "__invoke()" instead.', \get_class($this)), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling the "%s::handle()" method from the firewall is deprecated since Symfony 4.3, implement "__invoke()" instead.', \get_class($this->listener)), E_USER_DEPRECATED);
             $this->listener->handle($event);
         }
         $this->time = microtime(true) - $startTime;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
