### PR TITLE
[Lock] add the DSN object

### DIFF
--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -7,7 +7,8 @@ CHANGELOG
  * added InvalidTtlException  
  * deprecated `StoreInterface` in favor of `BlockingStoreInterface` and `PersistingStoreInterface`
  * `Factory` is deprecated, use `LockFactory` instead
-
+ * add `DSN` object to parse dsn in the component
+ 
 4.2.0
 -----
 

--- a/src/Symfony/Component/Lock/Dsn.php
+++ b/src/Symfony/Component/Lock/Dsn.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+
+/**
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+final class Dsn
+{
+    private $scheme;
+    private $host;
+    private $user;
+    private $password;
+    private $port;
+    private $path;
+    private $options;
+
+    public function __construct(string $scheme, string $host, ?string $user = null, ?string $password = null, ?int $port = null, ?string $path = null, array $options = [])
+    {
+        $this->scheme = $scheme;
+        $this->host = $host;
+        $this->user = $user;
+        $this->password = $password;
+        $this->port = $port;
+        $this->path = $path;
+        $this->options = $options;
+    }
+
+    public static function isValid(string $dsn)
+    {
+        return false !== parse_url($dsn);
+    }
+
+    public static function fromString(string $dsn, array $options): self
+    {
+        if (false === $parsedDsn = parse_url($dsn)) {
+            throw new InvalidArgumentException(sprintf('The "%s" DSN is invalid.', $dsn));
+        }
+
+        parse_str($parsedDsn['query'] ?? '', $options);
+
+        return new self($parsedDsn['scheme'],
+            $parsedDsn['host'],
+            isset($parsedDsn['user']) ? urldecode($parsedDsn['user']) : null,
+            isset($parsedDsn['pass']) ? urldecode($parsedDsn['pass']) : null,
+            $parsedDsn['port'] ?? null, $parsedDsn['path'] ?? null,
+            $options);
+    }
+
+    public function getScheme(): string
+    {
+        return $this->scheme;
+    }
+
+    public function getHost(string $default = null): ?string
+    {
+        return $this->host ?? $default;
+    }
+
+    public function getUser(): ?string
+    {
+        return $this->user;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    public function getPort(int $default = null): ?int
+    {
+        return $this->port ?? $default;
+    }
+
+    public function getPath(string $default = null): ?string
+    {
+        return $this->path ?? $default;
+    }
+
+    public function getOption(string $key, $default = null)
+    {
+        return $this->options[$key] ?? $default;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/DsnTest.php
+++ b/src/Symfony/Component/Lock/Tests/DsnTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\Dsn;
+
+/**
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+class DsnTest extends TestCase
+{
+    public function testIsValid()
+    {
+        $this->assertTrue(Dsn::isValid('redis://elsa:secret@localhost:6321/1?test=1'));
+    }
+
+    public function testIsNotValid()
+    {
+        $this->assertFalse(Dsn::isValid('gerard:////'));
+    }
+
+    public function testFromString()
+    {
+        $parsedDsn = Dsn::fromString('redis://elsa:secret@localhost:6321/1?test=1', []);
+        $this->assertSame($parsedDsn->getScheme(), 'redis');
+        $this->assertSame($parsedDsn->getHost(), 'localhost');
+        $this->assertSame($parsedDsn->getUser(), 'elsa');
+        $this->assertSame($parsedDsn->getPassword(), 'secret');
+        $this->assertSame($parsedDsn->getPort(), 6321);
+        $this->assertSame($parsedDsn->getPath(), '/1');
+        $this->assertSame($parsedDsn->getOption('test'), '1');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | Sort of <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Linked to #32546   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | none atm <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

For the lock component we are using dsn for flock and for testing that we have DSN for redis and for memcache directly via the cache component, we could go one step futher and pass the dsn to the adapter directly. but that could be done in another PR.
