### PR TITLE
[Ldap] Add missing LdapUser::setPassword()

### DIFF
--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -90,6 +90,11 @@ class LdapUser implements UserInterface, EquatableInterface
         return $this->extraFields;
     }
 
+    public function setPassword(string $password)
+    {
+        $this->password = $password;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -125,11 +125,9 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
         }
 
         try {
-            if ($user->isEqualTo($this->loadUserByUsername($user->getUsername()))) {
-                $user->getEntry()->setAttribute($this->passwordAttribute, [$newEncodedPassword]);
-                $this->ldap->getEntryManager()->update($user->getEntry());
-                $user->setPassword($newEncodedPassword);
-            }
+            $user->getEntry()->setAttribute($this->passwordAttribute, [$newEncodedPassword]);
+            $this->ldap->getEntryManager()->update($user->getEntry());
+            $user->setPassword($newEncodedPassword);
         } catch (ExceptionInterface $e) {
             // ignore failed password upgrades
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Required for password migrations.