### PR TITLE
Add return types to internal|final|private methods

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Form\Type;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\QueryBuilder;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\IdReader;
@@ -51,12 +52,10 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
      *
      * @param object $choice The object
      *
-     * @return string The string representation of the object
-     *
      * @internal This method is public to be usable as callback. It should not
      *           be used in user code.
      */
-    public static function createChoiceLabel($choice)
+    public static function createChoiceLabel($choice): string
     {
         return (string) $choice;
     }
@@ -73,12 +72,10 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
      * @param string     $value  The choice value. Corresponds to the object's
      *                           ID here.
      *
-     * @return string The field name
-     *
      * @internal This method is public to be usable as callback. It should not
      *           be used in user code.
      */
-    public static function createChoiceName($choice, $key, $value)
+    public static function createChoiceName($choice, $key, $value): string
     {
         return str_replace('-', '_', (string) $value);
     }
@@ -88,17 +85,15 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
      * For instance in ORM two query builders with an equal SQL string and
      * equal parameters are considered to be equal.
      *
-     * @param object $queryBuilder
-     *
-     * @return array|false Array with important QueryBuilder parts or false if
-     *                     they can't be determined
+     * @return array|null Array with important QueryBuilder parts or null if
+     *                    they can't be determined
      *
      * @internal This method is public to be usable as callback. It should not
      *           be used in user code.
      */
-    public function getQueryBuilderPartsForCachingHash($queryBuilder)
+    public function getQueryBuilderPartsForCachingHash(QueryBuilder $queryBuilder): ?array
     {
-        return false;
+        return null;
     }
 
     public function __construct(ManagerRegistry $registry)
@@ -127,7 +122,7 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
                 // If there is no QueryBuilder we can safely cache DoctrineChoiceLoader,
                 // also if concrete Type can return important QueryBuilder parts to generate
                 // hash key we go for it as well
