### PR TITLE
[Ldap] Avoid extra user load on password upgrade

### DIFF
--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -125,11 +125,9 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
         }
 
         try {
-            if ($user->isEqualTo($this->loadUserByUsername($user->getUsername()))) {
-                $user->getEntry()->setAttribute($this->passwordAttribute, [$newEncodedPassword]);
-                $this->ldap->getEntryManager()->update($user->getEntry());
-                $user->setPassword($newEncodedPassword);
-            }
+            $user->getEntry()->setAttribute($this->passwordAttribute, [$newEncodedPassword]);
+            $this->ldap->getEntryManager()->update($user->getEntry());
+            $user->setPassword($newEncodedPassword);
         } catch (ExceptionInterface $e) {
             // ignore failed password upgrades
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

`upgradePassword()` should not need to check if the user has changed as it is called immediately after that the user has been loaded, `EntityUserProvider` does not have such equality check.