### PR TITLE
[Cache] Fix predis test

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -34,7 +34,7 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
 
         $params = [
             'scheme' => 'tcp',
-            'host' => 'localhost',
+            'host' => $redisHost,
             'port' => 6379,
             'persistent' => 0,
             'timeout' => 3,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

If `REDIS_HOST` is different from "localhost", `PredisAdapterTest` will go wrong.

Try these instructions below:
```bash
export REDIS_HOST=another_than_localhost
./phpunit src/Symfony/Component/Cache/Tests
```

> note: configure redis server with hostname "another_than_localhost"
![Screenshot from 2019-08-18 09-40-57](https://user-images.githubusercontent.com/16967350/63219445-667c6c80-c19c-11e9-9fce-ec42837ddf27.png)
