### PR TITLE
Allow configuring class names through methods instead of class parameters in Doctrine extensions

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -72,6 +72,8 @@ DoctrineBridge
  * Deprecated passing an `IdReader` to the `DoctrineChoiceLoader` when the query cannot be optimized with single id field.
  * Deprecated not passing an `IdReader` to the `DoctrineChoiceLoader` when the query can be optimized with single id field.
  * Deprecated `RegistryInterface`, use `Doctrine\Common\Persistence\ManagerRegistry`.
+ * Added a new `getMetadataDriverClass` method to replace class parameters in `AbstractDoctrineExtension`. This method
+   will be abstract in Symfony 5 and must be declared in extending classes.
 
 Filesystem
 ----------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -122,6 +122,7 @@ DoctrineBridge
  * Passing an `IdReader` to the `DoctrineChoiceLoader` when the query cannot be optimized with single id field will throw an exception, pass `null` instead
  * Not passing an `IdReader` to the `DoctrineChoiceLoader` when the query can be optimized with single id field will not apply any optimization
  * The `RegistryInterface` has been removed.
+ * Added a new `getMetadataDriverClass` method in `AbstractDoctrineExtension` to replace class parameters. 
 
 DomCrawler
 ----------

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added `DoctrineClearEntityManagerMiddleware`
  * deprecated `RegistryInterface`, use `Doctrine\Common\Persistence\ManagerRegistry`
  * added support for invokable event listeners
+ * added `getMetadataDriverClass` method to deprecate class parameters in service configuration files
 
 4.3.0
 -----

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -178,7 +178,7 @@ abstract class AbstractDoctrineExtension extends Extension
         if ($container->hasDefinition($this->getObjectManagerElementName($objectManager['name'].'_metadata_driver'))) {
             $chainDriverDef = $container->getDefinition($this->getObjectManagerElementName($objectManager['name'].'_metadata_driver'));
         } else {
-            $chainDriverDef = new Definition('%'.$this->getObjectManagerElementName('metadata.driver_chain.class%'));
+            $chainDriverDef = new Definition($this->getMetadataDriverClass('driver_chain'));
             $chainDriverDef->setPublic(false);
         }
 
@@ -194,12 +194,12 @@ abstract class AbstractDoctrineExtension extends Extension
                 }
                 $mappingDriverDef->setArguments($args);
             } elseif ('annotation' == $driverType) {
-                $mappingDriverDef = new Definition('%'.$this->getObjectManagerElementName('metadata.'.$driverType.'.class%'), [
+                $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
                     new Reference($this->getObjectManagerElementName('metadata.annotation_reader')),
                     array_values($driverPaths),
                 ]);
             } else {
-                $mappingDriverDef = new Definition('%'.$this->getObjectManagerElementName('metadata.'.$driverType.'.class%'), [
+                $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
                     array_values($driverPaths),
                 ]);
             }
@@ -433,6 +433,16 @@ abstract class AbstractDoctrineExtension extends Extension
      * @return string
      */
     abstract protected function getMappingResourceExtension();
+
+    /**
+     * The class name used by the various mapping drivers.
+     */
+    protected function getMetadataDriverClass(string $driverType): string
+    {
+        @trigger_error(sprintf('Not declaring the "%s" method in class "%s" is deprecated since Symfony 4.4. This method will be abstract in Symfony 5.0.', __METHOD__, static::class), E_USER_DEPRECATED);
+
+        return '%'.$this->getObjectManagerElementName('metadata.'.$driverType.'.class%');
+    }
 
     /**
      * Search for a manager that is declared as 'auto_mapping' = true.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

While removing class parameters for DoctrineBundle 2.0 (see https://github.com/doctrine/DoctrineBundle/issues/630), I noticed that the DoctrineExtension still requires them. This PR adds a new method that keeps legacy behaviour, but will dropped in Symfony 5. Extending classes (mainly DoctrineBundle and DoctrineMongoDBBundle) must implement this method themselves to return the appropriate class names instead of declaring them as class parameters in their service configuration. I'll create a separate for the master branch to make this method abstract in 5.0.

The cache driver class names are not being replaced in this PR, as we're dropping support for `doctrine/cache` in DoctrineBundle 2.0. A separate PR will be created to handle those deprecations and to clean up the code.