### PR TITLE
Removed calls to Twig\Environment::loadTemplate()

### DIFF
--- a/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
+++ b/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
@@ -154,7 +154,7 @@ class TwigRendererEngine extends AbstractRendererEngine
     {
         if (!$theme instanceof Template) {
             /* @var Template $theme */
-            $theme = $this->environment->loadTemplate($theme);
+            $theme = $this->environment->load($theme)->unwrap();
         }
 
         if (null === $this->template) {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -15,8 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader as TwigArrayLoader;
+use Twig\TemplateWrapper;
 
 class TranslationExtensionTest extends TestCase
 {
@@ -269,7 +271,7 @@ class TranslationExtensionTest extends TestCase
         $this->assertEquals('foo (custom)foo (foo)foo (custom)foo (custom)foo (fr)foo (custom)foo (fr)', trim($template->render([])));
     }
 
-    protected function getTemplate($template, $translator = null)
+    private function getTemplate($template, TranslatorInterface $translator = null): TemplateWrapper
     {
         if (null === $translator) {
             $translator = new Translator('en');
@@ -283,6 +285,6 @@ class TranslationExtensionTest extends TestCase
         $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
         $twig->addExtension(new TranslationExtension($translator));
 
-        return $twig->loadTemplate('index');
+        return $twig->load('index');
     }
 }

--- a/src/Symfony/Bridge/Twig/TwigEngine.php
+++ b/src/Symfony/Bridge/Twig/TwigEngine.php
@@ -126,7 +126,7 @@ class TwigEngine implements EngineInterface, StreamingEngineInterface
         }
 
         try {
-            return $this->environment->loadTemplate((string) $name);
+            return $this->environment->load((string) $name)->unwrap();
         } catch (LoaderError $e) {
             throw new \InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
@@ -73,7 +73,7 @@ class TemplateCacheCacheWarmer implements CacheWarmerInterface, ServiceSubscribe
 
         foreach ($templates as $template) {
             try {
-                $twig->loadTemplate($template);
+                $twig->load($template);
             } catch (Error $e) {
                 // problem during compilation, give up
             }

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
@@ -46,7 +46,7 @@ class TemplateCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInte
 
         foreach ($this->iterator as $template) {
             try {
-                $this->twig->loadTemplate($template);
+                $this->twig->load($template);
             } catch (Error $e) {
                 // problem during compilation, give up
                 // might be a syntax error or a non-Twig template

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -103,10 +103,6 @@ class TemplateManagerTest extends TestCase
     {
         $this->twigEnvironment = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
 
-        $this->twigEnvironment->expects($this->any())
-            ->method('loadTemplate')
-            ->willReturn('loadedTemplate');
-
         if (interface_exists('Twig\Loader\SourceContextLoaderInterface')) {
             $loader = $this->getMockBuilder('Twig\Loader\SourceContextLoaderInterface')->getMock();
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This PR prepares #33039. Twig 3 does not have the `loadTemplate()` anymore, so this PR replaces calls to that method.