### PR TITLE
[Mailer] Simplify the way TLS/SSL/STARTTLS work

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
@@ -44,6 +44,11 @@ class SesTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('smtps', 'ses'),
+            true,
+        ];
+
+        yield [
             new Dsn('smtp', 'example.com'),
             false,
         ];
@@ -84,13 +89,18 @@ class SesTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtp', 'ses', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
             new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger),
         ];
+
+        yield [
+            new Dsn('smtps', 'ses', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
+            new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable
     {
         yield [
             new Dsn('foo', 'ses', self::USER, self::PASSWORD),
-            'The "foo" scheme is not supported for mailer "ses". Supported schemes are: "api", "http", "smtp".',
+            'The "foo" scheme is not supported for mailer "ses". Supported schemes are: "api", "http", "smtp", "smtps".',
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
@@ -25,7 +25,7 @@ class SesSmtpTransport extends EsmtpTransport
      */
     public function __construct(string $username, string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct(sprintf('email-smtp.%s.amazonaws.com', $region ?: 'eu-west-1'), 587, 'tls', null, $dispatcher, $logger);
+        parent::__construct(sprintf('email-smtp.%s.amazonaws.com', $region ?: 'eu-west-1'), 587, true, null, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
@@ -36,11 +36,11 @@ final class SesTransportFactory extends AbstractTransportFactory
             return new SesHttpTransport($user, $password, $region, $this->client, $this->dispatcher, $this->logger);
         }
 
-        if ('smtp' === $scheme) {
+        if ('smtp' === $scheme || 'smtps' === $scheme) {
             return new SesSmtpTransport($user, $password, $region, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp']);
+        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp', 'smtps']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Tests/Transport/GmailTransportFactoryTest.php
@@ -23,6 +23,11 @@ class GmailTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('smtps', 'gmail'),
+            true,
+        ];
+
+        yield [
             new Dsn('smtp', 'example.com'),
             false,
         ];
@@ -34,13 +39,18 @@ class GmailTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtp', 'gmail', self::USER, self::PASSWORD),
             new GmailSmtpTransport(self::USER, self::PASSWORD, $this->getDispatcher(), $this->getLogger()),
         ];
+
+        yield [
+            new Dsn('smtps', 'gmail', self::USER, self::PASSWORD),
+            new GmailSmtpTransport(self::USER, self::PASSWORD, $this->getDispatcher(), $this->getLogger()),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable
     {
         yield [
             new Dsn('foo', 'gmail', self::USER, self::PASSWORD),
-            'The "foo" scheme is not supported for mailer "gmail". Supported schemes are: "smtp".',
+            'The "foo" scheme is not supported for mailer "gmail". Supported schemes are: "smtp", "smtps".',
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
@@ -22,7 +22,7 @@ class GmailSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.gmail.com', 465, 'ssl', null, $dispatcher, $logger);
+        parent::__construct('smtp.gmail.com', 465, true, null, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailTransportFactory.php
@@ -23,11 +23,11 @@ final class GmailTransportFactory extends AbstractTransportFactory
 {
     public function create(Dsn $dsn): TransportInterface
     {
-        if ('smtp' === $dsn->getScheme()) {
+        if ('smtp' === $dsn->getScheme() || 'smtps' === $dsn->getScheme()) {
             return new GmailSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn, ['smtp']);
+        throw new UnsupportedSchemeException($dsn, ['smtp', 'smtps']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillTransportFactoryTest.php
@@ -44,6 +44,11 @@ class MandrillTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('smtps', 'mandrill'),
+            true,
+        ];
+
+        yield [
             new Dsn('smtp', 'example.com'),
             false,
         ];
@@ -69,13 +74,18 @@ class MandrillTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtp', 'mandrill', self::USER, self::PASSWORD),
             new MandrillSmtpTransport(self::USER, self::PASSWORD, $dispatcher, $logger),
         ];
+
+        yield [
+            new Dsn('smtps', 'mandrill', self::USER, self::PASSWORD),
+            new MandrillSmtpTransport(self::USER, self::PASSWORD, $dispatcher, $logger),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable
     {
         yield [
             new Dsn('foo', 'mandrill', self::USER),
-            'The "foo" scheme is not supported for mailer "mandrill". Supported schemes are: "api", "http", "smtp".',
+            'The "foo" scheme is not supported for mailer "mandrill". Supported schemes are: "api", "http", "smtp", "smtps".',
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillSmtpTransport.php
@@ -22,7 +22,7 @@ class MandrillSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.mandrillapp.com', 587, 'tls', null, $dispatcher, $logger);
+        parent::__construct('smtp.mandrillapp.com', 587, true, null, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillTransportFactory.php
@@ -34,13 +34,13 @@ final class MandrillTransportFactory extends AbstractTransportFactory
             return new MandrillHttpTransport($user, $this->client, $this->dispatcher, $this->logger);
         }
 
-        if ('smtp' === $scheme) {
+        if ('smtp' === $scheme || 'smtps' === $scheme) {
             $password = $this->getPassword($dsn);
 
             return new MandrillSmtpTransport($user, $password, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp']);
+        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp', 'smtps']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunTransportFactoryTest.php
@@ -44,6 +44,11 @@ class MailgunTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('smtps', 'mailgun'),
+            true,
+        ];
+
+        yield [
             new Dsn('smtp', 'example.com'),
             false,
         ];
@@ -74,13 +79,18 @@ class MailgunTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtp', 'mailgun', self::USER, self::PASSWORD),
             new MailgunSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger),
         ];
+
+        yield [
+            new Dsn('smtps', 'mailgun', self::USER, self::PASSWORD),
+            new MailgunSmtpTransport(self::USER, self::PASSWORD, null, $dispatcher, $logger),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable
     {
         yield [
             new Dsn('foo', 'mailgun', self::USER, self::PASSWORD),
-            'The "foo" scheme is not supported for mailer "mailgun". Supported schemes are: "api", "http", "smtp".',
+            'The "foo" scheme is not supported for mailer "mailgun". Supported schemes are: "api", "http", "smtp", "smtps".',
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
@@ -22,7 +22,7 @@ class MailgunSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 465, 'ssl', null, $dispatcher, $logger);
+        parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 465, true, null, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunTransportFactory.php
@@ -36,11 +36,11 @@ final class MailgunTransportFactory extends AbstractTransportFactory
             return new MailgunHttpTransport($user, $password, $region, $this->client, $this->dispatcher, $this->logger);
         }
 
-        if ('smtp' === $scheme) {
+        if ('smtp' === $scheme || 'smtps' === $scheme) {
             return new MailgunSmtpTransport($user, $password, $region, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp']);
+        throw new UnsupportedSchemeException($dsn, ['api', 'http', 'smtp', 'smtps']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkTransportFactoryTest.php
@@ -38,6 +38,11 @@ class PostmarkTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('smtps', 'postmark'),
+            true,
+        ];
+
+        yield [
             new Dsn('smtp', 'example.com'),
             false,
         ];
@@ -57,13 +62,18 @@ class PostmarkTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtp', 'postmark', self::USER),
             new PostmarkSmtpTransport(self::USER, $dispatcher, $logger),
         ];
+
+        yield [
+            new Dsn('smtps', 'postmark', self::USER),
+            new PostmarkSmtpTransport(self::USER, $dispatcher, $logger),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable
     {
         yield [
             new Dsn('foo', 'postmark', self::USER),
-            'The "foo" scheme is not supported for mailer "postmark". Supported schemes are: "api", "smtp".',
+            'The "foo" scheme is not supported for mailer "postmark". Supported schemes are: "api", "smtp", "smtps".',
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
@@ -22,7 +22,7 @@ class PostmarkSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $id, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.postmarkapp.com', 587, 'tls', null, $dispatcher, $logger);
+        parent::__construct('smtp.postmarkapp.com', 587, true, null, $dispatcher, $logger);
 
         $this->setUsername($id);
         $this->setPassword($id);

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkTransportFactory.php
@@ -30,11 +30,11 @@ final class PostmarkTransportFactory extends AbstractTransportFactory
             return new PostmarkApiTransport($user, $this->client, $this->dispatcher, $this->logger);
         }
 
-        if ('smtp' === $scheme) {
+        if ('smtp' === $scheme || 'smtps' === $scheme) {
             return new PostmarkSmtpTransport($user, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn, ['api', 'smtp']);
+        throw new UnsupportedSchemeException($dsn, ['api', 'smtp', 'smtps']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
@@ -38,6 +38,11 @@ class SendgridTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('smtps', 'sendgrid'),
+            true,
+        ];
+
+        yield [
             new Dsn('smtp', 'example.com'),
             false,
         ];
@@ -57,13 +62,18 @@ class SendgridTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtp', 'sendgrid', self::USER),
             new SendgridSmtpTransport(self::USER, $dispatcher, $logger),
         ];
+
+        yield [
+            new Dsn('smtps', 'sendgrid', self::USER),
+            new SendgridSmtpTransport(self::USER, $dispatcher, $logger),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable
     {
         yield [
             new Dsn('foo', 'sendgrid', self::USER),
-            'The "foo" scheme is not supported for mailer "sendgrid". Supported schemes are: "api", "smtp".',
+            'The "foo" scheme is not supported for mailer "sendgrid". Supported schemes are: "api", "smtp", "smtps".',
         ];
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -22,7 +22,7 @@ class SendgridSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $key, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.sendgrid.net', 465, 'ssl', null, $dispatcher, $logger);
+        parent::__construct('smtp.sendgrid.net', 465, true, null, $dispatcher, $logger);
 
         $this->setUsername('apikey');
         $this->setPassword($key);

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridTransportFactory.php
@@ -29,11 +29,11 @@ final class SendgridTransportFactory extends AbstractTransportFactory
             return new SendgridApiTransport($key, $this->client, $this->dispatcher, $this->logger);
         }
 
-        if ('smtp' === $dsn->getScheme()) {
+        if ('smtp' === $dsn->getScheme() || 'smtps' === $dsn->getScheme()) {
             return new SendgridSmtpTransport($key, $this->dispatcher, $this->logger);
         }
 
-        throw new UnsupportedSchemeException($dsn, ['api', 'smtp']);
+        throw new UnsupportedSchemeException($dsn, ['api', 'smtp', 'smtps']);
     }
 
     public function supports(Dsn $dsn): bool

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 4.4.0
 -----
 
+ * STARTTLS cannot be enabled anymore (it is used automatically if TLS is disabled and the server supports STARTTLS)
+ * [BC BREAK] Removed the `encryption` DSN option (use `smtps` instead)
+ * Added support for the `smtps` protocol (does the same as using `smtp` and port `465`)
  * Added PHPUnit constraints
  * Added `MessageDataCollector`
  * Added `MessageEvents` and `MessageLoggerListener` to allow collecting sent emails

--- a/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
@@ -69,7 +69,7 @@ abstract class TransportFactoryTestCase extends TestCase
         $factory = $this->getFactory();
 
         $this->assertEquals($transport, $factory->create($dsn));
-        if ('smtp' !== $dsn->getScheme()) {
+        if ('smtp' !== $dsn->getScheme() && 'smtps' !== $dsn->getScheme()) {
             $this->assertStringMatchesFormat($dsn->getScheme().'://%S'.$dsn->getHost().'%S', $transport->getName());
         }
     }

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -23,6 +23,11 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('smtps', 'example.com'),
+            true,
+        ];
+
+        yield [
             new Dsn('api', 'example.com'),
             false,
         ];
@@ -33,19 +38,33 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
         $eventDispatcher = $this->getDispatcher();
         $logger = $this->getLogger();
 
-        $transport = new EsmtpTransport('example.com', 25, null, null, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('localhost', 25, false, null, $eventDispatcher, $logger);
 
         yield [
-            new Dsn('smtp', 'example.com'),
+            new Dsn('smtp', 'localhost'),
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 99, 'ssl', 'login', $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 99, true, 'login', $eventDispatcher, $logger);
         $transport->setUsername(self::USER);
         $transport->setPassword(self::PASSWORD);
 
         yield [
-            new Dsn('smtp', 'example.com', self::USER, self::PASSWORD, 99, ['encryption' => 'ssl', 'auth_mode' => 'login']),
+            new Dsn('smtps', 'example.com', self::USER, self::PASSWORD, 99, ['auth_mode' => 'login']),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, null, $eventDispatcher, $logger);
+
+        yield [
+            new Dsn('smtps', 'example.com'),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, null, $eventDispatcher, $logger);
+
+        yield [
+            new Dsn('smtp', 'example.com', '', '', 465),
             $transport,
         ];
     }

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Transport\Smtp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+
+class EsmtpTransportTest extends TestCase
+{
+    public function testName()
+    {
+        $t = new EsmtpTransport();
+        $this->assertEquals('smtp://localhost', $t->getName());
+
+        $t = new EsmtpTransport('example.com');
+        if (\defined('OPENSSL_VERSION_NUMBER')) {
+            $this->assertEquals('smtps://example.com', $t->getName());
+        } else {
+            $this->assertEquals('smtp://example.com', $t->getName());
+        }
+
+        $t = new EsmtpTransport('example.com', 2525);
+        $this->assertEquals('smtp://example.com:2525', $t->getName());
+
+        $t = new EsmtpTransport('example.com', 0, true);
+        $this->assertEquals('smtps://example.com', $t->getName());
+
+        $t = new EsmtpTransport('example.com', 0, false);
+        $this->assertEquals('smtp://example.com', $t->getName());
+
+        $t = new EsmtpTransport('example.com', 466, true);
+        $this->assertEquals('smtps://example.com:466', $t->getName());
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -20,9 +20,9 @@ class SmtpTransportTest extends TestCase
     public function testName()
     {
         $t = new SmtpTransport();
-        $this->assertEquals('smtp://localhost:25', $t->getName());
+        $this->assertEquals('smtps://localhost', $t->getName());
 
-        $t = new SmtpTransport((new SocketStream())->setHost('127.0.0.1')->setPort(2525));
+        $t = new SmtpTransport((new SocketStream())->setHost('127.0.0.1')->setPort(2525)->disableTls());
         $this->assertEquals('smtp://127.0.0.1:2525', $t->getName());
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream/SocketStreamTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream/SocketStreamTest.php
@@ -37,7 +37,6 @@ class SocketStreamTest extends TestCase
                 'cafile' => __FILE__,
             ],
         ]);
-        $s->setEncryption('ssl');
         $s->setHost('smtp.gmail.com');
         $s->setPort(465);
         $s->initialize();

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -22,12 +22,12 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
 {
     public function create(Dsn $dsn): TransportInterface
     {
-        $encryption = $dsn->getOption('encryption');
+        $tls = 'smtps' === $dsn->getScheme() ? true : null;
         $authMode = $dsn->getOption('auth_mode');
-        $port = $dsn->getPort(25);
+        $port = $dsn->getPort(0);
         $host = $dsn->getHost();
 
-        $transport = new EsmtpTransport($host, $port, $encryption, $authMode, $this->dispatcher, $this->logger);
+        $transport = new EsmtpTransport($host, $port, $tls, $authMode, $this->dispatcher, $this->logger);
 
         if ($user = $dsn->getUser()) {
             $transport->setUsername($user);
@@ -42,6 +42,6 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
 
     public function supports(Dsn $dsn): bool
     {
-        return 'smtp' === $dsn->getScheme();
+        return 'smtp' === $dsn->getScheme() || 'smtps' === $dsn->getScheme();
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -129,7 +129,13 @@ class SmtpTransport extends AbstractTransport
     public function getName(): string
     {
         if ($this->stream instanceof SocketStream) {
-            return sprintf('smtp://%s:%d', $this->stream->getHost(), $this->stream->getPort());
+            $name = sprintf('smtp%s://%s', ($tls = $this->stream->isTLS()) ? 's' : '', $this->stream->getHost());
+            $port = $this->stream->getPort();
+            if (!(25 === $port || ($tls && 465 === $port))) {
+                $name .= ':'.$port;
+            }
+
+            return $name;
         }
 
         return sprintf('smtp://sendmail');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | -

The way TLS/SSL/STARTTLS is handled is not easy to understand. It's inherited from Swiftmailer and today, I've spent some time to see if we could improve it.

First, the current way: `setEncryption()` takes a string, either `ssl` or `tls`:

 * `ssl`: to enable TLS support on the connection
 * `tls`: to enable `STARTTLS` (upgrade the connection)

There is also a `isTLS()` method which is really confusing due to the fact that both configuration are about TLS anyway.

So, this PR changes things radically:

 * The `setEncryption` method and the `encryption` option on the DSN are gone.

 * TLS is used by default and you can disable it via `disableTls()`. Being secure by default is probably a good idea anyway (like using HTTPS by default instead of HTTP).

 * A new "protocol" SMTPS is supported now and is a way to say that you want TLS; so use `smtps://localhost` to set TLS instead of `smtp://localhost?encryption=ssl`. Note that using `smtp://localhost:465` does the same. All third-party providers now supports both `smtp` and `smtps` protocol even if that does the exact same thing for them (TLS is always enabled).

 * The port is automatically determined based on the TLS setting (if not set explicitly). So 465 for TLS and falls back to 25.

 * There is no more way to enable `STARTTLS`. If you don't configure TLS on the connection and if the server supports `STARTTLS`, then we will enable it automatically.

Great document about all of this: https://www.fastmail.com/help/technical/ssltlsstarttls.html

