### PR TITLE
[WebProfiler] Improve HttpClient Panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -8,6 +8,17 @@
             <span class="sf-toolbar-value">{{ collector.requestCount }}</span>
         {% endset %}
 
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                <b>Total requests</b>
+                <span>{{ collector.requestCount }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>HTTP errors</b>
+                <span class="sf-toolbar-status sf-toolbar-status-red">{{ collector.errorCount }}</span>
+            </div>
+        {% endset %}
+
         {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: status_color }) }}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | np    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #33311  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | ?

Wishlist from issue :

- [x] the panel UI could be improved I suppose, e.g. a tooltip on hover in the toolbar
- [ ] putting requests in the "Performance" tab would be great (all timings are already in the collected "info")
- [ ] ~response bodies are not collected yet~ https://github.com/symfony/symfony/pull/33315#discussion_r317353605
- [ ] when a transport error occurs, (ie the "error" info is populated) we should maybe have a better display too?
- [x] add a copy-as-curl button next to each request

**[EDIT 07 oct 19]**
This PR contains :
- Display a tooltip in Toolbar
- Add a link only for GET Request in profiler panel
![image](https://user-images.githubusercontent.com/13260307/66316799-389be480-e910-11e9-888e-7703c87c7b10.png)