### PR TITLE
Fix inconsistent return points

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ExpressionLanguage/DoctrineParserCache.php
+++ b/src/Symfony/Bridge/Doctrine/ExpressionLanguage/DoctrineParserCache.php
@@ -37,7 +37,7 @@ class DoctrineParserCache implements ParserCacheInterface
     public function fetch($key)
     {
         if (false === $value = $this->cache->fetch($key)) {
-            return;
+            return null;
         }
 
         return $value;

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -118,6 +118,8 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
 
             return new ValueGuess(!$mapping['joinColumns'][0]['nullable'], Guess::HIGH_CONFIDENCE);
         }
+
+        return null;
     }
 
     /**
@@ -137,6 +139,8 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
                 return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
             }
         }
+
+        return null;
     }
 
     /**
@@ -150,6 +154,8 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
                 return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
             }
         }
+
+        return null;
     }
 
     protected function getMetadata($class)
@@ -171,5 +177,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
                 // not an entity or mapped super class, using Doctrine ORM 2.2
             }
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -157,6 +157,8 @@ abstract class DoctrineType extends AbstractType
 
                 return $doctrineChoiceLoader;
             }
+
+            return null;
         };
 
         $choiceName = function (Options $options) {
@@ -171,6 +173,7 @@ abstract class DoctrineType extends AbstractType
             }
 
             // Otherwise, an incrementing integer is used as name automatically
+            return null;
         };
 
         // The choices are always indexed by ID (see "choices" normalizer
@@ -187,6 +190,7 @@ abstract class DoctrineType extends AbstractType
             }
 
             // Otherwise, an incrementing integer is used as value automatically
+            return null;
         };
 
         $emNormalizer = function (Options $options, $em) {

--- a/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandler.php
+++ b/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandler.php
@@ -248,6 +248,8 @@ class DbalSessionHandler implements \SessionHandlerInterface
                 return "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) ".
                     "ON CONFLICT ($this->idCol) DO UPDATE SET ($this->dataCol, $this->timeCol) = (EXCLUDED.$this->dataCol, EXCLUDED.$this->timeCol)";
         }
+
+        return null;
     }
 
     private function getServerVersion()

--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -42,9 +42,9 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         try {
             $metadata = $this->classMetadataFactory->getMetadataFor($class);
         } catch (MappingException $exception) {
-            return;
+            return null;
         } catch (OrmMappingException $exception) {
-            return;
+            return null;
         }
 
         $properties = array_merge($metadata->getFieldNames(), $metadata->getAssociationNames());
@@ -68,9 +68,9 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         try {
             $metadata = $this->classMetadataFactory->getMetadataFor($class);
         } catch (MappingException $exception) {
-            return;
+            return null;
         } catch (OrmMappingException $exception) {
-            return;
+            return null;
         }
 
         if ($metadata->hasAssociation($property)) {
@@ -162,6 +162,8 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                     return $builtinType ? [new Type($builtinType, $nullable)] : null;
             }
         }
+
+        return null;
     }
 
     /**
@@ -225,5 +227,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             case DBALType::OBJECT:
                 return Type::BUILTIN_TYPE_OBJECT;
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineFooType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineFooType.php
@@ -47,7 +47,7 @@ class DoctrineFooType extends Type
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
         if (null === $value) {
-            return;
+            return null;
         }
         if (!$value instanceof Foo) {
             throw new ConversionException(sprintf('Expected %s, got %s', 'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\Foo', \gettype($value)));
@@ -62,7 +62,7 @@ class DoctrineFooType extends Type
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if (null === $value) {
-            return;
+            return null;
         }
         if (!\is_string($value)) {
             throw ConversionException::conversionFailed($value, self::NAME);

--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -25,6 +25,8 @@ class ClockMock
         }
 
         self::$now = is_numeric($enable) ? (float) $enable : ($enable ? microtime(true) : null);
+
+        return null;
     }
 
     public static function time()
@@ -54,6 +56,8 @@ class ClockMock
         }
 
         self::$now += $us / 1000000;
+
+        return null;
     }
 
     public static function microtime($asFloat = false)

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -180,6 +180,8 @@ class DeprecationErrorHandler
                 ++$ref;
             }
             ++$deprecations[$group.'Count'];
+
+            return null;
         };
         $oldErrorHandler = set_error_handler($deprecationHandler);
 
@@ -291,6 +293,8 @@ class DeprecationErrorHandler
                 return \call_user_func(DeprecationErrorHandler::getPhpUnitErrorHandler(), $type, $msg, $file, $line, $context);
             }
             $deprecations[] = array(error_reporting(), $msg, $file);
+
+            return null;
         });
 
         register_shutdown_function(function () use ($outputFile, &$deprecations) {

--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
@@ -95,11 +95,7 @@ class CoverageListenerTrait
         $sutFqcn = str_replace('\\Tests\\', '\\', $class);
         $sutFqcn = preg_replace('{Test$}', '', $sutFqcn);
 
-        if (!class_exists($sutFqcn)) {
-            return;
-        }
-
-        return $sutFqcn;
+        return class_exists($sutFqcn) ? $sutFqcn : null;
     }
 
     public function __destruct()

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -357,6 +357,8 @@ class SymfonyTestsListenerTrait
             $msg = 'Unsilenced deprecation: '.$msg;
         }
         $this->gatheredDeprecations[] = $msg;
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -135,7 +135,7 @@ $argv = isset($_SERVER['argv']) ? $_SERVER['argv'] : array();
 $argc = isset($_SERVER['argc']) ? $_SERVER['argc'] : 0;
 
 if ($PHPUNIT_VERSION < 8.0) {
-    $argv = array_filter($argv, function ($v) use (&$argc) { if ('--do-not-cache-result' !== $v) return true; --$argc; });
+    $argv = array_filter($argv, function ($v) use (&$argc) { if ('--do-not-cache-result' !== $v) return true; --$argc; return false; });
 } elseif (filter_var(getenv('SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE'), FILTER_VALIDATE_BOOLEAN)) {
     $argv[] = '--do-not-cache-result';
     ++$argc;

--- a/src/Symfony/Bridge/ProxyManager/Legacy/ProxiedMethodReturnExpression.php
+++ b/src/Symfony/Bridge/ProxyManager/Legacy/ProxiedMethodReturnExpression.php
@@ -46,7 +46,7 @@ if (class_exists(Version::class) && version_compare(\defined(Version::class.'::V
             $functionLoader = $functionLoader[0];
         }
         if (!\is_object($functionLoader)) {
-            return;
+            return null;
         }
         if ($functionLoader instanceof ClassLoader) {
             return $functionLoader;
@@ -57,6 +57,8 @@ if (class_exists(Version::class) && version_compare(\defined(Version::class.'::V
         if ($functionLoader instanceof \Symfony\Component\ErrorHandler\DebugClassLoader) {
             return $getComposerClassLoader($functionLoader->getClassLoader());
         }
+
+        return null;
     };
 
     $classLoader = null;

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -83,9 +83,8 @@ class AppVariable
         }
 
         $user = $token->getUser();
-        if (\is_object($user)) {
-            return $user;
-        }
+
+        return \is_object($user) ? $user : null;
     }
 
     /**
@@ -113,9 +112,7 @@ class AppVariable
             throw new \RuntimeException('The "app.session" variable is not available.');
         }
 
-        if ($request = $this->getRequest()) {
-            return $request->getSession();
-        }
+        return ($request = $this->getRequest()) ? $request->getSession() : null;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -220,16 +220,16 @@ EOF
             return $entity;
         }
         if ('tests' === $type) {
-            return;
+            return null;
         }
         if ('functions' === $type || 'filters' === $type) {
             $cb = $entity->getCallable();
             if (null === $cb) {
-                return;
+                return null;
             }
             if (\is_array($cb)) {
                 if (!method_exists($cb[0], $cb[1])) {
-                    return;
+                    return null;
                 }
                 $refl = new \ReflectionMethod($cb[0], $cb[1]);
             } elseif (\is_object($cb) && method_exists($cb, '__invoke')) {
@@ -268,6 +268,8 @@ EOF
 
             return $args;
         }
+
+        return null;
     }
 
     private function getPrettyMetadata($type, $entity, $decorated)
@@ -302,5 +304,7 @@ EOF
         if ('filters' === $type) {
             return $meta ? '('.implode(', ', $meta).')' : '';
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
@@ -55,7 +55,7 @@ class DumpExtension extends AbstractExtension
     public function dump(Environment $env, $context)
     {
         if (!$env->isDebug()) {
-            return;
+            return null;
         }
 
         if (2 === \func_num_args()) {

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
@@ -115,7 +115,7 @@ class TranslationNodeVisitor extends AbstractNodeVisitor
         } elseif ($arguments->hasNode($index)) {
             $argument = $arguments->getNode($index);
         } else {
-            return;
+            return null;
         }
 
         return $this->getReadDomainFromNode($argument);

--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -71,6 +71,8 @@ class UndefinedCallableHandler
         }
 
         self::onUndefined($name, 'filter', self::$filterComponents[$name]);
+
+        return true;
     }
 
     public static function onUndefinedFunction($name)
@@ -80,6 +82,8 @@ class UndefinedCallableHandler
         }
 
         self::onUndefined($name, 'function', self::$functionComponents[$name]);
+
+        return true;
     }
 
     private static function onUndefined($name, $type, $component)

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -86,7 +86,7 @@ EOF
                 'For dumping a specific option, add its path as the second argument of this command. (e.g. <comment>config:dump-reference FrameworkBundle profiler.matcher</comment> to dump the <comment>framework.profiler.matcher</comment> configuration)',
             ]);
 
-            return;
+            return null;
         }
 
         $extension = $this->findExtension($name);
@@ -129,5 +129,7 @@ EOF
         }
 
         $io->writeln(null === $path ? $dumper->dump($configuration, $extension->getNamespace()) : $dumper->dumpAtPath($configuration, $path));
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -93,5 +93,7 @@ EOF
         }
 
         $io->table([], $tableRows);
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -154,10 +154,13 @@ EOF
         }
     }
 
+    /**
+     * @return callable|null
+     */
     private function extractCallable(Route $route)
     {
         if (!$route->hasDefault('_controller')) {
-            return;
+            return null;
         }
 
         $controller = $route->getDefault('_controller');
@@ -178,5 +181,7 @@ EOF
             return $controller;
         } catch (\InvalidArgumentException $e) {
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -149,5 +149,7 @@ EOF
 
             return 1;
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -242,7 +242,7 @@ EOF
         if (!\count($operation->getDomains())) {
             $errorIo->warning('No translation messages were found.');
 
-            return;
+            return null;
         }
 
         $resultMessage = 'Translation files were successfully updated';
@@ -307,6 +307,8 @@ EOF
         }
 
         $errorIo->success($resultMessage.'.');
