### PR TITLE
[TwigBridge] Throw an exception when one uses email as a context variable in a TemplatedEmail

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
+++ b/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Mime;
 
 use League\HTMLToMarkdown\HtmlConverter;
 use Symfony\Component\Mime\BodyRendererInterface;
+use Symfony\Component\Mime\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Message;
 use Twig\Environment;
 
@@ -44,7 +45,12 @@ final class BodyRenderer implements BodyRendererInterface
             return;
         }
 
-        $vars = array_merge($this->context, $message->getContext(), [
+        $messageContext = $message->getContext();
+        if (isset($messageContext['email'])) {
+            throw new InvalidArgumentException(sprintf('A "%s" context cannot have an "email" entry as this is a reserved variable.', TemplatedEmail::class));
+        }
+
+        $vars = array_merge($this->context, $messageContext, [
             'email' => new WrappedTemplatedEmail($this->twig, $message),
         ]);
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | refs #33310
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
