### PR TITLE
[ErrorHandler] Registering basic exception handler to handle early failures

### DIFF
--- a/src/Symfony/Component/ErrorHandler/composer.json
+++ b/src/Symfony/Component/ErrorHandler/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-kernel": "^3.4|^4.0|^5.0"
     },
+    "suggest": {
+        "symfony/error-renderer": "For better error rendering"
+    },
     "conflict": {
         "symfony/http-kernel": "<3.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This behavior was previously handled by the removed `ExceptionHandler` class in https://github.com/symfony/symfony/pull/32637.

As this method is mainly called during Kernel boot, where nothing is yet available, the Response content is always HTML. Otherwise, If all goes well on booting, this exception handler will be replaced in `DebugHandlersListener` class:
https://github.com/symfony/symfony/blob/8073b8abfb82d59c6acabce7cec7bfb3af24738a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php#L139

where the advanced exception handler mechanism is activated.