+
+        return null;
     }
 
     private function filterCatalogue(MessageCatalogue $catalogue, $domain)

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -142,7 +142,9 @@ class JsonDescriptor extends Descriptor
     protected function describeContainerAlias(Alias $alias, array $options = [], ContainerBuilder $builder = null)
     {
         if (!$builder) {
-            return $this->writeData($this->getContainerAliasData($alias), $options);
+            $this->writeData($this->getContainerAliasData($alias), $options);
+
+            return;
         }
 
         $this->writeData(

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -249,7 +249,9 @@ class MarkdownDescriptor extends Descriptor
             ."\n".'- Public: '.($alias->isPublic() && !$alias->isPrivate() ? 'yes' : 'no');
 
         if (!isset($options['id'])) {
-            return $this->write($output);
+            $this->write($output);
+
+            return;
         }
 
         $this->write(sprintf("### %s\n\n%s\n", $options['id'], $output));

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -369,7 +369,7 @@ class TextDescriptor extends Descriptor
             return;
         }
 
-        return $this->describeContainerDefinition($builder->getDefinition((string) $alias), array_merge($options, ['id' => (string) $alias]));
+        $this->describeContainerDefinition($builder->getDefinition((string) $alias), array_merge($options, ['id' => (string) $alias]));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -98,7 +98,9 @@ class XmlDescriptor extends Descriptor
         $dom->appendChild($dom->importNode($this->getContainerAliasDocument($alias, isset($options['id']) ? $options['id'] : null)->childNodes->item(0), true));
 
         if (!$builder) {
-            return $this->writeDocument($dom);
+            $this->writeDocument($dom);
+
+            return;
         }
 
         $dom->appendChild($dom->importNode($this->getContainerDefinitionDocument($builder->getDefinition((string) $alias), (string) $alias)->childNodes->item(0), true));

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php
@@ -34,10 +34,6 @@ class SessionListener extends AbstractSessionListener
 
     protected function getSession()
     {
-        if (!$this->container->has('session')) {
-            return;
-        }
-
-        return $this->container->get('session');
+        return $this->container->get('session', ContainerInterface::NULL_ON_INVALID_REFERENCE);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
@@ -34,10 +34,6 @@ class TestSessionListener extends AbstractTestSessionListener
 
     protected function getSession()
     {
-        if (!$this->container->has('session')) {
-            return;
-        }
-
-        return $this->container->get('session');
+        return $this->container->get('session', ContainerInterface::NULL_ON_INVALID_REFERENCE);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -45,15 +45,12 @@ class GlobalVariables
     public function getUser()
     {
         if (!$token = $this->getToken()) {
-            return;
+            return null;
         }
 
         $user = $token->getUser();
-        if (!\is_object($user)) {
-            return;
-        }
 
-        return $user;
+        return \is_object($user) ? $user : null;
     }
 
     /**
@@ -61,9 +58,7 @@ class GlobalVariables
      */
     public function getRequest()
     {
-        if ($this->container->has('request_stack')) {
-            return $this->container->get('request_stack')->getCurrentRequest();
-        }
+        return $this->container->has('request_stack') ? $this->container->get('request_stack')->getCurrentRequest() : null;
     }
 
     /**
@@ -71,9 +66,7 @@ class GlobalVariables
      */
     public function getSession()
     {
-        if ($request = $this->getRequest()) {
-            return $request->getSession();
-        }
+        return ($request = $this->getRequest()) ? $request->getSession() : null;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -110,7 +110,7 @@ class CodeHelper extends Helper
      * @param string $file A file path
      * @param int    $line The selected line number
      *
-     * @return string An HTML string
+     * @return string|null An HTML string
      */
     public function fileExcerpt($file, $line)
     {
@@ -138,6 +138,8 @@ class CodeHelper extends Helper
 
             return '<ol start="'.max($line - 3, 1).'">'.implode("\n", $lines).'</ol>';
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/StopwatchHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/StopwatchHelper.php
@@ -35,12 +35,14 @@ class StopwatchHelper extends Helper
 
     public function __call($method, $arguments = [])
     {
-        if (null !== $this->stopwatch) {
-            if (method_exists($this->stopwatch, $method)) {
-                return \call_user_func_array([$this->stopwatch, $method], $arguments);
-            }
-
-            throw new \BadMethodCallException(sprintf('Method "%s" of Stopwatch does not exist', $method));
+        if (null === $this->stopwatch) {
+            return null;
         }
+
+        if (method_exists($this->stopwatch, $method)) {
+            return \call_user_func_array([$this->stopwatch, $method], $arguments);
+        }
+
+        throw new \BadMethodCallException(sprintf('Method "%s" of Stopwatch does not exist', $method));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -85,7 +85,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('property_accessor');
 
         if (!method_exists(PropertyAccessor::class, 'createCache')) {
-            return $this->assertFalse($container->hasDefinition('cache.property_access'));
+            $this->assertFalse($container->hasDefinition('cache.property_access'));
+
+            return;
         }
 
         $cache = $container->getDefinition('cache.property_access');
@@ -98,7 +100,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('property_accessor', ['kernel.debug' => true]);
 
         if (!method_exists(PropertyAccessor::class, 'createCache')) {
-            return $this->assertFalse($container->hasDefinition('cache.property_access'));
+            $this->assertFalse($container->hasDefinition('cache.property_access'));
+
+            return;
         }
 
         $cache = $container->getDefinition('cache.property_access');

--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -109,5 +109,7 @@ EOF
         }
 
         $output->writeln('ACL tables have been initialized successfully.');
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -168,6 +168,8 @@ EOF
         }
 
         $errorIo->success('Password encoding succeeded');
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/ContainerAwareRuntimeLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/ContainerAwareRuntimeLoader.php
@@ -49,5 +49,7 @@ class ContainerAwareRuntimeLoader implements RuntimeLoaderInterface
         if (null !== $this->logger) {
             $this->logger->warning(sprintf('Class "%s" is not configured as a Twig runtime. Add the "twig.runtime" tag to the related service in the container.', $class));
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -98,9 +98,7 @@ class ProfilerControllerTest extends TestCase
             ->expects($this->exactly(2))
             ->method('loadProfile')
             ->willReturnCallback(function ($token) {
-                if ('found' == $token) {
-                    return new Profile($token);
-                }
+                return 'found' == $token ? new Profile($token) : null;
             })
         ;
 

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -155,5 +155,7 @@ EOF
 
             return 1;
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStatusCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStatusCommand.php
@@ -88,5 +88,7 @@ EOF
                 return 1;
             }
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStopCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStopCommand.php
@@ -62,5 +62,7 @@ EOF
 
             return 1;
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -101,6 +101,12 @@ class WebServerConfig
         return $this->hostname.':'.$this->port;
     }
 
+    /**
+     * @param string $documentRoot
+     * @param string $env
+     *
+     * @return string|null
+     */
     private function findFrontController($documentRoot, $env)
     {
         $fileNames = $this->getFrontControllerFileNames($env);
@@ -110,13 +116,23 @@ class WebServerConfig
                 return $fileName;
             }
         }
+
+        return null;
     }
 
+    /**
+     * @param string $env
+     *
+     * @return array
+     */
     private function getFrontControllerFileNames($env)
     {
         return ['app_'.$env.'.php', 'app.php', 'index_'.$env.'.php', 'index.php'];
     }
 
+    /**
+     * @return int
+     */
     private function findBestPort()
     {
         $port = 8000;

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -60,6 +60,8 @@ class CookieJar
                 }
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -177,6 +177,8 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
         foreach ($this->getItems([$key]) as $item) {
             return $item;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -113,6 +113,8 @@ class ApcClassLoader
 
             return true;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -161,6 +161,8 @@ class ClassLoader
 
             return true;
         }
+
+        return null;
     }
 
     /**
@@ -203,5 +205,7 @@ class ClassLoader
         if ($this->useIncludePath && $file = stream_resolve_include_path($classPath)) {
             return $file;
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/ClassLoader/MapClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/MapClassLoader.php
@@ -63,8 +63,6 @@ class MapClassLoader
      */
     public function findFile($class)
     {
-        if (isset($this->map[$class])) {
-            return $this->map[$class];
-        }
+        return isset($this->map[$class]) ? $this->map[$class] : null;
     }
 }

