### PR TITLE
Use PHP 7.4 on deps=low

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,16 @@ env:
 matrix:
     include:
         - php: 5.5
-          env: php_extra="5.6 7.0 7.1"
-        - php: 7.2
-          env: deps=high
+          env: php_extra="5.6 7.0 7.1 7.2"
         - php: 7.3
+          env: deps=high
+        - php: 7.4snapshot
           env: deps=low
         - php: 7.4snapshot
+          env: deps=
     allow_failures:
         - php: 7.4snapshot
+          env: deps=
     fast_finish: true
 
 cache:
@@ -73,6 +75,12 @@ before_install:
       export COMPOSER_UP='composer update --no-progress --no-suggest --ansi'
       export COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n')
       find ~/.phpenv -name xdebug.ini -delete
+
+      if [[ $TRAVIS_PHP_VERSION = 7.4* && $deps ]]; then
+          export PHPUNIT_X="$PHPUNIT_X,issue-32995"
+      elif [[ $TRAVIS_PHP_VERSION = 7.4* ]]; then
+          export PHPUNIT_X="$PHPUNIT --group issue-32995"
+      fi
 
       if [[ $TRAVIS_PHP_VERSION = 5.* || $TRAVIS_PHP_VERSION = hhvm* ]]; then
           composer () {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "doctrine/common": "~2.4",
         "fig/link-util": "^1.0",
-        "twig/twig": "^1.40|^2.9",
+        "twig/twig": "^1.41|^2.10",
         "psr/cache": "~1.0",
         "psr/container": "^1.0",
         "psr/link": "^1.0",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -22,6 +22,7 @@
         "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {
+        "doctrine/annotations": "~1.7",
         "symfony/stopwatch": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/form": "^3.3.10|~4.0",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^5.5.9|>=7.0.8",
-        "twig/twig": "^1.40|^2.9"
+        "twig/twig": "^1.41|^2.10"
     },
     "require-dev": {
         "fig/link-util": "^1.0",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\Validator\ValidatorBuilder;
 class ValidatorCacheWarmerTest extends TestCase
 {
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testWarmUp()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.5.9|>=7.0.8",
         "ext-xml": "*",
-        "symfony/cache": "~3.4|~4.0",
+        "symfony/cache": "~3.4.31|^4.3.4",
         "symfony/class-loader": "~3.2",
         "symfony/dependency-injection": "^3.4.24|^4.2.5",
         "symfony/config": "^3.4.31|^4.3.4",
@@ -36,7 +36,7 @@
         "fig/link-util": "^1.0",
         "symfony/asset": "~3.3|~4.0",
         "symfony/browser-kit": "~2.8|~3.0|~4.0",
-        "symfony/console": "~3.4|~4.0",
+        "symfony/console": "~3.4.31|^4.3.4",
         "symfony/css-selector": "~2.8|~3.0|~4.0",
         "symfony/dom-crawler": "~2.8|~3.0|~4.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -56,7 +56,7 @@
         "symfony/property-info": "~3.3|~4.0",
         "symfony/lock": "~3.4|~4.0",
         "symfony/web-link": "~3.3|~4.0",
-        "doctrine/annotations": "~1.0",
+        "doctrine/annotations": "~1.7",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0",
         "twig/twig": "~1.34|~2.4"
     },

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -44,7 +44,7 @@
         "symfony/yaml": "~3.4|~4.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0",
         "doctrine/doctrine-bundle": "~1.5",
-        "twig/twig": "~1.34|~2.4"
+        "twig/twig": "~1.41|~2.10"
     },
     "conflict": {
         "symfony/var-dumper": "<3.3",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
         "symfony/http-kernel": "^3.3|~4.0",
         "symfony/polyfill-ctype": "~1.8",
-        "twig/twig": "~1.40|~2.9"
+        "twig/twig": "~1.41|~2.10"
     },
     "require-dev": {
         "symfony/asset": "~2.8|~3.0|~4.0",
@@ -37,7 +37,7 @@
         "symfony/yaml": "~2.8|~3.0|~4.0",
         "symfony/framework-bundle": "^3.3.11|~4.0",
         "symfony/web-link": "~3.3|~4.0",
-        "doctrine/annotations": "~1.0",
+        "doctrine/annotations": "~1.7",
         "doctrine/cache": "~1.0"
     },
     "conflict": {

--- a/src/Symfony/Component/Config/Tests/Resource/ClassExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ClassExistenceResourceTest.php
@@ -76,6 +76,8 @@ EOF
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testBadParentWithTimestamp()
@@ -85,6 +87,8 @@ EOF
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testBadParentWithNoTimestamp()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -378,6 +378,8 @@ class AutowirePassTest extends TestCase
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testParentClassNotFoundThrowsException()
@@ -692,6 +694,8 @@ class AutowirePassTest extends TestCase
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testIgnoreServiceWithClassNotExisting()
@@ -893,6 +897,8 @@ class AutowirePassTest extends TestCase
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testExceptionWhenAliasDoesNotExist()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -62,6 +62,8 @@ class ResolveBindingsPassTest extends TestCase
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testMissingParent()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -894,6 +894,8 @@ class PhpDumperTest extends TestCase
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testHotPathOptimizations()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -108,6 +108,8 @@ class FileLoaderTest extends TestCase
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testRegisterClassesWithExclude()
@@ -140,6 +142,8 @@ class FileLoaderTest extends TestCase
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testNestedRegisterClasses()
@@ -171,6 +175,8 @@ class FileLoaderTest extends TestCase
     }
 
     /**
+     * @group issue-32995
+     *
      * @runInSeparateProcess https://github.com/symfony/symfony/issues/32995
      */
     public function testMissingParentClass()

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -31,7 +31,7 @@
         "symfony/cache": "~3.1|~4.0",
         "symfony/dependency-injection": "~3.3|~4.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0",
-        "doctrine/annotations": "~1.0"
+        "doctrine/annotations": "~1.7"
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -32,11 +32,12 @@
         "symfony/expression-language": "~2.8|~3.0|~4.0",
         "symfony/cache": "~3.1|~4.0",
         "symfony/property-access": "~2.8|~3.0|~4.0",
-        "doctrine/annotations": "~1.0",
+        "doctrine/annotations": "~1.7",
         "doctrine/cache": "~1.0",
-        "egulias/email-validator": "^1.2.8|~2.0"
+        "egulias/email-validator": "^2.1.10"
     },
     "conflict": {
+        "doctrine/lexer": "<1.0.2",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/dependency-injection": "<3.3",
         "symfony/http-kernel": "<3.3.5",

--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^5.5.9|>=7.0.8",
-        "symfony/property-access": "~2.3|~3.0|~4.0"
+        "symfony/property-access": "~3.4.31|^4.3.4"
     },
     "require-dev": {
         "psr/log": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Having a job on PHP 7.4 will allow using return type covariance as described in #33236