### PR TITLE
[Mailer] Don't duplicate addresses in Sendgrid Transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
@@ -67,7 +67,7 @@ class SendgridTransport extends AbstractApiTransport
         }
 
         $personalization = [
-            'to' => array_map($addressStringifier, $this->getRecipients($email, $envelope)),
+            'to' => array_map($addressStringifier, $email->getTo()),
             'subject' => $email->getSubject(),
         ];
         if ($emails = array_map($addressStringifier, $email->getCc())) {

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Http/Api/SendgridTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Http/Api/SendgridTransportTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Http\Api;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\Sendgrid\Http\Api\SendgridTransport;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class SendgridTransportTest extends TestCase
+{
+    public function testSend()
+    {
+        $email = new Email();
+        $email->from('foo@example.com')
+            ->to('bar@example.com')
+            ->bcc('baz@example.com');
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(202);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://api.sendgrid.com/v3/mail/send', [
+                'json' => [
+                    'personalizations' => [
+                        [
+                            'to' => [['email' => 'bar@example.com']],
+                            'subject' => null,
+                            'bcc' => [['email' => 'baz@example.com']],
+                        ],
+                    ],
+                    'from' => ['email' => 'foo@example.com'],
+                    'content' => [],
+                ],
+                'auth_bearer' => 'foo',
+            ])
+            ->willReturn($response);
+
+        $mailer = new SendgridTransport('foo', $httpClient);
+
+        $mailer->send($email);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33135
| License       | MIT
| Doc PR        | N/A

Sendgrid requires the `to`, `cc` and `bcc` fields to be unique