--- a/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/Psr4ClassLoader.php
@@ -55,6 +55,8 @@ class Psr4ClassLoader
                 }
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
@@ -112,6 +112,8 @@ class WinCacheClassLoader
 
             return true;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
@@ -106,6 +106,8 @@ class XcacheClassLoader
 
             return true;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -306,5 +306,7 @@ class XmlReferenceDumper
         if (\is_array($value)) {
             return implode(',', $value);
         }
+
+        return '';
     }
 }

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -168,5 +168,7 @@ abstract class FileLoader extends Loader
                 throw new FileLoaderLoadException($resource, $sourceResource, null, $e, $type);
             }
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/Console/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/Console/EventListener/ErrorListener.php
@@ -40,7 +40,9 @@ class ErrorListener implements EventSubscriberInterface
         $error = $event->getError();
 
         if (!$inputString = $this->getInputString($event)) {
-            return $this->logger->error('An error occurred while using the console. Message: "{message}"', ['exception' => $error, 'message' => $error->getMessage()]);
+            $this->logger->error('An error occurred while using the console. Message: "{message}"', ['exception' => $error, 'message' => $error->getMessage()]);
+
+            return;
         }
 
         $this->logger->error('Error thrown while running command "{command}". Message: "{message}"', ['exception' => $error, 'command' => $inputString, 'message' => $error->getMessage()]);
@@ -59,7 +61,9 @@ class ErrorListener implements EventSubscriberInterface
         }
 
         if (!$inputString = $this->getInputString($event)) {
-            return $this->logger->debug('The console exited with code "{code}"', ['code' => $exitCode]);
+            $this->logger->debug('The console exited with code "{code}"', ['code' => $exitCode]);
+
+            return;
         }
 
         $this->logger->debug('Command "{command}" exited with code "{code}"', ['command' => $inputString, 'code' => $exitCode]);

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -288,6 +288,8 @@ class ArgvInput extends Input
 
             return $token;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -46,6 +46,8 @@ class ArrayInput extends Input
 
             return $value;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -355,7 +355,9 @@ class SymfonyStyle extends OutputStyle
         $chars = substr(str_replace(PHP_EOL, "\n", $this->bufferedOutput->fetch()), -2);
 
         if (!isset($chars[0])) {
-            return $this->newLine(); //empty history, so we should start with a new line.
+            $this->newLine(); //empty history, so we should start with a new line.
+
+            return;
         }
         //Prepend new line for each non LF chars (This means no blank line was output before)
         $this->newLine(2 - substr_count($chars, "\n"));

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerEscaping.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerEscaping.php
@@ -73,6 +73,8 @@ class TokenizerEscaping
             if (0x10000 > $c) {
                 return \chr(0xE0 | $c >> 12).\chr(0x80 | $c >> 6 & 0x3F).\chr(0x80 | $c & 0x3F);
             }
+
+            return '';
         }, $value);
     }
 }

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -317,6 +317,12 @@ class DebugClassLoader
         return $deprecations;
     }
 
