### PR TITLE
Partially Revert "Remove trailing space in all markdown files"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1.md
@@ -5,11 +5,11 @@
 - Scheme: http|https
 - Method: GET|HEAD
 - Class: Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub
-- Defaults:
+- Defaults: 
     - `name`: Joseph
-- Requirements:
+- Requirements: 
     - `name`: [a-z]+
-- Options:
+- Options: 
     - `compiler_class`: Symfony\Component\Routing\RouteCompiler
     - `opt1`: val1
     - `opt2`: val2

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2.md
@@ -7,7 +7,7 @@
 - Class: Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub
 - Defaults: NONE
 - Requirements: NO CUSTOM
-- Options:
+- Options: 
     - `compiler_class`: Symfony\Component\Routing\RouteCompiler
     - `opt1`: val1
     - `opt2`: val2

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1.md
@@ -8,11 +8,11 @@ route_1
 - Scheme: http|https
 - Method: GET|HEAD
 - Class: Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub
-- Defaults:
+- Defaults: 
     - `name`: Joseph
-- Requirements:
+- Requirements: 
     - `name`: [a-z]+
-- Options:
+- Options: 
     - `compiler_class`: Symfony\Component\Routing\RouteCompiler
     - `opt1`: val1
     - `opt2`: val2
@@ -30,7 +30,7 @@ route_2
 - Class: Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub
 - Defaults: NONE
 - Requirements: NO CUSTOM
-- Options:
+- Options: 
     - `compiler_class`: Symfony\Component\Routing\RouteCompiler
     - `opt1`: val1
     - `opt2`: val2


### PR DESCRIPTION
This reverts commit 5a3c19846e22399f5ce43d366346dd404e2f825f.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33142
| License       | MIT
| Doc PR        | -