### PR TITLE
Mark all dispatched event classes as final

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added `Question::setTrimmable` default to true to allow the answer to be trimmed
  * added method `preventRedrawFasterThan()` and `forceRedrawSlowerThan()` on `ProgressBar`
  * `Application` implements `ResetInterface`
+ * marked all dispatched event classes as `@final`
 
 4.3.0
 -----

--- a/src/Symfony/Component/Console/Event/ConsoleCommandEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleCommandEvent.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Console\Event;
  * Allows to do things before the command is executed, like skipping the command or changing the input.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class ConsoleCommandEvent extends ConsoleEvent
 {

--- a/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Allows to manipulate the exit code of a command after its execution.
  *
  * @author Francesco Levorato <git@flevour.net>
+ *
+ * @final since Symfony 4.4
  */
 class ConsoleTerminateEvent extends ConsoleEvent
 {

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * deprecated using `int` or `float` as data for the `NumberType` when the `input` option is set to `string`
  * The type guesser guesses the HTML accept attribute when a mime type is configured in the File or Image constraint.
  * Overriding the methods `FormIntegrationTestCase::setUp()`, `TypeTestCase::setUp()` and `TypeTestCase::tearDown()` without the `void` return-type is deprecated.
+ * marked all dispatched event classes as `@final`
 
 4.3.0
 -----

--- a/src/Symfony/Component/Form/Event/PostSetDataEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSetDataEvent.php
@@ -17,6 +17,8 @@ use Symfony\Component\Form\FormEvent;
  * This event is dispatched at the end of the Form::setData() method.
  *
  * This event is mostly here for reading data after having pre-populated the form.
+ *
+ * @final since Symfony 4.4
  */
 class PostSetDataEvent extends FormEvent
 {

--- a/src/Symfony/Component/Form/Event/PostSubmitEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSubmitEvent.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\FormEvent;
  * once the model and view data have been denormalized.
  *
  * It can be used to fetch data after denormalization.
+ *
+ * @final since Symfony 4.4
  */
 class PostSubmitEvent extends FormEvent
 {

--- a/src/Symfony/Component/Form/Event/PreSetDataEvent.php
+++ b/src/Symfony/Component/Form/Event/PreSetDataEvent.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\FormEvent;
  * It can be used to:
  *  - Modify the data given during pre-population;
  *  - Modify a form depending on the pre-populated data (adding or removing fields dynamically).
+ *
+ * @final since Symfony 4.4
  */
 class PreSetDataEvent extends FormEvent
 {

--- a/src/Symfony/Component/Form/Event/PreSubmitEvent.php
+++ b/src/Symfony/Component/Form/Event/PreSubmitEvent.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\FormEvent;
  * It can be used to:
  *  - Change data from the request, before submitting the data to the form.
  *  - Add or remove form fields, before submitting the data to the form.
+ *
+ * @final since Symfony 4.4
  */
 class PreSubmitEvent extends FormEvent
 {

--- a/src/Symfony/Component/Form/Event/SubmitEvent.php
+++ b/src/Symfony/Component/Form/Event/SubmitEvent.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\FormEvent;
  * transforms back the normalized data to the model and view data.
  *
  * It can be used to change data from the normalized representation of the data.
+ *
+ * @final since Symfony 4.4
  */
 class SubmitEvent extends FormEvent
 {

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
    fallback directories. Resources like service definitions are usually loaded relative to the
    current directory or with a glob pattern. The fallback directories have never been advocated
    so you likely do not use those in any app based on the SF Standard or Flex edition.
+ * Marked all dispatched event classes as `@final`
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
@@ -22,6 +22,8 @@ namespace Symfony\Component\HttpKernel\Event;
  * controller.
  *
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @final since Symfony 4.4
  */
 class ControllerArgumentsEvent extends FilterControllerArgumentsEvent
 {

--- a/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
@@ -21,6 +21,8 @@ namespace Symfony\Component\HttpKernel\Event;
  * Controllers should be callables.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class ControllerEvent extends FilterControllerEvent
 {

--- a/src/Symfony/Component/HttpKernel/Event/ExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ExceptionEvent.php
@@ -23,6 +23,8 @@ namespace Symfony\Component\HttpKernel\Event;
  * event.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class ExceptionEvent extends GetResponseForExceptionEvent
 {

--- a/src/Symfony/Component/HttpKernel/Event/FinishRequestEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FinishRequestEvent.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\HttpKernel\Event;
  * Triggered whenever a request is fully processed.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @final since Symfony 4.4
  */
 class FinishRequestEvent extends KernelEvent
 {

--- a/src/Symfony/Component/HttpKernel/Event/ResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ResponseEvent.php
@@ -19,6 +19,8 @@ namespace Symfony\Component\HttpKernel\Event;
  * browser.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class ResponseEvent extends FilterResponseEvent
 {

--- a/src/Symfony/Component/HttpKernel/Event/TerminateEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/TerminateEvent.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\HttpKernel\Event;
  * will always return the value of `HttpKernelInterface::MASTER_REQUEST`.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @final since Symfony 4.4
  */
 class TerminateEvent extends PostResponseEvent
 {

--- a/src/Symfony/Component/HttpKernel/Event/ViewEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ViewEvent.php
@@ -19,6 +19,8 @@ namespace Symfony\Component\HttpKernel\Event;
  * response is set.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class ViewEvent extends GetResponseForControllerResultEvent
 {

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
    `Symfony\Component\Mailer\Transport\TransportFactoryInterface` and tagging with `mailer.transport_factory` tag in DI.
  * Added `Symfony\Component\Mailer\Test\TransportFactoryTestCase` to ease testing custom transport factories.
  * Added `SentMessage::getDebug()` and `TransportExceptionInterface::getDebug` to help debugging
+ * Made `MessageEvent` final
 
 4.3.0
 -----

--- a/src/Symfony/Component/Mailer/Event/MessageEvent.php
+++ b/src/Symfony/Component/Mailer/Event/MessageEvent.php
@@ -20,7 +20,7 @@ use Symfony\Component\Mime\RawMessage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class MessageEvent extends Event
+final class MessageEvent extends Event
 {
     private $message;
     private $envelope;

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
    pass a `RoutableMessageBus`  instance instead.
  * Added support for auto trimming of Redis streams.
  * `InMemoryTransport` handle acknowledged and rejected messages.
+ * Made all dispatched worker event classes final.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
+++ b/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
@@ -24,7 +24,7 @@ use Symfony\Component\Messenger\Envelope;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-class SendMessageToTransportsEvent
+final class SendMessageToTransportsEvent
 {
     private $envelope;
 

--- a/src/Symfony/Component/Messenger/Event/WorkerMessageFailedEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerMessageFailedEvent.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Envelope;
  *
  * The event name is the class name.
  */
-class WorkerMessageFailedEvent extends AbstractWorkerMessageEvent
+final class WorkerMessageFailedEvent extends AbstractWorkerMessageEvent
 {
     private $throwable;
     private $willRetry;

--- a/src/Symfony/Component/Messenger/Event/WorkerMessageHandledEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerMessageHandledEvent.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Messenger\Event;
  *
  * The event name is the class name.
  */
-class WorkerMessageHandledEvent extends AbstractWorkerMessageEvent
+final class WorkerMessageHandledEvent extends AbstractWorkerMessageEvent
 {
 }

--- a/src/Symfony/Component/Messenger/Event/WorkerMessageReceivedEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerMessageReceivedEvent.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Messenger\Event;
  *
  * The event name is the class name.
  */
-class WorkerMessageReceivedEvent extends AbstractWorkerMessageEvent
+final class WorkerMessageReceivedEvent extends AbstractWorkerMessageEvent
 {
     private $shouldHandle = true;
 

--- a/src/Symfony/Component/Messenger/Event/WorkerStoppedEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerStoppedEvent.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Messenger\Event;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class WorkerStoppedEvent
+final class WorkerStoppedEvent
 {
 }

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Added and implemented `PasswordUpgraderInterface`, for opportunistic password migrations
  * Added `Guard\PasswordAuthenticatedInterface`, an optional interface
    for "guard" authenticators that deal with user passwords
+ * Marked all dispatched event classes as `@final`
 
 4.3.0
 -----

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationFailureEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationFailureEvent.php
@@ -18,6 +18,8 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  * This event is dispatched on authentication failure.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class AuthenticationFailureEvent extends AuthenticationEvent
 {

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationSuccessEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationSuccessEvent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Event;
 
+/**
+ * @final since Symfony 4.4
+ */
 class AuthenticationSuccessEvent extends AuthenticationEvent
 {
 }

--- a/src/Symfony/Component/Security/Core/Event/VoteEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/VoteEvent.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
  *
  * @internal
  */
-class VoteEvent extends Event
+final class VoteEvent extends Event
 {
     private $voter;
     private $subject;

--- a/src/Symfony/Component/Security/Http/Event/DeauthenticatedEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/DeauthenticatedEvent.php
@@ -18,6 +18,8 @@ use Symfony\Contracts\EventDispatcher\Event;
  * Deauthentication happens in case the user has changed when trying to refresh the token.
  *
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class DeauthenticatedEvent extends Event
 {

--- a/src/Symfony/Component/Security/Http/Event/InteractiveLoginEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/InteractiveLoginEvent.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class InteractiveLoginEvent extends Event
 {

--- a/src/Symfony/Component/Security/Http/Event/SwitchUserEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/SwitchUserEvent.php
@@ -20,6 +20,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * SwitchUserEvent.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class SwitchUserEvent extends Event
 {

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+* Marked all dispatched event classes as `@final`
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
+++ b/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @final since Symfony 4.4
+ */
 class AnnounceEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/CompletedEvent.php
+++ b/src/Symfony/Component/Workflow/Event/CompletedEvent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @final since Symfony 4.4
+ */
 class CompletedEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/EnterEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnterEvent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @final since Symfony 4.4
+ */
 class EnterEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/EnteredEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnteredEvent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @final since Symfony 4.4
+ */
 class EnteredEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -19,6 +19,8 @@ use Symfony\Component\Workflow\TransitionBlockerList;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since Symfony 4.4
  */
 class GuardEvent extends Event
 {

--- a/src/Symfony/Component/Workflow/Event/LeaveEvent.php
+++ b/src/Symfony/Component/Workflow/Event/LeaveEvent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @final since Symfony 4.4
+ */
 class LeaveEvent extends Event
 {
 }

--- a/src/Symfony/Component/Workflow/Event/TransitionEvent.php
+++ b/src/Symfony/Component/Workflow/Event/TransitionEvent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Workflow\Event;
 
+/**
+ * @final since Symfony 4.4
+ */
 class TransitionEvent extends Event
 {
     private $context;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I think we should mark all our Event classes as final. There is no point in people extending them as the libraries that use the event, will only dispatch this event. So extending events in user-land achieves nothing as the subclasses won't be dispatched.
I'm not talking about the base events that are meant to be extended like KernelEvent, but the leaf events like ExceptionEvent, ResponseEvent etc.
Then we can also make them real final in 5.0 as the events are value objects that should not be mocked.