### PR TITLE
[Intl] make polyfill classes abstract, fix edge case

### DIFF
--- a/src/Symfony/Component/Intl/Collator/Collator.php
+++ b/src/Symfony/Component/Intl/Collator/Collator.php
@@ -33,7 +33,7 @@ use Symfony\Component\Intl\Locale\Locale;
  *
  * @internal
  */
-class Collator
+abstract class Collator
 {
     /* Attribute constants */
     const FRENCH_COLLATION = 0;
@@ -86,13 +86,13 @@ class Collator
      *
      * @param string|null $locale The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en")
      *
-     * @return self
+     * @return static
      *
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      */
     public static function create($locale)
     {
-        return new self($locale);
+        return new static($locale);
     }
 
     /**

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -46,7 +46,7 @@ use Symfony\Component\Intl\Locale\Locale;
  *
  * @internal
  */
-class IntlDateFormatter
+abstract class IntlDateFormatter
 {
     /**
      * The error code from the last operation.
@@ -78,9 +78,9 @@ class IntlDateFormatter
      */
     private $defaultDateFormats = [
         self::NONE => '',
-        self::FULL => 'EEEE, LLLL d, y',
-        self::LONG => 'LLLL d, y',
-        self::MEDIUM => 'LLL d, y',
+        self::FULL => 'EEEE, MMMM d, y',
+        self::LONG => 'MMMM d, y',
+        self::MEDIUM => 'MMM d, y',
         self::SHORT => 'M/d/yy',
     ];
 
@@ -160,7 +160,7 @@ class IntlDateFormatter
      *                                                          One of the calendar constants
      * @param string|null                             $pattern  Optional pattern to use when formatting
      *
-     * @return self
+     * @return static
      *
      * @see https://php.net/intldateformatter.create
      * @see http://userguide.icu-project.org/formatparse/datetime
@@ -170,7 +170,7 @@ class IntlDateFormatter
      */
     public static function create($locale, $datetype, $timetype, $timezone = null, $calendar = self::GREGORIAN, $pattern = null)
     {
-        return new self($locale, $datetype, $timetype, $timezone, $calendar, $pattern);
+        return new static($locale, $datetype, $timetype, $timezone, $calendar, $pattern);
     }
 
     /**
@@ -600,14 +600,19 @@ class IntlDateFormatter
      */
     protected function getDefaultPattern()
     {
-        $patternParts = [];
+        $pattern = '';
         if (self::NONE !== $this->datetype) {
-            $patternParts[] = $this->defaultDateFormats[$this->datetype];
+            $pattern = $this->defaultDateFormats[$this->datetype];
         }
         if (self::NONE !== $this->timetype) {
-            $patternParts[] = $this->defaultTimeFormats[$this->timetype];
+            if (self::FULL === $this->datetype || self::LONG === $this->datetype) {
+                $pattern .= ' \'at\' ';
+            } elseif (self::NONE !== $this->datetype) {
+                $pattern .= ', ';
+            }
+            $pattern .= $this->defaultTimeFormats[$this->timetype];
         }
 
-        return implode(', ', $patternParts);
+        return $pattern;
     }
 }

--- a/src/Symfony/Component/Intl/Locale/Locale.php
+++ b/src/Symfony/Component/Intl/Locale/Locale.php
@@ -24,7 +24,7 @@ use Symfony\Component\Intl\Exception\MethodNotImplementedException;
  *
  * @internal
  */
-class Locale
+abstract class Locale
 {
     const DEFAULT_LOCALE = null;
 

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -40,7 +40,7 @@ use Symfony\Component\Intl\Locale\Locale;
  *
  * @internal
  */
-class NumberFormatter
+abstract class NumberFormatter
 {
     /* Format style constants */
     const PATTERN_DECIMAL = 0;
@@ -286,7 +286,7 @@ class NumberFormatter
      *                             NumberFormat::PATTERN_RULEBASED. It must conform to  the syntax
      *                             described in the ICU DecimalFormat or ICU RuleBasedNumberFormat documentation
      *
-     * @return self
+     * @return static
      *
      * @see https://php.net/numberformatter.create
      * @see http://www.icu-project.org/apiref/icu4c/classDecimalFormat.html#_details
@@ -298,7 +298,7 @@ class NumberFormatter
      */
     public static function create($locale = 'en', $style = null, $pattern = null)
     {
-        return new self($locale, $style, $pattern);
+        return new static($locale, $style, $pattern);
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/Collator/CollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/CollatorTest.php
@@ -19,7 +19,7 @@ class CollatorTest extends AbstractCollatorTest
     public function testConstructorWithUnsupportedLocale()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
-        new Collator('pt_BR');
+        $this->getCollator('pt_BR');
     }
 
     public function testCompare()
@@ -90,12 +90,14 @@ class CollatorTest extends AbstractCollatorTest
 
     public function testStaticCreate()
     {
-        $collator = Collator::create('en');
+        $collator = $this->getCollator('en');
+        $collator = $collator::create('en');
         $this->assertInstanceOf('\Symfony\Component\Intl\Collator\Collator', $collator);
     }
 
     protected function getCollator($locale)
     {
-        return new Collator($locale);
+        return new class($locale) extends Collator {
+        };
     }
 }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -43,8 +43,6 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
 
     /**
      * When a time zone is not specified, it uses the system default however it returns null in the getter method.
-     *
-     * @see StubIntlDateFormatterTest::testDefaultTimeZoneIntl()
      */
     public function testConstructorDefaultTimeZone()
     {
@@ -60,14 +58,14 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
 
     public function testConstructorWithoutDateType()
     {
-        $formatter = new IntlDateFormatter('en', null, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN);
+        $formatter = $this->getDateFormatter('en', null, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN);
 
-        $this->assertSame('EEEE, LLLL d, y, h:mm a', $formatter->getPattern());
+        $this->assertSame('EEEE, MMMM d, y \'at\' h:mm a', $formatter->getPattern());
     }
 
     public function testConstructorWithoutTimeType()
     {
-        $formatter = new IntlDateFormatter('en', IntlDateFormatter::SHORT, null, 'UTC', IntlDateFormatter::GREGORIAN);
+        $formatter = $this->getDateFormatter('en', IntlDateFormatter::SHORT, null, 'UTC', IntlDateFormatter::GREGORIAN);
 
         $this->assertSame('M/d/yy, h:mm:ss a zzzz', $formatter->getPattern());
     }
@@ -963,14 +961,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
     }
 
     /**
-     * @param $locale
-     * @param $datetype
-     * @param $timetype
-     * @param null $timezone
-     * @param int  $calendar
-     * @param null $pattern
-     *
-     * @return mixed
+     * @return IntlDateFormatter|\IntlDateFormatter
      */
     abstract protected function getDateFormatter($locale, $datetype, $timetype, $timezone = null, $calendar = IntlDateFormatter::GREGORIAN, $pattern = null);
 

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -18,31 +18,32 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
 {
     public function testConstructor()
     {
-        $formatter = new IntlDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, 'y-M-d');
+        $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, 'y-M-d');
         $this->assertEquals('y-M-d', $formatter->getPattern());
     }
 
     public function testConstructorWithoutLocale()
     {
-        $formatter = new IntlDateFormatter(null, IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, 'y-M-d');
+        $formatter = $this->getDateFormatter(null, IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, 'y-M-d');
         $this->assertEquals('y-M-d', $formatter->getPattern());
     }
 
     public function testConstructorWithoutCalendar()
     {
-        $formatter = new IntlDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', null, 'y-M-d');
+        $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', null, 'y-M-d');
         $this->assertEquals('y-M-d', $formatter->getPattern());
     }
 
     public function testConstructorWithUnsupportedLocale()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
-        new IntlDateFormatter('pt_BR', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
+        $this->getDateFormatter('pt_BR', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
     }
 
     public function testStaticCreate()
     {
-        $formatter = IntlDateFormatter::create('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
+        $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
+        $formatter = $formatter::create('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT);
         $this->assertInstanceOf('\Symfony\Component\Intl\DateFormatter\IntlDateFormatter', $formatter);
     }
 
@@ -75,7 +76,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
     {
         $this->expectException('Symfony\Component\Intl\Exception\NotImplementedException');
         $pattern = 'Y';
-        $formatter = new IntlDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, $pattern);
+        $formatter = $this->getDateFormatter('en', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT, 'UTC', IntlDateFormatter::GREGORIAN, $pattern);
         $formatter->format(0);
     }
 
@@ -178,7 +179,8 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
 
     protected function getDateFormatter($locale, $datetype, $timetype, $timezone = null, $calendar = IntlDateFormatter::GREGORIAN, $pattern = null)
     {
-        return new IntlDateFormatter($locale, $datetype, $timetype, $timezone, $calendar, $pattern);
+        return new class($locale, $datetype, $timetype, $timezone, $calendar, $pattern) extends IntlDateFormatter {
+        };
     }
 
     protected function getIntlErrorMessage()

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -23,19 +23,19 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
     public function testConstructorWithUnsupportedLocale()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
-        new NumberFormatter('pt_BR');
+        $this->getNumberFormatter('pt_BR');
     }
 
     public function testConstructorWithUnsupportedStyle()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException');
-        new NumberFormatter('en', NumberFormatter::PATTERN_DECIMAL);
+        $this->getNumberFormatter('en', NumberFormatter::PATTERN_DECIMAL);
     }
 
     public function testConstructorWithPatternDifferentThanNull()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MethodArgumentNotImplementedException');
-        new NumberFormatter('en', NumberFormatter::DECIMAL, '');
+        $this->getNumberFormatter('en', NumberFormatter::DECIMAL, '');
     }
 
     public function testSetAttributeWithUnsupportedAttribute()
@@ -62,10 +62,8 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
 
     public function testCreate()
     {
-        $this->assertInstanceOf(
-            '\Symfony\Component\Intl\NumberFormatter\NumberFormatter',
-            NumberFormatter::create('en', NumberFormatter::DECIMAL)
-        );
+        $formatter = $this->getNumberFormatter('en', NumberFormatter::DECIMAL);
+        $this->assertInstanceOf(NumberFormatter::class, $formatter::create('en', NumberFormatter::DECIMAL));
     }
 
     public function testFormatWithCurrencyStyle()
@@ -171,7 +169,8 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
 
     protected function getNumberFormatter($locale = 'en', $style = null, $pattern = null)
     {
-        return new NumberFormatter($locale, $style, $pattern);
+        return new class($locale, $style, $pattern) extends NumberFormatter {
+        };
     }
 
     protected function getIntlErrorMessage()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

While working on return types, I keep stumbling on those classes that are `@internal`, but for which we must not add return types, because they're polyfills and are extended by stubs found in the `Resources` folder of the component.

Making the polyfills abstract fixes the linting issue.
This made me discover we have a glitch in the `getPattern()` implementation, that makes our version diverge from intl's. Fixed here too.

On 4.4 because let's not disrupt 3.4.