### PR TITLE
[FrameworkBundle] Fix BrowserKit assertions to make them compatible with Panther

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestAssertionsTrait.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
-use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Test\Constraint as BrowserKitConstraint;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint as DomCrawlerConstraint;
@@ -186,7 +186,7 @@ trait WebTestAssertionsTrait
         self::assertThat(self::getRequest(), $constraint, $message);
     }
 
-    private static function getClient(KernelBrowser $newClient = null): ?KernelBrowser
+    private static function getClient(AbstractBrowser $newClient = null): ?AbstractBrowser
     {
         static $client;
 
@@ -194,7 +194,7 @@ trait WebTestAssertionsTrait
             return $client = $newClient;
         }
 
-        if (!$client instanceof KernelBrowser) {
+        if (!$client instanceof AbstractBrowser) {
             static::fail(sprintf('A client must be set to make assertions on it. Did you forget to call "%s::createClient()"?', __CLASS__));
         }
 

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorAttributeValueSame.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorAttributeValueSame.php
@@ -47,7 +47,7 @@ final class CrawlerSelectorAttributeValueSame extends Constraint
             return false;
         }
 
-        return $this->expectedText === trim($crawler->getNode(0)->getAttribute($this->attribute));
+        return $this->expectedText === trim($crawler->attr($this->attribute));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo (remove the line telling that these assertions aren't compatible with Panther)

Backport of essential fixes provided by https://github.com/symfony/symfony/pull/32207. It allows most assertions to work with Panther even when using Symfony 4.3.