### PR TITLE
Fix missing exporter in PHPUnit constraint poylfill

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV6.php
@@ -49,6 +49,10 @@ trait ConstraintTraitForV6
      */
     protected function exporter()
     {
+        if (null === $this->exporter) {
+            $this->exporter = new Exporter();
+        }
+
         return $this->exporter;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | -

Since PHPUnit 7 drops the constructor in `PHPUnit\Framework\Constraint\Constraint`, overriding the constructor in a user land constraint breaks. To do so, we create an exporter in `exporter()` as is done in PHPUnit > 7.