### PR TITLE
[Validator] Add simple helper ConstraintViolationList::hasViolation

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * removed `ValidatorBuilderInterface`
  * passing a null message when instantiating a `ConstraintViolation` is not allowed
  * changed the default value of `Length::$allowEmptyString` to `false` and made it optional
+ * add the `hasViolation` method to `ConstraintViolationListInterface`
 
 4.4.0
 -----

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -184,6 +184,6 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
      */
     public function hasViolation(): bool
     {
-        return 0 !== count($this->violations);
+        return 0 !== \count($this->violations);
     }
 }

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -178,4 +178,12 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
 
         return new static($violations);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasViolation(): bool
+    {
+        return 0 !== count($this->violations);
+    }
 }

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -63,9 +63,9 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
     public function remove(int $offset);
 
     /**
-     * Return Whether the List contains violation exists
+     * Return Whether the list contains or not violation.
      *
-     * @return bool Whether the List contains violation exists
+     * @return bool Whether the list contains or not violation
      */
     public function hasViolation(): bool;
 }

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -61,4 +61,11 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
      * @param int $offset The offset to remove
      */
     public function remove(int $offset);
+
+    /**
+     * Return Whether the List contains violation exists
+     *
+     * @return bool Whether the List contains violation exists
+     */
+    public function hasViolation(): bool;
 }

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -146,12 +146,30 @@ EOF;
         $this->assertCount($violationsCount, $specificErrors);
     }
 
+    /**
+     * @dataProvider hasViolationProvider
+     */
+    public function testHasViolation(bool $expected, ConstraintViolationList $violationList)
+    {
+        $this->assertEquals($expected, $violationList->hasViolation());
+    }
+
     public function findByCodesProvider()
     {
         return [
             ['code1', 2],
             [['code1', 'code2'], 3],
             ['code3', 0],
+        ];
+    }
+
+    public function hasViolationProvider()
+    {
+        $violation = $this->getViolation('Error', null, null, 'code1');
+
+        return [
+            [true, new ConstraintViolationList([$violation])],
+            [false, new ConstraintViolationList],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | /no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | ?    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #33230   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I know that is not the `PR` of the century but I would like to add an helper to check if a `ConstraintViolationList` contains or not violation.

At the moment we have to do this to check if `ConstraintViolationList` has some errors, 

```php
if (0 !== count($violations)) {
```
This is what is done in [doc](https://symfony.com/doc/current/components/validator.html#usage) and [Api Platform](https://github.com/api-platform/core/blob/master/src/Bridge/Symfony/Validator/Validator.php#L62) and I would like to replace it by 

```php
if($violations->hasViolation())
```

It's better to reading and easier to be implemented with IDE autocompletion (for newcomers) that are not familiar with the `Validator` component.



