### PR TITLE
Typo - Fix bad classnames in Exceptions docblocks

### DIFF
--- a/src/Symfony/Component/Ldap/Exception/AlreadyExistsException.php
+++ b/src/Symfony/Component/Ldap/Exception/AlreadyExistsException.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Ldap\Exception;
  *
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
  */
-class AlreadyExistsException extends ConnectionException implements ExceptionInterface
+class AlreadyExistsException extends ConnectionException
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/ConnectionTimeoutException.php
+++ b/src/Symfony/Component/Ldap/Exception/ConnectionTimeoutException.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Ldap\Exception;
 
 /**
- * ConnectionException is thrown if binding to ldap time out.
+ * ConnectionTimeoutException is thrown if binding to ldap time out.
  *
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
  */
-class ConnectionTimeoutException extends ConnectionException implements ExceptionInterface
+class ConnectionTimeoutException extends ConnectionException
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/InvalidCredentialsException.php
+++ b/src/Symfony/Component/Ldap/Exception/InvalidCredentialsException.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Ldap\Exception;
 
 /**
- * ConnectionException is thrown if binding to ldap has been done with invalid credentials .
+ * InvalidCredentialsException is thrown if binding to ldap has been done with invalid credentials.
  *
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
  */
-class InvalidCredentialsException extends ConnectionException implements ExceptionInterface
+class InvalidCredentialsException extends ConnectionException
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Set right classname in some Exceptions docblocks.