+    /**
+     * @param string $file
+     * @param string $class
+     *
+     * @return array|null
+     */
     public function checkCase(\ReflectionClass $refl, $file, $class)
     {
         $real = explode('\\', $class.strrchr($file, '.'));
@@ -333,7 +339,7 @@ class DebugClassLoader
         array_splice($tail, 0, $i + 1);
 
         if (!$tail) {
-            return;
+            return null;
         }
 
         $tail = \DIRECTORY_SEPARATOR.implode(\DIRECTORY_SEPARATOR, $tail);
@@ -349,6 +355,8 @@ class DebugClassLoader
         ) {
             return [substr($tail, -$tailLen + 1), substr($real, -$tailLen + 1), substr($real, 0, -$tailLen + 1)];
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -599,7 +599,9 @@ class ErrorHandler
         $this->exceptionHandler = null;
         try {
             if (null !== $exceptionHandler) {
-                return \call_user_func($exceptionHandler, $exception);
+                $exceptionHandler($exception);
+
+                return;
             }
             $handlerException = $handlerException ?: $exception;
         } catch (\Exception $handlerException) {

--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -71,6 +71,8 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
 
             return new ClassNotFoundException($message, $exception);
         }
+
+        return null;
     }
 
     /**
@@ -196,6 +198,8 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
                 return $candidate;
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -439,5 +439,7 @@ class ClassLoader
         } elseif ('Test\\'.__NAMESPACE__.'\UseTraitWithInternalMethod' === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class UseTraitWithInternalMethod { use \\'.__NAMESPACE__.'\Fixtures\TraitWithInternalMethod; }');
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -156,7 +156,7 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass implements Repe
         }
 
         if (!$this->container->hasDefinition($id)) {
-            return;
+            return null;
         }
 
         return $this->container->normalizeId($id);

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckArgumentsValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckArgumentsValidityPass.php
@@ -81,5 +81,7 @@ class CheckArgumentsValidityPass extends AbstractRecursivePass
                 }
             }
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -354,7 +354,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     public function getReflectionClass($class, $throw = true)
     {
         if (!$class = $this->getParameterBag()->resolveValue($class)) {
-            return;
+            return null;
         }
 
         if (isset(self::$internalTypes[$class])) {
@@ -621,7 +621,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             $definition = $this->getDefinition($id);
         } catch (ServiceNotFoundException $e) {
             if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
-                return;
+                return null;
             }
 
             throw $e;

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -65,7 +65,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
 
         if (false !== $i || 'string' !== $prefix) {
             if (null === $env = $getEnv($name)) {
-                return;
+                return null;
             }
         } elseif (isset($_ENV[$name])) {
             $env = $_ENV[$name];
@@ -77,7 +77,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             }
 
             if (null === $env = $this->container->getParameter("env($name)")) {
-                return;
+                return null;
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -84,11 +84,12 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
         $class = $container->getReflectionClass($class);
         $constructor = $class ? $class->getConstructor() : null;
 
-        if ($class && (!$constructor || !$constructor->getNumberOfRequiredParameters())) {
-            return $class->newInstance();
-        }
+        return $class && (!$constructor || !$constructor->getNumberOfRequiredParameters()) ? $class->newInstance() : null;
     }
 
+    /**
+     * @return array
+     */
     final protected function processConfiguration(ConfigurationInterface $configuration, array $configs)
     {
         $processor = new Processor();

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
@@ -58,8 +58,7 @@ class ProxyHelper
         if ('self' === $lcName) {
             return $prefix.$r->getDeclaringClass()->name;
         }
-        if ($parent = $r->getDeclaringClass()->getParentClass()) {
-            return $prefix.$parent->name;
-        }
+
+        return ($parent = $r->getDeclaringClass()->getParentClass()) ? $prefix.$parent->name : null;
     }
 }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1053,9 +1053,7 @@ class Crawler implements \Countable, \IteratorAggregate
      */
     public function getNode($position)
     {
-        if (isset($this->nodes[$position])) {
-            return $this->nodes[$position];
-        }
+        return isset($this->nodes[$position]) ? $this->nodes[$position] : null;
     }
 
     /**
@@ -1115,7 +1113,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * @param string $prefix
      *
-     * @return string
+     * @return string|null
      *
      * @throws \InvalidArgumentException
      */
@@ -1128,9 +1126,7 @@ class Crawler implements \Countable, \IteratorAggregate
         // ask for one namespace, otherwise we'd get a collection with an item for each node
         $namespaces = $domxpath->query(sprintf('(//namespace::*[name()="%s"])[last()]', $this->defaultNamespacePrefix === $prefix ? '' : $prefix));
 
-        if ($node = $namespaces->item(0)) {
-            return $node->nodeValue;
-        }
+        return ($node = $namespaces->item(0)) ? $node->nodeValue : null;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -72,9 +72,8 @@ abstract class FormField
         }
 
         $labels = $xpath->query('ancestor::label[1]', $this->node);
-        if ($labels->length > 0) {
-            return $labels->item(0);
-        }
+
+        return $labels->length > 0 ? $labels->item(0) : null;
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -79,7 +79,7 @@ class EventDispatcher implements EventDispatcherInterface
     public function getListenerPriority($eventName, $listener)
     {
         if (empty($this->listeners[$eventName])) {
-            return;
+            return null;
         }
 
         if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure) {
@@ -97,6 +97,8 @@ class EventDispatcher implements EventDispatcherInterface
                 }
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -21,7 +21,7 @@ class FilesystemTestCase extends TestCase
     protected $longPathNamesWindows = [];
 
     /**
-     * @var \Symfony\Component\Filesystem\Filesystem
+     * @var Filesystem
      */
     protected $filesystem = null;
 
@@ -110,9 +110,8 @@ class FilesystemTestCase extends TestCase
         $this->markAsSkippedIfPosixIsMissing();
 
         $infos = stat($filepath);
-        if ($datas = posix_getpwuid($infos['uid'])) {
-            return $datas['name'];
-        }
+
+        return ($datas = posix_getpwuid($infos['uid'])) ? $datas['name'] : null;
     }
 
     protected function getFileGroup($filepath)

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -140,6 +140,7 @@ abstract class AbstractExtension implements FormExtensionInterface
      */
     protected function loadTypeGuesser()
     {
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
@@ -80,9 +80,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
                 // when such values are passed to
                 // ChoiceListInterface::getValuesForChoices(). Handle this case
                 // so that the call to getValue() doesn't break.
-                if (\is_object($choice) || \is_array($choice)) {
-                    return $accessor->getValue($choice, $value);
-                }
+                return \is_object($choice) || \is_array($choice) ? $accessor->getValue($choice, $value) : null;
             };
         }
 
@@ -113,9 +111,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
                 // when such values are passed to
                 // ChoiceListInterface::getValuesForChoices(). Handle this case
                 // so that the call to getValue() doesn't break.
-                if (\is_object($choice) || \is_array($choice)) {
-                    return $accessor->getValue($choice, $value);
-                }
+                return \is_object($choice) || \is_array($choice) ? $accessor->getValue($choice, $value) : null;
             };
         }
 
@@ -191,6 +187,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
                     return $accessor->getValue($choice, $groupBy);
                 } catch (UnexpectedTypeException $e) {
                     // Don't group if path is not readable
+                    return null;
                 }
             };
         }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