-                if (!$options['query_builder'] || false !== ($qbParts = $this->getQueryBuilderPartsForCachingHash($options['query_builder']))) {
+                if (!$options['query_builder'] || null !== $qbParts = $this->getQueryBuilderPartsForCachingHash($options['query_builder'])) {
                     $hash = CachingFactoryDecorator::generateHash([
                         $options['em'],
                         $options['class'],

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -68,14 +68,10 @@ class EntityType extends DoctrineType
      * We consider two query builders with an equal SQL string and
      * equal parameters to be equal.
      *
-     * @param QueryBuilder $queryBuilder
-     *
-     * @return array
-     *
      * @internal This method is public to be usable as callback. It should not
      *           be used in user code.
      */
-    public function getQueryBuilderPartsForCachingHash($queryBuilder)
+    public function getQueryBuilderPartsForCachingHash(QueryBuilder $queryBuilder): ?array
     {
         return [
             $queryBuilder->getQuery()->getSQL(),

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php
@@ -29,10 +29,8 @@ class LazyLoadingValueHolderGenerator extends BaseGenerator
 
     /**
      * {@inheritdoc}
-     *
-     * @return void
      */
-    public function generate(\ReflectionClass $originalClass, ClassGenerator $classGenerator)
+    public function generate(\ReflectionClass $originalClass, ClassGenerator $classGenerator): void
     {
         parent::generate($originalClass, $classGenerator);
 

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -40,7 +40,7 @@ class ProxyDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function isProxyCandidate(Definition $definition)
+    public function isProxyCandidate(Definition $definition): bool
     {
         return ($definition->isLazy() || $definition->hasTag('proxy')) && $this->proxyGenerator->getProxifiedClass($definition);
     }
@@ -48,7 +48,7 @@ class ProxyDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode = null)
+    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode = null): string
     {
         $instantiation = 'return';
 
@@ -82,7 +82,7 @@ EOF;
     /**
      * {@inheritdoc}
      */
-    public function getProxyCode(Definition $definition)
+    public function getProxyCode(Definition $definition): string
     {
         $code = $this->classGenerator->generate($this->generateProxyClass($definition));
 

--- a/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
@@ -93,7 +93,7 @@ class RoutingExtension extends AbstractExtension
      *
      * @final
      */
-    public function isUrlGenerationSafe(Node $argsNode)
+    public function isUrlGenerationSafe(Node $argsNode): array
     {
         // support named arguments
         $paramsNode = $argsNode->hasNode('parameters') ? $argsNode->getNode('parameters') : (

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
@@ -57,7 +57,7 @@ class RouterCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInterf
      *
      * @return bool always true
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }
@@ -65,7 +65,7 @@ class RouterCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInterf
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return [
             'router' => RouterInterface::class,

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -213,11 +213,9 @@ EOF
     /**
      * Loads the ContainerBuilder from the cache.
      *
-     * @return ContainerBuilder
-     *
      * @throws \LogicException
      */
-    protected function getContainerBuilder()
+    protected function getContainerBuilder(): ContainerBuilder
     {
         if ($this->containerBuilder) {
             return $this->containerBuilder;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -84,23 +84,12 @@ abstract class Descriptor implements DescriptorInterface
         }
     }
 
-    /**
-     * Returns the output.
-     *
-     * @return OutputInterface The output
-     */
-    protected function getOutput()
+    protected function getOutput(): OutputInterface
     {
         return $this->output;
     }
 
-    /**
-     * Writes content to output.
-     *
-     * @param string $content
-     * @param bool   $decorated
-     */
-    protected function write($content, $decorated = false)
+    protected function write(string $content, bool $decorated = false)
     {
         $this->output->write($content, false, $decorated ? OutputInterface::OUTPUT_NORMAL : OutputInterface::OUTPUT_RAW);
     }
@@ -182,10 +171,8 @@ abstract class Descriptor implements DescriptorInterface
      * Formats a value as string.
      *
      * @param mixed $value
-     *
-     * @return string
      */
-    protected function formatValue($value)
+    protected function formatValue($value): string
     {
         if (\is_object($value)) {
             return sprintf('object(%s)', \get_class($value));
@@ -202,10 +189,8 @@ abstract class Descriptor implements DescriptorInterface
      * Formats a parameter.
      *
      * @param mixed $value
-     *
-     * @return string
      */
-    protected function formatParameter($value)
+    protected function formatParameter($value): string
     {
         if (\is_bool($value) || \is_array($value) || (null === $value)) {
             $jsonString = json_encode($value);
@@ -246,10 +231,8 @@ abstract class Descriptor implements DescriptorInterface
 
     /**
      * @param bool $showHidden
-     *
-     * @return array
      */
-    protected function findDefinitionsByTag(ContainerBuilder $builder, $showHidden)
+    protected function findDefinitionsByTag(ContainerBuilder $builder, $showHidden): array
     {
         $definitions = [];
         $tags = $builder->findTags();

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -198,10 +198,7 @@ class JsonDescriptor extends Descriptor
         $this->write(json_encode($data, $flags | JSON_PRETTY_PRINT)."\n");
     }
 
-    /**
-     * @return array
-     */
-    protected function getRouteData(Route $route)
+    protected function getRouteData(Route $route): array
     {
         $data = [
             'path' => $route->getPath(),

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/RedirectableCompiledUrlMatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/RedirectableCompiledUrlMatcher.php
@@ -24,7 +24,7 @@ class RedirectableCompiledUrlMatcher extends CompiledUrlMatcher implements Redir
     /**
      * {@inheritdoc}
      */
-    public function redirect($path, $route, $scheme = null)
+    public function redirect($path, $route, $scheme = null): array
     {
         return [
             '_controller' => 'Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::urlRedirectAction',

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -41,7 +42,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function isCompiled()
+    public function isCompiled(): bool
     {
         return $this->getPublicContainer()->isCompiled();
     }
@@ -49,7 +50,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function getParameterBag()
+    public function getParameterBag(): ParameterBagInterface
     {
         return $this->getPublicContainer()->getParameterBag();
     }
@@ -65,7 +66,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function hasParameter($name)
+    public function hasParameter($name): bool
     {
         return $this->getPublicContainer()->hasParameter($name);
     }
@@ -89,7 +90,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function has($id)
+    public function has($id): bool
     {
         return $this->getPublicContainer()->has($id) || $this->getPrivateContainer()->has($id);
     }
@@ -105,7 +106,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function initialized($id)
+    public function initialized($id): bool
     {
         return $this->getPublicContainer()->initialized($id);
     }
@@ -121,7 +122,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function getServiceIds()
+    public function getServiceIds(): array
     {
         return $this->getPublicContainer()->getServiceIds();
     }
@@ -129,7 +130,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function getRemovedIds()
+    public function getRemovedIds(): array
     {
         return $this->getPublicContainer()->getRemovedIds();
     }

--- a/src/Symfony/Bundle/SecurityBundle/EventListener/VoteListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/EventListener/VoteListener.php
@@ -39,7 +39,7 @@ class VoteListener implements EventSubscriberInterface
         $this->traceableAccessDecisionManager->addVoterVote($event->getVoter(), $event->getAttributes(), $event->getVote());
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return ['debug.security.authorization.vote' => 'onVoterVote'];
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php
@@ -38,10 +38,8 @@ class ContentSecurityPolicyHandler
      *  - The request - In case HTML content is fetched via AJAX and inserted in DOM, it must use the same nonce as origin
      *  - The response -  A call to getNonces() has already been done previously. Same nonce are returned
      *  - They are otherwise randomly generated
-     *
-     * @return array
      */
-    public function getNonces(Request $request, Response $response)
+    public function getNonces(Request $request, Response $response): array
     {
         if ($request->headers->has('X-SymfonyProfiler-Script-Nonce') && $request->headers->has('X-SymfonyProfiler-Style-Nonce')) {
             return [
@@ -83,7 +81,7 @@ class ContentSecurityPolicyHandler
      *
      * @return array Nonces used by the bundle in Content-Security-Policy header
      */
-    public function updateResponseHeaders(Request $request, Response $response)
+    public function updateResponseHeaders(Request $request, Response $response): array
     {
         if ($this->cspDisabled) {
             $this->removeCspHeaders($response);

--- a/src/Symfony/Component/Cache/Traits/PdoTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PdoTrait.php
@@ -403,10 +403,7 @@ trait PdoTrait
         return $this->conn;
     }
 
-    /**
-     * @return string
-     */
-    private function getServerVersion()
+    private function getServerVersion(): string
     {
         if (null === $this->serverVersion) {
             $conn = $this->conn instanceof \PDO ? $this->conn : $this->conn->getWrappedConnection();

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -50,10 +50,7 @@ class ApplicationDescription
         $this->showHidden = $showHidden;
     }
 
-    /**
-     * @return array
-     */
-    public function getNamespaces()
+    public function getNamespaces(): array
     {
         if (null === $this->namespaces) {
             $this->inspectApplication();
@@ -65,7 +62,7 @@ class ApplicationDescription
     /**
      * @return Command[]
      */
-    public function getCommands()
+    public function getCommands(): array
     {
         if (null === $this->commands) {
             $this->inspectApplication();
@@ -75,13 +72,9 @@ class ApplicationDescription
     }
 
     /**
-     * @param string $name
-     *
-     * @return Command
-     *
      * @throws CommandNotFoundException
      */
-    public function getCommand($name)
+    public function getCommand(string $name): Command
     {
         if (!isset($this->commands[$name]) && !isset($this->aliases[$name])) {
             throw new CommandNotFoundException(sprintf('Command %s does not exist.', $name));

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -26,10 +26,7 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class XmlDescriptor extends Descriptor
 {
-    /**
-     * @return \DOMDocument
-     */
-    public function getInputDefinitionDocument(InputDefinition $definition)
+    public function getInputDefinitionDocument(InputDefinition $definition): \DOMDocument
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($definitionXML = $dom->createElement('definition'));
@@ -47,10 +44,7 @@ class XmlDescriptor extends Descriptor
         return $dom;
     }
 
-    /**
-     * @return \DOMDocument
-     */
-    public function getCommandDocument(Command $command)
+    public function getCommandDocument(Command $command): \DOMDocument
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($commandXML = $dom->createElement('command'));
@@ -80,12 +74,7 @@ class XmlDescriptor extends Descriptor
         return $dom;
     }
 
-    /**
-     * @param string|null $namespace
-     *
-     * @return \DOMDocument
-     */
-    public function getApplicationDocument(Application $application, $namespace = null)
+    public function getApplicationDocument(Application $application, string $namespace = null): \DOMDocument
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($rootXml = $dom->createElement('symfony'));

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -42,13 +42,9 @@ class OutputFormatter implements WrappableOutputFormatterInterface
     /**
      * Escapes trailing "\" in given text.
      *
-     * @param string $text Text to escape
-     *
-     * @return string Escaped text
-     *
      * @internal
      */
-    public static function escapeTrailingBackslash($text)
+    public static function escapeTrailingBackslash(string $text): string
     {
         if ('\\' === substr($text, -1)) {
             $len = \strlen($text);
@@ -166,7 +162,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
             if (!$open && !$tag) {
                 // </>
                 $this->styleStack->pop();
-            } elseif (false === $style = $this->createStyleFromString($tag)) {
+            } elseif (null === $style = $this->createStyleFromString($tag)) {
                 $output .= $this->applyCurrentStyle($text, $output, $width, $currentLineLength);
             } elseif ($open) {
                 $this->styleStack->push($style);
@@ -194,17 +190,15 @@ class OutputFormatter implements WrappableOutputFormatterInterface
 
     /**
      * Tries to create new style instance from string.
-     *
-     * @return OutputFormatterStyle|false False if string is not format string
      */
-    private function createStyleFromString(string $string)
+    private function createStyleFromString(string $string): ?OutputFormatterStyleInterface
     {
         if (isset($this->styles[$string])) {
             return $this->styles[$string];
         }
 
         if (!preg_match_all('/([^=]+)=([^;]+)(;|$)/', $string, $matches, PREG_SET_ORDER)) {
-            return false;
+            return null;
         }
 
         $style = new OutputFormatterStyle();
@@ -225,7 +219,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
                     $style->setOption($option);
                 }
             } else {
-                return false;
+                return null;
             }
         }
 

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -333,15 +333,11 @@ class InputDefinition
     /**
      * Returns the InputOption name given a shortcut.
      *
-     * @param string $shortcut The shortcut
-     *
-     * @return string The InputOption name
-     *
      * @throws InvalidArgumentException When option given does not exist
      *
      * @internal
      */
-    public function shortcutToName($shortcut)
+    public function shortcutToName(string $shortcut): string
     {
         if (!isset($this->shortcuts[$shortcut])) {
             throw new InvalidArgumentException(sprintf('The "-%s" option does not exist.', $shortcut));

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -157,13 +157,9 @@ class OutputFormatterTest extends TestCase
     }
 
     /**
-     * @param string      $tag
-     * @param string|null $expected
-     * @param string|null $input
-     *
      * @dataProvider provideInlineStyleOptionsCases
      */
-    public function testInlineStyleOptions($tag, $expected = null, $input = null)
+    public function testInlineStyleOptions(string $tag, string $expected = null, string $input = null)
     {
         $styleString = substr($tag, 1, -1);
         $formatter = new OutputFormatter(true);
@@ -171,7 +167,7 @@ class OutputFormatterTest extends TestCase
         $method->setAccessible(true);
         $result = $method->invoke($formatter, $styleString);
         if (null === $expected) {
-            $this->assertFalse($result);
+            $this->assertNull($result);
             $expected = $tag.$input.'</'.$styleString.'>';
             $this->assertSame($expected, $formatter->format($expected));
         } else {

--- a/src/Symfony/Component/CssSelector/Node/ElementNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ElementNode.php
@@ -32,18 +32,12 @@ class ElementNode extends AbstractNode
         $this->element = $element;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getNamespace()
+    public function getNamespace(): ?string
     {
         return $this->namespace;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getElement()
+    public function getElement(): ?string
     {
         return $this->element;
     }

--- a/src/Symfony/Component/CssSelector/Node/FunctionNode.php
+++ b/src/Symfony/Component/CssSelector/Node/FunctionNode.php
@@ -52,7 +52,7 @@ class FunctionNode extends AbstractNode
     /**
      * @return Token[]
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }

--- a/src/Symfony/Component/CssSelector/Node/NegationNode.php
+++ b/src/Symfony/Component/CssSelector/Node/NegationNode.php
@@ -32,18 +32,12 @@ class NegationNode extends AbstractNode
         $this->subSelector = $subSelector;
     }
 
-    /**
-     * @return NodeInterface
-     */
-    public function getSelector()
+    public function getSelector(): NodeInterface
     {
         return $this->selector;
     }
 
-    /**
-     * @return NodeInterface
-     */
-    public function getSubSelector()
+    public function getSubSelector(): NodeInterface
     {
         return $this->subSelector;
     }

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -76,11 +76,9 @@ class TokenStream
     /**
      * Returns next token.
      *
-     * @return Token
-     *
      * @throws InternalErrorException If there is no more token
      */
-    public function getNext()
+    public function getNext(): Token
     {
         if ($this->peeking) {
             $this->peeking = false;
@@ -98,10 +96,8 @@ class TokenStream
 
     /**
      * Returns peeked token.
-     *
-     * @return Token
      */
-    public function getPeek()
+    public function getPeek(): Token
     {
         if (!$this->peeking) {
             $this->peeked = $this->getNext();
@@ -116,7 +112,7 @@ class TokenStream
      *
      * @return Token[]
      */
-    public function getUsed()
+    public function getUsed(): array
     {
         return $this->used;
     }
@@ -128,7 +124,7 @@ class TokenStream
      *
      * @throws SyntaxErrorException If next token is not an identifier
      */
-    public function getNextIdentifier()
+    public function getNextIdentifier(): string
     {
         $next = $this->getNext();
 
@@ -146,7 +142,7 @@ class TokenStream
      *
      * @throws SyntaxErrorException If next token is not an identifier or a star delimiter
      */
-    public function getNextIdentifierOrStar()
+    public function getNextIdentifierOrStar(): ?string
     {
         $next = $this->getNext();
 

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/Tokenizer.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/Tokenizer.php
@@ -50,10 +50,8 @@ class Tokenizer
 
     /**
      * Tokenize selector source code.
-     *
-     * @return TokenStream
      */
-    public function tokenize(Reader $reader)
+    public function tokenize(Reader $reader): TokenStream
     {
         $stream = new TokenStream();
 

--- a/src/Symfony/Component/CssSelector/XPath/Extension/AbstractExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/AbstractExtension.php
@@ -26,7 +26,7 @@ abstract class AbstractExtension implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getNodeTranslators()
+    public function getNodeTranslators(): array
     {
         return [];
     }
@@ -34,7 +34,7 @@ abstract class AbstractExtension implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getCombinationTranslators()
+    public function getCombinationTranslators(): array
     {
         return [];
     }
@@ -42,7 +42,7 @@ abstract class AbstractExtension implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getFunctionTranslators()
+    public function getFunctionTranslators(): array
     {
         return [];
     }
@@ -50,7 +50,7 @@ abstract class AbstractExtension implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getPseudoClassTranslators()
+    public function getPseudoClassTranslators(): array
     {
         return [];
     }
@@ -58,7 +58,7 @@ abstract class AbstractExtension implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributeMatchingTranslators()
+    public function getAttributeMatchingTranslators(): array
     {
         return [];
     }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/AttributeMatchingExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/AttributeMatchingExtension.php
@@ -29,7 +29,7 @@ class AttributeMatchingExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getAttributeMatchingTranslators()
+    public function getAttributeMatchingTranslators(): array
     {
         return [
             'exists' => [$this, 'translateExists'],
@@ -112,7 +112,7 @@ class AttributeMatchingExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'attribute-matching';
     }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/CombinationExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/CombinationExtension.php
@@ -43,18 +43,12 @@ class CombinationExtension extends AbstractExtension
         return $xpath->join('/descendant-or-self::*/', $combinedXpath);
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateChild(XPathExpr $xpath, XPathExpr $combinedXpath)
+    public function translateChild(XPathExpr $xpath, XPathExpr $combinedXpath): XPathExpr
     {
         return $xpath->join('/', $combinedXpath);
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateDirectAdjacent(XPathExpr $xpath, XPathExpr $combinedXpath)
+    public function translateDirectAdjacent(XPathExpr $xpath, XPathExpr $combinedXpath): XPathExpr
     {
         return $xpath
             ->join('/following-sibling::', $combinedXpath)
@@ -62,10 +56,7 @@ class CombinationExtension extends AbstractExtension
             ->addCondition('position() = 1');
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateIndirectAdjacent(XPathExpr $xpath, XPathExpr $combinedXpath)
+    public function translateIndirectAdjacent(XPathExpr $xpath, XPathExpr $combinedXpath): XPathExpr
     {
         return $xpath->join('/following-sibling::', $combinedXpath);
     }
@@ -73,7 +64,7 @@ class CombinationExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'combination';
     }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
@@ -33,7 +33,7 @@ class FunctionExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctionTranslators()
+    public function getFunctionTranslators(): array
     {
         return [
             'nth-child' => [$this, 'translateNthChild'],
@@ -164,7 +164,7 @@ class FunctionExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'function';
     }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
@@ -39,7 +39,7 @@ class HtmlExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getPseudoClassTranslators()
+    public function getPseudoClassTranslators(): array
     {
         return [
             'checked' => [$this, 'translateChecked'],
@@ -56,17 +56,14 @@ class HtmlExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctionTranslators()
+    public function getFunctionTranslators(): array
     {
         return [
             'lang' => [$this, 'translateLang'],
         ];
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateChecked(XPathExpr $xpath)
+    public function translateChecked(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition(
             '(@checked '
@@ -75,18 +72,12 @@ class HtmlExtension extends AbstractExtension
         );
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateLink(XPathExpr $xpath)
+    public function translateLink(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition("@href and (name(.) = 'a' or name(.) = 'link' or name(.) = 'area')");
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateDisabled(XPathExpr $xpath)
+    public function translateDisabled(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition(
             '('
@@ -112,10 +103,7 @@ class HtmlExtension extends AbstractExtension
         // todo: in the second half, add "and is not a descendant of that fieldset element's first legend element child, if any."
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateEnabled(XPathExpr $xpath)
+    public function translateEnabled(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition(
             '('
@@ -149,11 +137,9 @@ class HtmlExtension extends AbstractExtension
     }
 
     /**
-     * @return XPathExpr
-     *
      * @throws ExpressionErrorException
      */
-    public function translateLang(XPathExpr $xpath, FunctionNode $function)
+    public function translateLang(XPathExpr $xpath, FunctionNode $function): XPathExpr
     {
         $arguments = $function->getArguments();
         foreach ($arguments as $token) {
@@ -171,34 +157,22 @@ class HtmlExtension extends AbstractExtension
         ));
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateSelected(XPathExpr $xpath)
+    public function translateSelected(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition("(@selected and name(.) = 'option')");
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateInvalid(XPathExpr $xpath)
+    public function translateInvalid(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition('0');
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateHover(XPathExpr $xpath)
+    public function translateHover(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition('0');
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateVisited(XPathExpr $xpath)
+    public function translateVisited(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition('0');
     }
@@ -206,7 +180,7 @@ class HtmlExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'html';
     }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -62,7 +62,7 @@ class NodeExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getNodeTranslators()
+    public function getNodeTranslators(): array
     {
         return [
             'Selector' => [$this, 'translateSelector'],
@@ -185,7 +185,7 @@ class NodeExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'node';
     }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
@@ -29,7 +29,7 @@ class PseudoClassExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getPseudoClassTranslators()
+    public function getPseudoClassTranslators(): array
     {
         return [
             'root' => [$this, 'translateRoot'],
@@ -43,18 +43,12 @@ class PseudoClassExtension extends AbstractExtension
         ];
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateRoot(XPathExpr $xpath)
+    public function translateRoot(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition('not(parent::*)');
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateFirstChild(XPathExpr $xpath)
+    public function translateFirstChild(XPathExpr $xpath): XPathExpr
     {
         return $xpath
             ->addStarPrefix()
@@ -62,10 +56,7 @@ class PseudoClassExtension extends AbstractExtension
             ->addCondition('position() = 1');
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateLastChild(XPathExpr $xpath)
+    public function translateLastChild(XPathExpr $xpath): XPathExpr
     {
         return $xpath
             ->addStarPrefix()
@@ -74,11 +65,9 @@ class PseudoClassExtension extends AbstractExtension
     }
 
     /**
-     * @return XPathExpr
-     *
      * @throws ExpressionErrorException
      */
-    public function translateFirstOfType(XPathExpr $xpath)
+    public function translateFirstOfType(XPathExpr $xpath): XPathExpr
     {
         if ('*' === $xpath->getElement()) {
             throw new ExpressionErrorException('"*:first-of-type" is not implemented.');
@@ -90,11 +79,9 @@ class PseudoClassExtension extends AbstractExtension
     }
 
     /**
-     * @return XPathExpr
-     *
      * @throws ExpressionErrorException
      */
-    public function translateLastOfType(XPathExpr $xpath)
+    public function translateLastOfType(XPathExpr $xpath): XPathExpr
     {
         if ('*' === $xpath->getElement()) {
             throw new ExpressionErrorException('"*:last-of-type" is not implemented.');
@@ -105,10 +92,7 @@ class PseudoClassExtension extends AbstractExtension
             ->addCondition('position() = last()');
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateOnlyChild(XPathExpr $xpath)
+    public function translateOnlyChild(XPathExpr $xpath): XPathExpr
     {
         return $xpath
             ->addStarPrefix()
@@ -117,11 +101,9 @@ class PseudoClassExtension extends AbstractExtension
     }
 
     /**
-     * @return XPathExpr
-     *
      * @throws ExpressionErrorException
      */
-    public function translateOnlyOfType(XPathExpr $xpath)
+    public function translateOnlyOfType(XPathExpr $xpath): XPathExpr
     {
         if ('*' === $xpath->getElement()) {
             throw new ExpressionErrorException('"*:only-of-type" is not implemented.');
@@ -130,10 +112,7 @@ class PseudoClassExtension extends AbstractExtension
         return $xpath->addCondition('last() = 1');
     }
 
-    /**
-     * @return XPathExpr
-     */
-    public function translateEmpty(XPathExpr $xpath)
+    public function translateEmpty(XPathExpr $xpath): XPathExpr
     {
         return $xpath->addCondition('not(*) and not(string-length())');
     }
@@ -141,7 +120,7 @@ class PseudoClassExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'pseudo-class';
     }

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -215,7 +215,7 @@ class Translator implements TranslatorInterface
     /**
      * @return SelectorNode[]
      */
-    private function parseSelectors(string $css)
+    private function parseSelectors(string $css): array
     {
         foreach ($this->shortcutParsers as $shortcut) {
             $tokens = $shortcut->parse($css);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1496,11 +1496,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Gets removed binding ids.
      *
-     * @return array
-     *
      * @internal
      */
-    public function getRemovedBindingIds()
+    public function getRemovedBindingIds(): array
     {
         return $this->removedBindingIds;
     }
@@ -1508,11 +1506,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Removes bindings for a service.
      *
-     * @param string $id The service identifier
-     *
      * @internal
      */
-    public function removeBindings($id)
+    public function removeBindings(string $id)
     {
         if ($this->hasDefinition($id)) {
             foreach ($this->getDefinition($id)->getBindings() as $key => $binding) {
@@ -1527,11 +1523,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param mixed $value An array of conditionals to return
      *
-     * @return array An array of Service conditionals
-     *
      * @internal
      */
-    public static function getServiceConditionals($value)
+    public static function getServiceConditionals($value): array
     {
         $services = [];
 
@@ -1551,11 +1545,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param mixed $value An array of conditionals to return
      *
-     * @return array An array of uninitialized conditionals
-     *
      * @internal
      */
-    public static function getInitializedConditionals($value)
+    public static function getInitializedConditionals($value): array
     {
         $services = [];
 

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
@@ -25,7 +25,7 @@ class NullDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function isProxyCandidate(Definition $definition)
+    public function isProxyCandidate(Definition $definition): bool
     {
         return false;
     }
@@ -33,7 +33,7 @@ class NullDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode = null)
+    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode = null): string
     {
         return '';
     }
@@ -41,7 +41,7 @@ class NullDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProxyCode(Definition $definition)
+    public function getProxyCode(Definition $definition): string
     {
         return '';
     }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
@@ -21,7 +21,7 @@ class ProxyHelper
     /**
      * @return string|null The FQCN or builtin name of the type hint, or null when the type hint references an invalid self|parent context
      */
-    public static function getTypeHint(\ReflectionFunctionAbstract $r, \ReflectionParameter $p = null, $noBuiltin = false)
+    public static function getTypeHint(\ReflectionFunctionAbstract $r, \ReflectionParameter $p = null, $noBuiltin = false): ?string
     {
         if ($p instanceof \ReflectionParameter) {
             $type = $p->getType();

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -61,10 +61,8 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
 
     /**
      * Defines an instanceof-conditional to be applied to following service definitions.
-     *
-     * @return InstanceofConfigurator
      */
-    final public function instanceof(string $fqcn)
+    final public function instanceof(string $fqcn): InstanceofConfigurator
     {
         return $this->parent->instanceof($fqcn);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CustomExpressionLanguageFunctionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CustomExpressionLanguageFunctionTest.php
@@ -19,7 +19,7 @@ class CustomExpressionLanguageFunctionTest extends TestCase
             ->setArguments([new Expression('custom_func("foobar")')]);
 
         $container->addExpressionLanguageProvider(new class() implements ExpressionFunctionProviderInterface {
-            public function getFunctions()
+            public function getFunctions(): array
             {
                 return [
                     ExpressionFunction::fromPhp('strtolower', 'custom_func'),

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -196,7 +196,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
         $container = new ContainerBuilder();
 
         $subscriber = new class() implements ServiceSubscriberInterface {
-            public static function getSubscribedServices()
+            public static function getSubscribedServices(): array
             {
                 return [
                     'some.service' => 'stdClass',

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -327,7 +327,7 @@ class ContainerTest extends TestCase
         $c->set('bar', $bar = new class() implements ResetInterface {
             public $resetCounter = 0;
 
-            public function reset()
+            public function reset(): void
             {
                 ++$this->resetCounter;
             }

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -48,10 +48,8 @@ class FormFieldRegistry
 
     /**
      * Removes a field and its children from the registry.
-     *
-     * @param string $name The fully qualified name of the base field
      */
-    public function remove($name)
+    public function remove(string $name)
     {
         $segments = $this->getSegments($name);
         $target = &$this->fields;
@@ -68,13 +66,11 @@ class FormFieldRegistry
     /**
      * Returns the value of the field and its children.
      *
-     * @param string $name The fully qualified name of the field
-     *
      * @return mixed The value of the field
      *
      * @throws \InvalidArgumentException if the field does not exist
      */
-    public function &get($name)
+    public function &get(string $name)
     {
         $segments = $this->getSegments($name);
         $target = &$this->fields;
@@ -92,11 +88,9 @@ class FormFieldRegistry
     /**
      * Tests whether the form has the given field.
      *
-     * @param string $name The fully qualified name of the field
-     *
      * @return bool Whether the form has the given field
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         try {
             $this->get($name);
@@ -110,12 +104,11 @@ class FormFieldRegistry
     /**
      * Set the value of a field and its children.
      *
-     * @param string $name  The fully qualified name of the field
-     * @param mixed  $value The value
+     * @param mixed $value The value
      *
      * @throws \InvalidArgumentException if the field does not exist
      */
-    public function set($name, $value)
+    public function set(string $name, $value)
     {
         $target = &$this->get($name);
         if ((!\is_array($value) && $target instanceof Field\FormField) || $target instanceof Field\ChoiceFormField) {
@@ -135,7 +128,7 @@ class FormFieldRegistry
      *
      * @return FormField[] The list of fields as [string] Fully qualified name => (mixed) value)
      */
-    public function all()
+    public function all(): array
     {
         return $this->walk($this->fields, $this->base);
     }
@@ -146,12 +139,11 @@ class FormFieldRegistry
      * This function is made private because it allows overriding the $base and
      * the $values properties without any type checking.
      *
-     * @param string $base   The fully qualified name of the base field
-     * @param array  $values The values of the fields
+     * @param array $values The values of the fields
      *
      * @return static
      */
-    private static function create($base, array $values)
+    private static function create(string $base, array $values)
     {
         $registry = new static();
         $registry->base = $base;

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -139,7 +139,7 @@ class ExtractingEventDispatcher extends EventDispatcher implements EventSubscrib
         $this->listeners[] = [$eventName, $listener[1], $priority];
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         $events = [];
 

--- a/src/Symfony/Component/ExpressionLanguage/TokenStream.php
+++ b/src/Symfony/Component/ExpressionLanguage/TokenStream.php
@@ -83,10 +83,8 @@ class TokenStream
 
     /**
      * @internal
-     *
-     * @return string
      */
-    public function getExpression()
+    public function getExpression(): string
     {
         return $this->expression;
     }

--- a/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -41,14 +41,13 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
      * Optionally, a namespace string can be passed. Calling this method will
      * the same values, but different namespaces, will return different hashes.
      *
-     * @param mixed  $value     The value to hash
-     * @param string $namespace Optional. The namespace
+     * @param mixed $value The value to hash
      *
      * @return string The SHA-256 hash
      *
      * @internal
      */
-    public static function generateHash($value, $namespace = '')
+    public static function generateHash($value, string $namespace = ''): string
     {
         if (\is_object($value)) {
             $value = spl_object_hash($value);

--- a/src/Symfony/Component/Form/Util/OptionsResolverWrapper.php
+++ b/src/Symfony/Component/Form/Util/OptionsResolverWrapper.php
@@ -79,7 +79,7 @@ class OptionsResolverWrapper extends OptionsResolver
         return $this;
     }
 
-    public function resolve(array $options = [])
+    public function resolve(array $options = []): array
     {
         throw new AccessException('Resolve options is not supported.');
     }

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -41,7 +41,7 @@ class CurlHttpClientTest extends HttpClientTestCase
         $logger = new class() extends AbstractLogger {
             public $logs = [];
 
-            public function log($level, $message, array $context = [])
+            public function log($level, $message, array $context = []): void
             {
                 $this->logs[] = $message;
             }

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -147,11 +147,9 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * @return bool
-     *
      * @internal
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         if ($this->isStarted()) {
             ++$this->usageIndex;

--- a/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
@@ -29,20 +29,14 @@ final class SessionBagProxy implements SessionBagInterface
         $this->usageIndex = &$usageIndex;
     }
 
-    /**
-     * @return SessionBagInterface
-     */
-    public function getBag()
+    public function getBag(): SessionBagInterface
     {
         ++$this->usageIndex;
 
         return $this->bag;
     }
 
-    /**
-     * @return bool
-     */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         if (!isset($this->data[$this->bag->getStorageKey()])) {
             return true;
@@ -55,7 +49,7 @@ final class SessionBagProxy implements SessionBagInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->bag->getName();
     }
@@ -74,7 +68,7 @@ final class SessionBagProxy implements SessionBagInterface
     /**
      * {@inheritdoc}
      */
-    public function getStorageKey()
+    public function getStorageKey(): string
     {
         return $this->bag->getStorageKey();
     }

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -116,10 +116,8 @@ abstract class Bundle implements BundleInterface
 
     /**
      * Returns the bundle name (the class short name).
-     *
-     * @return string The Bundle name
      */
-    final public function getName()
+    final public function getName(): string
     {
         if (null === $this->name) {
             $this->parseClassName();

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -115,7 +115,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
      *
      * @return bool always false
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return false;
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 
 /**
@@ -32,7 +33,7 @@ class SessionListener extends AbstractSessionListener
         $this->container = $container;
     }
 
-    protected function getSession()
+    protected function getSession(): ?SessionInterface
     {
         if (!$this->container->has('session')) {
             return null;

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Sets the session in the request.
@@ -30,7 +31,7 @@ class TestSessionListener extends AbstractTestSessionListener
         parent::__construct($sessionOptions);
     }
 
-    protected function getSession()
+    protected function getSession(): ?SessionInterface
     {
         if (!$this->container->has('session')) {
             return null;

--- a/src/Symfony/Component/HttpKernel/HttpClientKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpClientKernel.php
@@ -56,7 +56,7 @@ final class HttpClientKernel implements HttpKernelInterface
         $response = new Response($response->getContent(!$catch), $response->getStatusCode(), $response->getHeaders(!$catch));
 
         $response->headers = new class($response->headers->all()) extends ResponseHeaderBag {
-            protected function computeCacheControlValue()
+            protected function computeCacheControlValue(): string
             {
                 return $this->getCacheControlHeader(); // preserve the original value
             }

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -110,14 +110,10 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      *
      * Exceptions are not caught.
      *
-     * @param int $type The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
-     *
-     * @return Response A Response instance
-     *
      * @throws \LogicException       If one of the listener does not behave as expected
      * @throws NotFoundHttpException When controller cannot be found
      */
-    private function handleRaw(Request $request, int $type = self::MASTER_REQUEST)
+    private function handleRaw(Request $request, int $type = self::MASTER_REQUEST): Response
     {
         $this->requestStack->push($request);
 
@@ -174,8 +170,6 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     /**
      * Filters a response object.
      *
-     * @param int $type The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
-     *
      * @throws \RuntimeException if the passed object is not a Response instance
      */
     private function filterResponse(Response $response, Request $request, int $type): Response
@@ -204,8 +198,6 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
 
     /**
      * Handles an exception by trying to convert it to a Response.
-     *
-     * @param int $type The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
      *
      * @throws \Exception
      */

--- a/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
@@ -91,39 +91,17 @@ abstract class AbstractDataGenerator
     }
 
     /**
-     * @param string $sourceDir
-     *
      * @return string[]
      */
-    abstract protected function scanLocales(LocaleScanner $scanner, $sourceDir);
+    abstract protected function scanLocales(LocaleScanner $scanner, string $sourceDir): array;
 
-    /**
-     * @param string $sourceDir
-     * @param string $tempDir
-     */
-    abstract protected function compileTemporaryBundles(BundleCompilerInterface $compiler, $sourceDir, $tempDir);
+    abstract protected function compileTemporaryBundles(BundleCompilerInterface $compiler, string $sourceDir, string $tempDir);
 
     abstract protected function preGenerate();
 
-    /**
-     * @param string $tempDir
-     * @param string $displayLocale
-     *
-     * @return array|null
-     */
-    abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale);
+    abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale): ?array;
 
-    /**
-     * @param string $tempDir
-     *
-     * @return array|null
-     */
-    abstract protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir);
+    abstract protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir): ?array;
 
-    /**
-     * @param string $tempDir
-     *
-     * @return array|null
-     */
-    abstract protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir);
+    abstract protected function generateDataForMeta(BundleEntryReaderInterface $reader, string $tempDir): ?array;
 }

--- a/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
@@ -51,7 +51,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, $sourceDir): array
     {
         return $scanner->scanLocales($sourceDir.'/curr');
     }
@@ -76,7 +76,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale): ?array
     {
         $localeBundle = $reader->read($tempDir, $displayLocale);
 
@@ -97,7 +97,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
         $rootBundle = $reader->read($tempDir, 'root');
 
@@ -110,7 +110,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
         $rootBundle = $reader->read($tempDir, 'root');
         $supplementalDataBundle = $reader->read($tempDir, 'supplementalData');

--- a/src/Symfony/Component/Intl/Data/Generator/GeneratorConfig.php
+++ b/src/Symfony/Component/Intl/Data/Generator/GeneratorConfig.php
@@ -38,10 +38,8 @@ class GeneratorConfig
 
     /**
      * Adds a writer to be used during the data conversion.
-     *
-     * @param string $targetDir The output directory
      */
-    public function addBundleWriter($targetDir, BundleWriterInterface $writer)
+    public function addBundleWriter(string $targetDir, BundleWriterInterface $writer)
     {
         $this->bundleWriters[$targetDir] = $writer;
     }
@@ -51,7 +49,7 @@ class GeneratorConfig
      *
      * @return BundleWriterInterface[]
      */
-    public function getBundleWriters()
+    public function getBundleWriters(): array
     {
         return $this->bundleWriters;
     }
@@ -62,7 +60,7 @@ class GeneratorConfig
      *
      * @return string An absolute path to a directory
      */
-    public function getSourceDir()
+    public function getSourceDir(): string
     {
         return $this->sourceDir;
     }
@@ -72,7 +70,7 @@ class GeneratorConfig
      *
      * @return string The ICU version string
      */
-    public function getIcuVersion()
+    public function getIcuVersion(): string
     {
         return $this->icuVersion;
     }

--- a/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
@@ -101,7 +101,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, $sourceDir): array
     {
         return $scanner->scanLocales($sourceDir.'/lang');
     }
@@ -126,7 +126,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale): ?array
     {
         $localeBundle = $reader->read($tempDir, $displayLocale);
 
@@ -148,14 +148,14 @@ class LanguageDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
         $rootBundle = $reader->read($tempDir, 'root');
         $metadataBundle = $reader->read($tempDir, 'metadata');

--- a/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
@@ -36,7 +36,7 @@ class LocaleDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, $sourceDir): array
     {
         $this->locales = $scanner->scanLocales($sourceDir.'/locales');
         $this->localeAliases = $scanner->scanAliases($sourceDir.'/locales');
@@ -74,7 +74,7 @@ class LocaleDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale): ?array
     {
         // Don't generate aliases, as they are resolved during runtime
         // Unless an alias is needed as fallback for de-duplication purposes
@@ -133,14 +133,14 @@ class LocaleDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
         return [
             'Locales' => $this->locales,

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -84,7 +84,7 @@ class RegionDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, $sourceDir): array
     {
         return $scanner->scanLocales($sourceDir.'/region');
     }
@@ -109,7 +109,7 @@ class RegionDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale): ?array
     {
         $localeBundle = $reader->read($tempDir, $displayLocale);
 
@@ -131,14 +131,14 @@ class RegionDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
         $rootBundle = $reader->read($tempDir, 'root');
         $metadataBundle = $reader->read($tempDir, 'metadata');

--- a/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
@@ -38,7 +38,7 @@ class ScriptDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, $sourceDir): array
     {
         return $scanner->scanLocales($sourceDir.'/lang');
     }
@@ -62,7 +62,7 @@ class ScriptDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale): ?array
     {
         $localeBundle = $reader->read($tempDir, $displayLocale);
 
@@ -84,14 +84,14 @@ class ScriptDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
         $rootBundle = $reader->read($tempDir, 'root');
 

--- a/src/Symfony/Component/Intl/Data/Generator/TimezoneDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/TimezoneDataGenerator.php
@@ -42,7 +42,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function scanLocales(LocaleScanner $scanner, $sourceDir)
+    protected function scanLocales(LocaleScanner $scanner, $sourceDir): array
     {
         $this->localeAliases = $scanner->scanAliases($sourceDir.'/locales');
 
@@ -75,7 +75,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale)
+    protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale): ?array
     {
         if (!$this->zoneToCountryMapping) {
             $this->zoneToCountryMapping = self::generateZoneToCountryMapping($reader->read($tempDir, 'windowsZones'));
@@ -126,7 +126,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
         $rootBundle = $reader->read($tempDir, 'root');
 
@@ -139,7 +139,7 @@ class TimezoneDataGenerator extends AbstractDataGenerator
     /**
      * {@inheritdoc}
      */
-    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir)
+    protected function generateDataForMeta(BundleEntryReaderInterface $reader, $tempDir): ?array
     {
         $rootBundle = $reader->read($tempDir, 'root');
 

--- a/src/Symfony/Component/Intl/Data/Util/LocaleScanner.php
+++ b/src/Symfony/Component/Intl/Data/Util/LocaleScanner.php
@@ -33,14 +33,12 @@ class LocaleScanner
     /**
      * Returns all locales found in the given directory.
      *
-     * @param string $sourceDir The directory with ICU files
-     *
      * @return array An array of locales. The result also contains locales that
      *               are in fact just aliases for other locales. Use
      *               {@link scanAliases()} to determine which of the locales
      *               are aliases
      */
-    public function scanLocales($sourceDir)
+    public function scanLocales(string $sourceDir): array
     {
         $locales = glob($sourceDir.'/*.txt');
 
@@ -60,12 +58,10 @@ class LocaleScanner
     /**
      * Returns all locale aliases found in the given directory.
      *
-     * @param string $sourceDir The directory with ICU files
-     *
      * @return array An array with the locale aliases as keys and the aliased
      *               locales as values
      */
-    public function scanAliases($sourceDir)
+    public function scanAliases(string $sourceDir): array
     {
         $locales = $this->scanLocales($sourceDir);
         $aliases = [];

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
@@ -74,7 +74,7 @@ class FullTransformer
      *
      * @return string The formatted value
      */
-    public function format(\DateTime $dateTime)
+    public function format(\DateTime $dateTime): string
     {
         $formatted = preg_replace_callback($this->regExp, function ($matches) use ($dateTime) {
             return $this->formatReplace($matches[0], $dateTime);
@@ -120,7 +120,7 @@ class FullTransformer
      *
      * @throws \InvalidArgumentException When the value can not be matched with pattern
      */
-    public function parse(\DateTime $dateTime, $value)
+    public function parse(\DateTime $dateTime, string $value)
     {
         $reverseMatchingRegExp = $this->getReverseMatchingRegExp($this->pattern);
         $reverseMatchingRegExp = '/^'.$reverseMatchingRegExp.'$/';

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimezoneTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimezoneTransformer.php
@@ -97,7 +97,7 @@ class TimezoneTransformer extends Transformer
      * @throws NotImplementedException   When the GMT time zone have minutes offset different than zero
      * @throws \InvalidArgumentException When the value can not be matched with pattern
      */
-    public static function getEtcTimeZoneId($formattedTimeZone)
+    public static function getEtcTimeZoneId(string $formattedTimeZone): string
     {
         if (preg_match('/GMT(?P<signal>[+-])(?P<hours>\d{2}):?(?P<minutes>\d{2})/', $formattedTimeZone, $matches)) {
             $hours = (int) $matches['hours'];

--- a/src/Symfony/Component/Intl/Globals/IntlGlobals.php
+++ b/src/Symfony/Component/Intl/Globals/IntlGlobals.php
@@ -58,10 +58,8 @@ abstract class IntlGlobals
      * Returns whether the error code indicates a failure.
      *
      * @param int $errorCode The error code returned by IntlGlobals::getErrorCode()
-     *
-     * @return bool
      */
-    public static function isFailure($errorCode)
+    public static function isFailure(int $errorCode): bool
     {
         return isset(self::$errorCodes[$errorCode])
             && $errorCode > self::U_ZERO_ERROR;
@@ -83,10 +81,8 @@ abstract class IntlGlobals
      * Returns the error message of the last operation.
      *
      * Returns "U_ZERO_ERROR" if no error occurred.
-     *
-     * @return string
      */
-    public static function getErrorMessage()
+    public static function getErrorMessage(): string
     {
         return self::$errorMessage;
     }
@@ -95,10 +91,8 @@ abstract class IntlGlobals
      * Returns the symbolic name for a given error code.
      *
      * @param int $code The error code returned by IntlGlobals::getErrorCode()
-     *
-     * @return string
      */
-    public static function getErrorName($code)
+    public static function getErrorName(int $code): string
     {
         return self::$errorCodes[$code] ?? '[BOGUS UErrorCode]';
     }
@@ -111,7 +105,7 @@ abstract class IntlGlobals
      *
      * @throws \InvalidArgumentException If the code is not one of the error constants in this class
      */
-    public static function setError($code, $message = '')
+    public static function setError(int $code, string $message = '')
     {
         if (!isset(self::$errorCodes[$code])) {
             throw new \InvalidArgumentException(sprintf('No such error code: "%s"', $code));

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -169,7 +169,7 @@ class Query extends AbstractQuery
      *
      * @internal
      */
-    public function getResources()
+    public function getResources(): array
     {
         return $this->results;
     }

--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -57,7 +57,7 @@ class LdapUser implements UserInterface, EquatableInterface
     /**
      * {@inheritdoc}
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }
@@ -65,14 +65,14 @@ class LdapUser implements UserInterface, EquatableInterface
     /**
      * {@inheritdoc}
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -27,11 +27,9 @@ class SemaphoreStore implements StoreInterface, BlockingStoreInterface
     /**
      * Returns whether or not the store is supported.
      *
-     * @return bool
-     *
      * @internal
      */
-    public static function isSupported()
+    public static function isSupported(): bool
     {
         return \extension_loaded('sysvsem');
     }

--- a/src/Symfony/Component/Messenger/MessageBus.php
+++ b/src/Symfony/Component/Messenger/MessageBus.php
@@ -44,7 +44,7 @@ class MessageBus implements MessageBusInterface
                     $this->middlewareHandlers = $middlewareHandlers;
                 }
 
-                public function getIterator()
+                public function getIterator(): \Traversable
                 {
                     if (null === $this->cachedIterator) {
                         $this->cachedIterator = new \ArrayObject(iterator_to_array($this->middlewareHandlers, false));

--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -54,10 +54,8 @@ abstract class AbstractPipes implements PipesInterface
 
     /**
      * Returns true if a system call has been interrupted.
-     *
-     * @return bool
      */
-    protected function hasSystemCallBeenInterrupted()
+    protected function hasSystemCallBeenInterrupted(): bool
     {
         $lastError = $this->lastError;
         $this->lastError = null;
@@ -92,7 +90,7 @@ abstract class AbstractPipes implements PipesInterface
      *
      * @throws InvalidArgumentException When an input iterator yields a non supported value
      */
-    protected function write()
+    protected function write(): ?array
     {
         if (!isset($this->pipes[0])) {
             return null;

--- a/src/Symfony/Component/Process/Pipes/UnixPipes.php
+++ b/src/Symfony/Component/Process/Pipes/UnixPipes.php
@@ -43,7 +43,7 @@ class UnixPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function getDescriptors()
+    public function getDescriptors(): array
     {
         if (!$this->haveReadSupport) {
             $nullstream = fopen('/dev/null', 'c');
@@ -81,7 +81,7 @@ class UnixPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function getFiles()
+    public function getFiles(): array
     {
         return [];
     }
@@ -89,7 +89,7 @@ class UnixPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function readAndWrite($blocking, $close = false)
+    public function readAndWrite($blocking, $close = false): array
     {
         $this->unblock();
         $w = $this->write();
@@ -138,7 +138,7 @@ class UnixPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function haveReadSupport()
+    public function haveReadSupport(): bool
     {
         return $this->haveReadSupport;
     }
@@ -146,7 +146,7 @@ class UnixPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function areOpen()
+    public function areOpen(): bool
     {
         return (bool) $this->pipes;
     }

--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -93,7 +93,7 @@ class WindowsPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function getDescriptors()
+    public function getDescriptors(): array
     {
         if (!$this->haveReadSupport) {
             $nullstream = fopen('NUL', 'c');
@@ -118,7 +118,7 @@ class WindowsPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function getFiles()
+    public function getFiles(): array
     {
         return $this->files;
     }
@@ -126,7 +126,7 @@ class WindowsPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function readAndWrite($blocking, $close = false)
+    public function readAndWrite($blocking, $close = false): array
     {
         $this->unblock();
         $w = $this->write();
@@ -161,7 +161,7 @@ class WindowsPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function haveReadSupport()
+    public function haveReadSupport(): bool
     {
         return $this->haveReadSupport;
     }
@@ -169,7 +169,7 @@ class WindowsPipes extends AbstractPipes
     /**
      * {@inheritdoc}
      */
-    public function areOpen()
+    public function areOpen(): bool
     {
         return $this->pipes && $this->fileHandles;
     }

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -73,7 +73,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     /**
      * {@inheritdoc}
      */
-    public function getShortDescription($class, $property, array $context = [])
+    public function getShortDescription($class, $property, array $context = []): ?string
     {
         /** @var $docBlock DocBlock */
         list($docBlock) = $this->getDocBlock($class, $property);
@@ -101,7 +101,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     /**
      * {@inheritdoc}
      */
-    public function getLongDescription($class, $property, array $context = [])
+    public function getLongDescription($class, $property, array $context = []): ?string
     {
         /** @var $docBlock DocBlock */
         list($docBlock) = $this->getDocBlock($class, $property);
@@ -117,7 +117,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes($class, $property, array $context = []): ?array
     {
         /** @var $docBlock DocBlock */
         list($docBlock, $source, $prefix) = $this->getDocBlock($class, $property);

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -75,7 +75,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * {@inheritdoc}
      */
-    public function getProperties($class, array $context = [])
+    public function getProperties($class, array $context = []): ?array
     {
         try {
             $reflectionClass = new \ReflectionClass($class);
@@ -131,7 +131,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes($class, $property, array $context = []): ?array
     {
         if ($fromMutator = $this->extractFromMutator($class, $property)) {
             return $fromMutator;
@@ -158,7 +158,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * {@inheritdoc}
      */
-    public function isReadable($class, $property, array $context = [])
+    public function isReadable($class, $property, array $context = []): ?bool
     {
         if ($this->isAllowedProperty($class, $property)) {
             return true;
@@ -172,7 +172,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * {@inheritdoc}
      */
-    public function isWritable($class, $property, array $context = [])
+    public function isWritable($class, $property, array $context = []): ?bool
     {
         if ($this->isAllowedProperty($class, $property)) {
             return true;

--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -33,7 +33,7 @@ class SerializerExtractor implements PropertyListExtractorInterface
     /**
      * {@inheritdoc}
      */
-    public function getProperties($class, array $context = [])
+    public function getProperties($class, array $context = []): ?array
     {
         if (!isset($context['serializer_groups']) || !\is_array($context['serializer_groups'])) {
             return null;

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -35,7 +35,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function isReadable($class, $property, array $context = [])
+    public function isReadable($class, $property, array $context = []): ?bool
     {
         return $this->extract('isReadable', [$class, $property, $context]);
     }
@@ -43,7 +43,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function isWritable($class, $property, array $context = [])
+    public function isWritable($class, $property, array $context = []): ?bool
     {
         return $this->extract('isWritable', [$class, $property, $context]);
     }
@@ -51,7 +51,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function getShortDescription($class, $property, array $context = [])
+    public function getShortDescription($class, $property, array $context = []): ?string
     {
         return $this->extract('getShortDescription', [$class, $property, $context]);
     }
@@ -59,7 +59,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function getLongDescription($class, $property, array $context = [])
+    public function getLongDescription($class, $property, array $context = []): ?string
     {
         return $this->extract('getLongDescription', [$class, $property, $context]);
     }
@@ -67,7 +67,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function getProperties($class, array $context = [])
+    public function getProperties($class, array $context = []): ?array
     {
         return $this->extract('getProperties', [$class, $context]);
     }
@@ -75,7 +75,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes($class, $property, array $context = []): ?array
     {
         return $this->extract('getTypes', [$class, $property, $context]);
     }

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -45,7 +45,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function getProperties($class, array $context = [])
+    public function getProperties($class, array $context = []): ?array
     {
         return $this->extract($this->listExtractors, 'getProperties', [$class, $context]);
     }
@@ -53,7 +53,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function getShortDescription($class, $property, array $context = [])
+    public function getShortDescription($class, $property, array $context = []): ?string
     {
         return $this->extract($this->descriptionExtractors, 'getShortDescription', [$class, $property, $context]);
     }
@@ -61,7 +61,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function getLongDescription($class, $property, array $context = [])
+    public function getLongDescription($class, $property, array $context = []): ?string
     {
         return $this->extract($this->descriptionExtractors, 'getLongDescription', [$class, $property, $context]);
     }
@@ -69,7 +69,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes($class, $property, array $context = []): ?array
     {
         return $this->extract($this->typeExtractors, 'getTypes', [$class, $property, $context]);
     }
@@ -77,7 +77,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function isReadable($class, $property, array $context = [])
+    public function isReadable($class, $property, array $context = []): ?bool
     {
         return $this->extract($this->accessExtractors, 'isReadable', [$class, $property, $context]);
     }
@@ -85,7 +85,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     /**
      * {@inheritdoc}
      */
-    public function isWritable($class, $property, array $context = [])
+    public function isWritable($class, $property, array $context = []): ?bool
     {
         return $this->extract($this->accessExtractors, 'isWritable', [$class, $property, $context]);
     }

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -47,10 +47,8 @@ class CollectionConfigurator
 
     /**
      * Creates a sub-collection.
-     *
-     * @return self
      */
-    final public function collection($name = '')
+    final public function collection($name = ''): self
     {
         return new self($this->collection, $this->name.$name, $this, $this->prefixes);
     }

--- a/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
@@ -33,10 +33,7 @@ class RoutingConfigurator
         $this->file = $file;
     }
 
-    /**
-     * @return ImportConfigurator
-     */
-    final public function import($resource, $type = null, $ignoreErrors = false)
+    final public function import($resource, $type = null, $ignoreErrors = false): ImportConfigurator
     {
         $this->loader->setCurrentDir(\dirname($this->path));
         $imported = $this->loader->import($resource, $type, $ignoreErrors, $this->file);
@@ -52,10 +49,7 @@ class RoutingConfigurator
         return new ImportConfigurator($this->collection, $mergedCollection);
     }
 
-    /**
-     * @return CollectionConfigurator
-     */
-    final public function collection($name = '')
+    final public function collection($name = ''): CollectionConfigurator
     {
         return new CollectionConfigurator($this->collection, $name);
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -49,7 +49,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     {
         $reader = new AnnotationReader();
         $this->loader = new class($reader) extends AnnotationClassLoader {
-            protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
+            protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot): void
             {
             }
         };
@@ -241,7 +241,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
             ->willReturn([])
         ;
         $loader = new class($reader) extends AnnotationClassLoader {
-            protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
+            protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot): void
             {
             }
         };
@@ -323,7 +323,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         ;
 
         $loader = new class($reader) extends AnnotationClassLoader {
-            protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
+            protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot): void
             {
             }
         };

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
@@ -49,7 +49,7 @@ final class PersistentToken implements PersistentTokenInterface
     /**
      * {@inheritdoc}
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -57,7 +57,7 @@ final class PersistentToken implements PersistentTokenInterface
     /**
      * {@inheritdoc}
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }
@@ -65,7 +65,7 @@ final class PersistentToken implements PersistentTokenInterface
     /**
      * {@inheritdoc}
      */
-    public function getSeries()
+    public function getSeries(): string
     {
         return $this->series;
     }
@@ -73,7 +73,7 @@ final class PersistentToken implements PersistentTokenInterface
     /**
      * {@inheritdoc}
      */
-    public function getTokenValue()
+    public function getTokenValue(): string
     {
         return $this->tokenValue;
     }
@@ -81,7 +81,7 @@ final class PersistentToken implements PersistentTokenInterface
     /**
      * {@inheritdoc}
      */
-    public function getLastUsed()
+    public function getLastUsed(): \DateTime
     {
         return $this->lastUsed;
     }

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -43,7 +43,7 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
      *
      * @throws AuthenticationCredentialsNotFoundException when the token storage has no authentication token
      */
-    final public function isGranted($attributes, $subject = null)
+    final public function isGranted($attributes, $subject = null): bool
     {
         if (null === ($token = $this->tokenStorage->getToken())) {
             throw new AuthenticationCredentialsNotFoundException('The token storage contains no authentication token. One possible reason may be that there is no firewall configured for this URL.');

--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -48,7 +48,7 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function decide(TokenInterface $token, array $attributes, $object = null)
+    public function decide(TokenInterface $token, array $attributes, $object = null): bool
     {
         $currentDecisionLog = [
             'attributes' => $attributes,
@@ -86,7 +86,7 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
     /**
      * @return string
      */
-    public function getStrategy()
+    public function getStrategy(): string
     {
         // The $strategy property is misleading because it stores the name of its
         // method (e.g. 'decideAffirmative') instead of the original strategy name
@@ -97,7 +97,7 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
     /**
      * @return iterable|VoterInterface[]
      */
-    public function getVoters()
+    public function getVoters(): iterable
     {
         return $this->voters;
     }
@@ -105,7 +105,7 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
     /**
      * @return array
      */
-    public function getDecisionLog()
+    public function getDecisionLog(): array
     {
         return $this->decisionLog;
     }

--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -61,19 +61,14 @@ class Security
      *
      * @param mixed $attributes
      * @param mixed $subject
-     *
-     * @return bool
      */
-    public function isGranted($attributes, $subject = null)
+    public function isGranted($attributes, $subject = null): bool
     {
         return $this->container->get('security.authorization_checker')
             ->isGranted($attributes, $subject);
     }
 
-    /**
-     * @return TokenInterface|null
-     */
-    public function getToken()
+    public function getToken(): ?TokenInterface
     {
         return $this->container->get('security.token_storage')->getToken();
     }

--- a/src/Symfony/Component/Security/Core/User/MissingUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/MissingUserProvider.php
@@ -32,7 +32,7 @@ class MissingUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadUserByUsername($username)
+    public function loadUserByUsername($username): UserInterface
     {
         throw new \BadMethodCallException();
     }
@@ -40,7 +40,7 @@ class MissingUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         throw new \BadMethodCallException();
     }
@@ -48,7 +48,7 @@ class MissingUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsClass($class)
+    public function supportsClass($class): bool
     {
         throw new \BadMethodCallException();
     }

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -140,10 +140,7 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
         $event->setResponse($response);
     }
 
-    /**
-     * @return Response|null
-     */
-    private function onSuccess(Request $request, TokenInterface $token)
+    private function onSuccess(Request $request, TokenInterface $token): ?Response
     {
         if (null !== $this->logger) {
             $this->logger->info('User has been authenticated successfully.', ['username' => $token->getUsername()]);

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -43,7 +43,7 @@ class ChainDecoder implements ContextAwareDecoderInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDecoding($format, array $context = [])
+    public function supportsDecoding($format, array $context = []): bool
     {
         try {
             $this->getDecoder($format, $context);

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -43,7 +43,7 @@ class ChainEncoder implements ContextAwareEncoderInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsEncoding($format, array $context = [])
+    public function supportsEncoding($format, array $context = []): bool
     {
         try {
             $this->getEncoder($format, $context);
@@ -56,12 +56,8 @@ class ChainEncoder implements ContextAwareEncoderInterface
 
     /**
      * Checks whether the normalization is needed for the given format.
-     *
-     * @param string $format
-     *
-     * @return bool
      */
-    public function needsNormalization($format, array $context = [])
+    public function needsNormalization(string $format, array $context = []): bool
     {
         $encoder = $this->getEncoder($format, $context);
 

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -66,7 +66,7 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null, array $context = [])
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return '[]' === substr($type, -2)
             && $this->serializer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -115,7 +115,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
     /**
      * {@inheritdoc}
      */
-    final public function serialize($data, $format, array $context = [])
+    final public function serialize($data, $format, array $context = []): string
     {
         if (!$this->supportsEncoding($format, $context)) {
             throw new NotEncodableValueException(sprintf('Serialization for the format %s is not supported', $format));

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -770,12 +770,12 @@ class ObjectNormalizerTest extends TestCase
     public function testAdvancedNameConverter()
     {
         $nameConverter = new class() implements AdvancedNameConverterInterface {
-            public function normalize($propertyName, string $class = null, string $format = null, array $context = [])
+            public function normalize($propertyName, string $class = null, string $format = null, array $context = []): string
             {
                 return sprintf('%s-%s-%s-%s', $propertyName, $class, $format, $context['foo']);
             }
 
-            public function denormalize($propertyName, string $class = null, string $format = null, array $context = [])
+            public function denormalize($propertyName, string $class = null, string $format = null, array $context = []): string
             {
                 return sprintf('%s-%s-%s-%s', $propertyName, $class, $format, $context['foo']);
             }

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -223,10 +223,7 @@ EOF
         }
     }
 
-    /**
-     * @return string|null
-     */
-    private function getStdin()
+    private function getStdin(): ?string
     {
         if (0 !== ftell(STDIN)) {
             return null;

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -286,11 +286,9 @@ abstract class Constraint
     /**
      * Optimizes the serialized value to minimize storage space.
      *
-     * @return array The properties to serialize
-     *
      * @internal
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         // Initialize "groups" option if it is not set
         $this->groups;

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -26,15 +26,9 @@ class DateValidator extends ConstraintValidator
     /**
      * Checks whether a date is valid.
      *
-     * @param int $year  The year
-     * @param int $month The month
-     * @param int $day   The day
-     *
-     * @return bool Whether the date is valid
-     *
      * @internal
      */
-    public static function checkDate($year, $month, $day)
+    public static function checkDate(int $year, int $month, int $day): bool
     {
         return checkdate($month, $day, $year);
     }

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -26,15 +26,9 @@ class TimeValidator extends ConstraintValidator
     /**
      * Checks whether a time is valid.
      *
-     * @param int $hour   The hour
-     * @param int $minute The minute
-     * @param int $second The second
-     *
-     * @return bool Whether the time is valid
-     *
      * @internal
      */
-    public static function checkTime($hour, $minute, $second)
+    public static function checkTime(int $hour, int $minute, float $second): bool
     {
         return $hour >= 0 && $hour < 24 && $minute >= 0 && $minute < 60 && $second >= 0 && $second < 60;
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -72,7 +72,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
             ['090909'],
             [90909],
             [new class() {
-                public function __toString()
+                public function __toString(): string
                 {
                     return '090909';
                 }
@@ -116,7 +116,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
             ['abcd'],
             ['090foo'],
             [new class() {
-                public function __toString()
+                public function __toString(): string
                 {
                     return 'abcd';
                 }

--- a/src/Symfony/Component/WebLink/EventListener/AddLinkHeaderListener.php
+++ b/src/Symfony/Component/WebLink/EventListener/AddLinkHeaderListener.php
@@ -50,7 +50,7 @@ class AddLinkHeaderListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [KernelEvents::RESPONSE => 'onKernelResponse'];
     }

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -199,10 +199,7 @@ EOF
         }
     }
 
-    /**
-     * @return string|null
-     */
-    private function getStdin()
+    private function getStdin(): ?string
     {
         if (0 !== ftell(STDIN)) {
             return null;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -34,12 +34,7 @@ class Inline
     private static $objectForMap = false;
     private static $constantSupport = false;
 
-    /**
-     * @param int         $flags
-     * @param int|null    $parsedLineNumber
-     * @param string|null $parsedFilename
-     */
-    public static function initialize($flags, $parsedLineNumber = null, $parsedFilename = null)
+    public static function initialize(int $flags, int $parsedLineNumber = null, string $parsedFilename = null)
     {
         self::$exceptionOnInvalidType = (bool) (Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE & $flags);
         self::$objectSupport = (bool) (Yaml::PARSE_OBJECT & $flags);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33236  #33228 
| License       | MIT
| Doc PR        | -

Related to #33228
This adds return-type declarations to internal, final and private methods.
Found by using a patched DebugClassLoader + manual edits.