### PR TITLE
[Router] Fix TraceableUrlMatcher behaviour with trailing slash

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
@@ -11,14 +11,13 @@
 
 namespace Symfony\Component\Routing\Tests\Matcher;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
-class TraceableUrlMatcherTest extends TestCase
+class TraceableUrlMatcherTest extends UrlMatcherTest
 {
     public function test()
     {
@@ -118,5 +117,10 @@ class TraceableUrlMatcherTest extends TestCase
         $matchingRequest = Request::create('/foo', 'GET', [], [], [], ['HTTP_USER_AGENT' => 'Firefox']);
         $traces = $matcher->getTracesForRequest($matchingRequest);
         $this->assertEquals('Route matches!', $traces[0]['log']);
+    }
+
+    protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
+    {
+        return new TraceableUrlMatcher($routes, $context ?: new RequestContext());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32149 
| License       | MIT
| Doc PR        | ¤
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
This pull requests fixes the bug #32149. This issue was about TraceableUrlMatcher having a wrong behaviour regarding trailing slashes (according to UrlMatcher and documentation).

With this pull requests, the test class TraceableUrlMatcherTest now extends UrlMatcherTest, to prevent such behaviour digression.

Thanks @nicolas-grekas for his feedback on the issue #32149 