### PR TITLE
Fix getMaxFilesize() returning zero

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -217,7 +217,7 @@ class UploadedFile extends File
         $sizePostMax = self::parseFilesize(ini_get('post_max_size'));
         $sizeUploadMax = self::parseFilesize(ini_get('upload_max_filesize'));
 
-        return min([$sizePostMax, $sizeUploadMax]);
+        return min($sizePostMax ?: PHP_INT_MAX, $sizeUploadMax ?: PHP_INT_MAX);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -281,4 +281,18 @@ class UploadedFileTest extends TestCase
 
         $this->assertFalse($file->isValid());
     }
+
+    public function testGetMaxFilesize()
+    {
+        $size = UploadedFile::getMaxFilesize();
+
+        $this->assertIsInt($size);
+        $this->assertGreaterThan(0, $size);
+
+        if (0 === (int) ini_get('post_max_size') && 0 === (int) ini_get('upload_max_filesize')) {
+            $this->assertSame(PHP_INT_MAX, $size);
+        } else {
+            $this->assertLessThan(PHP_INT_MAX, $size);
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32790
| License       | MIT

With #32790 a BC break got introduced. Previously an empty `upload_max_filesize` returned `PHP_INT_MAX` but after the changes from #32790 it returns `0`.

Setting `upload_max_filesize` or `post_max_size` to `0` or `''` disables the limit so for both cases `PHP_INT_MAX` should be returned.