### PR TITLE
[ErrorHandler] Registering basic exception handler for late failures

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -557,6 +557,18 @@ class ErrorHandlerTest extends TestCase
         $handler->handleException(new \Exception());
     }
 
+    public function testSendPhpResponse()
+    {
+        $handler = new ErrorHandler();
+        $handler->setExceptionHandler([$handler, 'sendPhpResponse']);
+
+        ob_start();
+        $handler->handleException(new \RuntimeException('Class Foo not found'));
+        $response = ob_get_clean();
+
+        self::assertStringContainsString('Class Foo not found', $response);
+    }
+
     /**
      * @dataProvider errorHandlerWhenLoggingProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Follow-up https://github.com/symfony/symfony/pull/33260 but when all handlers fail. 

It'll becomes common since 4.4 where the user has control over the error rendering mechanism. If they make a mistake, we have a support page to show it, currently a blank page is displayed.