### PR TITLE
[TwigBridge] Mark all classes extending twig as @final

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * marked all classes extending twig as `@final`
  * deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
    `DebugCommand::__construct()` method, swap the variables position.
 

--- a/src/Symfony/Bridge/Twig/Extension/AssetExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/AssetExtension.php
@@ -19,6 +19,8 @@ use Twig\TwigFunction;
  * Twig extension for the Symfony Asset component.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class AssetExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -19,6 +19,8 @@ use Twig\TwigFilter;
  * Twig extension relate to PHP code and used by the profiler and the default exception templates.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class CodeExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/CsrfExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CsrfExtension.php
@@ -17,6 +17,8 @@ use Twig\TwigFunction;
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class CsrfExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/CsrfRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/CsrfRuntime.php
@@ -16,6 +16,8 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class CsrfRuntime
 {

--- a/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
@@ -24,6 +24,8 @@ use Twig\TwigFunction;
  * Provides integration of the dump() function with Twig.
  *
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @final since Symfony 4.4
  */
 class DumpExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/ExpressionExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/ExpressionExtension.php
@@ -19,6 +19,8 @@ use Twig\TwigFunction;
  * ExpressionExtension gives a way to create Expressions from a template.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class ExpressionExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -25,6 +25,8 @@ use Twig\TwigTest;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class FormExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
@@ -22,6 +22,8 @@ use Twig\TwigFunction;
  * Twig extension for the Symfony HttpFoundation component.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class HttpFoundationExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -19,6 +19,8 @@ use Twig\TwigFunction;
  * Provides integration with the HttpKernel component.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class HttpKernelExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelRuntime.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
  * Provides integration with the HttpKernel component.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class HttpKernelRuntime
 {

--- a/src/Symfony/Bridge/Twig/Extension/LogoutUrlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/LogoutUrlExtension.php
@@ -19,6 +19,8 @@ use Twig\TwigFunction;
  * LogoutUrlHelper provides generator functions for the logout URL to Twig.
  *
  * @author Jeremy Mikola <jmikola@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class LogoutUrlExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/ProfilerExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/ProfilerExtension.php
@@ -17,6 +17,8 @@ use Twig\Profiler\Profile;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class ProfilerExtension extends BaseProfilerExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
@@ -22,6 +22,8 @@ use Twig\TwigFunction;
  * Provides integration of the Routing component with Twig.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class RoutingExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -21,6 +21,8 @@ use Twig\TwigFunction;
  * SecurityExtension exposes security context features.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class SecurityExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
@@ -20,6 +20,8 @@ use Twig\TokenParser\TokenParserInterface;
  * Twig extension for the stopwatch helper.
  *
  * @author Wouter J <wouter@wouterj.nl>
+ *
+ * @final since Symfony 4.4
  */
 class StopwatchExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/WebLinkExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WebLinkExtension.php
@@ -21,6 +21,8 @@ use Twig\TwigFunction;
  * Twig extension for the Symfony WebLink component.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class WebLinkExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -21,6 +21,8 @@ use Twig\TwigFunction;
  * WorkflowExtension.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since Symfony 4.4
  */
 class WorkflowExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
@@ -20,6 +20,8 @@ use Twig\TwigFilter;
  * Provides integration of the Yaml component with Twig.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class YamlExtension extends AbstractExtension
 {

--- a/src/Symfony/Bridge/Twig/Node/DumpNode.php
+++ b/src/Symfony/Bridge/Twig/Node/DumpNode.php
@@ -16,6 +16,8 @@ use Twig\Node\Node;
 
 /**
  * @author Julien Galenski <julien.galenski@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class DumpNode extends Node
 {

--- a/src/Symfony/Bridge/Twig/Node/FormThemeNode.php
+++ b/src/Symfony/Bridge/Twig/Node/FormThemeNode.php
@@ -17,6 +17,8 @@ use Twig\Node\Node;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class FormThemeNode extends Node
 {

--- a/src/Symfony/Bridge/Twig/Node/RenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/RenderBlockNode.php
@@ -21,6 +21,8 @@ use Twig\Node\Expression\FunctionExpression;
  * is "foo", the block "foo" will be rendered.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class RenderBlockNode extends FunctionExpression
 {

--- a/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
@@ -18,6 +18,8 @@ use Twig\Node\Expression\FunctionExpression;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class SearchAndRenderBlockNode extends FunctionExpression
 {

--- a/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
+++ b/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
@@ -19,6 +19,8 @@ use Twig\Node\Node;
  * Represents a stopwatch node.
  *
  * @author Wouter J <wouter@wouterj.nl>
+ *
+ * @final since Symfony 4.4
  */
 class StopwatchNode extends Node
 {

--- a/src/Symfony/Bridge/Twig/Node/TransDefaultDomainNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransDefaultDomainNode.php
@@ -17,6 +17,8 @@ use Twig\Node\Node;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class TransDefaultDomainNode extends Node
 {

--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -24,6 +24,8 @@ class_exists('Twig\Node\Expression\ArrayExpression');
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class TransNode extends Node
 {

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -27,6 +27,8 @@ use Twig\NodeVisitor\AbstractNodeVisitor;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class TranslationDefaultDomainNodeVisitor extends AbstractNodeVisitor
 {

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
@@ -22,6 +22,8 @@ use Twig\NodeVisitor\AbstractNodeVisitor;
  * TranslationNodeVisitor extracts translation messages.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class TranslationNodeVisitor extends AbstractNodeVisitor
 {

--- a/src/Symfony/Bridge/Twig/TokenParser/DumpTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/DumpTokenParser.php
@@ -26,6 +26,8 @@ use Twig\TokenParser\AbstractTokenParser;
  *     {% dump foo, bar %}
  *
  * @author Julien Galenski <julien.galenski@gmail.com>
+ *
+ * @final since Symfony 4.4
  */
 class DumpTokenParser extends AbstractTokenParser
 {

--- a/src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php
@@ -21,6 +21,8 @@ use Twig\TokenParser\AbstractTokenParser;
  * Token Parser for the 'form_theme' tag.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class FormThemeTokenParser extends AbstractTokenParser
 {

--- a/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
@@ -21,6 +21,8 @@ use Twig\TokenParser\AbstractTokenParser;
  * Token Parser for the stopwatch tag.
  *
  * @author Wouter J <wouter@wouterj.nl>
+ *
+ * @final since Symfony 4.4
  */
 class StopwatchTokenParser extends AbstractTokenParser
 {

--- a/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
@@ -18,6 +18,7 @@ use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Node;
 use Twig\Node\TextNode;
 use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
 /**
  * Token Parser for the 'transchoice' tag.
@@ -25,8 +26,10 @@ use Twig\Token;
  * @author Fabien Potencier <fabien@symfony.com>
  *
  * @deprecated since Symfony 4.2, use the "trans" tag with a "%count%" parameter instead
+ *
+ * @final since Symfony 4.4
  */
-class TransChoiceTokenParser extends TransTokenParser
+class TransChoiceTokenParser extends AbstractTokenParser
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bridge/Twig/TokenParser/TransDefaultDomainTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransDefaultDomainTokenParser.php
@@ -20,6 +20,8 @@ use Twig\TokenParser\AbstractTokenParser;
  * Token Parser for the 'trans_default_domain' tag.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class TransDefaultDomainTokenParser extends AbstractTokenParser
 {

--- a/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
@@ -24,6 +24,8 @@ use Twig\TokenParser\AbstractTokenParser;
  * Token Parser for the 'trans' tag.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 4.4
  */
 class TransTokenParser extends AbstractTokenParser
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes-ish
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | refs #33039
| License       | MIT
| Doc PR        | n/a

Classes defining extensions/nodes/node visitors/token parsers should not be changed. They should be final.

That would also help with Twig 3.0 which introduces type hints (including return types).
