### PR TITLE
[Intl] Cleanup unused language aliases entry

### DIFF
--- a/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
@@ -158,7 +158,6 @@ class LanguageDataGenerator extends AbstractDataGenerator
         return [
             'Version' => $rootBundle['Version'],
             'Languages' => $this->languageCodes,
-            'Aliases' => array_column(iterator_to_array($metadataBundle['alias']['language']), 'replacement'),
             'Alpha2ToAlpha3' => $this->generateAlpha2ToAlpha3Mapping($metadataBundle),
         ];
     }

--- a/src/Symfony/Component/Intl/Resources/data/languages/meta.json
+++ b/src/Symfony/Component/Intl/Resources/data/languages/meta.json
@@ -622,7 +622,6 @@
         "zxx",
         "zza"
     ],
-    "Aliases": [],
     "Alpha2ToAlpha3": {
         "aa": "aar",
         "ab": "abk",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The data entry `Aliases` in languages is never used.

https://github.com/symfony/symfony/blob/50c59112298669e7724a42a8ee1a1fe6d1e1b536/src/Symfony/Component/Intl/Data/Provider/LanguageDataProvider.php#L44-L47

Already crashes with 

```
Symfony\Component\Intl\Exception\MissingResourceException:
Couldn't read the indices [Aliases] for the locale "root" in "src/Symfony/Component/Intl/Resources/data/languages".
```

The locale should be `meta`, which would return an empty array :man_shrugging: 