### PR TITLE
[wip] Partially revert https://github.com/symfony/symfony/pull/31620 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -522,13 +522,6 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('session')
-                    ->validate()
-                        ->ifTrue(function ($v) {
-                            return empty($v['handler_id']) && !empty($v['save_path']);
-                        })
-                        ->thenInvalid('Session save path is ignored without a handler service')
-                    ->end()
-                    ->info('session configuration')
                     ->canBeEnabled()
                     ->children()
                         ->scalarNode('storage_id')->defaultValue('session.storage.native')->end()
@@ -553,7 +546,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('gc_divisor')->end()
                         ->scalarNode('gc_probability')->defaultValue(1)->end()
                         ->scalarNode('gc_maxlifetime')->end()
-                        ->scalarNode('save_path')->end()
+                        ->scalarNode('save_path')->defaultValue('%kernel.cache_dir%/sessions')->end()
                         ->integerNode('metadata_update_threshold')
                             ->defaultValue(0)
                             ->info('seconds to wait between 2 session metadata updates')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -918,7 +918,7 @@ class FrameworkExtension extends Extension
         if (null === $config['handler_id']) {
             // If the user set a save_path without using a non-default \SessionHandler, it will silently be ignored
             if (isset($config['save_path'])) {
-                throw new LogicException('Session save path is ignored without a handler service');
+                @trigger_error('Session save path is ignored without a handler service, and deprecated since Symfony 4.4. It will throw a LogicException from Symfony 5.0.', E_USER_DEPRECATED);
             }
 
             // Set the handler class to be null
@@ -926,10 +926,6 @@ class FrameworkExtension extends Extension
             $container->getDefinition('session.storage.php_bridge')->replaceArgument(0, null);
         } else {
             $container->setAlias('session.handler', $config['handler_id'])->setPrivate(true);
-        }
-
-        if (!isset($config['save_path'])) {
-            $config['save_path'] = ini_get('session.save_path');
         }
 
         $container->setParameter('session.save_path', $config['save_path']);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -294,6 +294,7 @@ class ConfigurationTest extends TestCase
                 'cookie_httponly' => true,
                 'cookie_samesite' => null,
                 'gc_probability' => 1,
+                'save_path' => '%kernel.cache_dir%/sessions',
                 'metadata_update_threshold' => 0,
             ],
             'request' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -548,9 +548,12 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Session save path is ignored without a handler service, and deprecated since Symfony 4.4. It will throw a LogicException from Symfony 5.0.
+     */
     public function testNullSessionHandlerWithSavePath()
     {
-        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $this->createContainerFromFile('session_savepath');
     }
 


### PR DESCRIPTION
Fixes a bc break on session configuration.

Restore old config behaviour but throw a deprecation notice instead of a `LogicException`

| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no TODO <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    
| Fixed tickets | https://github.com/symfony/symfony/issues/32837 (partial fix)
| License       | MIT
| Doc PR        | n/a

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
