### PR TITLE
[Mime] Trim and remove line breaks from NamedAddress name arg

### DIFF
--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -40,11 +40,11 @@ class Address
             self::$validator = new EmailValidator();
         }
 
-        if (!self::$validator->isValid($address, new RFCValidation())) {
+        $this->address = trim($address);
+
+        if (!self::$validator->isValid($this->address, new RFCValidation())) {
             throw new RfcComplianceException(sprintf('Email "%s" does not comply with addr-spec of RFC 2822.', $address));
         }
-
-        $this->address = $address;
     }
 
     public function getAddress(): string

--- a/src/Symfony/Component/Mime/NamedAddress.php
+++ b/src/Symfony/Component/Mime/NamedAddress.php
@@ -24,7 +24,7 @@ final class NamedAddress extends Address
     {
         parent::__construct($address);
 
-        $this->name = $name;
+        $this->name = trim(str_replace(["\n", "\r"], '', $name));
     }
 
     public function getName(): string

--- a/src/Symfony/Component/Mime/Tests/NamedAddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/NamedAddressTest.php
@@ -24,4 +24,19 @@ class NamedAddressTest extends TestCase
         $this->assertEquals('Fabien <fabien@xn--symfon-nwa.com>', $a->toString());
         $this->assertEquals('fabien@xn--symfon-nwa.com', $a->getEncodedAddress());
     }
+
+    public function nameEmptyDataProvider(): array
+    {
+        return [[''], [' '], [" \r\n "]];
+    }
+
+    /**
+     * @dataProvider nameEmptyDataProvider
+     */
+    public function testNameEmpty(string $name)
+    {
+        $mail = 'mail@example.org';
+
+        $this->assertSame($mail, (new NamedAddress($mail, $name))->getEncodedNamedAddress());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | YES
| New feature?  | NO
| BC breaks?    | NO     <!-- see https://symfony.com/bc -->
| Deprecations? | NO <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | YES    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This patch trims the name argument of named address in order to avoid some cases where the name is a non-empty input consisting of whitespace and line breaks which would lead to forming of addresses such as `" " <mail@example.org>` <sup>1</sup>

---

In a large Symfony codebase that deals with sending large volumes of email we encountered an issue after the Mailer was changed from PHPMailer to the Symfony Mailer component.

The issue: Some emails would not render correctly as either plaintext or html but instead the original email source with headers and quoted-printable content would render in clients such as MS Outlook 2003, later versions of Outlook and other clients do not seem affected.

After some investigation we found that the error came from a line that looked like this: `$message->addTo(new NamedAddress($contact->getEmailCanonical(), $contact->getFullName()))`.

The `getFullName` method simply concated the first/last name with a space in between. For contacts without either, this resulted in representation 1. This causes MS Outlook 2003 (potentially Outlook 2000 as well but this was not tested) to malfunction and completely fail to render the email.

This patch aims to fix the aforementioned issue.