### PR TITLE
Add missing return annotations on magic methods

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -83,6 +83,8 @@ class Cookie
 
     /**
      * Returns the HTTP representation of the Cookie.
+     *
+     * @return string
      */
     public function __toString()
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ReferenceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ReferenceConfigurator.php
@@ -59,6 +59,9 @@ class ReferenceConfigurator extends AbstractConfigurator
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return $this->id;

--- a/src/Symfony/Component/DependencyInjection/Variable.php
+++ b/src/Symfony/Component/DependencyInjection/Variable.php
@@ -33,6 +33,9 @@ class Variable
         $this->name = $name;
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return $this->name;

--- a/src/Symfony/Component/ExpressionLanguage/Node/Node.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/Node.php
@@ -33,6 +33,9 @@ class Node
         $this->attributes = $attributes;
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         $attributes = [];

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -114,6 +114,9 @@ abstract class DataCollector implements DataCollectorInterface
         return $casters;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         if (__CLASS__ !== $c = (new \ReflectionMethod($this, 'serialize'))->getDeclaringClass()->name) {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -870,6 +870,9 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $this->__construct($environment, $debug);
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         if (__CLASS__ !== $c = (new \ReflectionMethod($this, 'serialize'))->getDeclaringClass()->name) {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -288,6 +288,9 @@ class Profile
         return isset($this->collectors[$name]);
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         return ['token', 'parent', 'children', 'collectors', 'ip', 'method', 'url', 'time', 'statusCode'];

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -125,6 +125,9 @@ class DataPart extends TextPart
         }
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         // converts the body to a string

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -179,6 +179,9 @@ class TextPart extends AbstractPart
         return 'quoted-printable';
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         // convert resources to strings for serialization

--- a/src/Symfony/Component/VarDumper/Caster/ConstStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ConstStub.php
@@ -26,6 +26,9 @@ class ConstStub extends Stub
         $this->value = 1 < \func_num_args() ? $value : $name;
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return (string) $this->value;

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -137,6 +137,9 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
         return null;
     }
 
+    /**
+     * @return bool
+     */
     public function __isset($key)
     {
         return null !== $this->seek($key);
@@ -165,6 +168,9 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
         throw new \BadMethodCallException(self::class.' objects are immutable.');
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         $value = $this->getValue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

My script had a bug, spotted by reviewing #33267
These annotations express our intention to add real return types in a future major release (likely v6)