### PR TITLE
 [VarDumper] Remove useless variable

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
@@ -26,7 +26,7 @@ class FunctionsTest extends TestCase
 
         ob_start();
         $return = dump($var1);
-        $out = ob_get_clean();
+        ob_end_clean();
 
         $this->assertEquals($var1, $return);
     }
@@ -41,7 +41,7 @@ class FunctionsTest extends TestCase
 
         ob_start();
         $return = dump($var1, $var2, $var3);
-        $out = ob_get_clean();
+        ob_end_clean();
 
         $this->assertEquals([$var1, $var2, $var3], $return);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

I think  `$out` variable is useless in both case
