### PR TITLE
[Mailer] Remove the auth mode DSN option and support in the eSMTP transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
@@ -25,7 +25,7 @@ class SesSmtpTransport extends EsmtpTransport
      */
     public function __construct(string $username, string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct(sprintf('email-smtp.%s.amazonaws.com', $region ?: 'eu-west-1'), 587, true, null, $dispatcher, $logger);
+        parent::__construct(sprintf('email-smtp.%s.amazonaws.com', $region ?: 'eu-west-1'), 587, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Transport/GmailSmtpTransport.php
@@ -22,7 +22,7 @@ class GmailSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.gmail.com', 465, true, null, $dispatcher, $logger);
+        parent::__construct('smtp.gmail.com', 465, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillSmtpTransport.php
@@ -22,7 +22,7 @@ class MandrillSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.mandrillapp.com', 587, true, null, $dispatcher, $logger);
+        parent::__construct('smtp.mandrillapp.com', 587, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
@@ -22,7 +22,7 @@ class MailgunSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 465, true, null, $dispatcher, $logger);
+        parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 465, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
@@ -22,7 +22,7 @@ class PostmarkSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $id, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.postmarkapp.com', 587, true, null, $dispatcher, $logger);
+        parent::__construct('smtp.postmarkapp.com', 587, true, $dispatcher, $logger);
 
         $this->setUsername($id);
         $this->setPassword($id);

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -22,7 +22,7 @@ class SendgridSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $key, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.sendgrid.net', 465, true, null, $dispatcher, $logger);
+        parent::__construct('smtp.sendgrid.net', 465, true, $dispatcher, $logger);
 
         $this->setUsername('apikey');
         $this->setPassword($key);

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * [BC BREAK] removed the `auth_mode` DSN option (it is now always determined automatically)
  * STARTTLS cannot be enabled anymore (it is used automatically if TLS is disabled and the server supports STARTTLS)
  * [BC BREAK] Removed the `encryption` DSN option (use `smtps` instead)
  * Added support for the `smtps` protocol (does the same as using `smtp` and port `465`)

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -38,30 +38,30 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
         $eventDispatcher = $this->getDispatcher();
         $logger = $this->getLogger();
 
-        $transport = new EsmtpTransport('localhost', 25, false, null, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('localhost', 25, false, $eventDispatcher, $logger);
 
         yield [
             new Dsn('smtp', 'localhost'),
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 99, true, 'login', $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 99, true, $eventDispatcher, $logger);
         $transport->setUsername(self::USER);
         $transport->setPassword(self::PASSWORD);
 
         yield [
-            new Dsn('smtps', 'example.com', self::USER, self::PASSWORD, 99, ['auth_mode' => 'login']),
+            new Dsn('smtps', 'example.com', self::USER, self::PASSWORD, 99),
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, null, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
 
         yield [
             new Dsn('smtps', 'example.com'),
             $transport,
         ];
 
-        $transport = new EsmtpTransport('example.com', 465, true, null, $eventDispatcher, $logger);
+        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
 
         yield [
             new Dsn('smtp', 'example.com', '', '', 465),

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -23,11 +23,10 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $tls = 'smtps' === $dsn->getScheme() ? true : null;
-        $authMode = $dsn->getOption('auth_mode');
         $port = $dsn->getPort(0);
         $host = $dsn->getHost();
 
-        $transport = new EsmtpTransport($host, $port, $tls, $authMode, $this->dispatcher, $this->logger);
+        $transport = new EsmtpTransport($host, $port, $tls, $this->dispatcher, $this->logger);
 
         if ($user = $dsn->getUser()) {
             $transport->setUsername($user);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | -

The authentication mode can be automatically negotiated between the Mailer and the SMTP server. There is an option to force it to a given auth mode, but I don't see any valid use case. So, let's remove that feature.