@@ -73,7 +73,7 @@ class ArrayToPartsTransformer implements DataTransformerInterface
         if (\count($emptyKeys) > 0) {
             if (\count($emptyKeys) === \count($this->partMapping)) {
                 // All parts empty
-                return;
+                return null;
             }
 
             throw new TransformationFailedException(sprintf('The keys "%s" should not be empty', implode('", "', $emptyKeys)));

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
@@ -42,7 +42,7 @@ class ChoiceToValueTransformer implements DataTransformerInterface
 
         if (1 !== \count($choices)) {
             if (null === $value || '' === $value) {
-                return;
+                return null;
             }
 
             throw new TransformationFailedException(sprintf('The choice "%s" does not exist or is not unique', $value));

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeZoneToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeZoneToStringTransformer.php
@@ -34,7 +34,7 @@ class DateTimeZoneToStringTransformer implements DataTransformerInterface
     public function transform($dateTimeZone)
     {
         if (null === $dateTimeZone) {
-            return;
+            return null;
         }
 
         if ($this->multiple) {
@@ -58,7 +58,7 @@ class DateTimeZoneToStringTransformer implements DataTransformerInterface
     public function reverseTransform($value)
     {
         if (null === $value) {
-            return;
+            return null;
         }
 
         if ($this->multiple) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -251,7 +251,7 @@ class ChoiceType extends AbstractType
     {
         $emptyData = function (Options $options) {
             if ($options['expanded'] && !$options['multiple']) {
-                return;
+                return null;
             }
 
             if ($options['multiple']) {
@@ -284,13 +284,13 @@ class ChoiceType extends AbstractType
         $placeholderNormalizer = function (Options $options, $placeholder) {
             if ($options['multiple']) {
                 // never use an empty value for this case
-                return;
+                return null;
             } elseif ($options['required'] && ($options['expanded'] || isset($options['attr']['size']) && $options['attr']['size'] > 1)) {
                 // placeholder for required radio buttons or a select with size > 1 does not make sense
-                return;
+                return null;
             } elseif (false === $placeholder) {
                 // an empty value should be added but the user decided otherwise
-                return;
+                return null;
             } elseif ($options['expanded'] && '' === $placeholder) {
                 // never use an empty label for radio buttons
                 return 'None';
@@ -380,9 +380,6 @@ class ChoiceType extends AbstractType
         }
     }
 
-    /**
-     * @return mixed
-     */
     private function addSubForm(FormBuilderInterface $builder, $name, ChoiceView $choiceView, array $options)
     {
         $choiceOpts = [

--- a/src/Symfony/Component/Form/Extension/Validator/Type/BaseValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/BaseValidatorExtension.php
@@ -36,7 +36,7 @@ abstract class BaseValidatorExtension extends AbstractTypeExtension
             }
 
             if (empty($groups)) {
-                return;
+                return null;
             }
 
             if (\is_callable($groups)) {

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -153,6 +153,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\IsFalse':
                 return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\CheckboxType', [], Guess::MEDIUM_CONFIDENCE);
         }
+
+        return null;
     }
 
     /**
@@ -168,6 +170,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\IsTrue':
                 return new ValueGuess(true, Guess::HIGH_CONFIDENCE);
         }
+
+        return null;
     }
 
     /**
@@ -196,6 +200,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 }
                 break;
         }
+
+        return null;
     }
 
     /**
@@ -232,6 +238,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 }
                 break;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
@@ -54,9 +54,7 @@ class MappingRule
      */
     public function match($propertyPath)
     {
-        if ($propertyPath === $this->propertyPath) {
-            return $this->getTarget();
-        }
+        return $propertyPath === $this->propertyPath ? $this->getTarget() : null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -757,9 +757,7 @@ class Form implements \IteratorAggregate, FormInterface
             return $this->clickedButton;
         }
 
-        if ($this->parent && method_exists($this->parent, 'getClickedButton')) {
-            return $this->parent->getClickedButton();
-        }
+        return $this->parent && method_exists($this->parent, 'getClickedButton') ? $this->parent->getClickedButton() : null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Util/StringUtil.php
+++ b/src/Symfony/Component/Form/Util/StringUtil.php
@@ -53,5 +53,7 @@ class StringUtil
         if (preg_match('~([^\\\\]+?)(type)?$~i', $fqcn, $matches)) {
             return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], ['\\1_\\2', '\\1_\\2'], $matches[1]));
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser.php
@@ -90,5 +90,7 @@ class ExtensionGuesser implements ExtensionGuesserInterface
                 return $extension;
             }
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
@@ -129,5 +129,7 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
         if (2 === \count($this->guessers) && !FileBinaryMimeTypeGuesser::isSupported() && !FileinfoMimeTypeGuesser::isSupported()) {
             throw new \LogicException('Unable to guess the mime type as no guessers are available (Did you enable the php_fileinfo extension?)');
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -97,49 +97,49 @@ class Request
     /**
      * Custom parameters.
      *
-     * @var \Symfony\Component\HttpFoundation\ParameterBag
+     * @var ParameterBag
      */
     public $attributes;
 
     /**
      * Request body parameters ($_POST).
      *
-     * @var \Symfony\Component\HttpFoundation\ParameterBag
+     * @var ParameterBag
      */
     public $request;
 
     /**
      * Query string parameters ($_GET).
      *
-     * @var \Symfony\Component\HttpFoundation\ParameterBag
+     * @var ParameterBag
      */
     public $query;
 
     /**
      * Server and execution environment parameters ($_SERVER).
      *
-     * @var \Symfony\Component\HttpFoundation\ServerBag
+     * @var ServerBag
      */
     public $server;
 
     /**
      * Uploaded files ($_FILES).
      *
-     * @var \Symfony\Component\HttpFoundation\FileBag
+     * @var FileBag
      */
     public $files;
 
     /**
      * Cookies ($_COOKIE).
      *
-     * @var \Symfony\Component\HttpFoundation\ParameterBag
+     * @var ParameterBag
      */
     public $cookies;
 
     /**
      * Headers (taken from the $_SERVER).
      *
-     * @var \Symfony\Component\HttpFoundation\HeaderBag
+     * @var HeaderBag
      */
     public $headers;
 
@@ -199,7 +199,7 @@ class Request
     protected $format;
 
     /**
-     * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
+     * @var SessionInterface
      */
     protected $session;
 
@@ -1449,6 +1449,8 @@ class Request
                 return $format;
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -88,7 +88,7 @@ class Response
     const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;                             // RFC6585
 
     /**
-     * @var \Symfony\Component\HttpFoundation\ResponseHeaderBag
+     * @var ResponseHeaderBag
      */
     public $headers;
 
@@ -790,6 +790,8 @@ class Response
         if (null !== $this->getExpires()) {
             return (int) $this->getExpires()->format('U') - (int) $this->getDate()->format('U');
         }
+
+        return null;
     }
 
     /**
@@ -846,6 +848,8 @@ class Response
         if (null !== $maxAge = $this->getMaxAge()) {
             return $maxAge - $this->getAge();
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -87,9 +87,7 @@ abstract class Bundle implements BundleInterface
             }
         }
 
-        if ($this->extension) {
-            return $this->extension;
-        }
+        return $this->extension ?: null;
     }
 
     /**
@@ -199,9 +197,7 @@ abstract class Bundle implements BundleInterface
      */
     protected function createContainerExtension()
     {
-        if (class_exists($class = $this->getContainerExtensionClass())) {
-            return new $class();
-        }
+        return class_exists($class = $this->getContainerExtensionClass()) ? new $class() : null;
     }
 
     private function parseClassName()

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -103,17 +103,17 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
     {
         if ($this->supportsParameterType) {
             if (!$type = $parameter->getType()) {
-                return;
+                return null;
             }
             $name = $type instanceof \ReflectionNamedType ? $type->getName() : $type->__toString();
             if ('array' === $name && !$type->isBuiltin()) {
                 // Special case for HHVM with variadics
-                return;
+                return null;
             }
         } elseif (preg_match('/^(?:[^ ]++ ){4}([a-zA-Z_\x7F-\xFF][^ ]++)/', $parameter, $name)) {
             $name = $name[1];
         } else {
-            return;
+            return null;
         }
         $lcName = strtolower($name);
 
@@ -121,7 +121,7 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
             return $name;
         }
         if (!$function instanceof \ReflectionMethod) {
-            return;
+            return null;
         }
         if ('self' === $lcName) {
             return $function->getDeclaringClass()->name;
@@ -129,5 +129,7 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
         if ($parent = $function->getDeclaringClass()->getParentClass()) {
             return $parent->name;
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -102,7 +102,7 @@ class FileLinkFormatter implements \Serializable
             $request = $this->requestStack->getMasterRequest();
             if ($request instanceof Request) {
                 if ($this->urlFormat instanceof \Closure && !$this->urlFormat = \call_user_func($this->urlFormat)) {
-                    return;
+                    return null;
                 }
 
                 return [
@@ -111,5 +111,7 @@ class FileLinkFormatter implements \Serializable
                 ];
             }
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
@@ -108,5 +108,7 @@ class FragmentHandler
         }
 
         $response->sendContent();
+
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -109,6 +109,8 @@ abstract class AbstractSurrogate implements SurrogateInterface
                 throw $e;
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -111,5 +111,7 @@ class Esi extends AbstractSurrogate
 
         // remove ESI/1.0 from the Surrogate-Control header
         $this->removeFromControl($response);
+
+        return $response;
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -94,5 +94,7 @@ class Ssi extends AbstractSurrogate
 
         // remove SSI/1.0 from the Surrogate-Control header
         $this->removeFromControl($response);
+
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -607,7 +607,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                 if (isset($collectedLogs[$message])) {
                     ++$collectedLogs[$message]['count'];
 
-                    return;
+                    return null;
                 }
 
                 $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
@@ -627,6 +627,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                     'trace' => $backtrace,
                     'count' => 1,
                 ];
+
+                return null;
             });
         }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -248,16 +248,19 @@ class Profiler
         return $this->collectors[$name];
     }
 
+    /**
+     * @return int|null
+     */
     private function getTimestamp($value)
     {
         if (null === $value || '' == $value) {
-            return;
+            return null;
         }
 
         try {
             $value = new \DateTime(is_numeric($value) ? '@'.$value : $value);
         } catch (\Exception $e) {
-            return;
+            return null;
         }
 
         return $value->getTimestamp();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -88,7 +88,7 @@ class EsiTest extends TestCase
         $request = Request::create('/');
         $response = new Response();
         $response->headers->set('Content-Type', 'text/plain');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
 
         $this->assertFalse($response->headers->has('x-body-eval'));
     }
@@ -99,7 +99,7 @@ class EsiTest extends TestCase
 
         $request = Request::create('/');
         $response = new Response('<esi:remove> <a href="http://www.example.com">www.example.com</a> </esi:remove> Keep this'."<esi:remove>\n <a>www.example.com</a> </esi:remove> And this");
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
 
         $this->assertEquals(' Keep this And this', $response->getContent());
     }
