### PR TITLE
[FrameworkBundle] Move conditional/optional commands from console.xml to their dedicated XML config files

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -277,8 +277,6 @@ class FrameworkExtension extends Extension
                 $container->removeDefinition('form.type_extension.form.validator');
                 $container->removeDefinition('form.type_guesser.validator');
             }
-        } else {
-            $container->removeDefinition('console.command.form_debug');
         }
 
         if ($this->isConfigEnabled($container, $config['assets'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -301,14 +301,6 @@ class FrameworkExtension extends Extension
 
         if ($this->messengerConfigEnabled = $this->isConfigEnabled($container, $config['messenger'])) {
             $this->registerMessengerConfiguration($config['messenger'], $container, $loader, $config['serializer'], $config['validation']);
-        } else {
-            $container->removeDefinition('console.command.messenger_consume_messages');
-            $container->removeDefinition('console.command.messenger_debug');
-            $container->removeDefinition('console.command.messenger_stop_workers');
-            $container->removeDefinition('console.command.messenger_setup_transports');
-            $container->removeDefinition('console.command.messenger_failed_messages_retry');
-            $container->removeDefinition('console.command.messenger_failed_messages_show');
-            $container->removeDefinition('console.command.messenger_failed_messages_remove');
         }
 
         $propertyInfoEnabled = $this->isConfigEnabled($container, $config['property_info']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -127,16 +127,6 @@
             <tag name="console.command" command="lint:yaml" />
         </service>
 
-        <service id="console.command.form_debug" class="Symfony\Component\Form\Command\DebugCommand">
-            <argument type="service" id="form.registry" />
-            <argument type="collection" /> <!-- All form types namespaces are stored here by FormPass -->
-            <argument type="collection" /> <!-- All services form types are stored here by FormPass -->
-            <argument type="collection" /> <!-- All type extensions are stored here by FormPass -->
-            <argument type="collection" /> <!-- All type guessers are stored here by FormPass -->
-            <argument type="service" id="debug.file_link_formatter" on-invalid="null" />
-            <tag name="console.command" command="debug:form" />
-        </service>
-
         <service id="console.command.error_renderer_debug" class="Symfony\Component\ErrorRenderer\Command\DebugCommand">
             <argument type="collection" /> <!-- All error renderers are injected here by ErrorRendererPass -->
             <argument type="service" id="debug.file_link_formatter" on-invalid="null" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -81,64 +81,6 @@
             <tag name="console.command" command="debug:event-dispatcher" />
         </service>
 
-        <service id="console.command.messenger_consume_messages" class="Symfony\Component\Messenger\Command\ConsumeMessagesCommand">
-            <argument /> <!-- Routable message bus -->
-            <argument type="service" id="messenger.receiver_locator" />
-            <argument type="service" id="logger" on-invalid="null" />
-            <argument type="collection" /> <!-- Receiver names -->
-            <argument type="service" id="messenger.retry_strategy_locator" />
-            <argument type="service" id="event_dispatcher" />
-            <call method="setCachePoolForRestartSignal">
-                <argument type="service" id="cache.messenger.restart_workers_signal" />
-            </call>
-
-            <tag name="console.command" command="messenger:consume" />
-            <tag name="console.command" command="messenger:consume-messages" />
-            <tag name="monolog.logger" channel="messenger" />
-        </service>
-
-        <service id="console.command.messenger_setup_transports" class="Symfony\Component\Messenger\Command\SetupTransportsCommand">
-            <argument type="service" id="messenger.receiver_locator" />
-            <argument type="collection" /> <!-- Receiver names -->
-
-            <tag name="console.command" command="messenger:setup-transports" />
-        </service>
-
-        <service id="console.command.messenger_debug" class="Symfony\Component\Messenger\Command\DebugCommand">
-            <argument type="collection" /> <!-- Message to handlers mapping -->
-            <tag name="console.command" command="debug:messenger" />
-        </service>
-
-        <service id="console.command.messenger_stop_workers" class="Symfony\Component\Messenger\Command\StopWorkersCommand">
-            <argument type="service" id="cache.messenger.restart_workers_signal" />
-            <tag name="console.command" command="messenger:stop-workers" />
-        </service>
-
-        <service id="console.command.messenger_failed_messages_retry" class="Symfony\Component\Messenger\Command\FailedMessagesRetryCommand">
-            <argument /> <!-- Receiver name -->
-            <argument /> <!-- Receiver locator -->
-            <argument type="service" id="messenger.routable_message_bus" />
-            <argument type="service" id="event_dispatcher" />
-            <argument /> <!-- Retry strategy -->
-            <argument type="service" id="logger" />
-
-            <tag name="console.command" command="messenger:failed:retry" />
-        </service>
-
-        <service id="console.command.messenger_failed_messages_show" class="Symfony\Component\Messenger\Command\FailedMessagesShowCommand">
-            <argument /> <!-- Receiver name -->
-            <argument /> <!-- Receiver locator -->
-
-            <tag name="console.command" command="messenger:failed:show" />
-        </service>
-
-        <service id="console.command.messenger_failed_messages_remove" class="Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand">
-            <argument /> <!-- Receiver name -->
-            <argument /> <!-- Receiver locator -->
-
-            <tag name="console.command" command="messenger:failed:remove" />
-        </service>
-
         <service id="console.command.router_debug" class="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand">
             <argument type="service" id="router" />
             <argument type="service" id="debug.file_link_formatter" on-invalid="null" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -111,5 +111,16 @@
             <argument type="service" id="translator"/>
             <argument type="string">%validator.translation_domain%</argument>
         </service>
+
+        <!-- commands -->
+        <service id="console.command.form_debug" class="Symfony\Component\Form\Command\DebugCommand">
+            <argument type="service" id="form.registry" />
+            <argument type="collection" /> <!-- All form types namespaces are stored here by FormPass -->
+            <argument type="collection" /> <!-- All services form types are stored here by FormPass -->
+            <argument type="collection" /> <!-- All type extensions are stored here by FormPass -->
+            <argument type="collection" /> <!-- All type guessers are stored here by FormPass -->
+            <argument type="service" id="debug.file_link_formatter" on-invalid="null" />
+            <tag name="console.command" command="debug:form" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -110,5 +110,64 @@
             <argument /> <!-- Message bus locator -->
             <argument type="service" id="messenger.default_bus" />
         </service>
+
+        <!-- commands -->
+        <service id="console.command.messenger_consume_messages" class="Symfony\Component\Messenger\Command\ConsumeMessagesCommand">
+            <argument /> <!-- Routable message bus -->
+            <argument type="service" id="messenger.receiver_locator" />
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="collection" /> <!-- Receiver names -->
+            <argument type="service" id="messenger.retry_strategy_locator" />
+            <argument type="service" id="event_dispatcher" />
+            <call method="setCachePoolForRestartSignal">
+                <argument type="service" id="cache.messenger.restart_workers_signal" />
+            </call>
+
+            <tag name="console.command" command="messenger:consume" />
+            <tag name="console.command" command="messenger:consume-messages" />
+            <tag name="monolog.logger" channel="messenger" />
+        </service>
+
+        <service id="console.command.messenger_setup_transports" class="Symfony\Component\Messenger\Command\SetupTransportsCommand">
+            <argument type="service" id="messenger.receiver_locator" />
+            <argument type="collection" /> <!-- Receiver names -->
+
+            <tag name="console.command" command="messenger:setup-transports" />
+        </service>
+
+        <service id="console.command.messenger_debug" class="Symfony\Component\Messenger\Command\DebugCommand">
+            <argument type="collection" /> <!-- Message to handlers mapping -->
+            <tag name="console.command" command="debug:messenger" />
+        </service>
+
+        <service id="console.command.messenger_stop_workers" class="Symfony\Component\Messenger\Command\StopWorkersCommand">
+            <argument type="service" id="cache.messenger.restart_workers_signal" />
+            <tag name="console.command" command="messenger:stop-workers" />
+        </service>
+
+        <service id="console.command.messenger_failed_messages_retry" class="Symfony\Component\Messenger\Command\FailedMessagesRetryCommand">
+            <argument /> <!-- Receiver name -->
+            <argument /> <!-- Receiver locator -->
+            <argument type="service" id="messenger.routable_message_bus" />
+            <argument type="service" id="event_dispatcher" />
+            <argument /> <!-- Retry strategy -->
+            <argument type="service" id="logger" />
+
+            <tag name="console.command" command="messenger:failed:retry" />
+        </service>
+
+        <service id="console.command.messenger_failed_messages_show" class="Symfony\Component\Messenger\Command\FailedMessagesShowCommand">
+            <argument /> <!-- Receiver name -->
+            <argument /> <!-- Receiver locator -->
+
+            <tag name="console.command" command="messenger:failed:show" />
+        </service>
+
+        <service id="console.command.messenger_failed_messages_remove" class="Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand">
+            <argument /> <!-- Receiver name -->
+            <argument /> <!-- Receiver locator -->
+
+            <tag name="console.command" command="messenger:failed:remove" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The Messenger commands are defined in `console.xml`, but they should really be defined in `messenger.xml` to avoid the dance to remove them when Messenger is not available. The `console.xml` file defines commands part of FrameworkBundle which are always available.

The same goes for some other ones that I've moved as well.
