### PR TITLE
[Mailer] Add support for the queued flag in the EmailCount assertion

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
@@ -25,6 +25,11 @@ trait MailerAssertionsTrait
         self::assertThat(self::getMessageMailerEvents(), new MailerConstraint\EmailCount($count, $transport), $message);
     }
 
+    public static function assertQueuedEmailCount(int $count, string $transport = null, string $message = ''): void
+    {
+        self::assertThat(self::getMessageMailerEvents(), new MailerConstraint\EmailCount($count, $transport, true), $message);
+    }
+
     public static function assertEmailIsQueued(MessageEvent $event, string $message = ''): void
     {
         self::assertThat($event, new MailerConstraint\EmailIsQueued(), $message);

--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -54,7 +54,7 @@ class Mailer implements MailerInterface
                     throw new TransportException('Cannot send message without a valid envelope.', 0, $e);
                 }
             }
-            $event = new MessageEvent($message, $envelope, $this->transport->getName());
+            $event = new MessageEvent($message, $envelope, $this->transport->getName(), true);
             $this->dispatcher->dispatch($event);
         }
 

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -67,7 +67,7 @@ abstract class AbstractTransport implements TransportInterface
             }
         }
 
-        $event = new MessageEvent($message, $envelope, $this->getName(), true);
+        $event = new MessageEvent($message, $envelope, $this->getName());
         $this->dispatcher->dispatch($event);
         $envelope = $event->getEnvelope();
         if (!$envelope->getRecipients()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | -

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
