### PR TITLE
Explain how DispatchAfterCurrentBusMiddleware works

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -26,6 +26,8 @@ use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
  * means sub-dispatched messages with a DispatchAfterCurrentBus stamp would be
  * handled after the Doctrine transaction has been committed.
  *
+ * All busses will share the same instance of this middleware.
+ *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

It took me a while to figure out how the `DispatchAfterCurrentBusMiddleware` middleware worked. I thought all busses would have their own set of middleware instances but it turns out they use shared middleware. 
