### PR TITLE
Fix max retries strategy in Symfony Messenger

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1212,7 +1212,7 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                         ->children()
                                             ->scalarNode('service')->defaultNull()->info('Service id to override the retry strategy entirely')->end()
-                                            ->integerNode('max_retries')->defaultValue(3)->min(0)->end()
+                                            ->integerNode('max_retries')->defaultValue(3)->min(-1)->end()
                                             ->integerNode('delay')->defaultValue(1000)->min(0)->info('Time in ms to delay (or the initial value when multiplier is used)')->end()
                                             ->floatNode('multiplier')->defaultValue(2)->min(1)->info('If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries))')->end()
                                             ->integerNode('max_delay')->defaultValue(0)->min(0)->info('Max time in ms that a retry should ever be delayed (0 = infinite)')->end()

--- a/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
@@ -39,7 +39,7 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
     private $maxDelayMilliseconds;
 
     /**
-     * @param int   $maxRetries           The maximum number of time to retry (null means indefinitely)
+     * @param int   $maxRetries           The maximum number of time to retry (null or -1 means indefinitely)
      * @param int   $delayMilliseconds    Amount of time to delay (or the initial value when multiplier is used)
      * @param float $multiplier           Multiplier to apply to the delay each time a retry occurs
      * @param int   $maxDelayMilliseconds Maximum delay to allow (0 means no maximum)
@@ -66,7 +66,7 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
 
     public function isRetryable(Envelope $message): bool
     {
-        if (null === $this->maxRetries) {
+        if (null === $this->maxRetries || -1 === $this->maxRetries) {
             return true;
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
@@ -26,6 +26,16 @@ class MultiplierRetryStrategyTest extends TestCase
         $this->assertTrue($strategy->isRetryable($envelope));
     }
 
+    public function testIsRetryableWithMinusOneMax()
+    {
+        $strategy = new MultiplierRetryStrategy(-1);
+        $envelope = new Envelope(new \stdClass(), [new RedeliveryStamp(0, 'sender_alias')]);
+        $this->assertTrue($strategy->isRetryable($envelope));
+
+        $envelope = new Envelope(new \stdClass(), [new RedeliveryStamp(1, 'sender_alias')]);
+        $this->assertTrue($strategy->isRetryable($envelope));
+    }
+
     public function testIsRetryableWithNullMax()
     {
         $strategy = new MultiplierRetryStrategy(null);


### PR DESCRIPTION
Fix the possibility to have an infinite max retry strategy in Messenger
Related issue: https://github.com/symfony/symfony/issues/33284

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33284 
| License       | MIT