@@ -110,7 +110,7 @@ class EsiTest extends TestCase
 
         $request = Request::create('/');
         $response = new Response('<esi:comment text="some comment &gt;" /> Keep this');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
 
         $this->assertEquals(' Keep this', $response->getContent());
     }
@@ -121,23 +121,23 @@ class EsiTest extends TestCase
 
         $request = Request::create('/');
         $response = new Response('foo <esi:comment text="some comment" /><esi:include src="..." alt="alt" onerror="continue" />');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
 
         $this->assertEquals('foo <?php echo $this->surrogate->handle($this, \'...\', \'alt\', true) ?>'."\n", $response->getContent());
         $this->assertEquals('ESI', $response->headers->get('x-body-eval'));
 
         $response = new Response('foo <esi:comment text="some comment" /><esi:include src="foo\'" alt="bar\'" onerror="continue" />');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
 
         $this->assertEquals('foo <?php echo $this->surrogate->handle($this, \'foo\\\'\', \'bar\\\'\', true) ?>'."\n", $response->getContent());
 
         $response = new Response('foo <esi:include src="..." />');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
 
         $this->assertEquals('foo <?php echo $this->surrogate->handle($this, \'...\', \'\', false) ?>'."\n", $response->getContent());
 
         $response = new Response('foo <esi:include src="..."></esi:include>');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
 
         $this->assertEquals('foo <?php echo $this->surrogate->handle($this, \'...\', \'\', false) ?>'."\n", $response->getContent());
     }
@@ -148,7 +148,7 @@ class EsiTest extends TestCase
 
         $request = Request::create('/');
         $response = new Response('<?php <? <% <script language=php>');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
 
         $this->assertEquals('<?php echo "<?"; ?>php <?php echo "<?"; ?> <?php echo "<%"; ?> <?php echo "<s"; ?>cript language=php>', $response->getContent());
     }
@@ -160,7 +160,7 @@ class EsiTest extends TestCase
 
         $request = Request::create('/');
         $response = new Response('foo <esi:include />');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
     }
 
     public function testProcessRemoveSurrogateControlHeader()
@@ -170,16 +170,16 @@ class EsiTest extends TestCase
         $request = Request::create('/');
         $response = new Response('foo <esi:include src="..." />');
         $response->headers->set('Surrogate-Control', 'content="ESI/1.0"');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
         $this->assertEquals('ESI', $response->headers->get('x-body-eval'));
 
         $response->headers->set('Surrogate-Control', 'no-store, content="ESI/1.0"');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
         $this->assertEquals('ESI', $response->headers->get('x-body-eval'));
         $this->assertEquals('no-store', $response->headers->get('surrogate-control'));
 
         $response->headers->set('Surrogate-Control', 'content="ESI/1.0", no-store');
-        $esi->process($request, $response);
+        $this->assertSame($response, $esi->process($request, $response));
         $this->assertEquals('ESI', $response->headers->get('x-body-eval'));
         $this->assertEquals('no-store', $response->headers->get('surrogate-control'));
     }

--- a/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
@@ -90,6 +90,8 @@ class CurrencyDataGenerator extends AbstractDataGenerator
 
             return $data;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
@@ -134,6 +134,8 @@ class LanguageDataGenerator extends AbstractDataGenerator
 
             return $data;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -104,6 +104,8 @@ class RegionDataGenerator extends AbstractDataGenerator
 
             return $data;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
@@ -73,6 +73,8 @@ class ScriptDataGenerator extends AbstractDataGenerator
 
             return $data;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
@@ -101,7 +101,7 @@ class FullTransformer
      * @param string    $dateChars The date characters to be replaced with a formatted ICU value
      * @param \DateTime $dateTime  A DateTime object to be used to generate the formatted value
      *
-     * @return string The formatted value
+     * @return string|null The formatted value
      *
      * @throws NotImplementedException When it encounters a not implemented date character
      */
@@ -123,6 +123,8 @@ class FullTransformer
         if (false !== strpos($this->notImplementedChars, $dateChars[0])) {
             throw new NotImplementedException(sprintf('Unimplemented date character "%s" in format "%s"', $dateChars[0], $this->pattern));
         }
+
+        return null;
     }
 
     /**
@@ -196,6 +198,8 @@ class FullTransformer
 
                 return "(?P<$captureName>".$transformer->getReverseMatchingRegExp($length).')';
             }
+
+            return null;
         }, $escapedPattern);
 
         return $reverseMatchingRegExp;

--- a/src/Symfony/Component/Intl/Locale.php
+++ b/src/Symfony/Component/Intl/Locale.php
@@ -104,9 +104,7 @@ final class Locale extends \Locale
 
         // Don't return default fallback for "root", "meta" or others
         // Normal locales have two or three letters
-        if (\strlen($locale) < 4) {
-            return self::$defaultFallback;
-        }
+        return \strlen($locale) < 4 ? self::$defaultFallback : null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundle.php
@@ -83,7 +83,7 @@ class CurrencyBundle extends CurrencyDataProvider implements CurrencyBundleInter
         try {
             return parent::getFractionDigits($currency);
         } catch (MissingResourceException $e) {
-            return;
+            return null;
         }
     }
 
@@ -95,7 +95,7 @@ class CurrencyBundle extends CurrencyDataProvider implements CurrencyBundleInter
         try {
             return parent::getRoundingIncrement($currency);
         } catch (MissingResourceException $e) {
-            return;
+            return null;
         }
     }
 

--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -62,7 +62,7 @@ function get_icu_version_from_genrb($genrb)
     }
 
     if (!preg_match('/ICU version ([\d\.]+)/', implode('', $output), $matches)) {
-        return;
+        return null;
     }
 
     return $matches[1];

--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -88,12 +88,14 @@ abstract class AbstractPipes implements PipesInterface
     /**
      * Writes input to stdin.
      *
+     * @return array|null
+     *
      * @throws InvalidArgumentException When an input iterator yields a non supported value
      */
     protected function write()
     {
         if (!isset($this->pipes[0])) {
-            return;
+            return null;
         }
         $input = $this->input;
 
@@ -122,7 +124,7 @@ abstract class AbstractPipes implements PipesInterface
 
         // let's have a look if something changed in streams
         if (false === @stream_select($r, $w, $e, 0, 0)) {
-            return;
+            return null;
         }
 
         foreach ($w as $stdin) {
@@ -166,6 +168,8 @@ abstract class AbstractPipes implements PipesInterface
         } elseif (!$w) {
             return [$this->pipes[0]];
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1231,6 +1231,8 @@ class ProcessTest extends TestCase
 
                 return $stream;
             }
+
+            return null;
         };
 
         $input = new InputStream();

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassMagicCall.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassMagicCall.php
@@ -33,5 +33,7 @@ class TestClassMagicCall
         if ('setMagicCallProperty' === $method) {
             $this->magicCallProperty = reset($args);
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -89,6 +89,8 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
                 return $varDescription;
             }
         }
