### PR TITLE
Add types to routing and DI configuration traits.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AbstractTrait.php
@@ -19,7 +19,7 @@ trait AbstractTrait
      *
      * @return $this
      */
-    final public function abstract(bool $abstract = true)
+    final public function abstract(bool $abstract = true): self
     {
         $this->definition->setAbstract($abstract);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ArgumentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ArgumentTrait.php
@@ -16,11 +16,9 @@ trait ArgumentTrait
     /**
      * Sets the arguments to pass to the service constructor/factory method.
      *
-     * @param array $arguments An array of arguments
-     *
      * @return $this
      */
-    final public function args(array $arguments)
+    final public function args(array $arguments): self
     {
         $this->definition->setArguments(static::processValue($arguments, true));
 
@@ -35,7 +33,7 @@ trait ArgumentTrait
      *
      * @return $this
      */
-    final public function arg($key, $value)
+    final public function arg($key, $value): self
     {
         $this->definition->setArgument($key, static::processValue($value, true));
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutoconfigureTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutoconfigureTrait.php
@@ -23,7 +23,7 @@ trait AutoconfigureTrait
      *
      * @throws InvalidArgumentException when a parent is already set
      */
-    final public function autoconfigure(bool $autoconfigured = true)
+    final public function autoconfigure(bool $autoconfigured = true): self
     {
         if ($autoconfigured && $this->definition instanceof ChildDefinition) {
             throw new InvalidArgumentException(sprintf('The service "%s" cannot have a "parent" and also have "autoconfigure". Try disabling autoconfiguration for the service.', $this->id));

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutowireTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutowireTrait.php
@@ -18,7 +18,7 @@ trait AutowireTrait
      *
      * @return $this
      */
-    final public function autowire(bool $autowired = true)
+    final public function autowire(bool $autowired = true): self
     {
         $this->definition->setAutowired($autowired);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
@@ -31,7 +31,7 @@ trait BindTrait
      *
      * @return $this
      */
-    final public function bind($nameOrFqcn, $valueOrRef)
+    final public function bind(string $nameOrFqcn, $valueOrRef): self
     {
         $valueOrRef = static::processValue($valueOrRef, true);
         if (!preg_match('/^(?:(?:array|bool|float|int|string)[ \t]*+)?\$/', $nameOrFqcn) && !$valueOrRef instanceof Reference) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/CallTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/CallTrait.php
@@ -25,7 +25,7 @@ trait CallTrait
      *
      * @throws InvalidArgumentException on empty $method param
      */
-    final public function call($method, array $arguments = [])
+    final public function call(string $method, array $arguments = []): self
     {
         $this->definition->addMethodCall($method, static::processValue($arguments, true));
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ClassTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ClassTrait.php
@@ -18,7 +18,7 @@ trait ClassTrait
      *
      * @return $this
      */
-    final public function class($class)
+    final public function class(?string $class): self
     {
         $this->definition->setClass($class);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
@@ -20,7 +20,7 @@ trait ConfiguratorTrait
      *
      * @return $this
      */
-    final public function configurator($configurator)
+    final public function configurator($configurator): self
     {
         $this->definition->setConfigurator(static::processValue($configurator, true));
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DecorateTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DecorateTrait.php
@@ -18,15 +18,13 @@ trait DecorateTrait
     /**
      * Sets the service that this service is decorating.
      *
-     * @param string|null $id        The decorated service id, use null to remove decoration
-     * @param string|null $renamedId The new decorated service id
-     * @param int         $priority  The priority of decoration
+     * @param string|null $id The decorated service id, use null to remove decoration
      *
      * @return $this
      *
      * @throws InvalidArgumentException in case the decorated service id and the new decorated service id are equals
      */
-    final public function decorate($id, $renamedId = null, $priority = 0)
+    final public function decorate(?string $id, string $renamedId = null, int $priority = 0): self
     {
         $this->definition->setDecoratedService($id, $renamedId, $priority);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DeprecateTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DeprecateTrait.php
@@ -24,7 +24,7 @@ trait DeprecateTrait
      *
      * @throws InvalidArgumentException when the message template is invalid
      */
-    final public function deprecate($template = null)
+    final public function deprecate(string $template = null): self
     {
         $this->definition->setDeprecated(true, $template);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
@@ -22,7 +22,7 @@ trait FactoryTrait
      *
      * @return $this
      */
-    final public function factory($factory)
+    final public function factory($factory): self
     {
         if (\is_string($factory) && 1 === substr_count($factory, ':')) {
             $factoryParts = explode(':', $factory);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FileTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FileTrait.php
@@ -16,11 +16,9 @@ trait FileTrait
     /**
      * Sets a file to require before creating the service.
      *
-     * @param string $file A full pathname to include
-     *
      * @return $this
      */
-    final public function file($file)
+    final public function file(string $file): self
     {
         $this->definition->setFile($file);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/LazyTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/LazyTrait.php
@@ -20,7 +20,7 @@ trait LazyTrait
      *
      * @return $this
      */
-    final public function lazy($lazy = true)
+    final public function lazy($lazy = true): self
     {
         $this->definition->setLazy((bool) $lazy);
         if (\is_string($lazy)) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
@@ -23,7 +23,7 @@ trait ParentTrait
      *
      * @throws InvalidArgumentException when parent cannot be set
      */
-    final public function parent(string $parent)
+    final public function parent(string $parent): self
     {
         if (!$this->allowParent) {
             throw new InvalidArgumentException(sprintf('A parent cannot be defined when either "_instanceof" or "_defaults" are also defined for service prototype "%s".', $this->id));

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PropertyTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PropertyTrait.php
@@ -18,7 +18,7 @@ trait PropertyTrait
      *
      * @return $this
      */
-    final public function property(string $name, $value)
+    final public function property(string $name, $value): self
     {
         $this->definition->setProperty($name, static::processValue($value, true));
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PublicTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PublicTrait.php
@@ -16,7 +16,7 @@ trait PublicTrait
     /**
      * @return $this
      */
-    final public function public()
+    final public function public(): self
     {
         $this->definition->setPublic(true);
 
@@ -26,7 +26,7 @@ trait PublicTrait
     /**
      * @return $this
      */
-    final public function private()
+    final public function private(): self
     {
         $this->definition->setPublic(false);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ShareTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ShareTrait.php
@@ -16,11 +16,9 @@ trait ShareTrait
     /**
      * Sets if the service must be shared or not.
      *
-     * @param bool $shared Whether the service must be shared or not
-     *
      * @return $this
      */
-    final public function share($shared = true)
+    final public function share(bool $shared = true): self
     {
         $this->definition->setShared($shared);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/SyntheticTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/SyntheticTrait.php
@@ -19,7 +19,7 @@ trait SyntheticTrait
      *
      * @return $this
      */
-    final public function synthetic(bool $synthetic = true)
+    final public function synthetic(bool $synthetic = true): self
     {
         $this->definition->setSynthetic($synthetic);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
@@ -18,14 +18,11 @@ trait TagTrait
     /**
      * Adds a tag for this definition.
      *
-     * @param string $name       The tag name
-     * @param array  $attributes An array of attributes
-     *
      * @return $this
      */
-    final public function tag($name, array $attributes = [])
+    final public function tag(string $name, array $attributes = []): self
     {
-        if (!\is_string($name) || '' === $name) {
+        if ('' === $name) {
             throw new InvalidArgumentException(sprintf('The tag name for service "%s" must be a non-empty string.', $this->id));
         }
 

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -26,7 +26,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function defaults(array $defaults)
+    final public function defaults(array $defaults): self
     {
         $this->route->addDefaults($defaults);
 
@@ -38,7 +38,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function requirements(array $requirements)
+    final public function requirements(array $requirements): self
     {
         $this->route->addRequirements($requirements);
 
@@ -50,7 +50,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function options(array $options)
+    final public function options(array $options): self
     {
         $this->route->addOptions($options);
 
@@ -62,7 +62,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function utf8(bool $utf8 = true)
+    final public function utf8(bool $utf8 = true): self
     {
         $this->route->addOptions(['utf8' => $utf8]);
 
@@ -74,7 +74,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function condition(string $condition)
+    final public function condition(string $condition): self
     {
         $this->route->setCondition($condition);
 
@@ -86,7 +86,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function host(string $pattern)
+    final public function host(string $pattern): self
     {
         $this->route->setHost($pattern);
 
@@ -101,7 +101,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function schemes(array $schemes)
+    final public function schemes(array $schemes): self
     {
         $this->route->setSchemes($schemes);
 
@@ -116,7 +116,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function methods(array $methods)
+    final public function methods(array $methods): self
     {
         $this->route->setMethods($methods);
 
@@ -130,7 +130,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function controller($controller)
+    final public function controller($controller): self
     {
         $this->route->addDefaults(['_controller' => $controller]);
 
@@ -142,7 +142,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function locale(string $locale)
+    final public function locale(string $locale): self
     {
         $this->route->addDefaults(['_locale' => $locale]);
 
@@ -154,7 +154,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function format(string $format)
+    final public function format(string $format): self
     {
         $this->route->addDefaults(['_format' => $format]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | I don't think so.
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32179, #33228
| License       | MIT
| Doc PR        | N/A

This PR backports the type declarations added to the configurator traits of the Routing and DI components. These traits expose only final methods, so it should be pretty safe to add return types to them.

The only scenario I could make up where this change will break something is if a trait is used to override a method: https://3v4l.org/EAsk8 But I doubt that those traits are used that way.

On master, we've used the `object` return type for the fluent methods. That type is not available on 4.4 where we have to support php 7.1. I'm using `self` instead. Since the methods are final and thus cannot be overridden, I believe that we shouldn't run into covariance issues here, so `self` should be safe.