### PR TITLE
[Ldap] Make LdapUserProvider::refreshUser() actually reload the user entry

### DIFF
--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added the "extra_fields" option, an array of custom fields to pull from the LDAP server
+ * Fix the refresh method of the Ldap user provider according to symfony preconization.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -108,7 +108,7 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
         }
 
-        return new LdapUser($user->getEntry(), $user->getUsername(), $user->getPassword(), $user->getRoles());
+        return $this->loadUserByUsername($user->getUsername());
     }
 
     /**

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -330,4 +330,16 @@ class LdapUserProviderTest extends TestCase
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword', ['email']);
         $this->assertInstanceOf(LdapUser::class, $provider->loadUserByUsername('foo'));
     }
+
+    public function testRefreshSendUnsupportedUserExceptionWhenProvidedUserIsNotLdapUserOne() {
+        // Todo
+    }
+
+    public function testRefreshIsSuccessFullWhenLdapUserIsTheSameAsSessionOne() {
+        // Todo
+    }
+
+    public function testRefreshFailsWhenLdapUserIsNotTheSameAsSessionOne() {
+        // Todo
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
