### PR TITLE
[Messenger] Added support for `from_transport` attribute on `messenger.message_handler` tag

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Added support for auto trimming of Redis streams.
  * `InMemoryTransport` handle acknowledged and rejected messages.
  * Made all dispatched worker event classes final.
+ * Added support for `from_transport` attribute on `messenger.message_handler` tag.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -109,6 +109,10 @@ class MessengerPass implements CompilerPassInterface
                         $options = ['method' => $options];
                     }
 
+                    if (!isset($options['from_transport']) && isset($tag['from_transport'])) {
+                        $options['from_transport'] = $tag['from_transport'];
+                    }
+
                     $priority = $tag['priority'] ?? $options['priority'] ?? 0;
                     $method = $options['method'] ?? '__invoke';
 

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -78,6 +78,25 @@ class MessengerPassTest extends TestCase
         );
     }
 
+    public function testFromTransportViaTagAttribute()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container
+            ->register(DummyHandler::class, DummyHandler::class)
+            ->addTag('messenger.message_handler', ['from_transport' => 'async'])
+        ;
+
+        (new MessengerPass())->process($container);
+
+        $handlersLocatorDefinition = $container->getDefinition($busId.'.messenger.handlers_locator');
+        $this->assertSame(HandlersLocator::class, $handlersLocatorDefinition->getClass());
+
+        $handlerDescriptionMapping = $handlersLocatorDefinition->getArgument(0);
+        $this->assertCount(1, $handlerDescriptionMapping);
+
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, [DummyHandler::class], [['from_transport' => 'async']]);
+    }
+
     public function testProcessHandlersByBus()
     {
         $container = $this->getContainerBuilder($commandBusId = 'command_bus');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33306
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/12231

Right now, it's only possible to have dynamic `from_transport` when using `MessageSubscriberInterface`. Things like `priority` and `bus` can already be added as attributes on the  messenger.message_handler` tag.

With this PR it now also supports `from_transport`.