### PR TITLE
[DomCrawler] Fix FileFormField PHPDoc

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -113,7 +113,7 @@ class ChoiceFormField extends FormField
     /**
      * Sets the value of the field.
      *
-     * @param string|array $value The value of the field
+     * @param string|array|bool $value The value of the field
      *
      * @throws \InvalidArgumentException When value type provided is not correct
      */

--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -48,7 +48,7 @@ class FileFormField extends FormField
     /**
      * Sets the value of the field.
      *
-     * @param string $value The value of the field
+     * @param string|null $value The value of the field
      */
     public function setValue($value)
     {

--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -99,7 +99,7 @@ abstract class FormField
     /**
      * Sets the value of the field.
      *
-     * @param string $value The value of the field
+     * @param string|array|bool|null $value The value of the field
      */
     public function setValue($value)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

`null` is a valid value, it is used in case of errors. Then the parent class must allow `null` values too. I think it's important regarding the ongoing process of adding typehints everywhere.