### PR TITLE
Fix AuthMode cannot be null, replace by login

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Google/Smtp/GmailTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Smtp/GmailTransport.php
@@ -24,7 +24,7 @@ class GmailTransport extends EsmtpTransport
 {
     public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.gmail.com', 465, 'ssl', null, $dispatcher, $logger);
+        parent::__construct('smtp.gmail.com', 465, 'ssl', 'login', $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.3  <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | https://symfony.com/doc/current/components/mailer.html#transport

I created an article for Mailer component, when i add all information with GmailTransport (username and password (or password app)).
I have got this error :
![image](https://user-images.githubusercontent.com/10236869/63606931-831c0880-c5d1-11e9-8579-83808dfc1ebc.png)

I see in GmailTransport, Authmode is null then cannot be null for Gmail.

But it's not an error, i can pr this docs and add more informations for this.