### PR TITLE
[4.4] Add return types on internal|final|private methods (bis)

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
@@ -63,7 +63,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function setSubject(string $subject)
+    public function setSubject(string $subject): self
     {
         $this->message->subject($subject);
 
@@ -78,7 +78,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function setReturnPath(string $address)
+    public function setReturnPath(string $address): self
     {
         $this->message->returnPath($address);
 
@@ -93,7 +93,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addFrom(string $address, string $name = null)
+    public function addFrom(string $address, string $name = null): self
     {
         $this->message->addFrom($name ? new NamedAddress($address, $name) : new Address($address));
 
@@ -111,7 +111,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addReplyTo(string $address)
+    public function addReplyTo(string $address): self
     {
         $this->message->addReplyTo($address);
 
@@ -129,7 +129,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addTo(string $address, string $name = null)
+    public function addTo(string $address, string $name = null): self
     {
         $this->message->addTo($name ? new NamedAddress($address, $name) : new Address($address));
 
@@ -147,7 +147,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addCc(string $address, string $name = null)
+    public function addCc(string $address, string $name = null): self
     {
         $this->message->addCc($name ? new NamedAddress($address, $name) : new Address($address));
 
@@ -165,7 +165,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function addBcc(string $address, string $name = null)
+    public function addBcc(string $address, string $name = null): self
     {
         $this->message->addBcc($name ? new NamedAddress($address, $name) : new Address($address));
 
@@ -183,7 +183,7 @@ final class WrappedTemplatedEmail
     /**
      * @return $this
      */
-    public function setPriority(int $priority)
+    public function setPriority(int $priority): self
     {
         $this->message->setPriority($priority);
 

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -67,7 +67,7 @@ final class CacheItem implements ItemInterface
      *
      * @return $this
      */
-    public function set($value)
+    public function set($value): self
     {
         $this->value = $value;
 
@@ -79,7 +79,7 @@ final class CacheItem implements ItemInterface
      *
      * @return $this
      */
-    public function expiresAt($expiration)
+    public function expiresAt($expiration): self
     {
         if (null === $expiration) {
             $this->expiry = $this->defaultLifetime > 0 ? microtime(true) + $this->defaultLifetime : null;
@@ -97,7 +97,7 @@ final class CacheItem implements ItemInterface
      *
      * @return $this
      */
-    public function expiresAfter($time)
+    public function expiresAfter($time): self
     {
         if (null === $time) {
             $this->expiry = $this->defaultLifetime > 0 ? microtime(true) + $this->defaultLifetime : null;

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -56,7 +56,7 @@ class TokenStream
      *
      * @return $this
      */
-    public function push(Token $token)
+    public function push(Token $token): self
     {
         $this->tokens[] = $token;
 
@@ -68,7 +68,7 @@ class TokenStream
      *
      * @return $this
      */
-    public function freeze()
+    public function freeze(): self
     {
         return $this;
     }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/ExtensionInterface.php
@@ -30,40 +30,38 @@ interface ExtensionInterface
      *
      * @return callable[]
      */
-    public function getNodeTranslators();
+    public function getNodeTranslators(): array;
 
     /**
      * Returns combination translators.
      *
      * @return callable[]
      */
-    public function getCombinationTranslators();
+    public function getCombinationTranslators(): array;
 
     /**
      * Returns function translators.
      *
      * @return callable[]
      */
-    public function getFunctionTranslators();
+    public function getFunctionTranslators(): array;
 
     /**
      * Returns pseudo-class translators.
      *
      * @return callable[]
      */
-    public function getPseudoClassTranslators();
+    public function getPseudoClassTranslators(): array;
 
     /**
      * Returns attribute operation translators.
      *
      * @return callable[]
      */
-    public function getAttributeMatchingTranslators();
+    public function getAttributeMatchingTranslators(): array;
 
     /**
      * Returns extension name.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -41,7 +41,7 @@ class NodeExtension extends AbstractExtension
     /**
      * @return $this
      */
-    public function setFlag(int $flag, bool $on)
+    public function setFlag(int $flag, bool $on): self
     {
         if ($on && !$this->hasFlag($flag)) {
             $this->flags += $flag;

--- a/src/Symfony/Component/DependencyInjection/ChildDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/ChildDefinition.php
@@ -109,7 +109,7 @@ class ChildDefinition extends Definition
     /**
      * @internal
      */
-    public function setAutoconfigured($autoconfigured)
+    public function setAutoconfigured($autoconfigured): self
     {
         throw new BadMethodCallException('A ChildDefinition cannot be autoconfigured.');
     }
@@ -117,7 +117,7 @@ class ChildDefinition extends Definition
     /**
      * @internal
      */
-    public function setInstanceofConditionals(array $instanceof)
+    public function setInstanceofConditionals(array $instanceof): self
     {
         throw new BadMethodCallException('A ChildDefinition cannot have instanceof conditionals set on it.');
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -137,7 +137,7 @@ class MergeExtensionConfigurationParameterBag extends EnvPlaceholderParameterBag
     /**
      * {@inheritdoc}
      */
-    public function getEnvPlaceholders()
+    public function getEnvPlaceholders(): array
     {
         return null !== $this->processedEnvPlaceholders ? $this->processedEnvPlaceholders : parent::getEnvPlaceholders();
     }
@@ -167,7 +167,7 @@ class MergeExtensionConfigurationContainerBuilder extends ContainerBuilder
     /**
      * {@inheritdoc}
      */
-    public function addCompilerPass(CompilerPassInterface $pass, $type = PassConfig::TYPE_BEFORE_OPTIMIZATION, int $priority = 0)
+    public function addCompilerPass(CompilerPassInterface $pass, $type = PassConfig::TYPE_BEFORE_OPTIMIZATION, int $priority = 0): self
     {
         throw new LogicException(sprintf('You cannot add compiler pass "%s" from extension "%s". Compiler passes must be registered before the container is compiled.', \get_class($pass), $this->extensionClass));
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ScalarFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ScalarFactory.php
@@ -7,7 +7,7 @@ final class ScalarFactory
     /**
      * @return string
      */
-    public static function getSomeValue()
+    public static function getSomeValue(): string
     {
         return 'some value';
     }

--- a/src/Symfony/Component/Form/Util/OptionsResolverWrapper.php
+++ b/src/Symfony/Component/Form/Util/OptionsResolverWrapper.php
@@ -24,7 +24,10 @@ class OptionsResolverWrapper extends OptionsResolver
 {
     private $undefined = [];
 
-    public function setNormalizer($option, \Closure $normalizer)
+    /**
+     * @return $this
+     */
+    public function setNormalizer($option, \Closure $normalizer): self
     {
         try {
             parent::setNormalizer($option, $normalizer);
@@ -35,7 +38,10 @@ class OptionsResolverWrapper extends OptionsResolver
         return $this;
     }
 
-    public function setAllowedValues($option, $allowedValues)
+    /**
+     * @return $this
+     */
+    public function setAllowedValues($option, $allowedValues): self
     {
         try {
             parent::setAllowedValues($option, $allowedValues);
@@ -46,7 +52,10 @@ class OptionsResolverWrapper extends OptionsResolver
         return $this;
     }
 
-    public function addAllowedValues($option, $allowedValues)
+    /**
+     * @return $this
+     */
+    public function addAllowedValues($option, $allowedValues): self
     {
         try {
             parent::addAllowedValues($option, $allowedValues);
@@ -57,7 +66,10 @@ class OptionsResolverWrapper extends OptionsResolver
         return $this;
     }
 
-    public function setAllowedTypes($option, $allowedTypes)
+    /**
+     * @return $this
+     */
+    public function setAllowedTypes($option, $allowedTypes): self
     {
         try {
             parent::setAllowedTypes($option, $allowedTypes);
@@ -68,7 +80,10 @@ class OptionsResolverWrapper extends OptionsResolver
         return $this;
     }
 
-    public function addAllowedTypes($option, $allowedTypes)
+    /**
+     * @return $this
+     */
+    public function addAllowedTypes($option, $allowedTypes): self
     {
         try {
             parent::addAllowedTypes($option, $allowedTypes);
@@ -84,7 +99,7 @@ class OptionsResolverWrapper extends OptionsResolver
         throw new AccessException('Resolve options is not supported.');
     }
 
-    public function getUndefinedOptions()
+    public function getUndefinedOptions(): array
     {
         return array_keys($this->undefined);
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/NotTaggedControllerValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/NotTaggedControllerValueResolver.php
@@ -58,7 +58,7 @@ final class NotTaggedControllerValueResolver implements ArgumentValueResolverInt
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         if (\is_array($controller = $request->attributes->get('_controller'))) {
             $controller = $controller[0].'::'.$controller[1];

--- a/src/Symfony/Component/HttpKernel/HttpClientKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpClientKernel.php
@@ -39,7 +39,7 @@ final class HttpClientKernel implements HttpKernelInterface
         $this->client = $client ?? HttpClient::create();
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
     {
         $headers = $this->getHeaders($request);
         $body = '';

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -47,7 +47,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function find($ip, $url, $limit, $method, $start = null, $end = null, $statusCode = null)
+    public function find($ip, $url, $limit, $method, $start = null, $end = null, $statusCode = null): array
     {
         $file = $this->getIndexFilename();
 
@@ -113,7 +113,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function read($token)
+    public function read($token): ?Profile
     {
         if (!$token || !file_exists($file = $this->getFilename($token))) {
             return null;
@@ -127,7 +127,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
      *
      * @throws \RuntimeException
      */
-    public function write(Profile $profile)
+    public function write(Profile $profile): bool
     {
         $file = $this->getFilename($profile->getToken());
 

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
@@ -38,7 +38,7 @@ interface ProfilerStorageInterface
      *
      * @return array An array of tokens
      */
-    public function find($ip, $url, $limit, $method, $start = null, $end = null);
+    public function find($ip, $url, $limit, $method, $start = null, $end = null): array;
 
     /**
      * Reads data associated with the given token.
@@ -49,14 +49,14 @@ interface ProfilerStorageInterface
      *
      * @return Profile|null The profile associated with token
      */
-    public function read($token);
+    public function read($token): ?Profile;
 
     /**
      * Saves a Profile.
      *
      * @return bool Write operation successful
      */
-    public function write(Profile $profile);
+    public function write(Profile $profile): bool;
 
     /**
      * Purges all data from the database.

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -159,10 +159,7 @@ class RegionDataGenerator extends AbstractDataGenerator
         ];
     }
 
-    /**
-     * @return array
-     */
-    protected function generateRegionNames(ArrayAccessibleResourceBundle $localeBundle)
+    protected function generateRegionNames(ArrayAccessibleResourceBundle $localeBundle): array
     {
         $unfilteredRegionNames = iterator_to_array($localeBundle['Countries']);
         $regionNames = [];

--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -49,7 +49,7 @@ class LdapUser implements UserInterface, EquatableInterface
     /**
      * {@inheritdoc}
      */
-    public function getRoles()
+    public function getRoles(): array
     {
         return $this->roles;
     }

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -64,7 +64,7 @@ final class Headers
      *
      * @return $this
      */
-    public function addMailboxListHeader(string $name, array $addresses)
+    public function addMailboxListHeader(string $name, array $addresses): self
     {
         return $this->add(new MailboxListHeader($name, Address::createArray($addresses)));
     }
@@ -74,7 +74,7 @@ final class Headers
      *
      * @return $this
      */
-    public function addMailboxHeader(string $name, $address)
+    public function addMailboxHeader(string $name, $address): self
     {
         return $this->add(new MailboxHeader($name, Address::create($address)));
     }
@@ -84,7 +84,7 @@ final class Headers
      *
      * @return $this
      */
-    public function addIdHeader(string $name, $ids)
+    public function addIdHeader(string $name, $ids): self
     {
         return $this->add(new IdentificationHeader($name, $ids));
     }
@@ -94,7 +94,7 @@ final class Headers
      *
      * @return $this
      */
-    public function addPathHeader(string $name, $path)
+    public function addPathHeader(string $name, $path): self
     {
         return $this->add(new PathHeader($name, $path instanceof Address ? $path : new Address($path)));
     }
@@ -102,7 +102,7 @@ final class Headers
     /**
      * @return $this
      */
-    public function addDateHeader(string $name, \DateTimeInterface $dateTime)
+    public function addDateHeader(string $name, \DateTimeInterface $dateTime): self
     {
         return $this->add(new DateHeader($name, $dateTime));
     }
@@ -110,7 +110,7 @@ final class Headers
     /**
      * @return $this
      */
-    public function addTextHeader(string $name, string $value)
+    public function addTextHeader(string $name, string $value): self
     {
         return $this->add(new UnstructuredHeader($name, $value));
     }
@@ -118,7 +118,7 @@ final class Headers
     /**
      * @return $this
      */
-    public function addParameterizedHeader(string $name, string $value, array $params = [])
+    public function addParameterizedHeader(string $name, string $value, array $params = []): self
     {
         return $this->add(new ParameterizedHeader($name, $value, $params));
     }
@@ -131,7 +131,7 @@ final class Headers
     /**
      * @return $this
      */
-    public function add(HeaderInterface $header)
+    public function add(HeaderInterface $header): self
     {
         static $map = [
             'date' => DateHeader::class,

--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -57,7 +57,7 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
     /**
      * {@inheritdoc}
      */
-    public function encodePassword($raw, $salt)
+    public function encodePassword($raw, $salt): string
     {
         if (\strlen($raw) > self::MAX_PASSWORD_LENGTH) {
             throw new BadCredentialsException('Invalid password.');

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -58,7 +58,7 @@ class AttributeMetadata implements AttributeMetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -76,7 +76,7 @@ class AttributeMetadata implements AttributeMetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getGroups()
+    public function getGroups(): array
     {
         return $this->groups;
     }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -24,10 +24,8 @@ interface AttributeMetadataInterface
 {
     /**
      * Gets the attribute name.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Adds this attribute to the given group.
@@ -41,7 +39,7 @@ interface AttributeMetadataInterface
      *
      * @return string[]
      */
-    public function getGroups();
+    public function getGroups(): array;
 
     /**
      * Sets the serialization max depth for this attribute.

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -60,7 +60,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -76,7 +76,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributesMetadata()
+    public function getAttributesMetadata(): array
     {
         return $this->attributesMetadata;
     }
@@ -98,7 +98,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getReflectionClass()
+    public function getReflectionClass(): \ReflectionClass
     {
         if (!$this->reflClass) {
             $this->reflClass = new \ReflectionClass($this->getName());
@@ -110,7 +110,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * {@inheritdoc}
      */
-    public function getClassDiscriminatorMapping()
+    public function getClassDiscriminatorMapping(): ?ClassDiscriminatorMapping
     {
         return $this->classDiscriminatorMapping;
     }

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -29,7 +29,7 @@ interface ClassMetadataInterface
      *
      * @return string The name of the backing class
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Adds an {@link AttributeMetadataInterface}.
@@ -41,7 +41,7 @@ interface ClassMetadataInterface
      *
      * @return AttributeMetadataInterface[]
      */
-    public function getAttributesMetadata();
+    public function getAttributesMetadata(): array;
 
     /**
      * Merges a {@link ClassMetadataInterface} in the current one.
@@ -50,15 +50,10 @@ interface ClassMetadataInterface
 
     /**
      * Returns a {@link \ReflectionClass} instance for this class.
-     *
-     * @return \ReflectionClass
      */
-    public function getReflectionClass();
+    public function getReflectionClass(): \ReflectionClass;
 
-    /**
-     * @return ClassDiscriminatorMapping|null
-     */
-    public function getClassDiscriminatorMapping();
+    public function getClassDiscriminatorMapping(): ?ClassDiscriminatorMapping;
 
     public function setClassDiscriminatorMapping(ClassDiscriminatorMapping $mapping = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Found while working on #33259

`: self` is used for final methods only. I'd have preferred using `: object` but that's not possible on PHP 7.1