### PR TITLE
Add return types to tests and final|internal|private methods

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Test/TestRepositoryFactory.php
+++ b/src/Symfony/Bridge/Doctrine/Test/TestRepositoryFactory.php
@@ -28,10 +28,8 @@ final class TestRepositoryFactory implements RepositoryFactory
 
     /**
      * {@inheritdoc}
-     *
-     * @return ObjectRepository
      */
-    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    public function getRepository(EntityManagerInterface $entityManager, $entityName): ObjectRepository
     {
         $repositoryHash = $this->getRepositoryHash($entityManager, $entityName);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -257,10 +257,7 @@ class DoctrineExtensionTest extends TestCase
         $method->invokeArgs($this->extension, [$objectManager, $container, $cacheName]);
     }
 
-    /**
-     * @return \Symfony\Component\DependencyInjection\ContainerBuilder
-     */
-    protected function createContainer(array $data = [])
+    protected function createContainer(array $data = []): ContainerBuilder
     {
         return new ContainerBuilder(new ParameterBag(array_merge([
             'kernel.bundles' => ['FrameworkBundle' => 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle'],

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/BaseUser.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/BaseUser.php
@@ -24,9 +24,6 @@ class BaseUser
 
     /**
      * BaseUser constructor.
-     *
-     * @param int    $id
-     * @param string $username
      */
     public function __construct(int $id, string $username)
     {
@@ -42,10 +39,7 @@ class BaseUser
         return $this->id;
     }
 
-    /**
-     * @return string
-     */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CompositeObjectNoToStringIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CompositeObjectNoToStringIdEntity.php
@@ -35,18 +35,12 @@ class CompositeObjectNoToStringIdEntity
         $this->objectTwo = $objectTwo;
     }
 
-    /**
-     * @return SingleIntIdNoToStringEntity
-     */
-    public function getObjectOne()
+    public function getObjectOne(): SingleIntIdNoToStringEntity
     {
         return $this->objectOne;
     }
 
-    /**
-     * @return SingleIntIdNoToStringEntity
-     */
-    public function getObjectTwo()
+    public function getObjectTwo(): SingleIntIdNoToStringEntity
     {
         return $this->objectTwo;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapper.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapper.php
@@ -20,10 +20,7 @@ class StringWrapper
         $this->string = $string;
     }
 
-    /**
-     * @return string
-     */
-    public function getString()
+    public function getString(): string
     {
         return $this->string;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapperType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapperType.php
@@ -34,10 +34,8 @@ class StringWrapperType extends StringType
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'string_wrapper';
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
@@ -35,7 +35,7 @@ class User implements UserInterface
         $this->name = $name;
     }
 
-    public function getRoles()
+    public function getRoles(): array
     {
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
@@ -39,15 +39,15 @@ class User implements UserInterface
     {
     }
 
-    public function getPassword()
+    public function getPassword(): ?string
     {
     }
 
-    public function getSalt()
+    public function getSalt(): ?string
     {
     }
 
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->name;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
@@ -51,7 +51,7 @@ class TestManagerRegistry extends ManagerRegistry
         $this->container = $container;
     }
 
-    public function getAliasNamespace($alias)
+    public function getAliasNamespace($alias): string
     {
         return 'Foo';
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineFooType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineFooType.php
@@ -27,20 +27,16 @@ class DoctrineFooType extends Type
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return $platform->getClobTypeDeclarationSQL([]);
     }
@@ -80,10 +76,8 @@ class DoctrineFooType extends Type
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
@@ -26,10 +26,7 @@ class ConsoleFormatterTest extends TestCase
         self::assertSame($expectedMessage, $formatter->format($record));
     }
 
-    /**
-     * @return array
-     */
-    public function providerFormatTests()
+    public function providerFormatTests(): array
     {
         $currentDateTime = new \DateTime();
 

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -148,9 +148,9 @@ class LoggerTest extends TestCase
 
 class ClassThatInheritLogger extends Logger
 {
-    public function getLogs()
+    public function getLogs(): array
     {
-        parent::getLogs();
+        return parent::getLogs();
     }
 
     public function countErrors()

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
@@ -99,9 +99,9 @@ class DebugProcessorTest extends TestCase
 
 class ClassThatInheritDebugProcessor extends DebugProcessor
 {
-    public function getLogs()
+    public function getLogs(): array
     {
-        parent::getLogs();
+        return parent::getLogs();
     }
 
     public function countErrors()

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -173,10 +173,7 @@ EOPHP;
         $this->assertSame(123, @$foo->dynamicProp);
     }
 
-    /**
-     * @return array
-     */
-    public function getProxyCandidates()
+    public function getProxyCandidates(): array
     {
         $definitions = [
             [new Definition(__CLASS__), true],

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StubTranslator implements TranslatorInterface
 {
-    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         return '[trans]'.strtr($id, $parameters).'[/trans]';
     }

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -123,10 +123,7 @@ class TwigExtractorTest extends TestCase
         }
     }
 
-    /**
-     * @return array
-     */
-    public function resourcesWithSyntaxErrorsProvider()
+    public function resourcesWithSyntaxErrorsProvider(): array
     {
         return [
             [__DIR__.'/../Fixtures'],
@@ -157,10 +154,7 @@ class TwigExtractorTest extends TestCase
         $this->assertEquals('Hi!', $catalogue->get('Hi!', 'messages'));
     }
 
-    /**
-     * @return array
-     */
-    public function resourceProvider()
+    public function resourceProvider(): array
     {
         $directory = __DIR__.'/../Fixtures/extractor/';
 

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
@@ -97,6 +97,8 @@ class TestContainer extends Container
 
     /**
      * {@inheritdoc}
+     *
+     * @return object|null
      */
     public function get($id, $invalidBehavior = /* self::EXCEPTION_ON_INVALID_REFERENCE */ 1)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
@@ -19,14 +19,14 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class TestAppKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [
             new FrameworkBundle(),
         ];
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__.'/test';
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -202,7 +202,7 @@ class ExtendedCallableClass extends CallableClass
 
 class RouteStub extends Route
 {
-    public function compile()
+    public function compile(): CompiledRoute
     {
         return new CompiledRoute('', '#PATH_REGEX#', [], [], '#HOST_REGEX#');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/DataCollectorTranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/DataCollectorTranslatorPassTest.php
@@ -108,7 +108,7 @@ class DataCollectorTranslatorPassTest extends TestCase
 
 class TranslatorWithTranslatorBag implements TranslatorInterface
 {
-    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/CustomPathBundle/src/CustomPathBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/CustomPathBundle/src/CustomPathBundle.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class CustomPathBundle extends Bundle
 {
-    public function getPath()
+    public function getPath(): string
     {
         return __DIR__.'/..';
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AbstractWebTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 abstract class AbstractWebTestCase extends BaseWebTestCase
 {
@@ -42,14 +43,14 @@ abstract class AbstractWebTestCase extends BaseWebTestCase
         $fs->remove($dir);
     }
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         require_once __DIR__.'/app/AppKernel.php';
 
         return 'Symfony\Bundle\FrameworkBundle\Tests\Functional\app\AppKernel';
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         $class = self::getKernelClass();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as FrameworkBundle
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Templating\EngineInterface as ComponentEngineInterface;
 
 class AutowiringTypesTest extends AbstractWebTestCase
@@ -70,7 +71,7 @@ class AutowiringTypesTest extends AbstractWebTestCase
         $this->assertInstanceOf(FilesystemAdapter::class, $autowiredServices->getCachePool());
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         return parent::createKernel(['test_case' => 'AutowiringTypes'] + $options);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
         $this->customConfig = $customConfig;
     }
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('test');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/TestExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/TestExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -42,7 +43,7 @@ class TestExtension extends Extension implements PrependExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         return new Configuration($this->customConfig);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TransDebug/TransSubscriberService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TransDebug/TransSubscriberService.php
@@ -24,7 +24,7 @@ class TransSubscriberService implements ServiceSubscriberInterface
         $this->container = $container;
     }
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return ['translator' => TranslatorInterface::class];
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class CachePoolsTest extends AbstractWebTestCase
 {
@@ -116,7 +117,7 @@ class CachePoolsTest extends AbstractWebTestCase
         $this->assertNotInstanceof(TagAwareAdapter::class, $pool7);
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         return parent::createKernel(['test_case' => 'CachePools'] + $options);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -45,7 +45,7 @@ class AppKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         if (!file_exists($filename = $this->getProjectDir().'/'.$this->testCase.'/bundles.php')) {
             throw new \RuntimeException(sprintf('The bundles file "%s" does not exist.', $filename));
@@ -54,17 +54,17 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/logs';
     }
@@ -89,7 +89,7 @@ class AppKernel extends Kernel
         $this->__construct($this->varDir, $this->testCase, $this->rootConfig, $this->environment, $this->debug);
     }
 
-    protected function getKernelParameters()
+    protected function getKernelParameters(): array
     {
         $parameters = parent::getKernelParameters();
         $parameters['kernel.test_case'] = $this->testCase;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -47,19 +47,19 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
         throw new Danger();
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [
             new FrameworkBundle(),
         ];
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return $this->cacheDir = sys_get_temp_dir().'/sf_micro_kernel';
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return $this->cacheDir;
     }
@@ -100,7 +100,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::EXCEPTION => 'onKernelException',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTemplateNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTemplateNameParser.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures;
 
 use Symfony\Component\Templating\TemplateNameParserInterface;
 use Symfony\Component\Templating\TemplateReference;
+use Symfony\Component\Templating\TemplateReferenceInterface;
 
 class StubTemplateNameParser implements TemplateNameParserInterface
 {
@@ -26,7 +27,7 @@ class StubTemplateNameParser implements TemplateNameParserInterface
         $this->rootTheme = $rootTheme;
     }
 
-    public function parse($name)
+    public function parse($name): TemplateReferenceInterface
     {
         list($bundle, $controller, $template) = explode(':', $name, 3);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTranslator.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StubTranslator implements TranslatorInterface
 {
-    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         return '[trans]'.strtr($id, $parameters).'[/trans]';
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -58,10 +58,8 @@ class PhpEngineTest extends TestCase
 
     /**
      * Creates a Container with a Session-containing Request service.
-     *
-     * @return Container
      */
-    protected function getContainer()
+    protected function getContainer(): Container
     {
         $container = new Container();
         $session = new Session(new MockArraySessionStorage());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -410,7 +410,7 @@ class TranslatorWithInvalidLocale extends Translator
     /**
      * {@inheritdoc}
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return 'invalid locale';
     }

--- a/src/Symfony/Bundle/SecurityBundle/SecurityUserValueResolver.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityUserValueResolver.php
@@ -37,7 +37,7 @@ final class SecurityUserValueResolver implements ArgumentValueResolverInterface
         $this->tokenStorage = $tokenStorage;
     }
 
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         // only security user implementations are supported
         if (UserInterface::class !== $argument->getType()) {
@@ -55,7 +55,7 @@ final class SecurityUserValueResolver implements ArgumentValueResolverInterface
         return $user instanceof UserInterface;
     }
 
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         yield $this->tokenStorage->getToken()->getUser();
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 abstract class AbstractWebTestCase extends BaseWebTestCase
 {
@@ -42,14 +43,14 @@ abstract class AbstractWebTestCase extends BaseWebTestCase
         $fs->remove($dir);
     }
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         require_once __DIR__.'/app/AppKernel.php';
 
         return 'Symfony\Bundle\SecurityBundle\Tests\Functional\app\AppKernel';
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         $class = self::getKernelClass();
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
 
@@ -29,7 +30,7 @@ class AutowiringTypesTest extends AbstractWebTestCase
         $this->assertInstanceOf(TraceableAccessDecisionManager::class, $autowiredServices->getAccessDecisionManager(), 'The debug.security.access.decision_manager service should be injected in non-debug mode');
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         return parent::createKernel(['test_case' => 'AutowiringTypes'] + $options);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FirewallEntryPointBundle/Security/EntryPointStub.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FirewallEntryPointBundle/Security/EntryPointStub.php
@@ -20,7 +20,7 @@ class EntryPointStub implements AuthenticationEntryPointInterface
 {
     const RESPONSE_TEXT = '2be8e651259189d841a19eecdf37e771e2431741';
 
-    public function start(Request $request, AuthenticationException $authException = null)
+    public function start(Request $request, AuthenticationException $authException = null): Response
     {
         return new Response(self::RESPONSE_TEXT);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Security/LocalizedFormFailureHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Security/LocalizedFormFailureHandler.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -27,7 +28,7 @@ class LocalizedFormFailureHandler implements AuthenticationFailureHandlerInterfa
         $this->router = $router;
     }
 
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         return new RedirectResponse($this->router->generate('localized_login_path', [], UrlGeneratorInterface::ABSOLUTE_URL));
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/JsonLoginBundle/Security/Http/JsonAuthenticationFailureHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/JsonLoginBundle/Security/Http/JsonAuthenticationFailureHandler.php
@@ -13,12 +13,13 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\JsonLoginBundle\
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 
 class JsonAuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
 {
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         return new JsonResponse(['message' => 'Something went wrong'], 500);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/JsonLoginBundle/Security/Http/JsonAuthenticationSuccessHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/JsonLoginBundle/Security/Http/JsonAuthenticationSuccessHandler.php
@@ -13,12 +13,13 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\JsonLoginBundle\
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 
 class JsonAuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterface
 {
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
     {
         return new JsonResponse(['message' => sprintf('Good game @%s!', $token->getUsername())]);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -46,12 +46,12 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function getContainerClass()
+    public function getContainerClass(): string
     {
         return parent::getContainerClass().substr(md5($this->rootConfig), -16);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         if (!is_file($filename = $this->getProjectDir().'/'.$this->testCase.'/bundles.php')) {
             throw new \RuntimeException(sprintf('The bundles file "%s" does not exist.', $filename));
@@ -60,17 +60,17 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/logs';
     }
@@ -91,7 +91,7 @@ class AppKernel extends Kernel
         $this->__construct($a[0], $a[1], $a[2], $a[3], $a[4]);
     }
 
-    protected function getKernelParameters()
+    protected function getKernelParameters(): array
     {
         $parameters = parent::getKernelParameters();
         $parameters['kernel.test_case'] = $this->testCase;

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
@@ -79,12 +79,12 @@ class CacheWarmingKernel extends Kernel
         parent::__construct(($withTemplating ? 'with' : 'without').'_templating', true);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'CacheWarming';
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [new FrameworkBundle(), new TwigBundle()];
     }
@@ -116,17 +116,17 @@ class CacheWarmingKernel extends Kernel
         }
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/CacheWarmingKernel/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/CacheWarmingKernel/logs';
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
@@ -32,7 +32,7 @@ class EmptyAppTest extends TestCase
 
 class EmptyAppKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [new TwigBundle()];
     }
@@ -49,12 +49,12 @@ class EmptyAppKernel extends Kernel
         });
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel/logs';
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -53,7 +53,7 @@ class NoTemplatingEntryTest extends TestCase
 
 class NoTemplatingEntryKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [new FrameworkBundle(), new TwigBundle()];
     }
@@ -75,12 +75,12 @@ class NoTemplatingEntryKernel extends Kernel
         });
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel/logs';
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -130,7 +130,7 @@ class ProfileDummy extends Profile
         parent::__construct('token');
     }
 
-    public function hasCollector($name)
+    public function hasCollector($name): bool
     {
         switch ($name) {
             case 'foo':

--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -41,6 +41,9 @@ class HttpBrowser extends AbstractBrowser
         parent::__construct([], $history, $cookieJar);
     }
 
+    /**
+     * @return Response
+     */
     protected function doRequest($request)
     {
         $headers = $this->getHeaders($request);

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\Response;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form as DomCrawlerForm;
 
 class SpecialResponse extends Response
@@ -38,6 +39,9 @@ class TestClient extends AbstractBrowser
         $this->nextScript = $script;
     }
 
+    /**
+     * @return object
+     */
     protected function doRequest($request)
     {
         if (null === $this->nextResponse) {
@@ -50,7 +54,7 @@ class TestClient extends AbstractBrowser
         return $response;
     }
 
-    protected function filterResponse($response)
+    protected function filterResponse($response): Response
     {
         if ($response instanceof SpecialResponse) {
             return new Response($response->getContent(), $response->getStatusCode(), $response->getHeaders());
@@ -934,6 +938,9 @@ class ClassThatInheritClient extends AbstractBrowser
         $this->nextResponse = $response;
     }
 
+    /**
+     * @return object
+     */
     protected function doRequest($request)
     {
         if (null === $this->nextResponse) {
@@ -946,7 +953,7 @@ class ClassThatInheritClient extends AbstractBrowser
         return $response;
     }
 
-    public function submit(DomCrawlerForm $form, array $values = [])
+    public function submit(DomCrawlerForm $form, array $values = []): Crawler
     {
         return parent::submit($form, $values);
     }

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -39,10 +39,7 @@ class TestClient extends AbstractBrowser
         $this->nextScript = $script;
     }
 
-    /**
-     * @return object
-     */
-    protected function doRequest($request)
+    protected function doRequest($request): Response
     {
         if (null === $this->nextResponse) {
             return new Response();
@@ -938,10 +935,7 @@ class ClassThatInheritClient extends AbstractBrowser
         $this->nextResponse = $response;
     }
 
-    /**
-     * @return object
-     */
-    protected function doRequest($request)
+    protected function doRequest($request): Response
     {
         if (null === $this->nextResponse) {
             return new Response();

--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -67,10 +67,7 @@ class TestHttpClient extends HttpBrowser
         return $response;
     }
 
-    /**
-     * @return object
-     */
-    protected function doRequest($request)
+    protected function doRequest($request): Response
     {
         $response = parent::doRequest($request);
 

--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -58,7 +58,7 @@ class TestHttpClient extends HttpBrowser
         $this->nextScript = $script;
     }
 
-    protected function filterResponse($response)
+    protected function filterResponse($response): Response
     {
         if ($response instanceof SpecialHttpResponse) {
             return new Response($response->getContent(), $response->getStatusCode(), $response->getHeaders());
@@ -67,6 +67,9 @@ class TestHttpClient extends HttpBrowser
         return $response;
     }
 
+    /**
+     * @return object
+     */
     protected function doRequest($request)
     {
         $response = parent::doRequest($request);

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -36,10 +36,8 @@ final class CacheItem implements ItemInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -54,10 +52,8 @@ final class CacheItem implements ItemInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
-    public function isHit()
+    public function isHit(): bool
     {
         return $this->isHit;
     }
@@ -153,11 +149,9 @@ final class CacheItem implements ItemInterface
     /**
      * Returns the list of tags bound to the value coming from the pool storage if any.
      *
-     * @return array
-     *
      * @deprecated since Symfony 4.2, use the "getMetadata()" method instead.
      */
-    public function getPreviousTags()
+    public function getPreviousTags(): array
     {
         @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.2, use the "getMetadata()" method instead.', __METHOD__), E_USER_DEPRECATED);
 
@@ -169,11 +163,9 @@ final class CacheItem implements ItemInterface
      *
      * @param string $key The key to validate
      *
-     * @return string
-     *
      * @throws InvalidArgumentException When $key is not valid
      */
-    public static function validateKey($key)
+    public static function validateKey($key): string
     {
         if (!\is_string($key)) {
             throw new InvalidArgumentException(sprintf('Cache key must be string, "%s" given', \is_object($key) ? \get_class($key) : \gettype($key)));

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 abstract class AbstractRedisAdapterTest extends AdapterTestCase
@@ -23,7 +24,7 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
 
     protected static $redis;
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new RedisAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 
@@ -22,7 +23,7 @@ class ApcuAdapterTest extends AdapterTestCase
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
     ];
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         if (!\function_exists('apcu_fetch') || !filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN)) {
             $this->markTestSkipped('APCu extension is required.');

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
@@ -24,7 +25,7 @@ class ArrayAdapterTest extends AdapterTestCase
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayAdapter is not.',
     ];
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new ArrayAdapter($defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
@@ -25,7 +26,7 @@ use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
  */
 class ChainAdapterTest extends AdapterTestCase
 {
-    public function createCachePool($defaultLifetime = 0, $testMethod = null)
+    public function createCachePool($defaultLifetime = 0, $testMethod = null): CacheItemPoolInterface
     {
         if ('testGetMetadata' === $testMethod) {
             return new ChainAdapter([new FilesystemAdapter('', $defaultLifetime)], $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\Cache\Tests\Fixtures\ArrayCache;
 
@@ -26,7 +27,7 @@ class DoctrineAdapterTest extends AdapterTestCase
         'testClearPrefix' => 'Doctrine cannot clear by prefix',
     ];
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new DoctrineAdapter(new ArrayCache($defaultLifetime), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/FilesystemAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/FilesystemAdapterTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  */
 class FilesystemAdapterTest extends AdapterTestCase
 {
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new FilesystemAdapter('', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/FilesystemTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/FilesystemTagAwareAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\FilesystemTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
@@ -21,7 +22,7 @@ class FilesystemTagAwareAdapterTest extends FilesystemAdapterTest
 {
     use TagAwareTestTrait;
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new FilesystemTagAwareAdapter('', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 
@@ -38,7 +39,7 @@ class MemcachedAdapterTest extends AdapterTestCase
         }
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $client = $defaultLifetime ? AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST')) : self::$client;
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
@@ -20,7 +21,7 @@ use Symfony\Component\Cache\Adapter\ProxyAdapter;
  */
 class NamespacedProxyAdapterTest extends ProxyAdapterTest
 {
-    public function createCachePool($defaultLifetime = 0, $testMethod = null)
+    public function createCachePool($defaultLifetime = 0, $testMethod = null): CacheItemPoolInterface
     {
         if ('testGetMetadata' === $testMethod) {
             return new ProxyAdapter(new FilesystemAdapter(), 'foo', $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
 
@@ -40,7 +41,7 @@ class PdoAdapterTest extends AdapterTestCase
         @unlink(self::$dbFile);
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new PdoAdapter('sqlite:'.self::$dbFile, 'ns', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Doctrine\DBAL\DriverManager;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
 
@@ -40,7 +41,7 @@ class PdoDbalAdapterTest extends AdapterTestCase
         @unlink(self::$dbFile);
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new PdoAdapter(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
@@ -70,7 +71,7 @@ class PhpArrayAdapterTest extends AdapterTestCase
         }
     }
 
-    public function createCachePool($defaultLifetime = 0, $testMethod = null)
+    public function createCachePool($defaultLifetime = 0, $testMethod = null): CacheItemPoolInterface
     {
         if ('testGetMetadata' === $testMethod || 'testClearPrefix' === $testMethod) {
             return new PhpArrayAdapter(self::$file, new FilesystemAdapter());
@@ -145,7 +146,7 @@ class PhpArrayAdapterWrapper extends PhpArrayAdapter
 {
     protected $data = [];
 
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
         (\Closure::bind(function () use ($item) {
             $key = $item->getKey();

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
@@ -42,7 +43,7 @@ class PhpArrayAdapterWithFallbackTest extends AdapterTestCase
         }
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new PhpArrayAdapter(self::$file, new FilesystemAdapter('php-array-fallback', $defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
@@ -23,7 +23,7 @@ class PhpFilesAdapterTest extends AdapterTestCase
         'testDefaultLifeTime' => 'PhpFilesAdapter does not allow configuring a default lifetime.',
     ];
 
-    public function createCachePool()
+    public function createCachePool(): CacheItemPoolInterface
     {
         return new PhpFilesAdapter('sf-cache');
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
@@ -24,7 +25,7 @@ class PredisTagAwareAdapterTest extends PredisAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(\Predis\Client::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
@@ -24,7 +25,7 @@ class PredisTagAwareClusterAdapterTest extends PredisClusterAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(\Predis\Client::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareRedisClusterAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
@@ -24,7 +25,7 @@ class PredisTagAwareRedisClusterAdapterTest extends PredisRedisClusterAdapterTes
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(\Predis\Client::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
@@ -29,10 +29,7 @@ class ProxyAdapterTest extends AdapterTestCase
         'testPrune' => 'ProxyAdapter just proxies',
     ];
 
-    /**
-     * @return CacheItemPoolInterface
-     */
-    public function createCachePool($defaultLifetime = 0, $testMethod = null)
+    public function createCachePool($defaultLifetime = 0, $testMethod = null): CacheItemPoolInterface
     {
         if ('testGetMetadata' === $testMethod) {
             return new ProxyAdapter(new FilesystemAdapter(), '', $defaultLifetime);
@@ -64,12 +61,12 @@ class TestingArrayAdapter extends ArrayAdapter
         $this->item = $item;
     }
 
-    public function getItem($key)
+    public function getItem($key): CacheItem
     {
         return $this->item;
     }
 
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
         if ($item === $this->item) {
             throw new \Exception('OK '.$item->get());

--- a/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
@@ -26,7 +27,7 @@ class Psr16AdapterTest extends AdapterTestCase
         'testClearPrefix' => 'SimpleCache cannot clear by prefix',
     ];
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new Psr16Adapter(new Psr16Cache(new FilesystemAdapter()), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Traits\RedisProxy;
@@ -23,7 +24,7 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
         self::$redis = AbstractAdapter::createConnection('redis://'.getenv('REDIS_HOST'), ['lazy' => true]);
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $adapter = parent::createCachePool($defaultLifetime);
         $this->assertInstanceOf(RedisProxy::class, self::$redis);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Traits\RedisClusterProxy;
@@ -29,7 +30,7 @@ class RedisClusterAdapterTest extends AbstractRedisAdapterTest
         self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['lazy' => true, 'redis_cluster' => true]);
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(RedisClusterProxy::class, self::$redis);
         $adapter = new RedisAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 use Symfony\Component\Cache\Traits\RedisProxy;
@@ -25,7 +26,7 @@ class RedisTagAwareAdapterTest extends RedisAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(RedisProxy::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
@@ -24,7 +25,7 @@ class RedisTagAwareArrayAdapterTest extends RedisArrayAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(\RedisArray::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 use Symfony\Component\Cache\Traits\RedisClusterProxy;
@@ -25,7 +26,7 @@ class RedisTagAwareClusterAdapterTest extends RedisClusterAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(RedisClusterProxy::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/SimpleCacheAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/SimpleCacheAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\SimpleCacheAdapter;
 use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\FilesystemCache;
@@ -26,7 +27,7 @@ class SimpleCacheAdapterTest extends AdapterTestCase
         'testClearPrefix' => 'SimpleCache cannot clear by prefix',
     ];
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new SimpleCacheAdapter(new FilesystemCache(), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
@@ -24,7 +25,7 @@ class TagAwareAdapterTest extends AdapterTestCase
 {
     use TagAwareTestTrait;
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new TagAwareAdapter(new FilesystemAdapter('', $defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TraceableAdapter;
 
@@ -23,7 +24,7 @@ class TraceableAdapterTest extends AdapterTestCase
         'testPrune' => 'TraceableAdapter just proxies',
     ];
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
     {
         return new TraceableAdapter(new FilesystemAdapter('', $defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/Fixtures/ArrayCache.php
+++ b/src/Symfony/Component/Cache/Tests/Fixtures/ArrayCache.php
@@ -13,10 +13,7 @@ class ArrayCache extends CacheProvider
         return $this->doContains($id) ? $this->data[$id][0] : false;
     }
 
-    /**
-     * @return bool
-     */
-    protected function doContains($id)
+    protected function doContains($id): bool
     {
         if (!isset($this->data[$id])) {
             return false;
@@ -27,40 +24,28 @@ class ArrayCache extends CacheProvider
         return !$expiry || microtime(true) < $expiry || !$this->doDelete($id);
     }
 
-    /**
-     * @return bool
-     */
-    protected function doSave($id, $data, $lifeTime = 0)
+    protected function doSave($id, $data, $lifeTime = 0): bool
     {
         $this->data[$id] = [$data, $lifeTime ? microtime(true) + $lifeTime : false];
 
         return true;
     }
 
-    /**
-     * @return bool
-     */
-    protected function doDelete($id)
+    protected function doDelete($id): bool
     {
         unset($this->data[$id]);
 
         return true;
     }
 
-    /**
-     * @return bool
-     */
-    protected function doFlush()
+    protected function doFlush(): bool
     {
         $this->data = [];
 
         return true;
     }
 
-    /**
-     * @return array|null
-     */
-    protected function doGetStats()
+    protected function doGetStats(): ?array
     {
         return null;
     }

--- a/src/Symfony/Component/Cache/Tests/Fixtures/ExternalAdapter.php
+++ b/src/Symfony/Component/Cache/Tests/Fixtures/ExternalAdapter.php
@@ -29,74 +29,47 @@ class ExternalAdapter implements CacheItemPoolInterface
         $this->cache = new ArrayAdapter($defaultLifetime);
     }
 
-    /**
-     * @return CacheItemInterface
-     */
-    public function getItem($key)
+    public function getItem($key): CacheItemInterface
     {
         return $this->cache->getItem($key);
     }
 
-    /**
-     * @return iterable
-     */
-    public function getItems(array $keys = [])
+    public function getItems(array $keys = []): iterable
     {
         return $this->cache->getItems($keys);
     }
 
-    /**
-     * @return bool
-     */
-    public function hasItem($key)
+    public function hasItem($key): bool
     {
         return $this->cache->hasItem($key);
     }
 
-    /**
-     * @return bool
-     */
-    public function clear()
+    public function clear(): bool
     {
         return $this->cache->clear();
     }
 
-    /**
-     * @return bool
-     */
-    public function deleteItem($key)
+    public function deleteItem($key): bool
     {
         return $this->cache->deleteItem($key);
     }
 
-    /**
-     * @return bool
-     */
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
         return $this->cache->deleteItems($keys);
     }
 
-    /**
-     * @return bool
-     */
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
         return $this->cache->save($item);
     }
 
-    /**
-     * @return bool
-     */
-    public function saveDeferred(CacheItemInterface $item)
+    public function saveDeferred(CacheItemInterface $item): bool
     {
         return $this->cache->saveDeferred($item);
     }
 
-    /**
-     * @return bool
-     */
-    public function commit()
+    public function commit(): bool
     {
         return $this->cache->commit();
     }

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests;
 
 use Cache\IntegrationTests\SimpleCacheTest;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Psr16Cache;
@@ -39,12 +40,12 @@ class Psr16CacheTest extends SimpleCacheTest
         }
     }
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new Psr16Cache(new FilesystemAdapter('', $defaultLifetime));
     }
 
-    public static function validKeys()
+    public static function validKeys(): array
     {
         return array_merge(parent::validKeys(), [["a\0b"]]);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\RedisCache;
 
 /**
@@ -26,7 +27,7 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
 
     protected static $redis;
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new RedisCache(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/ApcuCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ApcuCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\ApcuCache;
 
 /**
@@ -24,7 +25,7 @@ class ApcuCacheTest extends CacheTestCase
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
     ];
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         if (!\function_exists('apcu_fetch') || !filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) || ('cli' === \PHP_SAPI && !filter_var(ini_get('apc.enable_cli'), FILTER_VALIDATE_BOOLEAN))) {
             $this->markTestSkipped('APCu extension is required.');

--- a/src/Symfony/Component/Cache/Tests/Simple/ArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ArrayCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\ArrayCache;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\Cache\Simple\ArrayCache;
  */
 class ArrayCacheTest extends CacheTestCase
 {
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new ArrayCache($defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/CacheTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/CacheTestCase.php
@@ -26,10 +26,7 @@ abstract class CacheTestCase extends SimpleCacheTest
         }
     }
 
-    /**
-     * @return array
-     */
-    public static function validKeys()
+    public static function validKeys(): array
     {
         return array_merge(parent::validKeys(), [["a\0b"]]);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Cache\Simple\FilesystemCache;
  */
 class ChainCacheTest extends CacheTestCase
 {
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new ChainCache([new ArrayCache($defaultLifetime), new FilesystemCache('', $defaultLifetime)], $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/DoctrineCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/DoctrineCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\DoctrineCache;
 use Symfony\Component\Cache\Tests\Fixtures\ArrayCache;
 
@@ -25,7 +26,7 @@ class DoctrineCacheTest extends CacheTestCase
         'testNotUnserializable' => 'ArrayCache does not use serialize/unserialize',
     ];
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new DoctrineCache(new ArrayCache($defaultLifetime), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/FilesystemCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/FilesystemCacheTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Cache\Simple\FilesystemCache;
  */
 class FilesystemCacheTest extends CacheTestCase
 {
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new FilesystemCache('', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Simple\MemcachedCache;
 
@@ -41,7 +42,7 @@ class MemcachedCacheTest extends CacheTestCase
         }
     }
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         $client = $defaultLifetime ? AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), ['binary_protocol' => false]) : self::$client;
 

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Simple\MemcachedCache;
 
@@ -19,7 +20,7 @@ use Symfony\Component\Cache\Simple\MemcachedCache;
  */
 class MemcachedCacheTextModeTest extends MemcachedCacheTest
 {
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         $client = AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), ['binary_protocol' => false]);
 

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\PdoCache;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
 
@@ -41,7 +42,7 @@ class PdoCacheTest extends CacheTestCase
         @unlink(self::$dbFile);
     }
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new PdoCache('sqlite:'.self::$dbFile, 'ns', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Simple;
 
 use Doctrine\DBAL\DriverManager;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\PdoCache;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
 
@@ -42,7 +43,7 @@ class PdoDbalCacheTest extends CacheTestCase
         @unlink(self::$dbFile);
     }
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new PdoCache(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\NullCache;
 use Symfony\Component\Cache\Simple\PhpArrayCache;
 use Symfony\Component\Cache\Tests\Adapter\FilesystemAdapterTest;
@@ -62,7 +63,7 @@ class PhpArrayCacheTest extends CacheTestCase
         }
     }
 
-    public function createSimpleCache()
+    public function createSimpleCache(): CacheInterface
     {
         return new PhpArrayCacheWrapper(self::$file, new NullCache());
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWithFallbackTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 use Symfony\Component\Cache\Simple\PhpArrayCache;
 use Symfony\Component\Cache\Tests\Adapter\FilesystemAdapterTest;
@@ -49,7 +50,7 @@ class PhpArrayCacheWithFallbackTest extends CacheTestCase
         }
     }
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new PhpArrayCache(self::$file, new FilesystemCache('php-array-fallback', $defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWrapper.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWrapper.php
@@ -17,7 +17,7 @@ class PhpArrayCacheWrapper extends PhpArrayCache
 {
     protected $data = [];
 
-    public function set($key, $value, $ttl = null)
+    public function set($key, $value, $ttl = null): bool
     {
         (\Closure::bind(function () use ($key, $value) {
             $this->data[$key] = $value;
@@ -28,7 +28,7 @@ class PhpArrayCacheWrapper extends PhpArrayCache
         return true;
     }
 
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple($values, $ttl = null): bool
     {
         if (!\is_array($values) && !$values instanceof \Traversable) {
             return parent::setMultiple($values, $ttl);

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpFilesCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpFilesCacheTest.php
@@ -24,7 +24,7 @@ class PhpFilesCacheTest extends CacheTestCase
         'testDefaultLifeTime' => 'PhpFilesCache does not allow configuring a default lifetime.',
     ];
 
-    public function createSimpleCache()
+    public function createSimpleCache(): CacheInterface
     {
         return new PhpFilesCache('sf-cache');
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/Psr6CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/Psr6CacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\Psr6Cache;
 
 /**
@@ -22,7 +23,7 @@ abstract class Psr6CacheTest extends CacheTestCase
         'testPrune' => 'Psr6Cache just proxies',
     ];
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new Psr6Cache($this->createCacheItemPool($defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/TraceableCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/TraceableCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 use Symfony\Component\Cache\Simple\TraceableCache;
 
@@ -24,7 +25,7 @@ class TraceableCacheTest extends CacheTestCase
         'testPrune' => 'TraceableCache just proxies',
     ];
 
-    public function createSimpleCache($defaultLifetime = 0)
+    public function createSimpleCache($defaultLifetime = 0): CacheInterface
     {
         return new TraceableCache(new FilesystemCache('', $defaultLifetime));
     }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\ExprBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class ExprBuilderTest extends TestCase
@@ -201,10 +202,8 @@ class ExprBuilderTest extends TestCase
 
     /**
      * Create a test treebuilder with a variable node, and init the validation.
-     *
-     * @return TreeBuilder
      */
-    protected function getTestBuilder()
+    protected function getTestBuilder(): ExprBuilder
     {
         $builder = new TreeBuilder('test');
 
@@ -225,7 +224,7 @@ class ExprBuilderTest extends TestCase
      *
      * @return array The finalized config values
      */
-    protected function finalizeTestBuilder($testBuilder, $config = null)
+    protected function finalizeTestBuilder($testBuilder, $config = null): array
     {
         return $testBuilder
             ->end()
@@ -240,10 +239,8 @@ class ExprBuilderTest extends TestCase
      * Return a closure that will return the given value.
      *
      * @param mixed $val The value that the closure must return
-     *
-     * @return \Closure
      */
-    protected function returnClosure($val)
+    protected function returnClosure($val): \Closure
     {
         return function ($v) use ($val) {
             return $val;

--- a/src/Symfony/Component/Config/Tests/Fixtures/Builder/BarNodeDefinition.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Builder/BarNodeDefinition.php
@@ -12,11 +12,12 @@
 namespace Symfony\Component\Config\Tests\Fixtures\Builder;
 
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\NodeInterface;
 use Symfony\Component\Config\Tests\Fixtures\BarNode;
 
 class BarNodeDefinition extends NodeDefinition
 {
-    protected function createNode()
+    protected function createNode(): NodeInterface
     {
         return new BarNode($this->name);
     }

--- a/src/Symfony/Component/Config/Tests/Fixtures/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Builder/NodeBuilder.php
@@ -20,7 +20,7 @@ class NodeBuilder extends BaseNodeBuilder
         return $this->node($name, 'bar');
     }
 
-    protected function getNodeClass($type)
+    protected function getNodeClass($type): string
     {
         switch ($type) {
             case 'variable':

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ExampleConfiguration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('acme_root');
 

--- a/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
@@ -103,7 +103,7 @@ class TestFileLoader extends FileLoader
         return $resource;
     }
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return $this->supports;
     }

--- a/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/LoaderTest.php
@@ -105,7 +105,7 @@ class ProjectLoader1 extends Loader
     {
     }
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return \is_string($resource) && 'foo' === pathinfo($resource, PATHINFO_EXTENSION);
     }

--- a/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
@@ -204,7 +204,7 @@ class TestEventSubscriber implements EventSubscriberInterface
 {
     public static $subscribedEvents = [];
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return self::$subscribedEvents;
     }
@@ -228,7 +228,7 @@ class TestServiceSubscriber implements ServiceSubscriberInterface
 {
     public static $subscribedServices = [];
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return self::$subscribedServices;
     }

--- a/src/Symfony/Component/Config/Tests/Resource/ResourceStub.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ResourceStub.php
@@ -22,12 +22,12 @@ class ResourceStub implements SelfCheckingResourceInterface
         $this->fresh = $isFresh;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return 'stub';
     }
 
-    public function isFresh($timestamp)
+    public function isFresh($timestamp): bool
     {
         return $this->fresh;
     }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1758,7 +1758,7 @@ class CustomApplication extends Application
      *
      * @return InputDefinition An InputDefinition instance
      */
-    protected function getDefaultInputDefinition()
+    protected function getDefaultInputDefinition(): InputDefinition
     {
         return new InputDefinition([new InputOption('--custom', '-c', InputOption::VALUE_NONE, 'Set the custom input definition.')]);
     }
@@ -1768,7 +1768,7 @@ class CustomApplication extends Application
      *
      * @return HelperSet A HelperSet instance
      */
-    protected function getDefaultHelperSet()
+    protected function getDefaultHelperSet(): HelperSet
     {
         return new HelperSet([new FormatterHelper()]);
     }
@@ -1799,7 +1799,7 @@ class LazyCommand extends Command
 
 class DisabledCommand extends Command
 {
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return false;
     }

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -138,11 +138,11 @@ class ErrorListenerTest extends TestCase
 
 class NonStringInput extends Input
 {
-    public function getFirstArgument()
+    public function getFirstArgument(): ?string
     {
     }
 
-    public function hasParameterOption($values, $onlyParams = false)
+    public function hasParameterOption($values, $onlyParams = false): bool
     {
     }
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/DummyOutput.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/DummyOutput.php
@@ -20,10 +20,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
  */
 class DummyOutput extends BufferedOutput
 {
-    /**
-     * @return array
-     */
-    public function getLogs()
+    public function getLogs(): array
     {
         $logs = [];
         foreach (explode(PHP_EOL, trim($this->fetch())) as $message) {

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -867,10 +867,8 @@ class ProgressBarTest extends TestCase
 
     /**
      * Provides each defined format.
-     *
-     * @return array
      */
-    public function provideFormat()
+    public function provideFormat(): array
     {
         return [
             ['normal'],

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -148,10 +148,8 @@ class ProgressIndicatorTest extends TestCase
 
     /**
      * Provides each defined format.
-     *
-     * @return array
      */
-    public function provideFormat()
+    public function provideFormat(): array
     {
         return [
             ['normal'],

--- a/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
+++ b/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
@@ -32,10 +32,7 @@ class ConsoleLoggerTest extends TestCase
      */
     protected $output;
 
-    /**
-     * @return LoggerInterface
-     */
-    public function getLogger()
+    public function getLogger(): LoggerInterface
     {
         $this->output = new DummyOutput(OutputInterface::VERBOSITY_VERBOSE);
 
@@ -56,7 +53,7 @@ class ConsoleLoggerTest extends TestCase
      *
      * @return string[]
      */
-    public function getLogs()
+    public function getLogs(): array
     {
         return $this->output->getLogs();
     }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/FinalClasses.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/FinalClasses.php
@@ -41,7 +41,6 @@ class FinalClass4
 /**
  * @author John Doe
  *
- *
  * @final multiline
  * comment
  */

--- a/src/Symfony/Component/Debug/Tests/Fixtures/LoggerThatSetAnErrorHandler.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/LoggerThatSetAnErrorHandler.php
@@ -6,7 +6,7 @@ use Symfony\Component\Debug\BufferingLogger;
 
 class LoggerThatSetAnErrorHandler extends BufferingLogger
 {
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         set_error_handler('is_string');
         parent::log($level, $message, $context);

--- a/src/Symfony/Component/DependencyInjection/Argument/BoundArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/BoundArgument.php
@@ -43,7 +43,7 @@ final class BoundArgument implements ArgumentInterface
     /**
      * {@inheritdoc}
      */
-    public function getValues()
+    public function getValues(): array
     {
         return [$this->value, $this->identifier, $this->used, $this->type, $this->file];
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
@@ -89,10 +89,8 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
     /**
      * @param Reference[] $refMap
      * @param string|null $callerId
-     *
-     * @return Reference
      */
-    public static function register(ContainerBuilder $container, array $refMap, $callerId = null)
+    public static function register(ContainerBuilder $container, array $refMap, $callerId = null): Reference
     {
         foreach ($refMap as $id => $ref) {
             if (!$ref instanceof Reference) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ExtensionCompilerPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ExtensionCompilerPassTest.php
@@ -61,7 +61,7 @@ class DummyExtension extends Extension
         $this->alias = $alias;
     }
 
-    public function getAlias()
+    public function getAlias(): string
     {
         return $this->alias;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -406,7 +406,7 @@ class IntegrationTest extends TestCase
 
 class ServiceSubscriberStub implements ServiceSubscriberInterface
 {
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return [];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -132,7 +132,7 @@ class MergeExtensionConfigurationPassTest extends TestCase
 
 class FooConfiguration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('foo');
         $treeBuilder->getRootNode()
@@ -147,12 +147,12 @@ class FooConfiguration implements ConfigurationInterface
 
 class FooExtension extends Extension
 {
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'foo';
     }
 
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         return new FooConfiguration();
     }
@@ -179,12 +179,12 @@ class BarExtension extends Extension
 
 class ThrowingExtension extends Extension
 {
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'throwing';
     }
 
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         return new FooConfiguration();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -78,7 +78,7 @@ class SimpleProcessor implements EnvVarProcessorInterface
         return $getEnv($name);
     }
 
-    public static function getProvidedTypes()
+    public static function getProvidedTypes(): array
     {
         return ['foo' => 'string'];
     }
@@ -86,7 +86,7 @@ class SimpleProcessor implements EnvVarProcessorInterface
 
 class BadProcessor extends SimpleProcessor
 {
-    public static function getProvidedTypes()
+    public static function getProvidedTypes(): array
     {
         return ['foo' => 'string|foo'];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -313,7 +313,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
 
 class EnvConfiguration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('env_extension');
         $treeBuilder->getRootNode()
@@ -376,7 +376,7 @@ class EnvConfiguration implements ConfigurationInterface
 
 class EnvConfigurationWithoutRootNode implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         return new TreeBuilder();
     }
@@ -384,7 +384,7 @@ class EnvConfigurationWithoutRootNode implements ConfigurationInterface
 
 class ConfigurationWithArrayNodeRequiringOneElement implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('env_extension');
         $treeBuilder->getRootNode()
@@ -410,12 +410,12 @@ class EnvExtension extends Extension
         $this->configuration = $configuration ?? new EnvConfiguration();
     }
 
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'env_extension';
     }
 
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         return $this->configuration;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1328,7 +1328,7 @@ class Rot13EnvVarProcessor implements EnvVarProcessorInterface
         return str_rot13($getEnv($name));
     }
 
-    public static function getProvidedTypes()
+    public static function getProvidedTypes(): array
     {
         return ['rot13' => 'string'];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Extension/ExtensionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Extension/ExtensionTest.php
@@ -50,7 +50,7 @@ class EnableableExtension extends Extension
     {
     }
 
-    public function isConfigEnabled(ContainerBuilder $container, array $config)
+    public function isConfigEnabled(ContainerBuilder $container, array $config): bool
     {
         return parent::isConfigEnabled($container, $config);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarFactory.php
@@ -11,7 +11,7 @@ class BarFactory
 
     public function __construct(iterable $bars)
     {
-        $this->bars = \iterator_to_array($bars);
+        $this->bars = iterator_to_array($bars);
     }
 
     public function getDefaultBar(): BarInterface

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ScalarFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ScalarFactory.php
@@ -4,9 +4,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 final class ScalarFactory
 {
-    /**
-     * @return string
-     */
     public static function getSomeValue(): string
     {
         return 'some value';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriber.php
@@ -10,7 +10,7 @@ class TestServiceSubscriber implements ServiceSubscriberInterface
     {
     }
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return [
             __CLASS__,

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberChild.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberChild.php
@@ -6,7 +6,8 @@ use Symfony\Contracts\Service\ServiceSubscriberTrait;
 
 class TestServiceSubscriberChild extends TestServiceSubscriberParent
 {
-    use ServiceSubscriberTrait, TestServiceSubscriberTrait;
+    use ServiceSubscriberTrait;
+    use TestServiceSubscriberTrait;
 
     private function testDefinition2(): TestDefinition2
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services9.php
@@ -4,8 +4,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Bar\FooClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\Reference;
 
 require_once __DIR__.'/../includes/classes.php';
 require_once __DIR__.'/../includes/foo.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -5,10 +5,10 @@ require_once __DIR__.'/../includes/foo.php';
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -248,7 +248,7 @@ class TestFileLoader extends FileLoader
         return $resource;
     }
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return false;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
@@ -104,7 +104,7 @@ class SomeServiceSubscriber implements ServiceSubscriberInterface
         return $this->container->get('foo');
     }
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return ['bar' => 'stdClass'];
     }

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -1241,6 +1241,9 @@ HTML;
 
 class ClassThatInheritCrawler extends Crawler
 {
+    /**
+     * @return static
+     */
     public function children()
     {
         parent::children();

--- a/src/Symfony/Component/EventDispatcher/LegacyEventDispatcherProxy.php
+++ b/src/Symfony/Component/EventDispatcher/LegacyEventDispatcherProxy.php
@@ -50,6 +50,8 @@ final class LegacyEventDispatcherProxy implements EventDispatcherInterface
      * {@inheritdoc}
      *
      * @param string|null $eventName
+     *
+     * @return Event
      */
     public function dispatch($event/*, string $eventName = null*/)
     {
@@ -114,7 +116,7 @@ final class LegacyEventDispatcherProxy implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getListeners($eventName = null)
+    public function getListeners($eventName = null): array
     {
         return $this->dispatcher->getListeners($eventName);
     }
@@ -130,7 +132,7 @@ final class LegacyEventDispatcherProxy implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function hasListeners($eventName = null)
+    public function hasListeners($eventName = null): bool
     {
         return $this->dispatcher->hasListeners($eventName);
     }

--- a/src/Symfony/Component/EventDispatcher/LegacyEventProxy.php
+++ b/src/Symfony/Component/EventDispatcher/LegacyEventProxy.php
@@ -37,7 +37,7 @@ final class LegacyEventProxy extends Event
         return $this->event;
     }
 
-    public function isPropagationStopped()
+    public function isPropagationStopped(): bool
     {
         if (!$this->event instanceof ContractsEvent && !$this->event instanceof StoppableEventInterface) {
             return false;

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -312,7 +312,7 @@ class TraceableEventDispatcherTest extends TestCase
 
 class EventSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return ['foo' => 'call'];
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -179,7 +179,7 @@ class RegisterListenersPassTest extends TestCase
 
 class SubscriberService implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             'event' => 'onEvent',

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -482,7 +482,7 @@ class TestWithDispatcher
 
 class TestEventSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return ['pre.foo' => 'preFoo', 'post.foo' => 'postFoo'];
     }
@@ -490,7 +490,7 @@ class TestEventSubscriber implements EventSubscriberInterface
 
 class TestEventSubscriberWithPriorities implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             'pre.foo' => ['preFoo', 10],
@@ -501,7 +501,7 @@ class TestEventSubscriberWithPriorities implements EventSubscriberInterface
 
 class TestEventSubscriberWithMultipleListeners implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return ['pre.foo' => [
             ['preFoo1'],

--- a/src/Symfony/Component/EventDispatcher/Tests/LegacyEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/LegacyEventDispatcherTest.php
@@ -56,10 +56,7 @@ class LegacyEventDispatcherTest extends EventDispatcherTest
 
 class TestLegacyEventDispatcher extends EventDispatcher
 {
-    /**
-     * @return object
-     */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, Event $event = null): Event
     {
         return parent::dispatch($event, $eventName);
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/LegacyEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/LegacyEventDispatcherTest.php
@@ -56,6 +56,9 @@ class LegacyEventDispatcherTest extends EventDispatcherTest
 
 class TestLegacyEventDispatcher extends EventDispatcher
 {
+    /**
+     * @return object
+     */
     public function dispatch($eventName, Event $event = null)
     {
         return parent::dispatch($event, $eventName);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Fixtures/TestProvider.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Fixtures/TestProvider.php
@@ -17,7 +17,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionPhpFunction;
 
 class TestProvider implements ExpressionFunctionProviderInterface
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new ExpressionFunction('identity', function ($input) {

--- a/src/Symfony/Component/Filesystem/Tests/Fixtures/MockStream/MockStream.php
+++ b/src/Symfony/Component/Filesystem/Tests/Fixtures/MockStream/MockStream.php
@@ -25,10 +25,8 @@ class MockStream
      * @param int    $options     Holds additional flags set by the streams API
      * @param string $opened_path If the path is opened successfully, and STREAM_USE_PATH is set in options,
      *                            opened_path should be set to the full path of the file/resource that was actually opened
-     *
-     * @return bool
      */
-    public function stream_open($path, $mode, $options, &$opened_path)
+    public function stream_open($path, $mode, $options, &$opened_path): bool
     {
         return true;
     }
@@ -39,7 +37,7 @@ class MockStream
      *
      * @return array File stats
      */
-    public function url_stat($path, $flags)
+    public function url_stat($path, $flags): array
     {
         return [];
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1438,6 +1438,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
 class ClassThatInheritFinder extends Finder
 {
+    /**
+     * @return $this
+     */
     public function sortByName()
     {
         parent::sortByName();

--- a/src/Symfony/Component/Finder/Tests/GitignoreTest.php
+++ b/src/Symfony/Component/Finder/Tests/GitignoreTest.php
@@ -41,7 +41,7 @@ class GitignoreTest extends TestCase
      *               ],
      *               ]
      */
-    public function provider()
+    public function provider(): array
     {
         return [
             [

--- a/src/Symfony/Component/Finder/Tests/Iterator/MultiplePcreFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/MultiplePcreFilterIteratorTest.php
@@ -59,12 +59,12 @@ class TestMultiplePcreFilterIterator extends MultiplePcreFilterIterator
         throw new \BadFunctionCallException('Not implemented');
     }
 
-    public function isRegex($str)
+    public function isRegex($str): bool
     {
         return parent::isRegex($str);
     }
 
-    public function toRegex($str)
+    public function toRegex($str): string
     {
         throw new \BadFunctionCallException('Not implemented');
     }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
@@ -30,7 +30,7 @@ final class DateTimeImmutableToDateTimeTransformer implements DataTransformerInt
      *
      * @throws TransformationFailedException If the given value is not a \DateTimeImmutable
      */
-    public function transform($value)
+    public function transform($value): ?\DateTime
     {
         if (null === $value) {
             return null;
@@ -52,7 +52,7 @@ final class DateTimeImmutableToDateTimeTransformer implements DataTransformerInt
      *
      * @throws TransformationFailedException If the given value is not a \DateTime
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): ?\DateTimeImmutable
     {
         if (null === $value) {
             return null;

--- a/src/Symfony/Component/Form/Tests/AbstractExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractExtensionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\AbstractExtension;
+use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Tests\Fixtures\FooType;
 
 class AbstractExtensionTest extends TestCase
@@ -33,12 +34,12 @@ class AbstractExtensionTest extends TestCase
 
 class ConcreteExtension extends AbstractExtension
 {
-    protected function loadTypes()
+    protected function loadTypes(): array
     {
         return [new FooType()];
     }
 
-    protected function loadTypeGuesser()
+    protected function loadTypeGuesser(): ?FormTypeGuesserInterface
     {
     }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTest.php
@@ -218,10 +218,7 @@ abstract class AbstractChoiceListTest extends TestCase
         $this->assertNotEmpty($this->list->getChoicesForValues($values));
     }
 
-    /**
-     * @return \Symfony\Component\Form\ChoiceList\ChoiceListInterface
-     */
-    abstract protected function createChoiceList();
+    abstract protected function createChoiceList(): \Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 
     abstract protected function getChoices();
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\ChoiceList;
 
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -27,7 +28,7 @@ class ArrayChoiceListTest extends AbstractChoiceListTest
         parent::setUp();
     }
 
-    protected function createChoiceList()
+    protected function createChoiceList(): ChoiceListInterface
     {
         return new ArrayChoiceList($this->getChoices());
     }

--- a/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
+++ b/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
@@ -238,10 +238,7 @@ class FormPassTest extends TestCase
         $this->assertEquals($expectedRegisteredExtensions, $extDefinition->getArgument(1));
     }
 
-    /**
-     * @return array
-     */
-    public function addLegacyTaggedTypeExtensionsDataProvider()
+    public function addLegacyTaggedTypeExtensionsDataProvider(): array
     {
         return [
             [

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -333,7 +333,7 @@ class PropertyPathMapperTest extends TestCase
 
 class SubmittedForm extends Form
 {
-    public function isSubmitted()
+    public function isSubmitted(): bool
     {
         return true;
     }
@@ -341,7 +341,7 @@ class SubmittedForm extends Form
 
 class NotSynchronizedForm extends Form
 {
-    public function isSynchronized()
+    public function isSynchronized(): bool
     {
         return false;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -27,8 +27,11 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\MetadataInterface;
 use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ValidationListenerTest extends TestCase
@@ -137,12 +140,12 @@ class ValidationListenerTest extends TestCase
 
 class SubmittedNotSynchronizedForm extends Form
 {
-    public function isSubmitted()
+    public function isSubmitted(): bool
     {
         return true;
     }
 
-    public function isSynchronized()
+    public function isSynchronized(): bool
     {
         return false;
     }
@@ -157,32 +160,32 @@ class DummyValidator implements ValidatorInterface
         $this->violation = $violation;
     }
 
-    public function getMetadataFor($value)
+    public function getMetadataFor($value): MetadataInterface
     {
     }
 
-    public function hasMetadataFor($value)
+    public function hasMetadataFor($value): bool
     {
     }
 
-    public function validate($value, $constraints = null, $groups = null)
+    public function validate($value, $constraints = null, $groups = null): ConstraintViolationListInterface
     {
         return new ConstraintViolationList([$this->violation]);
     }
 
-    public function validateProperty($object, $propertyName, $groups = null)
+    public function validateProperty($object, $propertyName, $groups = null): ConstraintViolationListInterface
     {
     }
 
-    public function validatePropertyValue($objectOrClass, $propertyName, $value, $groups = null)
+    public function validatePropertyValue($objectOrClass, $propertyName, $value, $groups = null): ConstraintViolationListInterface
     {
     }
 
-    public function startContext()
+    public function startContext(): ContextualValidatorInterface
     {
     }
 
-    public function inContext(ExecutionContextInterface $context)
+    public function inContext(ExecutionContextInterface $context): ContextualValidatorInterface
     {
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
@@ -40,7 +40,7 @@ class UploadValidatorExtensionTest extends TypeTestCase
 
 class DummyTranslator implements TranslatorInterface
 {
-    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         return 'translated max {{ max }}!';
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Util/ServerParamsTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Util/ServerParamsTest.php
@@ -79,7 +79,7 @@ class DummyServerParams extends ServerParams
         $this->size = $size;
     }
 
-    public function getNormalizedIniPostMaxSize()
+    public function getNormalizedIniPostMaxSize(): string
     {
         return $this->size;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -93,18 +93,13 @@ class ViolationMapperTest extends TestCase
 
     /**
      * @param $propertyPath
-     *
-     * @return ConstraintViolation
      */
-    protected function getConstraintViolation($propertyPath)
+    protected function getConstraintViolation($propertyPath): ConstraintViolation
     {
         return new ConstraintViolation($this->message, $this->messageTemplate, $this->params, null, $propertyPath, null);
     }
 
-    /**
-     * @return FormError
-     */
-    protected function getFormError(ConstraintViolationInterface $violation, FormInterface $form)
+    protected function getFormError(ConstraintViolationInterface $violation, FormInterface $form): FormError
     {
         $error = new FormError($this->message, $this->messageTemplate, $this->params, null, $violation);
         $error->setOrigin($form);

--- a/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
@@ -36,7 +36,7 @@ class ChoiceSubType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FixedFilterListener.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FixedFilterListener.php
@@ -55,7 +55,7 @@ class FixedFilterListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SUBMIT => 'preSubmit',

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 
 class FooSubType extends AbstractType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
         return __NAMESPACE__.'\FooType';
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 
 class FooType extends AbstractType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
         return null;
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FormWithSameParentType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FormWithSameParentType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 
 class FormWithSameParentType extends AbstractType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
         return self::class;
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/RecursiveFormTypeBar.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/RecursiveFormTypeBar.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 
 class RecursiveFormTypeBar extends AbstractType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
         return RecursiveFormTypeBaz::class;
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/RecursiveFormTypeBaz.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/RecursiveFormTypeBaz.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 
 class RecursiveFormTypeBaz extends AbstractType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
         return RecursiveFormTypeFoo::class;
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/RecursiveFormTypeFoo.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/RecursiveFormTypeFoo.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 
 class RecursiveFormTypeFoo extends AbstractType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
         return RecursiveFormTypeBar::class;
     }

--- a/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
@@ -34,12 +34,12 @@ class TestExtension implements FormExtensionInterface
         $this->types[\get_class($type)] = $type;
     }
 
-    public function getType($name)
+    public function getType($name): FormTypeInterface
     {
         return isset($this->types[$name]) ? $this->types[$name] : null;
     }
 
-    public function hasType($name)
+    public function hasType($name): bool
     {
         return isset($this->types[$name]);
     }
@@ -55,17 +55,17 @@ class TestExtension implements FormExtensionInterface
         }
     }
 
-    public function getTypeExtensions($name)
+    public function getTypeExtensions($name): array
     {
         return isset($this->extensions[$name]) ? $this->extensions[$name] : [];
     }
 
-    public function hasTypeExtensions($name)
+    public function hasTypeExtensions($name): bool
     {
         return isset($this->extensions[$name]);
     }
 
-    public function getTypeGuesser()
+    public function getTypeGuesser(): ?FormTypeGuesserInterface
     {
         return $this->guesser;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -53,10 +53,7 @@ class NativeSessionStorageTest extends TestCase
         $this->savePath = null;
     }
 
-    /**
-     * @return NativeSessionStorage
-     */
-    protected function getStorage(array $options = [])
+    protected function getStorage(array $options = []): NativeSessionStorage
     {
         $storage = new NativeSessionStorage($options);
         $storage->registerBag(new AttributeBag());

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -49,10 +49,7 @@ class PhpBridgeSessionStorageTest extends TestCase
         $this->savePath = null;
     }
 
-    /**
-     * @return PhpBridgeSessionStorage
-     */
-    protected function getStorage()
+    protected function getStorage(): PhpBridgeSessionStorage
     {
         $storage = new PhpBridgeSessionStorage();
         $storage->registerBag(new AttributeBag());

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -43,7 +43,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getArguments(Request $request, $controller)
+    public function getArguments(Request $request, $controller): array
     {
         $arguments = [];
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DefaultValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DefaultValueResolver.php
@@ -25,7 +25,7 @@ final class DefaultValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         return $argument->hasDefaultValue() || (null !== $argument->getType() && $argument->isNullable() && !$argument->isVariadic());
     }
@@ -33,7 +33,7 @@ final class DefaultValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         yield $argument->hasDefaultValue() ? $argument->getDefaultValue() : null;
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/NotTaggedControllerValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/NotTaggedControllerValueResolver.php
@@ -34,7 +34,7 @@ final class NotTaggedControllerValueResolver implements ArgumentValueResolverInt
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         $controller = $request->attributes->get('_controller');
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
@@ -25,7 +25,7 @@ final class RequestAttributeValueResolver implements ArgumentValueResolverInterf
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         return !$argument->isVariadic() && $request->attributes->has($argument->getName());
     }
@@ -33,7 +33,7 @@ final class RequestAttributeValueResolver implements ArgumentValueResolverInterf
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         yield $request->attributes->get($argument->getName());
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestValueResolver.php
@@ -25,7 +25,7 @@ final class RequestValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         return Request::class === $argument->getType() || is_subclass_of($argument->getType(), Request::class);
     }
@@ -33,7 +33,7 @@ final class RequestValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         yield $request;
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -34,7 +34,7 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         $controller = $request->attributes->get('_controller');
 
@@ -58,7 +58,7 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         if (\is_array($controller = $request->attributes->get('_controller'))) {
             $controller = $controller[0].'::'.$controller[1];

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
@@ -26,7 +26,7 @@ final class SessionValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         if (!$request->hasSession()) {
             return false;
@@ -43,7 +43,7 @@ final class SessionValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         yield $request->getSession();
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/VariadicValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/VariadicValueResolver.php
@@ -25,7 +25,7 @@ final class VariadicValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         return $argument->isVariadic() && $request->attributes->has($argument->getName());
     }
@@ -33,7 +33,7 @@ final class VariadicValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         $values = $request->attributes->get($argument->getName());
 

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -21,7 +21,7 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createArgumentMetadata($controller)
+    public function createArgumentMetadata($controller): array
     {
         $arguments = [];
 

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerTest.php
@@ -59,7 +59,7 @@ class TestCacheWarmer extends CacheWarmer
         $this->writeCacheFile($this->file, 'content');
     }
 
-    public function isOptional()
+    public function isOptional(): bool
     {
         return false;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/TraceableValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/TraceableValueResolverTest.php
@@ -63,12 +63,12 @@ class TraceableValueResolverTest extends TestCase
 
 class ResolverStub implements ArgumentValueResolverInterface
 {
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         return true;
     }
 
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         yield 'first';
         yield 'second';

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -62,11 +62,11 @@ class ConfigDataCollectorTest extends TestCase
 
 class KernelForTest extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
     }
 
-    public function getBundles()
+    public function getBundles(): array
     {
         return [];
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
@@ -59,11 +60,11 @@ class FragmentRendererPassTest extends TestCase
 
 class RendererService implements FragmentRendererInterface
 {
-    public function render($uri, Request $request = null, array $options = [])
+    public function render($uri, Request $request = null, array $options = []): Response
     {
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'test';
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
@@ -66,7 +66,7 @@ class DumpListenerTest extends TestCase
 
 class MockCloner implements ClonerInterface
 {
-    public function cloneVar($var)
+    public function cloneVar($var): Data
     {
         return new Data([[$var.'-']]);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -167,7 +167,7 @@ class TestLogger extends Logger implements DebugLoggerInterface
 
 class TestKernel implements HttpKernelInterface
 {
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
     {
         return new Response('foo');
     }
@@ -175,7 +175,7 @@ class TestKernel implements HttpKernelInterface
 
 class TestKernelThatThrowsException implements HttpKernelInterface
 {
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
     {
         throw new \RuntimeException('bar');
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/CloneVarDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/CloneVarDataCollector.php
@@ -39,7 +39,7 @@ class CloneVarDataCollector extends DataCollector
         return $this->data;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'clone_var';
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForOverrideName.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForOverrideName.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\HttpKernel\Tests\Fixtures;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
 class KernelForOverrideName extends Kernel
 {
     protected $name = 'overridden';
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Fixtures;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
 class KernelForTest extends Kernel
@@ -21,7 +22,7 @@ class KernelForTest extends Kernel
         return $this->bundleMap;
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [];
     }
@@ -35,12 +36,12 @@ class KernelForTest extends Kernel
         return $this->booted;
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return $this->getProjectDir().'/Tests/Fixtures/cache.'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return $this->getProjectDir().'/Tests/Fixtures/logs';
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelWithoutBundles.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelWithoutBundles.php
@@ -13,11 +13,12 @@ namespace Symfony\Component\HttpKernel\Tests\Fixtures;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
 class KernelWithoutBundles extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [];
     }
@@ -26,7 +27,7 @@ class KernelWithoutBundles extends Kernel
     {
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/TestClient.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/TestClient.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 class TestClient extends HttpKernelBrowser
 {
-    protected function getScript($request)
+    protected function getScript($request): string
     {
         $script = parent::getScript($request);
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1555,7 +1555,7 @@ class TestKernel implements HttpKernelInterface
         $this->terminateCalled = true;
     }
 
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SubRequestHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SubRequestHandlerTest.php
@@ -143,7 +143,7 @@ class TestSubRequestHandlerKernel implements HttpKernelInterface
         $this->assertCallback = $assertCallback;
     }
 
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
     {
         $assertCallback = $this->assertCallback;
         $assertCallback($request, $type, $catch);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -54,7 +54,7 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
         }
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = false)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = false): Response
     {
         $this->catch = $catch;
         $this->backendRequest = [Request::getTrustedProxies(), Request::getTrustedHeaderSet(), $request];
@@ -72,7 +72,7 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
         return [$this, 'callController'];
     }
 
-    public function getArguments(Request $request, $controller)
+    public function getArguments(Request $request, $controller): array
     {
         return [$request];
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
@@ -43,7 +43,7 @@ class TestMultipleHttpKernel extends HttpKernel implements ControllerResolverInt
         return $this->backendRequest;
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = false)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = false): Response
     {
         $this->backendRequest = $request;
 
@@ -55,7 +55,7 @@ class TestMultipleHttpKernel extends HttpKernel implements ControllerResolverInt
         return [$this, 'callController'];
     }
 
-    public function getArguments(Request $request, $controller)
+    public function getArguments(Request $request, $controller): array
     {
         return [$request];
     }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\ResettableServicePass;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForOverrideName;
@@ -620,10 +621,8 @@ EOF;
 
     /**
      * Returns a mock for the BundleInterface.
-     *
-     * @return BundleInterface
      */
-    protected function getBundle($dir = null, $parent = null, $className = null, $bundleName = null)
+    protected function getBundle($dir = null, $parent = null, $className = null, $bundleName = null): BundleInterface
     {
         $bundle = $this
             ->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')
@@ -669,10 +668,8 @@ EOF;
      *
      * @param array $methods Additional methods to mock (besides the abstract ones)
      * @param array $bundles Bundles to register
-     *
-     * @return Kernel
      */
-    protected function getKernel(array $methods = [], array $bundles = [])
+    protected function getKernel(array $methods = [], array $bundles = []): Kernel
     {
         $methods[] = 'registerBundles';
 
@@ -716,7 +713,7 @@ class TestKernel implements HttpKernelInterface
         $this->terminateCalled = true;
     }
 
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
     {
     }
 }
@@ -735,7 +732,7 @@ class CustomProjectDirKernel extends Kernel
         $this->httpKernel = $httpKernel;
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [];
     }
@@ -744,7 +741,7 @@ class CustomProjectDirKernel extends Kernel
     {
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__.'/Fixtures';
     }
@@ -756,7 +753,7 @@ class CustomProjectDirKernel extends Kernel
         }
     }
 
-    protected function getHttpKernel()
+    protected function getHttpKernel(): HttpKernelInterface
     {
         return $this->httpKernel;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
@@ -57,7 +57,7 @@ class LoggerTest extends TestCase
      *
      * @return string[]
      */
-    public function getLogs()
+    public function getLogs(): array
     {
         return file($this->tmpFile, FILE_IGNORE_NEW_LINES);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Logger.php
@@ -41,74 +41,47 @@ class Logger implements LoggerInterface
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->logs[$level][] = $message;
     }
 
-    /**
-     * @return void
-     */
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
         $this->log('emergency', $message, $context);
     }
 
-    /**
-     * @return void
-     */
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
         $this->log('alert', $message, $context);
     }
 
-    /**
-     * @return void
-     */
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
         $this->log('critical', $message, $context);
     }
 
-    /**
-     * @return void
-     */
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
         $this->log('error', $message, $context);
     }
 
-    /**
-     * @return void
-     */
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
         $this->log('warning', $message, $context);
     }
 
-    /**
-     * @return void
-     */
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
         $this->log('notice', $message, $context);
     }
 
-    /**
-     * @return void
-     */
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
         $this->log('info', $message, $context);
     }
 
-    /**
-     * @return void
-     */
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
         $this->log('debug', $message, $context);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
@@ -30,7 +30,7 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
         return [$this, 'callController'];
     }
 
-    public function getArguments(Request $request, $controller)
+    public function getArguments(Request $request, $controller): array
     {
         return [$request];
     }

--- a/src/Symfony/Component/Intl/Intl.php
+++ b/src/Symfony/Component/Intl/Intl.php
@@ -109,7 +109,7 @@ final class Intl
      *
      * @return bool Returns true if the intl extension is installed, false otherwise
      */
-    public static function isExtensionLoaded()
+    public static function isExtensionLoaded(): bool
     {
         return class_exists('\ResourceBundle');
     }
@@ -121,7 +121,7 @@ final class Intl
      *
      * @deprecated since Symfony 4.3, to be removed in 5.0. Use {@see Currencies} instead.
      */
-    public static function getCurrencyBundle()
+    public static function getCurrencyBundle(): CurrencyBundleInterface
     {
         @trigger_error(sprintf('The method "%s()" is deprecated since Symfony 4.3, use "%s" instead.', __METHOD__, Currencies::class), E_USER_DEPRECATED);
 
@@ -143,7 +143,7 @@ final class Intl
      *
      * @deprecated since Symfony 4.3, to be removed in 5.0. Use {@see Languages} or {@see Scripts} instead.
      */
-    public static function getLanguageBundle()
+    public static function getLanguageBundle(): LanguageBundleInterface
     {
         @trigger_error(sprintf('The method "%s()" is deprecated since Symfony 4.3, use "%s" or "%s" instead.', __METHOD__, Languages::class, Scripts::class), E_USER_DEPRECATED);
 
@@ -169,7 +169,7 @@ final class Intl
      *
      * @deprecated since Symfony 4.3, to be removed in 5.0. Use {@see Locales} instead.
      */
-    public static function getLocaleBundle()
+    public static function getLocaleBundle(): LocaleBundleInterface
     {
         @trigger_error(sprintf('The method "%s()" is deprecated since Symfony 4.3, use "%s" instead.', __METHOD__, Locales::class), E_USER_DEPRECATED);
 
@@ -190,7 +190,7 @@ final class Intl
      *
      * @deprecated since Symfony 4.3, to be removed in 5.0. Use {@see Countries} instead.
      */
-    public static function getRegionBundle()
+    public static function getRegionBundle(): RegionBundleInterface
     {
         @trigger_error(sprintf('The method "%s()" is deprecated since Symfony 4.3, use "%s" instead.', __METHOD__, Countries::class), E_USER_DEPRECATED);
 
@@ -210,7 +210,7 @@ final class Intl
      *
      * @return string|null The ICU version or NULL if it could not be determined
      */
-    public static function getIcuVersion()
+    public static function getIcuVersion(): ?string
     {
         if (false === self::$icuVersion) {
             if (!self::isExtensionLoaded()) {
@@ -240,7 +240,7 @@ final class Intl
      *
      * @return string The version of the installed ICU data
      */
-    public static function getIcuDataVersion()
+    public static function getIcuDataVersion(): string
     {
         if (false === self::$icuDataVersion) {
             self::$icuDataVersion = trim(file_get_contents(self::getDataDirectory().'/version.txt'));
@@ -254,7 +254,7 @@ final class Intl
      *
      * @return string The ICU version of the stub classes
      */
-    public static function getIcuStubVersion()
+    public static function getIcuStubVersion(): string
     {
         return '64.2';
     }
@@ -264,7 +264,7 @@ final class Intl
      *
      * @return string The absolute path to the data directory
      */
-    public static function getDataDirectory()
+    public static function getDataDirectory(): string
     {
         return __DIR__.'/Resources/data';
     }

--- a/src/Symfony/Component/Intl/Tests/Collator/AbstractCollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/AbstractCollatorTest.php
@@ -54,9 +54,7 @@ abstract class AbstractCollatorTest extends TestCase
     }
 
     /**
-     * @param string $locale
-     *
-     * @return \Collator
+     * @return Collator|\Collator
      */
-    abstract protected function getCollator($locale);
+    abstract protected function getCollator(string $locale);
 }

--- a/src/Symfony/Component/Intl/Tests/Collator/CollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/CollatorTest.php
@@ -95,7 +95,7 @@ class CollatorTest extends AbstractCollatorTest
         $this->assertInstanceOf('\Symfony\Component\Intl\Collator\Collator', $collator);
     }
 
-    protected function getCollator($locale)
+    protected function getCollator(?string $locale): Collator
     {
         return new class($locale) extends Collator {
         };

--- a/src/Symfony/Component/Intl/Tests/Collator/Verification/CollatorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Collator/Verification/CollatorTest.php
@@ -29,7 +29,7 @@ class CollatorTest extends AbstractCollatorTest
         parent::setUp();
     }
 
-    protected function getCollator($locale)
+    protected function getCollator(?string $locale): \Collator
     {
         return new \Collator($locale);
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
@@ -756,10 +756,7 @@ abstract class AbstractDataProviderTest extends TestCase
         return self::$rootLocales;
     }
 
-    /**
-     * @return BundleEntryReader
-     */
-    protected function createEntryReader()
+    protected function createEntryReader(): BundleEntryReader
     {
         $entryReader = new BundleEntryReader($this->createBundleReader());
         $entryReader->setLocaleAliases($this->getLocaleAliases());
@@ -767,8 +764,5 @@ abstract class AbstractDataProviderTest extends TestCase
         return $entryReader;
     }
 
-    /**
-     * @return BundleReaderInterface
-     */
-    abstract protected function createBundleReader();
+    abstract protected function createBundleReader(): BundleReaderInterface;
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonCurrencyDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonCurrencyDataProviderTest.php
@@ -28,10 +28,7 @@ class JsonCurrencyDataProviderTest extends AbstractCurrencyDataProviderTest
         return Intl::getDataDirectory();
     }
 
-    /**
-     * @return BundleReaderInterface
-     */
-    protected function createBundleReader()
+    protected function createBundleReader(): BundleReaderInterface
     {
         return new JsonBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonLanguageDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonLanguageDataProviderTest.php
@@ -28,10 +28,7 @@ class JsonLanguageDataProviderTest extends AbstractLanguageDataProviderTest
         return Intl::getDataDirectory();
     }
 
-    /**
-     * @return BundleReaderInterface
-     */
-    protected function createBundleReader()
+    protected function createBundleReader(): BundleReaderInterface
     {
         return new JsonBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonLocaleDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonLocaleDataProviderTest.php
@@ -28,10 +28,7 @@ class JsonLocaleDataProviderTest extends AbstractLocaleDataProviderTest
         return Intl::getDataDirectory();
     }
 
-    /**
-     * @return BundleReaderInterface
-     */
-    protected function createBundleReader()
+    protected function createBundleReader(): BundleReaderInterface
     {
         return new JsonBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonRegionDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonRegionDataProviderTest.php
@@ -28,10 +28,7 @@ class JsonRegionDataProviderTest extends AbstractRegionDataProviderTest
         return Intl::getDataDirectory();
     }
 
-    /**
-     * @return BundleReaderInterface
-     */
-    protected function createBundleReader()
+    protected function createBundleReader(): BundleReaderInterface
     {
         return new JsonBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonScriptDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/Json/JsonScriptDataProviderTest.php
@@ -28,10 +28,7 @@ class JsonScriptDataProviderTest extends AbstractScriptDataProviderTest
         return Intl::getDataDirectory();
     }
 
-    /**
-     * @return BundleReaderInterface
-     */
-    protected function createBundleReader()
+    protected function createBundleReader(): BundleReaderInterface
     {
         return new JsonBundleReader();
     }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -965,10 +965,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
      */
     abstract protected function getDateFormatter($locale, $datetype, $timetype, $timezone = null, $calendar = IntlDateFormatter::GREGORIAN, $pattern = null);
 
-    /**
-     * @return string
-     */
-    abstract protected function getIntlErrorMessage();
+    abstract protected function getIntlErrorMessage(): string;
 
     /**
      * @return int
@@ -977,8 +974,6 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
 
     /**
      * @param int $errorCode
-     *
-     * @return bool
      */
-    abstract protected function isIntlFailure($errorCode);
+    abstract protected function isIntlFailure($errorCode): bool;
 }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/IntlDateFormatterTest.php
@@ -183,7 +183,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         };
     }
 
-    protected function getIntlErrorMessage()
+    protected function getIntlErrorMessage(): string
     {
         return IntlGlobals::getErrorMessage();
     }
@@ -193,7 +193,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         return IntlGlobals::getErrorCode();
     }
 
-    protected function isIntlFailure($errorCode)
+    protected function isIntlFailure($errorCode): bool
     {
         return IntlGlobals::isFailure($errorCode);
     }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
@@ -68,7 +68,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         return $formatter;
     }
 
-    protected function getIntlErrorMessage()
+    protected function getIntlErrorMessage(): string
     {
         return intl_get_error_message();
     }
@@ -78,7 +78,7 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         return intl_get_error_code();
     }
 
-    protected function isIntlFailure($errorCode)
+    protected function isIntlFailure($errorCode): bool
     {
         return intl_is_failure($errorCode);
     }

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -836,18 +836,11 @@ abstract class AbstractNumberFormatterTest extends TestCase
     }
 
     /**
-     * @param string $locale
-     * @param null   $style
-     * @param null   $pattern
-     *
-     * @return \NumberFormatter
+     * @return NumberFormatter|\NumberFormatter
      */
-    abstract protected function getNumberFormatter($locale = 'en', $style = null, $pattern = null);
+    abstract protected function getNumberFormatter(string $locale = 'en', string $style = null, string $pattern = null);
 
-    /**
-     * @return string
-     */
-    abstract protected function getIntlErrorMessage();
+    abstract protected function getIntlErrorMessage(): string;
 
     /**
      * @return int
@@ -856,8 +849,6 @@ abstract class AbstractNumberFormatterTest extends TestCase
 
     /**
      * @param int $errorCode
-     *
-     * @return bool
      */
-    abstract protected function isIntlFailure($errorCode);
+    abstract protected function isIntlFailure($errorCode): bool;
 }

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/NumberFormatterTest.php
@@ -167,13 +167,13 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         $formatter->setTextAttribute(null, null);
     }
 
-    protected function getNumberFormatter($locale = 'en', $style = null, $pattern = null)
+    protected function getNumberFormatter(?string $locale = 'en', string $style = null, string $pattern = null): NumberFormatter
     {
         return new class($locale, $style, $pattern) extends NumberFormatter {
         };
     }
 
-    protected function getIntlErrorMessage()
+    protected function getIntlErrorMessage(): string
     {
         return IntlGlobals::getErrorMessage();
     }
@@ -183,7 +183,7 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         return IntlGlobals::getErrorCode();
     }
 
-    protected function isIntlFailure($errorCode)
+    protected function isIntlFailure($errorCode): bool
     {
         return IntlGlobals::isFailure($errorCode);
     }

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/Verification/NumberFormatterTest.php
@@ -39,12 +39,12 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         parent::testGetTextAttribute();
     }
 
-    protected function getNumberFormatter($locale = 'en', $style = null, $pattern = null)
+    protected function getNumberFormatter(?string $locale = 'en', string $style = null, string $pattern = null): \NumberFormatter
     {
         return new \NumberFormatter($locale, $style, $pattern);
     }
 
-    protected function getIntlErrorMessage()
+    protected function getIntlErrorMessage(): string
     {
         return intl_get_error_message();
     }
@@ -54,7 +54,7 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         return intl_get_error_code();
     }
 
-    protected function isIntlFailure($errorCode)
+    protected function isIntlFailure($errorCode): bool
     {
         return intl_is_failure($errorCode);
     }

--- a/src/Symfony/Component/Ldap/Ldap.php
+++ b/src/Symfony/Component/Ldap/Ldap.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Ldap;
 
 use Symfony\Component\Ldap\Adapter\AdapterInterface;
+use Symfony\Component\Ldap\Adapter\EntryManagerInterface;
+use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Exception\DriverNotFoundException;
 
 /**
@@ -41,7 +43,7 @@ final class Ldap implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function query($dn, $query, array $options = [])
+    public function query($dn, $query, array $options = []): QueryInterface
     {
         return $this->adapter->createQuery($dn, $query, $options);
     }
@@ -49,7 +51,7 @@ final class Ldap implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function getEntryManager()
+    public function getEntryManager(): EntryManagerInterface
     {
         return $this->adapter->getEntryManager();
     }
@@ -57,7 +59,7 @@ final class Ldap implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function escape($subject, $ignore = '', $flags = 0)
+    public function escape($subject, $ignore = '', $flags = 0): string
     {
         return $this->adapter->escape($subject, $ignore, $flags);
     }

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Ldap\Adapter\AdapterInterface;
 use Symfony\Component\Ldap\Adapter\ConnectionInterface;
+use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Exception\DriverNotFoundException;
 use Symfony\Component\Ldap\Ldap;
 
@@ -54,6 +55,7 @@ class LdapTest extends TestCase
             ->expects($this->once())
             ->method('escape')
             ->with('foo', 'bar', 'baz')
+            ->willReturn('');
         ;
         $this->ldap->escape('foo', 'bar', 'baz');
     }
@@ -64,6 +66,7 @@ class LdapTest extends TestCase
             ->expects($this->once())
             ->method('createQuery')
             ->with('foo', 'bar', ['baz'])
+            ->willReturn($this->createMock(QueryInterface::class))
         ;
         $this->ldap->query('foo', 'bar', ['baz']);
     }

--- a/src/Symfony/Component/Lock/Key.php
+++ b/src/Symfony/Component/Lock/Key.php
@@ -74,15 +74,12 @@ final class Key
      *
      * @return float|null Remaining lifetime in seconds. Null when the key won't expire.
      */
-    public function getRemainingLifetime()
+    public function getRemainingLifetime(): ?float
     {
         return null === $this->expiringTime ? null : $this->expiringTime - microtime(true);
     }
 
-    /**
-     * @return bool
-     */
-    public function isExpired()
+    public function isExpired(): bool
     {
         return null !== $this->expiringTime && $this->expiringTime <= microtime(true);
     }

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -65,7 +65,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function acquire($blocking = false)
+    public function acquire($blocking = false): bool
     {
         try {
             if ($blocking) {
@@ -149,7 +149,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function isAcquired()
+    public function isAcquired(): bool
     {
         return $this->dirty = $this->store->exists($this->key);
     }
@@ -181,7 +181,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function isExpired()
+    public function isExpired(): bool
     {
         return $this->key->isExpired();
     }
@@ -189,7 +189,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function getRemainingLifetime()
+    public function getRemainingLifetime(): ?float
     {
         return $this->key->getRemainingLifetime();
     }

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -34,6 +34,9 @@ class LockTest extends TestCase
         $store
             ->expects($this->once())
             ->method('save');
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->assertTrue($lock->acquire(false));
     }
@@ -47,6 +50,9 @@ class LockTest extends TestCase
         $store
             ->expects($this->once())
             ->method('save');
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->assertTrue($lock->acquire(false));
     }
@@ -63,6 +69,9 @@ class LockTest extends TestCase
         $store
             ->expects($this->once())
             ->method('save');
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->assertTrue($lock->acquire(false));
     }
@@ -77,6 +86,9 @@ class LockTest extends TestCase
             ->expects($this->once())
             ->method('save')
             ->willThrowException(new LockConflictedException());
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->assertFalse($lock->acquire(false));
     }
@@ -91,6 +103,9 @@ class LockTest extends TestCase
             ->expects($this->once())
             ->method('save')
             ->willThrowException(new LockConflictedException());
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->assertFalse($lock->acquire(false));
     }
@@ -107,6 +122,9 @@ class LockTest extends TestCase
         $store
             ->expects($this->once())
             ->method('waitAndSave');
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->assertTrue($lock->acquire(true));
     }
@@ -124,6 +142,9 @@ class LockTest extends TestCase
             ->expects($this->once())
             ->method('putOffExpiration')
             ->with($key, 10);
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $lock->acquire();
     }
@@ -138,6 +159,9 @@ class LockTest extends TestCase
             ->expects($this->once())
             ->method('putOffExpiration')
             ->with($key, 10);
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $lock->refresh();
     }
@@ -152,6 +176,9 @@ class LockTest extends TestCase
             ->expects($this->once())
             ->method('putOffExpiration')
             ->with($key, 20);
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $lock->refresh(20);
     }
@@ -163,10 +190,9 @@ class LockTest extends TestCase
         $lock = new Lock($key, $store, 10);
 
         $store
-            ->expects($this->any())
             ->method('exists')
             ->with($key)
-            ->will($this->onConsecutiveCalls(true, false));
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->assertTrue($lock->isAcquired());
     }
@@ -219,7 +245,7 @@ class LockTest extends TestCase
 
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls([true, false])
+            ->willReturnOnConsecutiveCalls(true, false)
         ;
         $store
             ->expects($this->once())
@@ -238,7 +264,7 @@ class LockTest extends TestCase
 
         $store
             ->method('exists')
-            ->willReturnOnConsecutiveCalls([true, false])
+            ->willReturnOnConsecutiveCalls(true, false)
         ;
         $store
             ->expects($this->never())

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\RedisStore;
 
 /**
@@ -38,7 +39,7 @@ abstract class AbstractRedisStoreTest extends AbstractStoreTest
     /**
      * {@inheritdoc}
      */
-    public function getStore()
+    public function getStore(): PersistingStoreInterface
     {
         return new RedisStore($this->getRedisConnection());
     }

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractStoreTest.php
@@ -21,10 +21,7 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  */
 abstract class AbstractStoreTest extends TestCase
 {
-    /**
-     * @return PersistingStoreInterface
-     */
-    abstract protected function getStore();
+    abstract protected function getStore(): PersistingStoreInterface;
 
     public function testSave()
     {

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -39,7 +39,7 @@ class CombinedStoreTest extends AbstractStoreTest
     /**
      * {@inheritdoc}
      */
-    public function getStore()
+    public function getStore(): PersistingStoreInterface
     {
         $redis = new \Predis\Client('tcp://'.getenv('REDIS_HOST').':6379');
         try {

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\FlockStore;
 
 /**
@@ -24,7 +25,7 @@ class FlockStoreTest extends AbstractStoreTest
     /**
      * {@inheritdoc}
      */
-    protected function getStore()
+    protected function getStore(): PersistingStoreInterface
     {
         return new FlockStore();
     }

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\MemcachedStore;
 
 /**
@@ -46,7 +47,7 @@ class MemcachedStoreTest extends AbstractStoreTest
     /**
      * {@inheritdoc}
      */
-    public function getStore()
+    public function getStore(): PersistingStoreInterface
     {
         $memcached = new \Memcached();
         $memcached->addServer(getenv('MEMCACHED_HOST'), 11211);

--- a/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Doctrine\DBAL\DriverManager;
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PdoStore;
 
 /**
@@ -49,7 +50,7 @@ class PdoDbalStoreTest extends AbstractStoreTest
     /**
      * {@inheritdoc}
      */
-    public function getStore()
+    public function getStore(): PersistingStoreInterface
     {
         return new PdoStore(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]));
     }

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PdoStore;
 
 /**
@@ -49,7 +50,7 @@ class PdoStoreTest extends AbstractStoreTest
     /**
      * {@inheritdoc}
      */
-    public function getStore()
+    public function getStore(): PersistingStoreInterface
     {
         return new PdoStore('sqlite:'.self::$dbFile);
     }

--- a/src/Symfony/Component/Lock/Tests/Store/RetryTillSaveStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RetryTillSaveStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\RedisStore;
 use Symfony\Component\Lock\Store\RetryTillSaveStore;
 
@@ -21,7 +22,7 @@ class RetryTillSaveStoreTest extends AbstractStoreTest
 {
     use BlockingStoreTestTrait;
 
-    public function getStore()
+    public function getStore(): PersistingStoreInterface
     {
         $redis = new \Predis\Client('tcp://'.getenv('REDIS_HOST').':6379');
         try {

--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 
 /**
@@ -26,7 +27,7 @@ class SemaphoreStoreTest extends AbstractStoreTest
     /**
      * {@inheritdoc}
      */
-    protected function getStore()
+    protected function getStore(): PersistingStoreInterface
     {
         return new SemaphoreStore();
     }

--- a/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\StoreFactory;
 use Symfony\Component\Lock\Store\ZookeeperStore;
 
@@ -22,7 +23,10 @@ use Symfony\Component\Lock\Store\ZookeeperStore;
  */
 class ZookeeperStoreTest extends AbstractStoreTest
 {
-    public function getStore(): ZookeeperStore
+    /**
+     * @return ZookeeperStore
+     */
+    public function getStore(): PersistingStoreInterface
     {
         $zookeeper_server = getenv('ZOOKEEPER_HOST').':2181';
 

--- a/src/Symfony/Component/Mime/Header/DateHeader.php
+++ b/src/Symfony/Component/Mime/Header/DateHeader.php
@@ -35,10 +35,7 @@ final class DateHeader extends AbstractHeader
         $this->setDateTime($body);
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getBody()
+    public function getBody(): \DateTimeImmutable
     {
         return $this->getDateTime();
     }

--- a/src/Symfony/Component/Mime/Header/IdentificationHeader.php
+++ b/src/Symfony/Component/Mime/Header/IdentificationHeader.php
@@ -44,10 +44,7 @@ final class IdentificationHeader extends AbstractHeader
         $this->setId($body);
     }
 
-    /**
-     * @return array
-     */
-    public function getBody()
+    public function getBody(): array
     {
         return $this->getIds();
     }

--- a/src/Symfony/Component/Mime/Header/MailboxHeader.php
+++ b/src/Symfony/Component/Mime/Header/MailboxHeader.php
@@ -42,10 +42,8 @@ final class MailboxHeader extends AbstractHeader
 
     /**
      * @throws RfcComplianceException
-     *
-     * @return Address
      */
-    public function getBody()
+    public function getBody(): Address
     {
         return $this->getAddress();
     }

--- a/src/Symfony/Component/Mime/Header/MailboxListHeader.php
+++ b/src/Symfony/Component/Mime/Header/MailboxListHeader.php
@@ -48,7 +48,7 @@ final class MailboxListHeader extends AbstractHeader
      *
      * @return Address[]
      */
-    public function getBody()
+    public function getBody(): array
     {
         return $this->getAddresses();
     }

--- a/src/Symfony/Component/Mime/Header/PathHeader.php
+++ b/src/Symfony/Component/Mime/Header/PathHeader.php
@@ -40,10 +40,7 @@ final class PathHeader extends AbstractHeader
         $this->setAddress($body);
     }
 
-    /**
-     * @return Address
-     */
-    public function getBody()
+    public function getBody(): Address
     {
         return $this->getAddress();
     }

--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -86,8 +86,6 @@ abstract class AbstractPipes implements PipesInterface
     /**
      * Writes input to stdin.
      *
-     * @return array|null
-     *
      * @throws InvalidArgumentException When an input iterator yields a non supported value
      */
     protected function write(): ?array

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -955,7 +955,7 @@ class Process implements \IteratorAggregate
     }
 
     /**
-     * Gets the last output time in seconds
+     * Gets the last output time in seconds.
      *
      * @return float|null The last output time in seconds or null if it isn't started
      */

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestSingularAndPluralProps.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestSingularAndPluralProps.php
@@ -23,10 +23,7 @@ class TestSingularAndPluralProps
     /** @var array */
     private $emails = [];
 
-    /**
-     * @return string|null
-     */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
@@ -39,10 +36,7 @@ class TestSingularAndPluralProps
         $this->email = $email;
     }
 
-    /**
-     * @return array
-     */
-    public function getEmails()
+    public function getEmails(): array
     {
         return $this->emails;
     }

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TypeHinted.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TypeHinted.php
@@ -33,17 +33,11 @@ class TypeHinted
         return $this->date;
     }
 
-    /**
-     * @return \Countable
-     */
-    public function getCountable()
+    public function getCountable(): \Countable
     {
         return $this->countable;
     }
 
-    /**
-     * @param \Countable $countable
-     */
     public function setCountable(\Countable $countable)
     {
         $this->countable = $countable;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/CustomRouteCompiler.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/CustomRouteCompiler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Tests\Fixtures;
 
+use Symfony\Component\Routing\CompiledRoute;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCompiler;
 
@@ -19,7 +20,7 @@ class CustomRouteCompiler extends RouteCompiler
     /**
      * {@inheritdoc}
      */
-    public static function compile(Route $route)
+    public static function compile(Route $route): CompiledRoute
     {
         return new CustomCompiledRoute('', '', [], []);
     }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/CustomXmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/CustomXmlFileLoader.php
@@ -19,7 +19,7 @@ use Symfony\Component\Routing\Loader\XmlFileLoader;
  */
 class CustomXmlFileLoader extends XmlFileLoader
 {
-    protected function loadFile($file)
+    protected function loadFile($file): \DOMDocument
     {
         return XmlUtils::loadFile($file, function () { return true; });
     }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/RedirectableUrlMatcher.php
@@ -19,7 +19,7 @@ use Symfony\Component\Routing\Matcher\UrlMatcher;
  */
 class RedirectableUrlMatcher extends UrlMatcher implements RedirectableUrlMatcherInterface
 {
-    public function redirect($path, $route, $scheme = null)
+    public function redirect($path, $route, $scheme = null): array
     {
         return [
             '_controller' => 'Some controller reference...',

--- a/src/Symfony/Component/Routing/Tests/Fixtures/TestObjectRouteLoader.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/TestObjectRouteLoader.php
@@ -17,6 +17,9 @@ class TestObjectRouteLoader extends ObjectRouteLoader
 {
     public $loaderMap = [];
 
+    /**
+     * @return object
+     */
     protected function getServiceObject($id)
     {
         return $this->loaderMap[$id] ?? null;

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
@@ -98,11 +98,14 @@ class TestObjectLoader extends ObjectLoader
 {
     public $loaderMap = [];
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return 'service';
     }
 
+    /**
+     * @return object
+     */
     protected function getObject(string $id)
     {
         return $this->loaderMap[$id] ?? null;

--- a/src/Symfony/Component/Routing/Tests/Matcher/CompiledRedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/CompiledRedirectableUrlMatcherTest.php
@@ -33,7 +33,7 @@ class CompiledRedirectableUrlMatcherTest extends RedirectableUrlMatcherTest
 
 class TestCompiledRedirectableUrlMatcher extends CompiledUrlMatcher implements RedirectableUrlMatcherInterface
 {
-    public function redirect($path, $route, $scheme = null)
+    public function redirect($path, $route, $scheme = null): array
     {
         return [];
     }

--- a/src/Symfony/Component/Routing/Tests/Matcher/DumpedRedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/DumpedRedirectableUrlMatcherTest.php
@@ -39,7 +39,7 @@ class DumpedRedirectableUrlMatcherTest extends RedirectableUrlMatcherTest
 
 class TestDumpedRedirectableUrlMatcher extends UrlMatcher implements RedirectableUrlMatcherInterface
 {
-    public function redirect($path, $route, $scheme = null)
+    public function redirect($path, $route, $scheme = null): array
     {
         return [];
     }

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -487,7 +487,7 @@ class CompiledUrlMatcherDumperTest extends TestCase
 
 class TestCompiledUrlMatcher extends CompiledUrlMatcher implements RedirectableUrlMatcherInterface
 {
-    public function redirect($path, $route, $scheme = null)
+    public function redirect($path, $route, $scheme = null): array
     {
         return [];
     }

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -505,7 +505,7 @@ class PhpMatcherDumperTest extends TestCase
 
 abstract class RedirectableUrlMatcherStub extends UrlMatcher implements RedirectableUrlMatcherInterface
 {
-    public function redirect($path, $route, $scheme = null)
+    public function redirect($path, $route, $scheme = null): array
     {
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -83,9 +83,6 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
         ];
     }
 
-    /**
-     * @return string
-     */
     public function getStrategy(): string
     {
         // The $strategy property is misleading because it stores the name of its
@@ -102,9 +99,6 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
         return $this->voters;
     }
 
-    /**
-     * @return array
-     */
     public function getDecisionLog(): array
     {
         return $this->decisionLog;

--- a/src/Symfony/Component/Security/Core/Encoder/MigratingPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MigratingPasswordEncoder.php
@@ -34,7 +34,7 @@ final class MigratingPasswordEncoder extends BasePasswordEncoder implements Self
     /**
      * {@inheritdoc}
      */
-    public function encodePassword($raw, $salt)
+    public function encodePassword($raw, $salt): string
     {
         return $this->bestEncoder->encodePassword($raw, $salt);
     }
@@ -42,7 +42,7 @@ final class MigratingPasswordEncoder extends BasePasswordEncoder implements Self
     /**
      * {@inheritdoc}
      */
-    public function isPasswordValid($encoded, $raw, $salt)
+    public function isPasswordValid($encoded, $raw, $salt): bool
     {
         if ($this->bestEncoder->isPasswordValid($encoded, $raw, $salt)) {
             return true;

--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -78,7 +78,7 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
     /**
      * {@inheritdoc}
      */
-    public function isPasswordValid($encoded, $raw, $salt)
+    public function isPasswordValid($encoded, $raw, $salt): bool
     {
         if (72 < \strlen($raw) && 0 === strpos($encoded, '$2')) {
             // BCrypt encodes only the first 72 chars

--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -54,7 +54,7 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
     /**
      * {@inheritdoc}
      */
-    public function encodePassword($raw, $salt)
+    public function encodePassword($raw, $salt): string
     {
         if (\strlen($raw) > self::MAX_PASSWORD_LENGTH) {
             throw new BadCredentialsException('Invalid password.');
@@ -74,7 +74,7 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
     /**
      * {@inheritdoc}
      */
-    public function isPasswordValid($encoded, $raw, $salt)
+    public function isPasswordValid($encoded, $raw, $salt): bool
     {
         if (\strlen($raw) > self::MAX_PASSWORD_LENGTH) {
             return false;

--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -34,10 +34,7 @@ class Security
         $this->container = $container;
     }
 
-    /**
-     * @return UserInterface|null
-     */
-    public function getUser()
+    public function getUser(): ?UserInterface
     {
         if (!$token = $this->getToken()) {
             return null;

--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -34,7 +34,10 @@ class Security
         $this->container = $container;
     }
 
-    public function getUser(): ?UserInterface
+    /**
+     * @return UserInterface|null
+     */
+    public function getUser()
     {
         if (!$token = $this->getToken()) {
             return null;

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -164,11 +164,11 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
-    public function __toString()
+    public function __toString(): string
     {
     }
 
-    public function getRoles()
+    public function getRoles(): array
     {
     }
 
@@ -184,11 +184,11 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
-    public function getUsername()
+    public function getUsername(): string
     {
     }
 
-    public function isAuthenticated()
+    public function isAuthenticated(): bool
     {
     }
 
@@ -200,7 +200,7 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
     }
 
@@ -208,7 +208,7 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
-    public function hasAttribute($name)
+    public function hasAttribute($name): bool
     {
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -59,12 +59,12 @@ class VoterTest extends TestCase
 
 class VoterTest_Voter extends Voter
 {
-    protected function voteOnAttribute($attribute, $object, TokenInterface $token)
+    protected function voteOnAttribute($attribute, $object, TokenInterface $token): bool
     {
         return 'EDIT' === $attribute;
     }
 
-    protected function supports($attribute, $object)
+    protected function supports($attribute, $object): bool
     {
         return $object instanceof \stdClass && \in_array($attribute, ['EDIT', 'CREATE']);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BasePasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BasePasswordEncoderTest.php
@@ -16,11 +16,11 @@ use Symfony\Component\Security\Core\Encoder\BasePasswordEncoder;
 
 class PasswordEncoder extends BasePasswordEncoder
 {
-    public function encodePassword($raw, $salt)
+    public function encodePassword($raw, $salt): string
     {
     }
 
-    public function isPasswordValid($encoded, $raw, $salt)
+    public function isPasswordValid($encoded, $raw, $salt): bool
     {
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
@@ -139,15 +139,15 @@ class SomeUser implements UserInterface
     {
     }
 
-    public function getPassword()
+    public function getPassword(): ?string
     {
     }
 
-    public function getSalt()
+    public function getSalt(): ?string
     {
     }
 
-    public function getUsername()
+    public function getUsername(): string
     {
     }
 
@@ -164,7 +164,7 @@ class EncAwareUser extends SomeUser implements EncoderAwareInterface
 {
     public $encoderName = 'encoder_name';
 
-    public function getEncoderName()
+    public function getEncoderName(): string
     {
         return $this->encoderName;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
@@ -135,7 +135,7 @@ class EncoderFactoryTest extends TestCase
 
 class SomeUser implements UserInterface
 {
-    public function getRoles()
+    public function getRoles(): array
     {
     }
 
@@ -164,7 +164,7 @@ class EncAwareUser extends SomeUser implements EncoderAwareInterface
 {
     public $encoderName = 'encoder_name';
 
-    public function getEncoderName(): string
+    public function getEncoderName(): ?string
     {
         return $this->encoderName;
     }

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
@@ -40,10 +40,7 @@ class InMemoryUserProviderTest extends TestCase
         $this->assertFalse($refreshedUser->isCredentialsNonExpired());
     }
 
-    /**
-     * @return InMemoryUserProvider
-     */
-    protected function createProvider()
+    protected function createProvider(): InMemoryUserProvider
     {
         return new InMemoryUserProvider([
             'fabien' => [

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -61,7 +61,7 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
     /**
      * {@inheritdoc}
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }
@@ -69,7 +69,7 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
     /**
      * {@inheritdoc}
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
         return null;
     }
@@ -77,7 +77,7 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
     /**
      * {@inheritdoc}
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }
@@ -85,7 +85,7 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
     /**
      * {@inheritdoc}
      */
-    public function isAccountNonExpired()
+    public function isAccountNonExpired(): bool
     {
         return $this->accountNonExpired;
     }
@@ -93,7 +93,7 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
     /**
      * {@inheritdoc}
      */
-    public function isAccountNonLocked()
+    public function isAccountNonLocked(): bool
     {
         return $this->accountNonLocked;
     }
@@ -101,7 +101,7 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
     /**
      * {@inheritdoc}
      */
-    public function isCredentialsNonExpired()
+    public function isCredentialsNonExpired(): bool
     {
         return $this->credentialsNonExpired;
     }
@@ -109,7 +109,7 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
     /**
      * {@inheritdoc}
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return $this->enabled;
     }
@@ -129,7 +129,7 @@ final class User implements UserInterface, EquatableInterface, AdvancedUserInter
     /**
      * {@inheritdoc}
      */
-    public function isEqualTo(UserInterface $user)
+    public function isEqualTo(UserInterface $user): bool
     {
         if (!$user instanceof self) {
             return false;

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Guard\Tests\Authenticator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -98,21 +99,19 @@ class TestFormLoginAuthenticator extends AbstractFormLoginAuthenticator
     private $loginUrl;
     private $defaultSuccessRedirectUrl;
 
-    public function supports(Request $request)
+    public function supports(Request $request): bool
     {
         return true;
     }
 
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey): ?Response
     {
     }
 
     /**
      * @param mixed $defaultSuccessRedirectUrl
-     *
-     * @return TestFormLoginAuthenticator
      */
-    public function setDefaultSuccessRedirectUrl($defaultSuccessRedirectUrl)
+    public function setDefaultSuccessRedirectUrl($defaultSuccessRedirectUrl): TestFormLoginAuthenticator
     {
         $this->defaultSuccessRedirectUrl = $defaultSuccessRedirectUrl;
 
@@ -121,10 +120,8 @@ class TestFormLoginAuthenticator extends AbstractFormLoginAuthenticator
 
     /**
      * @param mixed $loginUrl
-     *
-     * @return TestFormLoginAuthenticator
      */
-    public function setLoginUrl($loginUrl)
+    public function setLoginUrl($loginUrl): TestFormLoginAuthenticator
     {
         $this->loginUrl = $loginUrl;
 
@@ -134,7 +131,7 @@ class TestFormLoginAuthenticator extends AbstractFormLoginAuthenticator
     /**
      * {@inheritdoc}
      */
-    protected function getLoginUrl()
+    protected function getLoginUrl(): string
     {
         return $this->loginUrl;
     }
@@ -158,7 +155,7 @@ class TestFormLoginAuthenticator extends AbstractFormLoginAuthenticator
     /**
      * {@inheritdoc}
      */
-    public function getUser($credentials, UserProviderInterface $userProvider)
+    public function getUser($credentials, UserProviderInterface $userProvider): ?UserInterface
     {
         return $userProvider->loadUserByUsername($credentials);
     }
@@ -166,7 +163,7 @@ class TestFormLoginAuthenticator extends AbstractFormLoginAuthenticator
     /**
      * {@inheritdoc}
      */
-    public function checkCredentials($credentials, UserInterface $user)
+    public function checkCredentials($credentials, UserInterface $user): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
@@ -32,7 +32,7 @@ final class UserValueResolver implements ArgumentValueResolverInterface
         $this->tokenStorage = $tokenStorage;
     }
 
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         // only security user implementations are supported
         if (UserInterface::class !== $argument->getType()) {
@@ -50,7 +50,7 @@ final class UserValueResolver implements ArgumentValueResolverInterface
         return $user instanceof UserInterface;
     }
 
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         yield $this->tokenStorage->getToken()->getUser();
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -380,17 +380,17 @@ class ContextListenerTest extends TestCase
 
 class NotSupportingUserProvider implements UserProviderInterface
 {
-    public function loadUserByUsername($username)
+    public function loadUserByUsername($username): UserInterface
     {
         throw new UsernameNotFoundException();
     }
 
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         throw new UnsupportedUserException();
     }
 
-    public function supportsClass($class)
+    public function supportsClass($class): bool
     {
         return false;
     }
@@ -405,11 +405,11 @@ class SupportingUserProvider implements UserProviderInterface
         $this->refreshedUser = $refreshedUser;
     }
 
-    public function loadUserByUsername($username)
+    public function loadUserByUsername($username): UserInterface
     {
     }
 
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         if (!$user instanceof User) {
             throw new UnsupportedUserException();
@@ -422,7 +422,7 @@ class SupportingUserProvider implements UserProviderInterface
         return $this->refreshedUser;
     }
 
-    public function supportsClass($class)
+    public function supportsClass($class): bool
     {
         return 'Symfony\Component\Security\Core\User\User' === $class;
     }

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -40,7 +40,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($propertyName, string $class = null, string $format = null, array $context = [])
+    public function normalize($propertyName, string $class = null, string $format = null, array $context = []): string
     {
         if (null === $class) {
             return $this->normalizeFallback($propertyName, $class, $format, $context);
@@ -56,7 +56,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function denormalize($propertyName, string $class = null, string $format = null, array $context = [])
+    public function denormalize($propertyName, string $class = null, string $format = null, array $context = []): string
     {
         if (null === $class) {
             return $this->denormalizeFallback($propertyName, $class, $format, $context);

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -544,11 +544,9 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     /**
      * @param string $attribute Attribute name
      *
-     * @return array
-     *
      * @internal
      */
-    protected function createChildContext(array $parentContext, $attribute/*, ?string $format */)
+    protected function createChildContext(array $parentContext, $attribute/*, ?string $format */): array
     {
         if (\func_num_args() < 3) {
             @trigger_error(sprintf('Method "%s::%s()" will have a third "?string $format" argument in version 5.0; not defining it is deprecated since Symfony 4.3.', \get_class($this), __FUNCTION__), E_USER_DEPRECATED);

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -567,7 +567,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      *
      * @internal
      */
-    protected function createChildContext(array $parentContext, $attribute/*, ?string $format */)
+    protected function createChildContext(array $parentContext, $attribute/*, ?string $format */): array
     {
         if (\func_num_args() >= 3) {
             $format = func_get_arg(2);

--- a/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
@@ -64,7 +64,7 @@ class Zoo
     /**
      * @return Animal[]
      */
-    public function getAnimals()
+    public function getAnimals(): array
     {
         return $this->animals;
     }
@@ -94,7 +94,7 @@ class ZooImmutable
     /**
      * @return Animal[]
      */
-    public function getAnimals()
+    public function getAnimals(): array
     {
         return $this->animals;
     }
@@ -110,10 +110,7 @@ class Animal
         echo '';
     }
 
-    /**
-     * @return string|null
-     */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -124,7 +124,7 @@ class ChainNormalizationAwareEncoder extends ChainEncoder implements Normalizati
 
 class NormalizationAwareEncoder implements EncoderInterface, NormalizationAwareInterface
 {
-    public function supportsEncoding($format)
+    public function supportsEncoding($format): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
@@ -38,7 +38,7 @@ class AbstractNormalizerDummy extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return true;
     }
@@ -53,7 +53,7 @@ class AbstractNormalizerDummy extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StaticConstructorNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StaticConstructorNormalizer.php
@@ -21,7 +21,7 @@ class StaticConstructorNormalizer extends ObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    protected function getConstructor(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes)
+    protected function getConstructor(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes): ?\ReflectionMethod
     {
         if (is_a($class, StaticConstructorDummy::class, true)) {
             return new \ReflectionMethod($class, 'create');

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -214,7 +214,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
 {
-    protected function extractAttributes($object, $format = null, array $context = [])
+    protected function extractAttributes($object, $format = null, array $context = []): array
     {
         return [];
     }
@@ -228,11 +228,14 @@ class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
         $object->$attribute = $value;
     }
 
-    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = [])
+    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = []): bool
     {
         return \in_array($attribute, ['foo', 'baz', 'quux', 'value']);
     }
 
+    /**
+     * @return object
+     */
     public function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes, string $format = null)
     {
         return parent::instantiateObject($data, $class, $context, $reflectionClass, $allowedAttributes, $format);
@@ -257,7 +260,7 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
         parent::__construct(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())));
     }
 
-    protected function extractAttributes($object, $format = null, array $context = [])
+    protected function extractAttributes($object, $format = null, array $context = []): array
     {
     }
 
@@ -294,14 +297,20 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
         $this->normalizers = $normalizers;
     }
 
-    public function serialize($data, $format, array $context = [])
+    public function serialize($data, $format, array $context = []): string
     {
     }
 
+    /**
+     * @return object
+     */
     public function deserialize($data, $type, $format, array $context = [])
     {
     }
 
+    /**
+     * @return object
+     */
     public function denormalize($data, $type, $format = null, array $context = [])
     {
         foreach ($this->normalizers as $normalizer) {
@@ -313,7 +322,7 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
         return null;
     }
 
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return true;
     }
@@ -321,7 +330,7 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
 
 class AbstractObjectNormalizerCollectionDummy extends AbstractObjectNormalizer
 {
-    protected function extractAttributes($object, $format = null, array $context = [])
+    protected function extractAttributes($object, $format = null, array $context = []): array
     {
     }
 
@@ -334,11 +343,14 @@ class AbstractObjectNormalizerCollectionDummy extends AbstractObjectNormalizer
         $object->$attribute = $value;
     }
 
-    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = [])
+    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = []): bool
     {
         return true;
     }
 
+    /**
+     * @return object
+     */
     public function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes, string $format = null)
     {
         return parent::instantiateObject($data, $class, $context, $reflectionClass, $allowedAttributes, $format);
@@ -380,7 +392,7 @@ class ArrayDenormalizerDummy implements DenormalizerInterface, SerializerAwareIn
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null, array $context = [])
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return '[]' === substr($type, -2)
             && $this->serializer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -301,16 +301,10 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
     {
     }
 
-    /**
-     * @return object
-     */
     public function deserialize($data, $type, $format, array $context = [])
     {
     }
 
-    /**
-     * @return object
-     */
     public function denormalize($data, $type, $format = null, array $context = [])
     {
         foreach ($this->normalizers as $normalizer) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1004,7 +1004,7 @@ class ObjectInner
 
 class FormatAndContextAwareNormalizer extends ObjectNormalizer
 {
-    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = [])
+    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = []): bool
     {
         if (\in_array($attribute, ['foo', 'bar']) && 'foo_and_bar_included' === $format) {
             return true;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
@@ -30,7 +30,7 @@ class TestDenormalizer implements DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
@@ -30,7 +30,7 @@ class TestNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
@@ -150,15 +150,15 @@ interface MyStreamingEngine extends StreamingEngineInterface, EngineInterface
 
 class TestEngine implements EngineInterface
 {
-    public function render($name, array $parameters = [])
+    public function render($name, array $parameters = []): string
     {
     }
 
-    public function exists($name)
+    public function exists($name): bool
     {
     }
 
-    public function supports($name)
+    public function supports($name): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Templating/Tests/Fixtures/SimpleHelper.php
+++ b/src/Symfony/Component/Templating/Tests/Fixtures/SimpleHelper.php
@@ -27,7 +27,7 @@ class SimpleHelper extends Helper
         return $this->value;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'foo';
     }

--- a/src/Symfony/Component/Templating/Tests/Helper/HelperTest.php
+++ b/src/Symfony/Component/Templating/Tests/Helper/HelperTest.php
@@ -26,7 +26,7 @@ class HelperTest extends TestCase
 
 class ProjectTemplateHelper extends Helper
 {
-    public function getName()
+    public function getName(): string
     {
         return 'foo';
     }

--- a/src/Symfony/Component/Templating/Tests/Loader/CacheLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/CacheLoaderTest.php
@@ -87,7 +87,7 @@ class ProjectTemplateLoaderVar extends Loader
         return false;
     }
 
-    public function isFresh(TemplateReferenceInterface $template, $time)
+    public function isFresh(TemplateReferenceInterface $template, $time): bool
     {
         return false;
     }

--- a/src/Symfony/Component/Templating/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/FilesystemLoaderTest.php
@@ -79,7 +79,7 @@ class ProjectTemplateLoader2 extends FilesystemLoader
         return $this->templatePathPatterns;
     }
 
-    public static function isAbsolutePath($path)
+    public static function isAbsolutePath($path): bool
     {
         return parent::isAbsolutePath($path);
     }

--- a/src/Symfony/Component/Templating/Tests/Loader/LoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/LoaderTest.php
@@ -42,7 +42,7 @@ class ProjectTemplateLoader4 extends Loader
         return $this->debugger;
     }
 
-    public function isFresh(TemplateReferenceInterface $template, $time)
+    public function isFresh(TemplateReferenceInterface $template, $time): bool
     {
         return false;
     }

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Templating\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Templating\Helper\SlotsHelper;
 use Symfony\Component\Templating\Loader\Loader;
+use Symfony\Component\Templating\Loader\LoaderInterface;
 use Symfony\Component\Templating\PhpEngine;
 use Symfony\Component\Templating\Storage\StringStorage;
 use Symfony\Component\Templating\TemplateNameParser;
@@ -194,7 +195,7 @@ class PhpEngineTest extends TestCase
 
 class ProjectTemplateEngine extends PhpEngine
 {
-    public function getLoader()
+    public function getLoader(): LoaderInterface
     {
         return $this->loader;
     }
@@ -219,7 +220,7 @@ class ProjectTemplateLoader extends Loader
         return false;
     }
 
-    public function isFresh(TemplateReferenceInterface $template, $time)
+    public function isFresh(TemplateReferenceInterface $template, $time): bool
     {
         return false;
     }

--- a/src/Symfony/Component/Templating/Tests/Storage/StorageTest.php
+++ b/src/Symfony/Component/Templating/Tests/Storage/StorageTest.php
@@ -25,7 +25,7 @@ class StorageTest extends TestCase
 
 class TestStorage extends Storage
 {
-    public function getContent()
+    public function getContent(): string
     {
     }
 }

--- a/src/Symfony/Component/Translation/Tests/DependencyInjection/fixtures/ServiceSubscriber.php
+++ b/src/Symfony/Component/Translation/Tests/DependencyInjection/fixtures/ServiceSubscriber.php
@@ -12,7 +12,7 @@ class ServiceSubscriber implements ServiceSubscriberInterface
     {
     }
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         return ['translator' => TranslatorInterface::class];
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/FileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/FileDumperTest.php
@@ -78,12 +78,12 @@ class FileDumperTest extends TestCase
 
 class ConcreteFileDumper extends FileDumper
 {
-    public function formatCatalogue(MessageCatalogue $messages, $domain, array $options = [])
+    public function formatCatalogue(MessageCatalogue $messages, $domain, array $options = []): string
     {
         return http_build_query($messages->all($domain), '', '&');
     }
 
-    protected function getExtension()
+    protected function getExtension(): string
     {
         return 'concrete';
     }

--- a/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
+++ b/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
@@ -57,10 +57,8 @@ class PluralizationRulesTest extends TestCase
      * This array should contain all currently known langcodes.
      *
      * As it is impossible to have this ever complete we should try as hard as possible to have it almost complete.
-     *
-     * @return array
      */
-    public function successLangcodes()
+    public function successLangcodes(): array
     {
         return [
             ['1', ['ay', 'bo', 'cgg', 'dz', 'id', 'ja', 'jbo', 'ka', 'kk', 'km', 'ko', 'ky']],
@@ -79,7 +77,7 @@ class PluralizationRulesTest extends TestCase
      *
      * @return array with nplural together with langcodes
      */
-    public function failingLangcodes()
+    public function failingLangcodes(): array
     {
         return [
             ['1', ['fa']],

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -300,7 +300,7 @@ class TranslatorCacheTest extends TestCase
 
 class StaleResource implements SelfCheckingResourceInterface
 {
-    public function isFresh($timestamp)
+    public function isFresh($timestamp): bool
     {
         return false;
     }
@@ -309,7 +309,7 @@ class StaleResource implements SelfCheckingResourceInterface
     {
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return '';
     }

--- a/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
@@ -44,7 +44,7 @@ final class PropertyInfoLoader implements LoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadClassMetadata(ClassMetadata $metadata)
+    public function loadClassMetadata(ClassMetadata $metadata): bool
     {
         $className = $metadata->getClassName();
         if (null !== $this->classValidatorRegexp && !preg_match($this->classValidatorRegexp, $className)) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -114,10 +114,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         $this->assertNoViolation();
     }
 
-    /**
-     * @return array
-     */
-    public function provideAllValidComparisons()
+    public function provideAllValidComparisons(): array
     {
         // The provider runs before setUp(), so we need to manually fix
         // the default timezone
@@ -171,15 +168,9 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         $this->validator->validate(5, $constraint);
     }
 
-    /**
-     * @return array
-     */
-    abstract public function provideValidComparisons();
+    abstract public function provideValidComparisons(): array;
 
-    /**
-     * @return array
-     */
-    abstract public function provideValidComparisonsToPropertyPath();
+    abstract public function provideValidComparisonsToPropertyPath(): array;
 
     /**
      * @dataProvider provideAllInvalidComparisons
@@ -233,10 +224,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
             ->assertRaised();
     }
 
-    /**
-     * @return array
-     */
-    public function provideAllInvalidComparisons()
+    public function provideAllInvalidComparisons(): array
     {
         // The provider runs before setUp(), so we need to manually fix
         // the default timezone
@@ -249,22 +237,14 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
         return $comparisons;
     }
 
-    /**
-     * @return array
-     */
-    abstract public function provideInvalidComparisons();
+    abstract public function provideInvalidComparisons(): array;
 
     /**
      * @param array|null $options Options for the constraint
-     *
-     * @return Constraint
      */
-    abstract protected function createConstraint(array $options = null);
+    abstract protected function createConstraint(array $options = null): Constraint;
 
-    /**
-     * @return string|null
-     */
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return null;
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -21,12 +21,12 @@ class ConcreteComposite extends Composite
 {
     public $constraints;
 
-    protected function getCompositeOption()
+    protected function getCompositeOption(): string
     {
         return 'constraints';
     }
 
-    public function getDefaultOption()
+    public function getDefaultOption(): ?string
     {
         return 'constraints';
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\DivisibleBy;
 use Symfony\Component\Validator\Constraints\DivisibleByValidator;
 
@@ -24,12 +25,12 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
         return new DivisibleByValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new DivisibleBy($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return DivisibleBy::NOT_DIVISIBLE_BY;
     }
@@ -37,7 +38,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [-7, 1],
@@ -54,7 +55,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [25],
@@ -64,7 +65,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Constraints\EqualToValidator;
 
@@ -24,12 +25,12 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
         return new EqualToValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new EqualTo($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return EqualTo::NOT_EQUAL_ERROR;
     }
@@ -37,7 +38,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [3, 3],
@@ -54,7 +55,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [5],
@@ -64,7 +65,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator;
 
@@ -24,12 +25,12 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
         return new GreaterThanOrEqualValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new GreaterThanOrEqual($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return GreaterThanOrEqual::TOO_LOW_ERROR;
     }
@@ -37,7 +38,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [3, 2],
@@ -57,7 +58,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [5],
@@ -68,7 +69,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\PositiveOrZero;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Component\Validator\Constraints\PositiveOrZero;
  */
 class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends GreaterThanOrEqualValidatorTest
 {
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new PositiveOrZero();
     }
@@ -26,7 +27,7 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [0, 0],
@@ -42,7 +43,7 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [-1, '-1', 0, '0', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\GreaterThanValidator;
 
@@ -24,12 +25,12 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
         return new GreaterThanValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new GreaterThan($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return GreaterThan::TOO_LOW_ERROR;
     }
@@ -37,7 +38,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [2, 1],
@@ -53,7 +54,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [6],
@@ -63,7 +64,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Positive;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Component\Validator\Constraints\Positive;
  */
 class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidatorTest
 {
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new Positive();
     }
@@ -26,7 +27,7 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [2, 0],
@@ -39,7 +40,7 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [0, '0', 0, '0', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\IdenticalTo;
 use Symfony\Component\Validator\Constraints\IdenticalToValidator;
 
@@ -24,17 +25,17 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         return new IdenticalToValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new IdenticalTo($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return IdenticalTo::NOT_IDENTICAL_ERROR;
     }
 
-    public function provideAllValidComparisons()
+    public function provideAllValidComparisons(): array
     {
         $this->setDefaultTimezone('UTC');
 
@@ -50,7 +51,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         $date = new \DateTime('2000-01-01');
         $object = new ComparisonTest_Class(2);
@@ -72,7 +73,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [5],
@@ -82,7 +83,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [1, '1', 2, '2', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Constraints\LessThanOrEqualValidator;
 
@@ -24,12 +25,12 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
         return new LessThanOrEqualValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new LessThanOrEqual($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return LessThanOrEqual::TOO_HIGH_ERROR;
     }
@@ -37,7 +38,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [1, 2],
@@ -59,7 +60,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [4],
@@ -70,7 +71,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [2, '2', 1, '1', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NegativeOrZero;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Component\Validator\Constraints\NegativeOrZero;
  */
 class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanOrEqualValidatorTest
 {
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new NegativeOrZero();
     }
@@ -26,7 +27,7 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [0, 0],
@@ -40,7 +41,7 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [2, '2', 0, '0', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\LessThan;
 use Symfony\Component\Validator\Constraints\LessThanValidator;
 
@@ -24,12 +25,12 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
         return new LessThanValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new LessThan($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return LessThan::TOO_HIGH_ERROR;
     }
@@ -37,7 +38,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [1, 2],
@@ -53,7 +54,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [4],
@@ -63,7 +64,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [3, '3', 2, '2', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Negative;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Component\Validator\Constraints\Negative;
  */
 class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
 {
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new Negative();
     }
@@ -26,7 +27,7 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [-1, 0],
@@ -39,7 +40,7 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [0, '0', 0, '0', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotEqualTo;
 use Symfony\Component\Validator\Constraints\NotEqualToValidator;
 
@@ -24,12 +25,12 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
         return new NotEqualToValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new NotEqualTo($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return NotEqualTo::IS_EQUAL_ERROR;
     }
@@ -37,7 +38,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [1, 2],
@@ -53,7 +54,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [0],
@@ -63,7 +64,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         return [
             [3, '3', 3, '3', 'integer'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotIdenticalTo;
 use Symfony\Component\Validator\Constraints\NotIdenticalToValidator;
 
@@ -24,12 +25,12 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         return new NotIdenticalToValidator();
     }
 
-    protected function createConstraint(array $options = null)
+    protected function createConstraint(array $options = null): Constraint
     {
         return new NotIdenticalTo($options);
     }
 
-    protected function getErrorCode()
+    protected function getErrorCode(): ?string
     {
         return NotIdenticalTo::IS_IDENTICAL_ERROR;
     }
@@ -37,7 +38,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisons()
+    public function provideValidComparisons(): array
     {
         return [
             [1, 2],
@@ -56,14 +57,14 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideValidComparisonsToPropertyPath()
+    public function provideValidComparisonsToPropertyPath(): array
     {
         return [
             [0],
         ];
     }
 
-    public function provideAllInvalidComparisons()
+    public function provideAllInvalidComparisons(): array
     {
         $this->setDefaultTimezone('UTC');
 
@@ -79,7 +80,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    public function provideInvalidComparisons()
+    public function provideInvalidComparisons(): array
     {
         $date = new \DateTime('2000-01-01');
         $object = new ComparisonTest_Class(2);

--- a/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
@@ -61,7 +61,7 @@ class ContainerConstraintValidatorFactoryTest extends TestCase
 
 class DummyConstraint extends Constraint
 {
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return DummyConstraintValidator::class;
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintA.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintA.php
@@ -19,7 +19,7 @@ class ConstraintA extends Constraint
     public $property1;
     public $property2;
 
-    public function getDefaultOption()
+    public function getDefaultOption(): ?string
     {
         return 'property2';
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintC.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintC.php
@@ -18,7 +18,7 @@ class ConstraintC extends Constraint
 {
     public $option1;
 
-    public function getRequiredOptions()
+    public function getRequiredOptions(): array
     {
         return ['option1'];
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValue.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValue.php
@@ -19,7 +19,7 @@ class ConstraintWithValue extends Constraint
     public $property;
     public $value;
 
-    public function getDefaultOption()
+    public function getDefaultOption(): ?string
     {
         return 'property';
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValueAsDefault.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValueAsDefault.php
@@ -19,7 +19,7 @@ class ConstraintWithValueAsDefault extends Constraint
     public $property;
     public $value;
 
-    public function getDefaultOption()
+    public function getDefaultOption(): ?string
     {
         return 'value';
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
@@ -13,13 +13,13 @@ namespace Symfony\Component\Validator\Tests\Fixtures;
 
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
-use Symfony\Component\Validator\MetadataInterface;
+use Symfony\Component\Validator\Mapping\MetadataInterface;
 
 class FakeMetadataFactory implements MetadataFactoryInterface
 {
     protected $metadatas = [];
 
-    public function getMetadataFor($class)
+    public function getMetadataFor($class): MetadataInterface
     {
         $hash = null;
 
@@ -43,7 +43,7 @@ class FakeMetadataFactory implements MetadataFactoryInterface
         return $this->metadatas[$class];
     }
 
-    public function hasMetadataFor($class)
+    public function hasMetadataFor($class): bool
     {
         $hash = null;
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FilesLoader.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FilesLoader.php
@@ -25,7 +25,7 @@ abstract class FilesLoader extends BaseFilesLoader
         parent::__construct($paths);
     }
 
-    protected function getFileLoaderInstance($file)
+    protected function getFileLoaderInstance($file): LoaderInterface
     {
         ++$this->timesCalled;
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -209,8 +209,10 @@ class LazyLoadingMetadataFactoryTest extends TestCase
 
 class TestLoader implements LoaderInterface
 {
-    public function loadClassMetadata(ClassMetadata $metadata)
+    public function loadClassMetadata(ClassMetadata $metadata): bool
     {
         $metadata->addConstraint(new ConstraintA());
+
+        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
@@ -38,10 +38,7 @@ abstract class AbstractTest extends AbstractValidatorTest
      */
     protected $validator;
 
-    /**
-     * @return ValidatorInterface
-     */
-    abstract protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = []);
+    abstract protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = []): ValidatorInterface;
 
     protected function setUp(): void
     {

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -23,10 +23,11 @@ use Symfony\Component\Validator\Tests\Constraints\Fixtures\ChildA;
 use Symfony\Component\Validator\Tests\Constraints\Fixtures\ChildB;
 use Symfony\Component\Validator\Tests\Fixtures\Entity;
 use Symfony\Component\Validator\Validator\RecursiveValidator;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class RecursiveValidatorTest extends AbstractTest
 {
-    protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = [])
+    protected function createValidator(MetadataFactoryInterface $metadataFactory, array $objectInitializers = []): ValidatorInterface
     {
         $translator = new IdentityTranslator();
         $translator->setLocale('en');

--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -46,7 +46,7 @@ class Caster
      *
      * @return array The array-cast of the object, with prefixed dynamic properties
      */
-    public static function castObject($obj, $class, $hasDebugInfo = false)
+    public static function castObject($obj, $class, $hasDebugInfo = false): array
     {
         $a = $obj instanceof \Closure ? [] : (array) $obj;
 
@@ -110,7 +110,7 @@ class Caster
      *
      * @return array The filtered array
      */
-    public static function filter(array $a, $filter, array $listedProperties = [], &$count = 0)
+    public static function filter(array $a, $filter, array $listedProperties = [], &$count = 0): array
     {
         $count = 0;
 

--- a/src/Symfony/Component/WebLink/HttpHeaderSerializer.php
+++ b/src/Symfony/Component/WebLink/HttpHeaderSerializer.php
@@ -26,10 +26,8 @@ final class HttpHeaderSerializer
      * Builds the value of the "Link" HTTP header.
      *
      * @param LinkInterface[]|\Traversable $links
-     *
-     * @return string|null
      */
-    public function serialize(iterable $links)
+    public function serialize(iterable $links): ?string
     {
         $elements = [];
         foreach ($links as $link) {

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -49,10 +49,8 @@ final class Definition
 
     /**
      * @deprecated since Symfony 4.3. Use getInitialPlaces() instead.
-     *
-     * @return string|null
      */
-    public function getInitialPlace()
+    public function getInitialPlace(): ?string
     {
         @trigger_error(sprintf('Calling %s::getInitialPlace() is deprecated since Symfony 4.3. Call getInitialPlaces() instead.', __CLASS__), E_USER_DEPRECATED);
 

--- a/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
@@ -46,7 +46,7 @@ final class MethodMarkingStore implements MarkingStoreInterface
     /**
      * {@inheritdoc}
      */
-    public function getMarking($subject)
+    public function getMarking($subject): Marking
     {
         $method = 'get'.ucfirst($this->property);
 

--- a/src/Symfony/Component/Workflow/SupportStrategy/ClassInstanceSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/ClassInstanceSupportStrategy.php
@@ -32,15 +32,12 @@ final class ClassInstanceSupportStrategy implements SupportStrategyInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Workflow $workflow, $subject)
+    public function supports(Workflow $workflow, $subject): bool
     {
         return $subject instanceof $this->className;
     }
 
-    /**
-     * @return string
-     */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }

--- a/src/Symfony/Component/Workflow/Tests/EventListener/AuditTrailListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/AuditTrailListenerTest.php
@@ -44,7 +44,7 @@ class Logger extends AbstractLogger
 {
     public $logs = [];
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->logs[] = $message;
     }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -574,10 +574,7 @@ class EventDispatcherMock implements \Symfony\Component\EventDispatcher\EventDis
 {
     public $dispatchedEvents = [];
 
-    /**
-     * @return object
-     */
-    public function dispatch($event, string $eventName = null)
+    public function dispatch($event, string $eventName = null): Event
     {
         $this->dispatchedEvents[] = $eventName;
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -574,9 +574,14 @@ class EventDispatcherMock implements \Symfony\Component\EventDispatcher\EventDis
 {
     public $dispatchedEvents = [];
 
+    /**
+     * @return object
+     */
     public function dispatch($event, string $eventName = null)
     {
         $this->dispatchedEvents[] = $eventName;
+
+        return $event;
     }
 
     public function addListener($eventName, $listener, $priority = 0)
@@ -595,7 +600,7 @@ class EventDispatcherMock implements \Symfony\Component\EventDispatcher\EventDis
     {
     }
 
-    public function getListeners($eventName = null)
+    public function getListeners($eventName = null): array
     {
     }
 
@@ -603,7 +608,7 @@ class EventDispatcherMock implements \Symfony\Component\EventDispatcher\EventDis
     {
     }
 
-    public function hasListeners($eventName = null)
+    public function hasListeners($eventName = null): bool
     {
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -110,10 +110,7 @@ YAML;
         return $filename;
     }
 
-    /**
-     * @return CommandTester
-     */
-    protected function createCommandTester()
+    protected function createCommandTester(): CommandTester
     {
         $application = new Application();
         $application->add(new LintCommand());

--- a/src/Symfony/Contracts/Tests/Cache/CacheTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Cache/CacheTraitTest.php
@@ -127,39 +127,39 @@ class TestPool implements CacheItemPoolInterface
 {
     use CacheTrait;
 
-    public function hasItem($key)
+    public function hasItem($key): bool
     {
     }
 
-    public function deleteItem($key)
+    public function deleteItem($key): bool
     {
     }
 
-    public function deleteItems(array $keys = [])
+    public function deleteItems(array $keys = []): bool
     {
     }
 
-    public function getItem($key)
+    public function getItem($key): CacheItemInterface
     {
     }
 
-    public function getItems(array $key = [])
+    public function getItems(array $key = []): iterable
     {
     }
 
-    public function saveDeferred(CacheItemInterface $item)
+    public function saveDeferred(CacheItemInterface $item): bool
     {
     }
 
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
     }
 
-    public function commit()
+    public function commit(): bool
     {
     }
 
-    public function clear()
+    public function clear(): bool
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33228 #33236
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

#33266 made me spot an issue with my logic to add return types with help from `DebugClassLoader`.
Here is a completing PR, with the logic expanded to test classes.

I need help to fix tests, /cc @derrabus :)