### PR TITLE
[Messenger] Stop worker when it should stop

### DIFF
--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -92,6 +92,10 @@ class Worker implements WorkerInterface
 
                     $this->handleMessage($envelope, $receiver, $transportName, $this->retryStrategies[$transportName] ?? null);
                     $onHandled($envelope);
+
+                    if ($this->shouldStop) {
+                        break 2;
+                    }
                 }
 
                 // after handling a single receiver, quit and start the loop again


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | NA   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | NA <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

There are 2 things about this PR:
* This PR fix the bug when using `limit`, `memory-limit`, `time-limit` options with command `messenger:consume`, these options does not work if the receiver return multiple messages
* This PR is the continue work of https://github.com/symfony/symfony/pull/32783
