### PR TITLE
[HttpKernel] Do not extend the new SF 4.3 ControllerEvent so we can make it final

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/FilterControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterControllerArgumentsEvent.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 /**
  * @deprecated since Symfony 4.3, use ControllerArgumentsEvent instead
  */
-class FilterControllerArgumentsEvent extends ControllerEvent
+class FilterControllerArgumentsEvent extends FilterControllerEvent
 {
     private $arguments;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | unlikely
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

See https://github.com/symfony/symfony/pull/33152#discussion_r313846346
Remember the ControllerEvent is new in SF 4.3 so we just go back to what it was before 4.3