### PR TITLE
[ErrorHandler] Added call() method utility to turns any PHP error into \ErrorException

### DIFF
--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 -----
 
  * added the component
+ * added `ErrorHandler::call()` method utility to turn any PHP error into `\ErrorException`

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -153,6 +153,32 @@ class ErrorHandler
         return $handler;
     }
 
+    /**
+     * Calls a function and turns any PHP error into \ErrorException.
+     *
+     * @return mixed What $function(...$arguments) returns
+     *
+     * @throws \ErrorException When $function(...$arguments) triggers a PHP error
+     */
+    public static function call(callable $function, ...$arguments)
+    {
+        set_error_handler(static function (int $type, string $message, string $file, int $line) {
+            if (__FILE__ === $file) {
+                $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+                $file = $trace[2]['file'] ?? $file;
+                $line = $trace[2]['line'] ?? $line;
+            }
+
+            throw new \ErrorException($message, 0, $type, $file, $line);
+        });
+
+        try {
+            return $function(...$arguments);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
     public function __construct(BufferingLogger $bootstrappingLogger = null)
     {
         if ($bootstrappingLogger) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/32936
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

**Issue** 

There is no easy way to catch PHP warnings, though some progress has been made in this area for PHP 8.0 (https://wiki.php.net/rfc/consistent_type_errors).

**Before**
```php
$file = file_get_contents('unknown.txt');
// PHP Warning:  file_get_contents(unknown.txt): failed to open stream: No such file or directory

// workaround:
$file = @file_get_contents('unknown.txt');
if (false === $file) {
    $e = error_get_last();
    throw new \ErrorException($e['message'], 0, $e['type'], $e['file'], $e['line']);
}
```

**After**
```php
$file = ErrorHandler::call('file_get_contents', 'unknown.txt');

// or
$file = ErrorHandler::call(static function () {
    return file_get_contents('unknown.txt');
});

// or (PHP 7.4)
$file = ErrorHandler::call(fn () => file_get_contents('unknown.txt'));
```

All credits to @nicolas-grekas https://github.com/symfony/symfony/issues/32936#issuecomment-518152681 and @vudaltsov for the idea.