+
+        return null;
     }
 
     /**
@@ -203,7 +205,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
         } catch (\ReflectionException $e) {
-            return;
+            return null;
         }
 
         try {
@@ -248,7 +250,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         }
 
         if (!isset($reflectionMethod)) {
-            return;
+            return null;
         }
 
         try {

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -124,6 +124,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         if ($fromAccessor = $this->extractFromAccessor($class, $property)) {
             return $fromAccessor;
         }
+
+        return null;
     }
 
     /**
@@ -166,7 +168,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     {
         list($reflectionMethod, $prefix) = $this->getMutatorMethod($class, $property);
         if (null === $reflectionMethod) {
-            return;
+            return null;
         }
 
         $reflectionParameters = $reflectionMethod->getParameters();
@@ -174,13 +176,13 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         if ($this->supportsParameterType) {
             if (!$reflectionType = $reflectionParameter->getType()) {
-                return;
+                return null;
             }
             $type = $this->extractFromReflectionType($reflectionType, $reflectionMethod);
 
             // HHVM reports variadics with "array" but not builtin type hints
             if (!$reflectionType->isBuiltin() && Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType()) {
-                return;
+                return null;
             }
         } elseif (preg_match('/^(?:[^ ]++ ){4}([a-zA-Z_\x7F-\xFF][^ ]++)/', $reflectionParameter, $info)) {
             if (Type::BUILTIN_TYPE_ARRAY === $info[1]) {
@@ -191,7 +193,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 $type = new Type(Type::BUILTIN_TYPE_OBJECT, $reflectionParameter->allowsNull(), $this->resolveTypeName($info[1], $reflectionMethod));
             }
         } else {
-            return;
+            return null;
         }
 
         if (\in_array($prefix, $this->arrayMutatorPrefixes)) {
@@ -213,16 +215,14 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     {
         list($reflectionMethod, $prefix) = $this->getAccessorMethod($class, $property);
         if (null === $reflectionMethod) {
-            return;
+            return null;
         }
 
         if ($this->supportsParameterType && $reflectionType = $reflectionMethod->getReturnType()) {
             return [$this->extractFromReflectionType($reflectionType, $reflectionMethod)];
         }
 
-        if (\in_array($prefix, ['is', 'can'])) {
-            return [new Type(Type::BUILTIN_TYPE_BOOL)];
-        }
+        return \in_array($prefix, ['is', 'can']) ? [new Type(Type::BUILTIN_TYPE_BOOL)] : null;
     }
 
     /**
@@ -310,6 +310,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 // Return null if the property doesn't exist
             }
         }
+
+        return null;
     }
 
     /**
@@ -321,7 +323,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      * @param string $class
      * @param string $property
      *
-     * @return array
+     * @return array|null
      */
     private function getMutatorMethod($class, $property)
     {
@@ -350,6 +352,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 }
             }
         }
+
+        return null;
     }
 
     /**
@@ -358,7 +362,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      * @param string                $methodName
      * @param \ReflectionProperty[] $reflectionProperties
      *
-     * @return string
+     * @return string|null
      */
     private function getPropertyName($methodName, array $reflectionProperties)
     {
@@ -379,5 +383,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
             return $matches[2];
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -103,5 +103,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface
                 return $value;
             }
         }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -123,6 +123,8 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
      * @throws MissingMandatoryParametersException When some parameters are missing that are mandatory for the route
      * @throws InvalidParameterException           When a parameter value for a placeholder is not correct because
      *                                             it does not match the requirement
+     *
+     * @return string|null
      */
     protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens, array $requiredSchemes = [])
     {
@@ -150,7 +152,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                             $this->logger->error($message, ['parameter' => $token[3], 'route' => $name, 'expected' => $token[2], 'given' => $mergedParams[$token[3]]]);
                         }
 
-                        return;
+                        return null;
                     }
 
                     $url = $token[1].$mergedParams[$token[3]].$url;
@@ -205,7 +207,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                             $this->logger->error($message, ['parameter' => $token[3], 'route' => $name, 'expected' => $token[2], 'given' => $mergedParams[$token[3]]]);
                         }
 
-                        return;
+                        return null;
                     }
 
                     $routeHost = $token[1].$mergedParams[$token[3]].$routeHost;

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -75,7 +75,7 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      * @param mixed[] $parameters    An array of parameters
      * @param int     $referenceType The type of reference to be generated (one of the constants)
      *
-     * @return string The generated URL
+     * @return string|null The generated URL
      *
      * @throws RouteNotFoundException              If the named route doesn't exist
      * @throws MissingMandatoryParametersException When some parameters are missing that are mandatory for the route

--- a/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
@@ -114,7 +114,7 @@ class StaticPrefixCollection
         $commonPrefix = $this->detectCommonPrefix($prefix, $itemPrefix);
 
         if (!$commonPrefix) {
-            return;
+            return null;
         }
 
         $child = new self($commonPrefix);

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -127,6 +127,8 @@ class TraceableUrlMatcher extends UrlMatcher
 
             return true;
         }
+
+        return [];
     }
 
     private function addTrace($log, $level = self::ROUTE_DOES_NOT_MATCH, $name = null, $route = null)

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -90,11 +90,21 @@ class ExceptionListener
         $exception = $event->getException();
         do {
             if ($exception instanceof AuthenticationException) {
-                return $this->handleAuthenticationException($event, $exception);
-            } elseif ($exception instanceof AccessDeniedException) {
-                return $this->handleAccessDeniedException($event, $exception);
-            } elseif ($exception instanceof LogoutException) {
-                return $this->handleLogoutException($exception);
+                $this->handleAuthenticationException($event, $exception);
+
+                return;
+            }
+
+            if ($exception instanceof AccessDeniedException) {
+                $this->handleAccessDeniedException($event, $exception);
+
+                return;
+            }
+
+            if ($exception instanceof LogoutException) {
+                $this->handleLogoutException($exception);
+
+                return;
             }
         } while (null !== $exception = $exception->getPrevious());
     }

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -135,6 +135,9 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
         $event->setResponse($response);
     }
 
+    /**
+     * @return Response|null
+     */
     private function onSuccess(Request $request, TokenInterface $token)
     {
         if (null !== $this->logger) {
@@ -151,7 +154,7 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
         }
 
         if (!$this->successHandler) {
-            return; // let the original request succeeds
+            return null; // let the original request succeeds
         }
 
         $response = $this->successHandler->onAuthenticationSuccess($request, $token);

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -148,6 +148,8 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
 
             throw $e;
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -241,7 +241,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $expectedTypes = [];
         foreach ($types as $type) {
             if (null === $data && $type->isNullable()) {
-                return;
+                return null;
             }
 
             if ($type->isCollection() && null !== ($collectionValueType = $type->getCollectionValueType()) && Type::BUILTIN_TYPE_OBJECT === $collectionValueType->getBuiltinType()) {

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -138,6 +138,8 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         if (\is_callable([$object, $haser])) {
             return $object->$haser();
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -121,7 +121,7 @@ class PropertyNormalizer extends AbstractObjectNormalizer
         try {
             $reflectionProperty = $this->getReflectionProperty($object, $attribute);
         } catch (\ReflectionException $reflectionException) {
-            return;
+            return null;
         }
 
         // Override visibility

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -250,6 +250,8 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
                 return $normalizer->denormalize($data, $type, $format, $context);
             }
         }
+
+        return null;
     }
 
     public function supportsDenormalization($data, $type, $format = null)

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -201,10 +201,13 @@ EOF
         }
     }
 
