### PR TITLE
Remove unnecessary statement

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1170,7 +1170,6 @@ EOF;
             if (!$id->isDeprecated()) {
                 continue;
             }
-            $id = (string) $id;
             $code .= '            '.$this->doExport($alias).' => '.$this->doExport($this->generateMethodName($alias)).",\n";
         }
 


### PR DESCRIPTION
The casting of `$id` to string inside the second foreach loop in `\Symfony\Component\DependencyInjection\Dumper\PhpDumper::addMethodMap` is redundant, as the variable is not used after the casting inside nor outside the loop (while still in the loop, it gets overridden upon next iteration).

| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #33206   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | no <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