+    /**
+     * @return string|null
+     */
     private function getStdin()
     {
         if (0 !== ftell(STDIN)) {
-            return;
+            return null;
         }
 
         $inputs = '';

--- a/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
@@ -86,9 +86,7 @@ class IcuResFileDumper extends FileDumper
     {
         $padding = \strlen($data) % 4;
 
-        if ($padding) {
-            return str_repeat("\xAA", 4 - $padding);
-        }
+        return $padding ? str_repeat("\xAA", 4 - $padding) : null;
     }
 
     private function getPosition($data)

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -231,6 +231,8 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
                 return $this->metadata[$domain][$key];
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -112,5 +112,6 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
      */
     protected function getErrorCode()
     {
+        return null;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -244,5 +244,6 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
      */
     protected function getErrorCode()
     {
+        return null;
     }
 }

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -34,7 +34,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * @return string The type of the value
+     * @return string|null The type of the value
      */
     public function getType()
     {
@@ -58,6 +58,8 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
         if (Stub::TYPE_RESOURCE === $item->type) {
             return $item->class.' resource';
         }
+
+        return null;
     }
 
     /**
@@ -127,6 +129,8 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
 
             return $item instanceof Stub || [] === $item ? $data : $item;
         }
+
+        return null;
     }
 
     public function __isset($key)

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -154,6 +154,8 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
                 setlocale(LC_NUMERIC, $locale);
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
@@ -41,6 +41,9 @@ trait VarDumperTestTrait
         $this->assertStringMatchesFormat(rtrim($dump), $this->getDump($data, null, $filter), $message);
     }
 
+    /**
+     * @return string|null
+     */
     protected function getDump($data, $key = null, $filter = 0)
     {
         $flags = getenv('DUMP_LIGHT_ARRAY') ? CliDumper::DUMP_LIGHT_ARRAY : 0;
@@ -52,7 +55,7 @@ trait VarDumperTestTrait
         $dumper->setColors(false);
         $data = $cloner->cloneVar($data, $filter)->withRefHandles(false);
         if (null !== $key && null === $data = $data->seek($key)) {
-            return;
+            return null;
         }
 
         return rtrim($dumper->dump($data, true));

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -196,10 +196,13 @@ EOF
         }
     }
 
+    /**
+     * @return string|null
+     */
     private function getStdin()
     {
         if (0 !== ftell(STDIN)) {
-            return;
+            return null;
         }
 
         $inputs = '';

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -644,7 +644,7 @@ class Inline
             case 'null' === $scalarLower:
             case '' === $scalar:
             case '~' === $scalar:
-                return;
+                return null;
             case 'true' === $scalarLower:
                 return true;
             case 'false' === $scalarLower:
@@ -672,7 +672,7 @@ class Inline
                             throw new ParseException('Object support when parsing a YAML file has been disabled.', self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
                         }
 
-                        return;
+                        return null;
                     case 0 === strpos($scalar, '!!php/object:'):
                         if (self::$objectSupport) {
                             @trigger_error(self::getDeprecationMessage('The !!php/object: tag to indicate dumped PHP objects is deprecated since Symfony 3.1 and will be removed in 4.0. Use the !php/object (without the colon) tag instead.'), E_USER_DEPRECATED);
@@ -684,7 +684,7 @@ class Inline
                             throw new ParseException('Object support when parsing a YAML file has been disabled.', self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
                         }
 
-                        return;
+                        return null;
                     case 0 === strpos($scalar, '!php/object'):
                         if (self::$objectSupport) {
                             return unserialize(self::parseScalar(substr($scalar, 12)));
@@ -694,7 +694,7 @@ class Inline
                             throw new ParseException('Object support when parsing a YAML file has been disabled.', self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
                         }
 
-                        return;
+                        return null;
                     case 0 === strpos($scalar, '!php/const:'):
                         if (self::$constantSupport) {
                             @trigger_error(self::getDeprecationMessage('The !php/const: tag to indicate dumped PHP constants is deprecated since Symfony 3.4 and will be removed in 4.0. Use the !php/const (without the colon) tag instead.'), E_USER_DEPRECATED);
@@ -709,7 +709,7 @@ class Inline
                             throw new ParseException(sprintf('The string "%s" could not be parsed as a constant. Have you forgotten to pass the "Yaml::PARSE_CONSTANT" flag to the parser?', $scalar), self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
                         }
 
-                        return;
+                        return null;
                     case 0 === strpos($scalar, '!php/const'):
                         if (self::$constantSupport) {
                             $i = 0;
@@ -723,7 +723,7 @@ class Inline
                             throw new ParseException(sprintf('The string "%s" could not be parsed as a constant. Have you forgotten to pass the "Yaml::PARSE_CONSTANT" flag to the parser?', $scalar), self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
                         }
 
-                        return;
+                        return null;
                     case 0 === strpos($scalar, '!!float '):
                         return (float) substr($scalar, 8);
                     case 0 === strpos($scalar, '!!binary '):
@@ -795,7 +795,7 @@ class Inline
     private static function parseTag($value, &$i, $flags)
     {
         if ('!' !== $value[$i]) {
-            return;
+            return null;
         }
 
         $tagLength = strcspn($value, " \t\n", $i + 1);
@@ -807,7 +807,7 @@ class Inline
         // Is followed by a scalar
         if ((!isset($value[$nextOffset]) || !\in_array($value[$nextOffset], ['[', '{'], true)) && 'tagged' !== $tag) {
             // Manage non-whitelisted scalars in {@link self::evaluateScalar()}
-            return;
+            return null;
         }
 
         // Built-in tags

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -564,7 +564,7 @@ class Parser
         $oldLineIndentation = $this->getCurrentLineIndentation();
 
         if (!$this->moveToNextLine()) {
-            return;
+            return '';
         }
 
         if (null === $indentation) {
@@ -607,7 +607,7 @@ class Parser
         } else {
             $this->moveToPreviousLine();
 
-            return;
+            return '';
         }
 
         if ($inSequence && $oldLineIndentation === $newIndent && isset($data[0][0]) && '-' === $data[0][0]) {
@@ -615,7 +615,7 @@ class Parser
             // and therefore no nested list or mapping
             $this->moveToPreviousLine();
 
-            return;
+            return '';
         }
 
         $isItUnindentedCollection = $this->isStringUnIndentedCollectionItem();
@@ -1102,14 +1102,17 @@ class Parser
         return $value;
     }
 
+    /**
+     * @return string|null
+     */
     private function getLineTag($value, $flags, $nextLineCheck = true)
     {
         if ('' === $value || '!' !== $value[0] || 1 !== self::preg_match('/^'.self::TAG_PATTERN.' *( +#.*)?$/', $value, $matches)) {
-            return;
+            return null;
         }
 
         if ($nextLineCheck && !$this->isNextLineIndented()) {
-            return;
+            return null;
         }
 
         $tag = substr($matches['tag'], 1);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -49,6 +49,8 @@ class ParserTest extends TestCase
                 }
 
                 $deprecations[] = $msg;
+
+                return null;
             });
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17201 in preparation for #33228
| License       | MIT
| Doc PR        | N/A

Inconsistent return points in methods prevent adding return types. I thought, I'll give it a try and fix them. After this PR, PhpStorm's inspection still finds 39 issues, but as far as I can tell, they're either false positives or fixture code.