### PR TITLE
[3.4] Fix return types declarations

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -89,6 +89,6 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
         return $qb->andWhere($where)
                   ->getQuery()
                   ->setParameter($parameter, $values, $parameterType)
-                  ->getResult();
+                  ->getResult() ?: [];
     }
 }

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -107,6 +107,8 @@ class TranslationDefaultDomainNodeVisitor extends AbstractNodeVisitor
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     public function getPriority()
     {

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
@@ -97,6 +97,8 @@ class TranslationNodeVisitor extends AbstractNodeVisitor
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     public function getPriority()
     {

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -106,9 +106,7 @@ class TwigExtractor extends AbstractFileExtractor implements ExtractorInterface
     }
 
     /**
-     * @param string|array $directory
-     *
-     * @return array
+     * {@inheritdoc}
      */
     protected function extractFromDirectory($directory)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1743,9 +1743,7 @@ class FrameworkExtension extends Extension
     }
 
     /**
-     * Returns the base path for the XSD files.
-     *
-     * @return string The XSD base path
+     * {@inheritdoc}
      */
     public function getXsdValidationBasePath()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
@@ -24,16 +24,16 @@ class ProfilerTest extends AbstractWebTestCase
         }
 
         $client->request('GET', '/profiler');
-        $this->assertFalse($client->getProfile());
+        $this->assertNull($client->getProfile());
 
         // enable the profiler for the next request
         $client->enableProfiler();
-        $this->assertFalse($client->getProfile());
+        $this->assertNull($client->getProfile());
         $client->request('GET', '/profiler');
         $this->assertIsObject($client->getProfile());
 
         $client->request('GET', '/profiler');
-        $this->assertFalse($client->getProfile());
+        $this->assertNull($client->getProfile());
     }
 
     public function getConfigs()

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -231,7 +231,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Gets the roles of the user.
      *
-     * @return array The roles
+     * @return array|Data
      */
     public function getRoles()
     {
@@ -241,7 +241,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Gets the inherited roles of the user.
      *
-     * @return array The inherited roles
+     * @return array|Data
      */
     public function getInheritedRoles()
     {
@@ -269,16 +269,25 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         return $this->data['authenticated'];
     }
 
+    /**
+     * @return bool
+     */
     public function isImpersonated()
     {
         return $this->data['impersonated'];
     }
 
+    /**
+     * @return string|null
+     */
     public function getImpersonatorUser()
     {
         return $this->data['impersonator_user'];
     }
 
+    /**
+     * @return string|null
+     */
     public function getImpersonationExitPath()
     {
         return $this->data['impersonation_exit_path'];
@@ -287,7 +296,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Get the class name of the security token.
      *
-     * @return string The token
+     * @return string|Data|null The token
      */
     public function getTokenClass()
     {
@@ -297,7 +306,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Get the full security token class as Data object.
      *
-     * @return Data
+     * @return Data|null
      */
     public function getToken()
     {
@@ -307,7 +316,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Get the logout URL.
      *
-     * @return string The logout URL
+     * @return string|null The logout URL
      */
     public function getLogoutUrl()
     {
@@ -317,7 +326,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Returns the FQCN of the security voters enabled in the application.
      *
-     * @return string[]
+     * @return string[]|Data
      */
     public function getVoters()
     {
@@ -337,7 +346,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Returns the log of the security decisions made by the access decision manager.
      *
-     * @return array
+     * @return array|Data
      */
     public function getAccessDecisionLog()
     {
@@ -347,13 +356,16 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     /**
      * Returns the configuration of the current firewall context.
      *
-     * @return array
+     * @return array|Data
      */
     public function getFirewall()
     {
         return $this->data['firewall'];
     }
 
+    /**
+     * @return array|Data
+     */
     public function getListeners()
     {
         return $this->data['listeners'];

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -130,9 +130,9 @@ abstract class AbstractFactory implements SecurityFactoryInterface
      * @param ContainerBuilder $container
      * @param string           $id
      * @param array            $config
-     * @param string           $defaultEntryPointId
+     * @param string|null      $defaultEntryPointId
      *
-     * @return string the entry point id
+     * @return string|null the entry point id
      */
     protected function createEntryPoint($container, $id, $config, $defaultEntryPointId)
     {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SecurityFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SecurityFactoryInterface.php
@@ -24,10 +24,10 @@ interface SecurityFactoryInterface
     /**
      * Configures the container services required to use the authentication listener.
      *
-     * @param string $id                The unique id of the firewall
-     * @param array  $config            The options array for the listener
-     * @param string $userProvider      The service id of the user provider
-     * @param string $defaultEntryPoint
+     * @param string      $id                The unique id of the firewall
+     * @param array       $config            The options array for the listener
+     * @param string      $userProvider      The service id of the user provider
+     * @param string|null $defaultEntryPoint
      *
      * @return array containing three values:
      *               - the provider id

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -798,9 +798,7 @@ class SecurityExtension extends Extension
     }
 
     /**
-     * Returns the base path for the XSD files.
-     *
-     * @return string The XSD base path
+     * {@inheritdoc}
      */
     public function getXsdValidationBasePath()
     {

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -255,9 +255,7 @@ class TwigExtension extends Extension
     }
 
     /**
-     * Returns the base path for the XSD files.
-     *
-     * @return string The XSD base path
+     * {@inheritdoc}
      */
     public function getXsdValidationBasePath()
     {

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -64,9 +64,7 @@ class WebProfilerExtension extends Extension
     }
 
     /**
-     * Returns the base path for the XSD files.
-     *
-     * @return string The XSD base path
+     * {@inheritdoc}
      */
     public function getXsdValidationBasePath()
     {

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -141,9 +141,9 @@ abstract class Client
      * Gets single server parameter for specified key.
      *
      * @param string $key     A key of the parameter to get
-     * @param string $default A default value when key is undefined
+     * @param mixed  $default A default value when key is undefined
      *
-     * @return string A value of the parameter
+     * @return mixed A value of the parameter
      */
     public function getServerParameter($key, $default = '')
     {

--- a/src/Symfony/Component/BrowserKit/Request.php
+++ b/src/Symfony/Component/BrowserKit/Request.php
@@ -107,7 +107,7 @@ class Request
     /**
      * Gets the request raw body data.
      *
-     * @return string The request raw body data
+     * @return string|null The request raw body data
      */
     public function getContent()
     {

--- a/src/Symfony/Component/Cache/DoctrineProvider.php
+++ b/src/Symfony/Component/Cache/DoctrineProvider.php
@@ -90,7 +90,7 @@ class DoctrineProvider extends CacheProvider implements PruneableInterface, Rese
      */
     protected function doFlush()
     {
-        $this->pool->clear();
+        return $this->pool->clear();
     }
 
     /**
@@ -98,5 +98,6 @@ class DoctrineProvider extends CacheProvider implements PruneableInterface, Rese
      */
     protected function doGetStats()
     {
+        return null;
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -40,6 +40,10 @@ class MaxIdLengthAdapterTest extends TestCase
             ->setConstructorArgs([str_repeat('-', 26)])
             ->getMock();
 
+        $cache
+            ->method('doFetch')
+            ->willReturn(['2:']);
+
         $reflectionClass = new \ReflectionClass(AbstractAdapter::class);
 
         $reflectionMethod = $reflectionClass->getMethod('getId');
@@ -56,7 +60,7 @@ class MaxIdLengthAdapterTest extends TestCase
         $reflectionProperty->setValue($cache, true);
 
         // Versioning enabled
-        $this->assertEquals('--------------------------:1:------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
+        $this->assertEquals('--------------------------:2:------------', $reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)]));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 12)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 23)])));
         $this->assertLessThanOrEqual(50, \strlen($reflectionMethod->invokeArgs($cache, [str_repeat('-', 40)])));

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -38,17 +38,13 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     }
 
     /**
-     * Normalizes keys between the different configuration formats.
+     * {@inheritdoc}
      *
      * Namely, you mostly have foo_bar in YAML while you have foo-bar in XML.
      * After running this method, all keys are normalized to foo_bar.
      *
      * If you have a mixed key like foo-bar_moo, it will not be altered.
      * The key will also not be altered if the target key already exists.
-     *
-     * @param mixed $value
-     *
-     * @return array The value with normalized keys
      */
     protected function preNormalize($value)
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -49,21 +49,37 @@ abstract class BaseNode implements NodeInterface
         $this->parent = $parent;
     }
 
+    /**
+     * @param string $key
+     */
     public function setAttribute($key, $value)
     {
         $this->attributes[$key] = $value;
     }
 
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     */
     public function getAttribute($key, $default = null)
     {
         return isset($this->attributes[$key]) ? $this->attributes[$key] : $default;
     }
 
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
     public function hasAttribute($key)
     {
         return isset($this->attributes[$key]);
     }
 
+    /**
+     * @return array
+     */
     public function getAttributes()
     {
         return $this->attributes;
@@ -74,6 +90,9 @@ abstract class BaseNode implements NodeInterface
         $this->attributes = $attributes;
     }
 
+    /**
+     * @param string $key
+     */
     public function removeAttribute($key)
     {
         unset($this->attributes[$key]);
@@ -92,7 +111,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Returns info message.
      *
-     * @return string The info text
+     * @return string|null The info text
      */
     public function getInfo()
     {
@@ -112,7 +131,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Retrieves the example configuration for this node.
      *
-     * @return string|array The example
+     * @return string|array|null The example
      */
     public function getExample()
     {

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -78,7 +78,7 @@ class PrototypedArrayNode extends ArrayNode
     /**
      * Retrieves the name of the attribute which value should be used as key.
      *
-     * @return string The name of the attribute
+     * @return string|null The name of the attribute
      */
     public function getKeyAttribute()
     {

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -152,7 +152,7 @@ class XmlUtils
      * @param \DOMElement $element     A \DOMElement instance
      * @param bool        $checkPrefix Check prefix in an element or an attribute name
      *
-     * @return array A PHP array
+     * @return mixed
      */
     public static function convertDomElementToArray(\DOMElement $element, $checkPrefix = true)
     {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -21,7 +21,6 @@ use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\ExceptionInterface;
-use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\DebugFormatterHelper;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -457,13 +456,8 @@ class Application
             return null;
         }
 
-        if (null === $command->getDefinition()) {
-            throw new LogicException(sprintf('Command class "%s" is not correctly initialized. You probably forgot to call the parent constructor.', \get_class($command)));
-        }
-
-        if (!$command->getName()) {
-            throw new LogicException(sprintf('The command defined in "%s" cannot have an empty name.', \get_class($command)));
-        }
+        // Will throw if the command is not correctly initialized.
+        $command->getDefinition();
 
         $this->commands[$command->getName()] = $command;
 
@@ -1023,7 +1017,7 @@ class Application
     /**
      * Gets the name of the command based on input.
      *
-     * @return string The command name
+     * @return string|null
      */
     protected function getCommandName(InputInterface $input)
     {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -40,8 +40,8 @@ class Command
     private $aliases = [];
     private $definition;
     private $hidden = false;
-    private $help;
-    private $description;
+    private $help = '';
+    private $description = '';
     private $ignoreValidationErrors = false;
     private $applicationDefinitionMerged = false;
     private $applicationDefinitionMergedWithArgs = false;
@@ -105,7 +105,7 @@ class Command
     /**
      * Gets the helper set.
      *
-     * @return HelperSet A HelperSet instance
+     * @return HelperSet|null A HelperSet instance
      */
     public function getHelperSet()
     {
@@ -115,7 +115,7 @@ class Command
     /**
      * Gets the application instance for this command.
      *
-     * @return Application An Application instance
+     * @return Application|null An Application instance
      */
     public function getApplication()
     {
@@ -347,6 +347,10 @@ class Command
      */
     public function getDefinition()
     {
+        if (null === $this->definition) {
+            throw new LogicException(sprintf('Command class "%s" is not correctly initialized. You probably forgot to call the parent constructor.', \get_class($this)));
+        }
+
         return $this->definition;
     }
 
@@ -453,6 +457,10 @@ class Command
      */
     public function getName()
     {
+        if (!$this->name) {
+            throw new LogicException(sprintf('The command defined in "%s" cannot have an empty name.', \get_class($this)));
+        }
+
         return $this->name;
     }
 

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -228,7 +228,7 @@ class Question
      *
      * The normalizer can ba a callable (a string), a closure or a class implementing __invoke.
      *
-     * @return callable
+     * @return callable|null
      */
     public function getNormalizer()
     {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -444,8 +444,6 @@ class Container implements ResettableContainerInterface
 
     /**
      * Creates a service by requiring its factory file.
-     *
-     * @return object The service created by the file
      */
     protected function load($file)
     {

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -796,7 +796,7 @@ class Definition
     /**
      * Gets the configurator to call after the service is fully initialized.
      *
-     * @return callable|null The PHP callable to call
+     * @return callable|array|null
      */
     public function getConfigurator()
     {

--- a/src/Symfony/Component/DependencyInjection/Dumper/DumperInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/DumperInterface.php
@@ -21,9 +21,7 @@ interface DumperInterface
     /**
      * Dumps the service container.
      *
-     * @param array $options An array of options
-     *
-     * @return string The representation of the service container
+     * @return string|array The representation of the service container
      */
     public function dump(array $options = []);
 }

--- a/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
@@ -37,7 +37,7 @@ interface ExtensionInterface
     /**
      * Returns the base path for the XSD files.
      *
-     * @return string The XSD base path
+     * @return string|false
      */
     public function getXsdValidationBasePath();
 

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -710,7 +710,7 @@ EOF
      *
      * @param \DOMElement $element A \DOMElement instance
      *
-     * @return array A PHP array
+     * @return mixed
      */
     public static function convertDomElementToArray(\DOMElement $element)
     {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -195,7 +195,7 @@ class ParameterBag implements ParameterBagInterface
      * @param string $value     The string to resolve
      * @param array  $resolving An array of keys that are being resolved (used internally to detect circular references)
      *
-     * @return string The resolved string
+     * @return mixed The resolved string
      *
      * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -43,7 +43,7 @@ class Crawler implements \Countable, \IteratorAggregate
     private $document;
 
     /**
-     * @var \DOMElement[]
+     * @var \DOMNode[]
      */
     private $nodes = [];
 
@@ -55,9 +55,7 @@ class Crawler implements \Countable, \IteratorAggregate
     private $isHtml = true;
 
     /**
-     * @param mixed  $node     A Node to use as the base for the crawling
-     * @param string $uri      The current URI
-     * @param string $baseHref The base href value
+     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $node A Node to use as the base for the crawling
      */
     public function __construct($node = null, $uri = null, $baseHref = null)
     {
@@ -102,7 +100,7 @@ class Crawler implements \Countable, \IteratorAggregate
      * This method uses the appropriate specialized add*() method based
      * on the type of the argument.
      *
-     * @param \DOMNodeList|\DOMNode|array|string|null $node A node
+     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $node A node
      *
      * @throws \InvalidArgumentException when node is not the expected type
      */
@@ -1049,7 +1047,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * @param int $position
      *
-     * @return \DOMElement|null
+     * @return \DOMNode|null
      */
     public function getNode($position)
     {
@@ -1065,7 +1063,7 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @return \ArrayIterator|\DOMElement[]
+     * @return \ArrayIterator|\DOMNode[]
      */
     public function getIterator()
     {
@@ -1146,7 +1144,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Creates a crawler for some subnodes.
      *
-     * @param \DOMElement|\DOMElement[]|\DOMNodeList|null $nodes
+     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $nodes
      *
      * @return static
      */

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -27,7 +27,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * @var bool
      */
-    private $disabled;
+    private $disabled = false;
 
     /**
      * @var ResolvedFormTypeInterface

--- a/src/Symfony/Component/Form/Extension/Core/Type/ButtonType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ButtonType.php
@@ -26,6 +26,7 @@ class ButtonType extends BaseType implements ButtonTypeInterface
      */
     public function getParent()
     {
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -190,6 +190,7 @@ class FormType extends BaseType
      */
     public function getParent()
     {
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Form/FormError.php
+++ b/src/Symfony/Component/Form/FormError.php
@@ -127,7 +127,7 @@ class FormError implements \Serializable
     /**
      * Returns the form that caused this error.
      *
-     * @return FormInterface The form that caused this error
+     * @return FormInterface|null The form that caused this error
      */
     public function getOrigin()
     {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -31,7 +31,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * @throws Exception\LogicException            when trying to set a parent for a form with
      *                                             an empty name
      */
-    public function setParent(self $parent = null);
+    public function setParent(FormInterface $parent = null);
 
     /**
      * Returns the parent form.

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Test\Traits;
 
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -37,9 +38,9 @@ trait ValidatorExtensionTrait
         }
 
         $this->validator = $this->getMockBuilder(ValidatorInterface::class)->getMock();
-        $metadata = $this->getMockBuilder(ClassMetadata::class)->disableOriginalConstructor()->setMethods(['addPropertyConstraint'])->getMock();
+        $metadata = $this->getMockBuilder(ClassMetadata::class)->setConstructorArgs([''])->setMethods(['addPropertyConstraint'])->getMock();
         $this->validator->expects($this->any())->method('getMetadataFor')->will($this->returnValue($metadata));
-        $this->validator->expects($this->any())->method('validate')->will($this->returnValue([]));
+        $this->validator->expects($this->any())->method('validate')->will($this->returnValue(new ConstraintViolationList()));
 
         return new ValidatorExtension($this->validator);
     }

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -346,7 +346,7 @@ abstract class AbstractRequestHandlerTest extends TestCase
             [1024, '1K', false],
             [null, '1K', false],
             [1024, '', false],
-            [1024, 0, false],
+            [1024, '0', false],
         ];
     }
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Form\Tests\ChoiceList\Factory;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Factory\CachingFactoryDecorator;
+use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -38,7 +40,7 @@ class CachingFactoryDecoratorTest extends TestCase
 
     public function testCreateFromChoicesEmpty()
     {
-        $list = new \stdClass();
+        $list = new ArrayChoiceList([]);
 
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
@@ -54,7 +56,7 @@ class CachingFactoryDecoratorTest extends TestCase
         // The top-most traversable is converted to an array
         $choices1 = new \ArrayIterator(['A' => 'a']);
         $choices2 = ['A' => 'a'];
-        $list = new \stdClass();
+        $list = new ArrayChoiceList([]);
 
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
@@ -69,8 +71,8 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $choices1 = ['key' => ['A' => 'a']];
         $choices2 = ['A' => 'a'];
-        $list1 = new \stdClass();
-        $list2 = new \stdClass();
+        $list1 = new ArrayChoiceList([]);
+        $list2 = new ArrayChoiceList([]);
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromChoices')
@@ -92,7 +94,7 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $choices1 = [$choice1];
         $choices2 = [$choice2];
-        $list = new \stdClass();
+        $list = new ArrayChoiceList([]);
 
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromChoices')
@@ -110,8 +112,8 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $choices1 = [$choice1];
         $choices2 = [$choice2];
-        $list1 = new \stdClass();
-        $list2 = new \stdClass();
+        $list1 = new ArrayChoiceList([]);
+        $list2 = new ArrayChoiceList([]);
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromChoices')
@@ -129,7 +131,7 @@ class CachingFactoryDecoratorTest extends TestCase
     public function testCreateFromChoicesSameValueClosure()
     {
         $choices = [1];
-        $list = new \stdClass();
+        $list = new ArrayChoiceList([]);
         $closure = function () {};
 
         $this->decoratedFactory->expects($this->once())
@@ -144,8 +146,8 @@ class CachingFactoryDecoratorTest extends TestCase
     public function testCreateFromChoicesDifferentValueClosure()
     {
         $choices = [1];
-        $list1 = new \stdClass();
-        $list2 = new \stdClass();
+        $list1 = new ArrayChoiceList([]);
+        $list2 = new ArrayChoiceList([]);
         $closure1 = function () {};
         $closure2 = function () {};
 
@@ -165,7 +167,7 @@ class CachingFactoryDecoratorTest extends TestCase
     public function testCreateFromLoaderSameLoader()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')->getMock();
-        $list = new \stdClass();
+        $list = new ArrayChoiceList([]);
 
         $this->decoratedFactory->expects($this->once())
             ->method('createListFromLoader')
@@ -180,8 +182,8 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $loader1 = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')->getMock();
         $loader2 = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')->getMock();
-        $list1 = new \stdClass();
-        $list2 = new \stdClass();
+        $list1 = new ArrayChoiceList([]);
+        $list2 = new ArrayChoiceList([]);
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createListFromLoader')
@@ -199,7 +201,7 @@ class CachingFactoryDecoratorTest extends TestCase
     public function testCreateFromLoaderSameValueClosure()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')->getMock();
-        $list = new \stdClass();
+        $list = new ArrayChoiceList([]);
         $closure = function () {};
 
         $this->decoratedFactory->expects($this->once())
@@ -214,8 +216,8 @@ class CachingFactoryDecoratorTest extends TestCase
     public function testCreateFromLoaderDifferentValueClosure()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')->getMock();
-        $list1 = new \stdClass();
-        $list2 = new \stdClass();
+        $list1 = new ArrayChoiceList([]);
+        $list2 = new ArrayChoiceList([]);
         $closure1 = function () {};
         $closure2 = function () {};
 
@@ -236,7 +238,7 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $preferred = ['a'];
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view = new \stdClass();
+        $view = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
@@ -252,8 +254,8 @@ class CachingFactoryDecoratorTest extends TestCase
         $preferred1 = ['a'];
         $preferred2 = ['b'];
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view1 = new \stdClass();
-        $view2 = new \stdClass();
+        $view1 = new ChoiceListView();
+        $view2 = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
@@ -272,7 +274,7 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $preferred = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view = new \stdClass();
+        $view = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
@@ -288,8 +290,8 @@ class CachingFactoryDecoratorTest extends TestCase
         $preferred1 = function () {};
         $preferred2 = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view1 = new \stdClass();
-        $view2 = new \stdClass();
+        $view1 = new ChoiceListView();
+        $view2 = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
@@ -308,7 +310,7 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $labels = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view = new \stdClass();
+        $view = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
@@ -324,8 +326,8 @@ class CachingFactoryDecoratorTest extends TestCase
         $labels1 = function () {};
         $labels2 = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view1 = new \stdClass();
-        $view2 = new \stdClass();
+        $view1 = new ChoiceListView();
+        $view2 = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
@@ -344,7 +346,7 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $index = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view = new \stdClass();
+        $view = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
@@ -360,8 +362,8 @@ class CachingFactoryDecoratorTest extends TestCase
         $index1 = function () {};
         $index2 = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view1 = new \stdClass();
-        $view2 = new \stdClass();
+        $view1 = new ChoiceListView();
+        $view2 = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
@@ -380,7 +382,7 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $groupBy = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view = new \stdClass();
+        $view = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
@@ -396,8 +398,8 @@ class CachingFactoryDecoratorTest extends TestCase
         $groupBy1 = function () {};
         $groupBy2 = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view1 = new \stdClass();
-        $view2 = new \stdClass();
+        $view1 = new ChoiceListView();
+        $view2 = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
@@ -416,7 +418,7 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $attr = ['class' => 'foobar'];
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view = new \stdClass();
+        $view = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
@@ -432,8 +434,8 @@ class CachingFactoryDecoratorTest extends TestCase
         $attr1 = ['class' => 'foobar1'];
         $attr2 = ['class' => 'foobar2'];
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view1 = new \stdClass();
-        $view2 = new \stdClass();
+        $view1 = new ChoiceListView();
+        $view2 = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')
@@ -452,7 +454,7 @@ class CachingFactoryDecoratorTest extends TestCase
     {
         $attr = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view = new \stdClass();
+        $view = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->once())
             ->method('createView')
@@ -468,8 +470,8 @@ class CachingFactoryDecoratorTest extends TestCase
         $attr1 = function () {};
         $attr2 = function () {};
         $list = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')->getMock();
-        $view1 = new \stdClass();
-        $view2 = new \stdClass();
+        $view1 = new ChoiceListView();
+        $view2 = new ChoiceListView();
 
         $this->decoratedFactory->expects($this->at(0))
             ->method('createView')

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/PropertyAccessDecoratorTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Form\Tests\ChoiceList\Factory;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator;
+use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
 /**
@@ -45,10 +47,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($choices, $callback) {
-                return array_map($callback, $choices);
+                return new ArrayChoiceList(array_map($callback, $choices));
             });
 
-        $this->assertSame(['value'], $this->factory->createListFromChoices($choices, 'property'));
+        $this->assertSame(['value' => 'value'], $this->factory->createListFromChoices($choices, 'property')->getChoices());
     }
 
     public function testCreateFromChoicesPropertyPathInstance()
@@ -59,10 +61,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($choices, $callback) {
-                return array_map($callback, $choices);
+                return new ArrayChoiceList(array_map($callback, $choices));
             });
 
-        $this->assertSame(['value'], $this->factory->createListFromChoices($choices, new PropertyPath('property')));
+        $this->assertSame(['value' => 'value'], $this->factory->createListFromChoices($choices, new PropertyPath('property'))->getChoices());
     }
 
     /**
@@ -88,10 +90,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($loader, $callback) {
-                return $callback((object) ['property' => 'value']);
+                return new ArrayChoiceList((array) $callback((object) ['property' => 'value']));
             });
 
-        $this->assertSame('value', $this->factory->createListFromLoader($loader, 'property'));
+        $this->assertSame(['value' => 'value'], $this->factory->createListFromLoader($loader, 'property')->getChoices());
     }
 
     /**
@@ -118,10 +120,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createListFromChoices')
             ->with($choices, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($choices, $callback) {
-                return array_map($callback, $choices);
+                return new ArrayChoiceList(array_map($callback, $choices));
             });
 
-        $this->assertSame([null], $this->factory->createListFromChoices($choices, 'property'));
+        $this->assertSame([null], $this->factory->createListFromChoices($choices, 'property')->getChoices());
     }
 
     // https://github.com/symfony/symfony/issues/5494
@@ -133,10 +135,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($loader, $callback) {
-                return $callback(null);
+                return new ArrayChoiceList((array) $callback(null));
             });
 
-        $this->assertNull($this->factory->createListFromLoader($loader, 'property'));
+        $this->assertSame([], $this->factory->createListFromLoader($loader, 'property')->getChoices());
     }
 
     public function testCreateFromLoaderPropertyPathInstance()
@@ -147,10 +149,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createListFromLoader')
             ->with($loader, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($loader, $callback) {
-                return $callback((object) ['property' => 'value']);
+                return new ArrayChoiceList((array) $callback((object) ['property' => 'value']));
             });
 
-        $this->assertSame('value', $this->factory->createListFromLoader($loader, new PropertyPath('property')));
+        $this->assertSame(['value' => 'value'], $this->factory->createListFromLoader($loader, new PropertyPath('property'))->getChoices());
     }
 
     public function testCreateViewPreferredChoicesAsPropertyPath()
@@ -161,13 +163,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred) {
-                return $preferred((object) ['property' => true]);
+                return new ChoiceListView((array) $preferred((object) ['property' => true]));
             });
 
-        $this->assertTrue($this->factory->createView(
-            $list,
-            'property'
-        ));
+        $this->assertSame([true], $this->factory->createView($list, 'property')->choices);
     }
 
     /**
@@ -196,13 +195,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred) {
-                return $preferred((object) ['property' => true]);
+                return new ChoiceListView((array) $preferred((object) ['property' => true]));
             });
 
-        $this->assertTrue($this->factory->createView(
-            $list,
-            new PropertyPath('property')
-        ));
+        $this->assertSame([true], $this->factory->createView($list, 'property')->choices);
     }
 
     // https://github.com/symfony/symfony/issues/5494
@@ -214,13 +210,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred) {
-                return $preferred((object) ['category' => null]);
+                return new ChoiceListView((array) $preferred((object) ['category' => null]));
             });
 
-        $this->assertFalse($this->factory->createView(
-            $list,
-            'category.preferred'
-        ));
+        $this->assertSame([false], $this->factory->createView($list, 'category.preferred')->choices);
     }
 
     public function testCreateViewLabelsAsPropertyPath()
@@ -231,14 +224,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label) {
-                return $label((object) ['property' => 'label']);
+                return new ChoiceListView((array) $label((object) ['property' => 'label']));
             });
 
-        $this->assertSame('label', $this->factory->createView(
-            $list,
-            null, // preferred choices
-            'property'
-        ));
+        $this->assertSame(['label'], $this->factory->createView($list, null, 'property')->choices);
     }
 
     /**
@@ -268,14 +257,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label) {
-                return $label((object) ['property' => 'label']);
+                return new ChoiceListView((array) $label((object) ['property' => 'label']));
             });
 
-        $this->assertSame('label', $this->factory->createView(
-            $list,
-            null, // preferred choices
-            new PropertyPath('property')
-        ));
+        $this->assertSame(['label'], $this->factory->createView($list, null, new PropertyPath('property'))->choices);
     }
 
     public function testCreateViewIndicesAsPropertyPath()
@@ -286,15 +271,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label, $index) {
-                return $index((object) ['property' => 'index']);
+                return new ChoiceListView((array) $index((object) ['property' => 'index']));
             });
 
-        $this->assertSame('index', $this->factory->createView(
-            $list,
-            null, // preferred choices
-            null, // label
-            'property'
-        ));
+        $this->assertSame(['index'], $this->factory->createView($list, null, null, 'property')->choices);
     }
 
     /**
@@ -325,15 +305,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label, $index) {
-                return $index((object) ['property' => 'index']);
+                return new ChoiceListView((array) $index((object) ['property' => 'index']));
             });
 
-        $this->assertSame('index', $this->factory->createView(
-            $list,
-            null, // preferred choices
-            null, // label
-            new PropertyPath('property')
-        ));
+        $this->assertSame(['index'], $this->factory->createView($list, null, null, new PropertyPath('property'))->choices);
     }
 
     public function testCreateViewGroupsAsPropertyPath()
@@ -344,16 +319,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
-                return $groupBy((object) ['property' => 'group']);
+                return new ChoiceListView((array) $groupBy((object) ['property' => 'group']));
             });
 
-        $this->assertSame('group', $this->factory->createView(
-            $list,
-            null, // preferred choices
-            null, // label
-            null, // index
-            'property'
-        ));
+        $this->assertSame(['group'], $this->factory->createView($list, null, null, null, 'property')->choices);
     }
 
     /**
@@ -385,16 +354,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
-                return $groupBy((object) ['property' => 'group']);
+                return new ChoiceListView((array) $groupBy((object) ['property' => 'group']));
             });
 
-        $this->assertSame('group', $this->factory->createView(
-            $list,
-            null, // preferred choices
-            null, // label
-            null, // index
-            new PropertyPath('property')
-        ));
+        $this->assertSame(['group'], $this->factory->createView($list, null, null, null, new PropertyPath('property'))->choices);
     }
 
     // https://github.com/symfony/symfony/issues/5494
@@ -406,16 +369,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, null, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy) {
-                return $groupBy((object) ['group' => null]);
+                return new ChoiceListView((array) $groupBy((object) ['group' => null]));
             });
 
-        $this->assertNull($this->factory->createView(
-            $list,
-            null, // preferred choices
-            null, // label
-            null, // index
-            'group.name'
-        ));
+        $this->assertSame([], $this->factory->createView($list, null, null, null, 'group.name')->choices);
     }
 
     public function testCreateViewAttrAsPropertyPath()
@@ -426,17 +383,10 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, null, null, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
-                return $attr((object) ['property' => 'attr']);
+                return new ChoiceListView((array) $attr((object) ['property' => 'attr']));
             });
 
-        $this->assertSame('attr', $this->factory->createView(
-            $list,
-            null, // preferred choices
-            null, // label
-            null, // index
-            null, // groups
-            'property'
-        ));
+        $this->assertSame(['attr'], $this->factory->createView($list, null, null, null, null, 'property')->choices);
     }
 
     /**
@@ -469,16 +419,9 @@ class PropertyAccessDecoratorTest extends TestCase
             ->method('createView')
             ->with($list, null, null, null, null, $this->isInstanceOf('\Closure'))
             ->willReturnCallback(function ($list, $preferred, $label, $index, $groupBy, $attr) {
-                return $attr((object) ['property' => 'attr']);
+                return new ChoiceListView((array) $attr((object) ['property' => 'attr']));
             });
 
-        $this->assertSame('attr', $this->factory->createView(
-            $list,
-            null, // preferred choices
-            null, // label
-            null, // index
-            null, // groups
-            new PropertyPath('property')
-        ));
+        $this->assertSame(['attr'], $this->factory->createView($list, null, null, null, null, new PropertyPath('property'))->choices);
     }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
@@ -56,10 +56,10 @@ class LazyChoiceListTest extends TestCase
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getChoices')
-            ->willReturn('RESULT');
+            ->willReturn(['RESULT']);
 
-        $this->assertSame('RESULT', $this->list->getChoices());
-        $this->assertSame('RESULT', $this->list->getChoices());
+        $this->assertSame(['RESULT'], $this->list->getChoices());
+        $this->assertSame(['RESULT'], $this->list->getChoices());
     }
 
     /**
@@ -96,10 +96,10 @@ class LazyChoiceListTest extends TestCase
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getValues')
-            ->willReturn('RESULT');
+            ->willReturn(['RESULT']);
 
-        $this->assertSame('RESULT', $this->list->getValues());
-        $this->assertSame('RESULT', $this->list->getValues());
+        $this->assertSame(['RESULT'], $this->list->getValues());
+        $this->assertSame(['RESULT'], $this->list->getValues());
     }
 
     public function testGetStructuredValuesLoadsLoadedListOnFirstCall()
@@ -112,10 +112,10 @@ class LazyChoiceListTest extends TestCase
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getStructuredValues')
-            ->willReturn('RESULT');
+            ->willReturn(['RESULT']);
 
-        $this->assertSame('RESULT', $this->list->getStructuredValues());
-        $this->assertSame('RESULT', $this->list->getStructuredValues());
+        $this->assertSame(['RESULT'], $this->list->getStructuredValues());
+        $this->assertSame(['RESULT'], $this->list->getStructuredValues());
     }
 
     public function testGetOriginalKeysLoadsLoadedListOnFirstCall()
@@ -128,10 +128,10 @@ class LazyChoiceListTest extends TestCase
         // The same list is returned by the loader
         $this->loadedList->expects($this->exactly(2))
             ->method('getOriginalKeys')
-            ->willReturn('RESULT');
+            ->willReturn(['RESULT']);
 
-        $this->assertSame('RESULT', $this->list->getOriginalKeys());
-        $this->assertSame('RESULT', $this->list->getOriginalKeys());
+        $this->assertSame(['RESULT'], $this->list->getOriginalKeys());
+        $this->assertSame(['RESULT'], $this->list->getOriginalKeys());
     }
 
     public function testGetChoicesForValuesForwardsCallIfListNotLoaded()
@@ -139,10 +139,10 @@ class LazyChoiceListTest extends TestCase
         $this->loader->expects($this->exactly(2))
             ->method('loadChoicesForValues')
             ->with(['a', 'b'])
-            ->willReturn('RESULT');
+            ->willReturn(['RESULT']);
 
-        $this->assertSame('RESULT', $this->list->getChoicesForValues(['a', 'b']));
-        $this->assertSame('RESULT', $this->list->getChoicesForValues(['a', 'b']));
+        $this->assertSame(['RESULT'], $this->list->getChoicesForValues(['a', 'b']));
+        $this->assertSame(['RESULT'], $this->list->getChoicesForValues(['a', 'b']));
     }
 
     public function testGetChoicesForValuesUsesLoadedList()
@@ -160,13 +160,13 @@ class LazyChoiceListTest extends TestCase
         $this->loadedList->expects($this->exactly(2))
             ->method('getChoicesForValues')
             ->with(['a', 'b'])
-            ->willReturn('RESULT');
+            ->willReturn(['RESULT']);
 
         // load choice list
         $this->list->getChoices();
 
-        $this->assertSame('RESULT', $this->list->getChoicesForValues(['a', 'b']));
-        $this->assertSame('RESULT', $this->list->getChoicesForValues(['a', 'b']));
+        $this->assertSame(['RESULT'], $this->list->getChoicesForValues(['a', 'b']));
+        $this->assertSame(['RESULT'], $this->list->getChoicesForValues(['a', 'b']));
     }
 
     /**
@@ -198,12 +198,12 @@ class LazyChoiceListTest extends TestCase
         $this->loadedList->expects($this->exactly(2))
             ->method('getValuesForChoices')
             ->with(['a', 'b'])
-            ->willReturn('RESULT');
+            ->willReturn(['RESULT']);
 
         // load choice list
         $this->list->getChoices();
 
-        $this->assertSame('RESULT', $this->list->getValuesForChoices(['a', 'b']));
-        $this->assertSame('RESULT', $this->list->getValuesForChoices(['a', 'b']));
+        $this->assertSame(['RESULT'], $this->list->getValuesForChoices(['a', 'b']));
+        $this->assertSame(['RESULT'], $this->list->getValuesForChoices(['a', 'b']));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -142,7 +142,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('getToken')
             ->with('FORM_NAME')
-            ->willReturn('token');
+            ->willReturn(new CsrfToken('TOKEN_ID', 'token'));
 
         $view = $this->factory
             ->createNamed('FORM_NAME', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
@@ -160,7 +160,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->tokenManager->expects($this->once())
             ->method('getToken')
             ->with('Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->willReturn('token');
+            ->willReturn(new CsrfToken('TOKEN_ID', 'token'));
 
         $view = $this->factory
             ->createNamed('', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\DataCollector\FormDataExtractor;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormView;
@@ -57,7 +58,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->willReturn(new \stdClass());
+            ->willReturn(new HiddenType());
 
         $form = $this->createBuilder('name')
             ->setType($type)
@@ -66,7 +67,7 @@ class FormDataExtractorTest extends TestCase
         $this->assertSame([
             'id' => 'name',
             'name' => 'name',
-            'type_class' => 'stdClass',
+            'type_class' => HiddenType::class,
             'synchronized' => true,
             'passed_options' => [],
             'resolved_options' => [],
@@ -78,7 +79,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->willReturn(new \stdClass());
+            ->willReturn(new HiddenType());
 
         $options = [
             'b' => 'foo',
@@ -96,7 +97,7 @@ class FormDataExtractorTest extends TestCase
         $this->assertSame([
             'id' => 'name',
             'name' => 'name',
-            'type_class' => 'stdClass',
+            'type_class' => HiddenType::class,
             'synchronized' => true,
             'passed_options' => [
                 'a' => 'bar',
@@ -112,7 +113,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->willReturn(new \stdClass());
+            ->willReturn(new HiddenType());
 
         $options = [
             'b' => 'foo',
@@ -127,7 +128,7 @@ class FormDataExtractorTest extends TestCase
         $this->assertSame([
             'id' => 'name',
             'name' => 'name',
-            'type_class' => 'stdClass',
+            'type_class' => HiddenType::class,
             'synchronized' => true,
             'passed_options' => [],
             'resolved_options' => [
@@ -143,7 +144,7 @@ class FormDataExtractorTest extends TestCase
         $type = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')->getMock();
         $type->expects($this->any())
             ->method('getInnerType')
-            ->willReturn(new \stdClass());
+            ->willReturn(new HiddenType());
 
         $grandParent = $this->createBuilder('grandParent')
             ->setCompound(true)
@@ -163,7 +164,7 @@ class FormDataExtractorTest extends TestCase
         $this->assertSame([
             'id' => 'grandParent_parent_name',
             'name' => 'name',
-            'type_class' => 'stdClass',
+            'type_class' => HiddenType::class,
             'synchronized' => true,
             'passed_options' => [],
             'resolved_options' => [],

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Tests;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeGuesserChain;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
@@ -193,11 +194,13 @@ class FormFactoryTest extends TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
+        $form = $this->createMock(FormInterface::class);
+
         $this->builder->expects($this->once())
             ->method('getForm')
-            ->willReturn('FORM');
+            ->willReturn($form);
 
-        $this->assertSame('FORM', $this->factory->create('TYPE', null, $options));
+        $this->assertSame($form, $this->factory->create('TYPE', null, $options));
     }
 
     public function testCreateNamed()
@@ -224,11 +227,13 @@ class FormFactoryTest extends TestCase
             ->method('buildForm')
             ->with($this->builder, $resolvedOptions);
 
+        $form = $this->createMock(FormInterface::class);
+
         $this->builder->expects($this->once())
             ->method('getForm')
-            ->willReturn('FORM');
+            ->willReturn($form);
 
-        $this->assertSame('FORM', $this->factory->createNamed('name', 'type', null, $options));
+        $this->assertSame($form, $this->factory->createNamed('name', 'type', null, $options));
     }
 
     public function testCreateBuilderForPropertyWithoutTypeGuesser()
@@ -242,11 +247,11 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [])
-            ->willReturn('builderInstance');
+            ->willReturn($this->builder);
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
 
-        $this->assertEquals('builderInstance', $this->builder);
+        $this->assertSame($this->builder, $this->builder);
     }
 
     public function testCreateBuilderForPropertyCreatesFormWithHighestConfidence()
@@ -274,11 +279,11 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', null, ['attr' => ['maxlength' => 7]])
-            ->willReturn('builderInstance');
+            ->willReturn($this->builder);
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
 
-        $this->assertEquals('builderInstance', $this->builder);
+        $this->assertSame($this->builder, $this->builder);
     }
 
     public function testCreateBuilderCreatesTextFormIfNoGuess()
@@ -293,11 +298,11 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->willReturn('builderInstance');
+            ->willReturn($this->builder);
 
         $this->builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
 
-        $this->assertEquals('builderInstance', $this->builder);
+        $this->assertSame($this->builder, $this->builder);
     }
 
     public function testOptionsCanBeOverridden()
@@ -316,7 +321,7 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['attr' => ['class' => 'foo', 'maxlength' => 11]])
-            ->willReturn('builderInstance');
+            ->willReturn($this->builder);
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
@@ -325,7 +330,7 @@ class FormFactoryTest extends TestCase
             ['attr' => ['maxlength' => 11]]
         );
 
-        $this->assertEquals('builderInstance', $this->builder);
+        $this->assertSame($this->builder, $this->builder);
     }
 
     public function testCreateBuilderUsesMaxLengthIfFound()
@@ -351,14 +356,14 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['attr' => ['maxlength' => 20]])
-            ->willReturn('builderInstance');
+            ->willReturn($this->builder);
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
             'firstName'
         );
 
-        $this->assertEquals('builderInstance', $this->builder);
+        $this->assertSame($this->builder, $this->builder);
     }
 
     public function testCreateBuilderUsesMaxLengthAndPattern()
@@ -384,7 +389,7 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['attr' => ['maxlength' => 20, 'pattern' => '.{5,}', 'class' => 'tinymce']])
-            ->willReturn('builderInstance');
+            ->willReturn($this->builder);
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
@@ -393,7 +398,7 @@ class FormFactoryTest extends TestCase
             ['attr' => ['class' => 'tinymce']]
         );
 
-        $this->assertEquals('builderInstance', $this->builder);
+        $this->assertSame($this->builder, $this->builder);
     }
 
     public function testCreateBuilderUsesRequiredSettingWithHighestConfidence()
@@ -419,14 +424,14 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['required' => false])
-            ->willReturn('builderInstance');
+            ->willReturn($this->builder);
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
             'firstName'
         );
 
-        $this->assertEquals('builderInstance', $this->builder);
+        $this->assertSame($this->builder, $this->builder);
     }
 
     public function testCreateBuilderUsesPatternIfFound()
@@ -452,14 +457,14 @@ class FormFactoryTest extends TestCase
         $factory->expects($this->once())
             ->method('createNamedBuilder')
             ->with('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, ['attr' => ['pattern' => '[a-zA-Z]']])
-            ->willReturn('builderInstance');
+            ->willReturn($this->builder);
 
         $this->builder = $factory->createBuilderForProperty(
             'Application\Author',
             'firstName'
         );
 
-        $this->assertEquals('builderInstance', $this->builder);
+        $this->assertSame($this->builder, $this->builder);
     }
 
     private function getMockFactory(array $methods = [])

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -327,12 +327,12 @@ class BinaryFileResponse extends Response
         if (null !== $content) {
             throw new \LogicException('The content cannot be set on a BinaryFileResponse instance.');
         }
+
+        return $this;
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @return false
      */
     public function getContent()
     {

--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -75,8 +75,8 @@ class FileBag extends ParameterBag
             return $file;
         }
 
-        $file = $this->fixPhpFilesArray($file);
         if (\is_array($file)) {
+            $file = $this->fixPhpFilesArray($file);
             $keys = array_keys($file);
             sort($keys);
 
@@ -109,14 +109,12 @@ class FileBag extends ParameterBag
      * It's safe to pass an already converted array, in which case this method
      * just returns the original array unmodified.
      *
+     * @param array $data
+     *
      * @return array
      */
     protected function fixPhpFilesArray($data)
     {
-        if (!\is_array($data)) {
-            return $data;
-        }
-
         $keys = array_keys($data);
         sort($keys);
 

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -121,7 +121,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
         }
 
         if ($first) {
-            return \count($headers[$key]) ? $headers[$key][0] : $default;
+            return \count($headers[$key]) ? (string) $headers[$key][0] : $default;
         }
 
         return $headers[$key];

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -528,6 +528,10 @@ class Request
         try {
             $content = $this->getContent();
         } catch (\LogicException $e) {
+            if (\PHP_VERSION_ID >= 70400) {
+                throw $e;
+            }
+
             return trigger_error($e, E_USER_ERROR);
         }
 
@@ -912,7 +916,7 @@ class Request
      * ("Client-Ip" for instance), configure it via the $trustedHeaderSet
      * argument of the Request::setTrustedProxies() method instead.
      *
-     * @return string The client IP address
+     * @return string|null The client IP address
      *
      * @see getClientIps()
      * @see https://wikipedia.org/wiki/X-Forwarded-For

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -407,7 +407,7 @@ class Response
     /**
      * Gets the current response content.
      *
-     * @return string Content
+     * @return string|false
      */
     public function getContent()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
@@ -97,7 +97,7 @@ class NamespacedAttributeBag extends AttributeBag
      * @param string $name         Key name
      * @param bool   $writeContext Write context, default false
      *
-     * @return array
+     * @return array|null
      */
     protected function &resolveAttributePath($name, $writeContext = false)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -40,9 +40,6 @@ class MemcachedSessionHandler extends AbstractSessionHandler
      *  * prefix: The prefix to use for the memcached keys in order to avoid collision
      *  * expiretime: The time to live in seconds.
      *
-     * @param \Memcached $memcached A \Memcached instance
-     * @param array      $options   An associative array of Memcached options
-     *
      * @throws \InvalidArgumentException When unsupported options are passed
      */
     public function __construct(\Memcached $memcached, array $options = [])
@@ -58,7 +55,7 @@ class MemcachedSessionHandler extends AbstractSessionHandler
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function close()
     {
@@ -74,7 +71,7 @@ class MemcachedSessionHandler extends AbstractSessionHandler
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function updateTimestamp($sessionId, $data)
     {
@@ -102,7 +99,7 @@ class MemcachedSessionHandler extends AbstractSessionHandler
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function gc($maxlifetime)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NullSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NullSessionHandler.php
@@ -67,7 +67,7 @@ class NullSessionHandler extends AbstractSessionHandler
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function gc($maxlifetime)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -286,7 +286,7 @@ class PdoSessionHandler extends AbstractSessionHandler
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function gc($maxlifetime)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/StrictSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/StrictSessionHandler.php
@@ -94,7 +94,7 @@ class StrictSessionHandler extends AbstractSessionHandler
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function gc($maxlifetime)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
@@ -31,7 +31,7 @@ abstract class AbstractProxy
     /**
      * Gets the session.save_handler name.
      *
-     * @return string
+     * @return string|null
      */
     public function getSaveHandlerName()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -76,7 +76,7 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function gc($maxlifetime)
     {

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -136,8 +136,6 @@ class StreamedResponse extends Response
 
     /**
      * {@inheritdoc}
-     *
-     * @return false
      */
     public function getContent()
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -107,7 +107,7 @@ class BinaryFileResponseTest extends ResponseTestCase
 
         $this->assertEquals(206, $response->getStatusCode());
         $this->assertEquals($responseRange, $response->headers->get('Content-Range'));
-        $this->assertSame($length, $response->headers->get('Content-Length'));
+        $this->assertSame((string) $length, $response->headers->get('Content-Length'));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -144,7 +144,8 @@ class SessionHandlerProxyTest extends TestCase
     {
         $mock = $this->getMockBuilder(['SessionHandlerInterface', 'SessionUpdateTimestampHandlerInterface'])->getMock();
         $mock->expects($this->once())
-            ->method('updateTimestamp');
+            ->method('updateTimestamp')
+            ->willReturn(false);
 
         $proxy = new SessionHandlerProxy($mock);
         $proxy->updateTimestamp('id', 'data');

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -58,7 +58,7 @@ class ArgumentMetadata
      *
      * The type is the PHP class in 5.5+ and additionally the basic type in PHP 7.0+.
      *
-     * @return string
+     * @return string|null
      */
     public function getType()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -119,7 +119,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
     /**
      * Gets the token.
      *
-     * @return string The token
+     * @return string|null The token
      */
     public function getToken()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
@@ -55,7 +55,7 @@ class ExceptionDataCollector extends DataCollector
     /**
      * Gets the exception.
      *
-     * @return \Exception The exception
+     * @return \Exception|FlattenException
      */
     public function getException()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -72,11 +72,6 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         }
     }
 
-    /**
-     * Gets the logs.
-     *
-     * @return array An array of logs
-     */
     public function getLogs()
     {
         return isset($this->data['logs']) ? $this->data['logs'] : [];

--- a/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
@@ -132,7 +132,7 @@ class TimeDataCollector extends DataCollector implements LateDataCollectorInterf
     /**
      * Gets the request time.
      *
-     * @return int The time
+     * @return float
      */
     public function getStartTime()
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -110,7 +110,7 @@ abstract class AbstractSurrogate implements SurrogateInterface
             }
         }
 
-        return null;
+        return '';
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -95,6 +95,6 @@ class Ssi extends AbstractSurrogate
         // remove SSI/1.0 from the Surrogate-Control header
         $this->removeFromControl($response);
 
-        return null;
+        return $response;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -206,7 +206,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     /**
      * Gets a HTTP kernel from the container.
      *
-     * @return HttpKernel
+     * @return HttpKernelInterface
      */
     protected function getHttpKernel()
     {
@@ -425,7 +425,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     public function getStartTime()
     {
-        return $this->debug ? $this->startTime : -INF;
+        return $this->debug && null !== $this->startTime ? $this->startTime : -INF;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -138,7 +138,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Gets the request start time (not available if debug is disabled).
      *
-     * @return int The request start timestamp
+     * @return float The request start timestamp
      */
     public function getStartTime();
 

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -102,7 +102,7 @@ class Profile
     /**
      * Returns the IP.
      *
-     * @return string The IP
+     * @return string|null The IP
      */
     public function getIp()
     {
@@ -122,7 +122,7 @@ class Profile
     /**
      * Returns the request method.
      *
-     * @return string The request method
+     * @return string|null The request method
      */
     public function getMethod()
     {
@@ -137,13 +137,16 @@ class Profile
     /**
      * Returns the URL.
      *
-     * @return string The URL
+     * @return string|null The URL
      */
     public function getUrl()
     {
         return $this->url;
     }
 
+    /**
+     * @param string $url
+     */
     public function setUrl($url)
     {
         $this->url = $url;
@@ -180,7 +183,7 @@ class Profile
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getStatusCode()
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -65,12 +65,12 @@ class Profiler
     /**
      * Loads the Profile for the given Response.
      *
-     * @return Profile|false A Profile instance
+     * @return Profile|null A Profile instance
      */
     public function loadProfileFromResponse(Response $response)
     {
         if (!$token = $response->headers->get('X-Debug-Token')) {
-            return false;
+            return null;
         }
 
         return $this->loadProfile($token);
@@ -81,7 +81,7 @@ class Profiler
      *
      * @param string $token A token
      *
-     * @return Profile A Profile instance
+     * @return Profile|null A Profile instance
      */
     public function loadProfile($token)
     {

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -49,6 +49,9 @@ class BundleTest extends TestCase
         $this->assertNull($bundle2->registerCommands($app));
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetContainerExtensionWithInvalidClass()
     {
         $this->expectException('LogicException');

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -23,7 +23,7 @@ class LoggerDataCollectorTest extends TestCase
             ->getMockBuilder('Symfony\Component\HttpKernel\Log\DebugLoggerInterface')
             ->setMethods(['countErrors', 'getLogs', 'clear'])
             ->getMock();
-        $logger->expects($this->once())->method('countErrors')->willReturn('foo');
+        $logger->expects($this->once())->method('countErrors')->willReturn(123);
         $logger->expects($this->exactly(2))->method('getLogs')->willReturn([]);
 
         $c = new LoggerDataCollector($logger, __DIR__.'/');

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
@@ -44,7 +44,7 @@ class TimeDataCollectorTest extends TestCase
         $this->assertEquals(0, $c->getStartTime());
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
-        $kernel->expects($this->once())->method('getStartTime')->willReturn(123456);
+        $kernel->expects($this->once())->method('getStartTime')->willReturn(123456.0);
 
         $c = new TimeDataCollector($kernel);
         $request = new Request();

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Config\EnvParametersResource;
 use Symfony\Component\HttpKernel\DependencyInjection\ResettableServicePass;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForOverrideName;

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -721,8 +721,8 @@ EOF;
     {
         $this->expectException('LogicException');
         $this->expectExceptionMessage('Trying to register two bundles with the same name "DuplicateName"');
-        $fooBundle = $this->getBundle(null, null, 'FooBundle', 'DuplicateName');
-        $barBundle = $this->getBundle(null, null, 'BarBundle', 'DuplicateName');
+        $fooBundle = $this->getBundle(__DIR__.'/Fixtures/FooBundle', null, 'FooBundle', 'DuplicateName');
+        $barBundle = $this->getBundle(__DIR__.'/Fixtures/BarBundle', null, 'BarBundle', 'DuplicateName');
 
         $kernel = $this->getKernel([], [$fooBundle, $barBundle]);
         $kernel->boot();

--- a/src/Symfony/Component/HttpKernel/Tests/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Logger.php
@@ -22,6 +22,9 @@ class Logger implements LoggerInterface
         $this->clear();
     }
 
+    /**
+     * @return array
+     */
     public function getLogs($level = false)
     {
         return false === $level ? $this->logs : $this->logs[$level];

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -415,7 +415,7 @@ class IntlDateFormatter
      *                         contain -1 otherwise it will contain the position at which parsing
      *                         ended. If $parse_pos > strlen($value), the parse fails immediately.
      *
-     * @return int Parsed value as a timestamp
+     * @return int|false Parsed value as a timestamp
      *
      * @see https://php.net/intldateformatter.parse
      *

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -71,7 +71,7 @@ class Process implements \IteratorAggregate
     private $status = self::STATUS_READY;
     private $incrementalOutputOffset = 0;
     private $incrementalErrorOutputOffset = 0;
-    private $tty;
+    private $tty = false;
     private $pty;
     private $inheritEnv = false;
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -864,7 +864,7 @@ class Process implements \IteratorAggregate
      * @param int|float $timeout The timeout in seconds
      * @param int       $signal  A POSIX signal to send in case the process has not stop at timeout, default is SIGKILL (9)
      *
-     * @return int The exit-code of the process
+     * @return int|null The exit-code of the process or null if it's not running
      */
     public function stop($timeout = 10, $signal = null)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -193,7 +193,7 @@ class PropertyPathBuilder
     /**
      * Returns the current property path.
      *
-     * @return PropertyPathInterface The constructed property path
+     * @return PropertyPathInterface|null The constructed property path
      */
     public function getPropertyPath()
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -40,7 +40,7 @@ interface PropertyPathInterface extends \Traversable
      *
      * If this property path only contains one item, null is returned.
      *
-     * @return PropertyPath|null The parent path or null
+     * @return self|null The parent path or null
      */
     public function getParent();
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
@@ -30,6 +30,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     {
         $this->assertIsString($class);
         $this->assertIsString($property);
+
+        return null;
     }
 
     /**
@@ -39,6 +41,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     {
         $this->assertIsString($class);
         $this->assertIsString($property);
+
+        return null;
     }
 
     /**
@@ -48,6 +52,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     {
         $this->assertIsString($class);
         $this->assertIsString($property);
+
+        return null;
     }
 
     /**
@@ -57,6 +63,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     {
         $this->assertIsString($class);
         $this->assertIsString($property);
+
+        return null;
     }
 
     /**
@@ -66,6 +74,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     {
         $this->assertIsString($class);
         $this->assertIsString($property);
+
+        return null;
     }
 
     /**
@@ -74,6 +84,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     public function getProperties($class, array $context = [])
     {
         $this->assertIsString($class);
+
+        return null;
     }
 
     private function assertIsString($string)

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -263,9 +263,9 @@ class Router implements RouterInterface, RequestMatcherInterface
     }
 
     /**
-     * Gets the UrlMatcher instance associated with this Router.
+     * Gets the UrlMatcher or RequestMatcher instance associated with this Router.
      *
-     * @return UrlMatcherInterface A UrlMatcherInterface instance
+     * @return UrlMatcherInterface|RequestMatcherInterface
      */
     public function getMatcher()
     {

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
 class DaoAuthenticationProviderTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testRetrieveUserWhenProviderDoesNotReturnAnUserInterface()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationServiceException');

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -62,6 +62,9 @@ class UserAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->getSupportedToken());
     }
 
+    /**
+     * @group legacy
+     */
     public function testAuthenticateWhenProviderDoesNotReturnAnUserInterface()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationServiceException');

--- a/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Security\Guard\Tests\Provider;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\Provider\GuardAuthenticationProvider;
+use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
 
@@ -68,7 +68,7 @@ class GuardAuthenticationProviderTest extends TestCase
             ->with($enteredCredentials, $mockedUser)
             // authentication works!
             ->willReturn(true);
-        $authedToken = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $authedToken = $this->getMockBuilder(GuardTokenInterface::class)->getMock();
         $authenticatorB->expects($this->once())
             ->method('createAuthenticatedToken')
             ->with($mockedUser, $providerKey)
@@ -130,7 +130,7 @@ class GuardAuthenticationProviderTest extends TestCase
             ->with($enteredCredentials, $mockedUser)
             // authentication works!
             ->willReturn(true);
-        $authedToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $authedToken = $this->getMockBuilder(GuardTokenInterface::class)->getMock();
         $authenticatorB->expects($this->once())
             ->method('createAuthenticatedToken')
             ->with($mockedUser, $providerKey)

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
@@ -31,7 +31,7 @@ interface AuthenticationSuccessHandlerInterface
      * is called by authentication listeners inheriting from
      * AbstractAuthenticationListener.
      *
-     * @return Response never null
+     * @return Response
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token);
 }

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeServicesInterface.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeServicesInterface.php
@@ -46,7 +46,7 @@ interface RememberMeServicesInterface
      * make sure to throw an AuthenticationException as this will consequentially
      * result in a call to loginFail() and therefore an invalidation of the cookie.
      *
-     * @return TokenInterface
+     * @return TokenInterface|null
      */
     public function autoLogin(Request $request);
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Authentication;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Security;
@@ -62,7 +63,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
     public function testRedirect()
     {
-        $response = new Response();
+        $response = new RedirectResponse('/login');
         $this->httpUtils->expects($this->once())
             ->method('createRedirectResponse')->with($this->request, '/login')
             ->willReturn($response);

--- a/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\EntryPoint;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Http\EntryPoint\FormAuthenticationEntryPoint;
@@ -21,7 +22,7 @@ class FormAuthenticationEntryPointTest extends TestCase
     public function testStart()
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
-        $response = new Response();
+        $response = new RedirectResponse('/the/login/path');
 
         $httpKernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $httpUtils = $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')->getMock();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -72,6 +72,9 @@ class ExceptionListenerTest extends TestCase
         ];
     }
 
+    /**
+     * @group legacy
+     */
     public function testExceptionWhenEntryPointReturnsBadValue()
     {
         $event = $this->createEvent(new AuthenticationException());

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -122,6 +122,9 @@ class LogoutListenerTest extends TestCase
         $listener->handle($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testSuccessHandlerReturnsNonResponse()
     {
         $this->expectException('RuntimeException');

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Tests\Http\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -40,6 +41,10 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
             ->method('checkRequestPath')
             ->willReturn(true)
         ;
+        $httpUtils
+            ->method('createRedirectResponse')
+            ->willReturn(new RedirectResponse('/hello'))
+        ;
 
         $failureHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface')->getMock();
         $failureHandler
@@ -52,7 +57,7 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
         $authenticationManager
             ->expects($ok ? $this->once() : $this->never())
             ->method('authenticate')
-            ->willReturn(new Response())
+            ->willReturnArgument(0)
         ;
 
         $listener = new UsernamePasswordFormAuthenticationListener(
@@ -61,7 +66,7 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
             $this->getMockBuilder('Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface')->getMock(),
             $httpUtils,
             'TheProviderKey',
-            $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface')->getMock(),
+            new DefaultAuthenticationSuccessHandler($httpUtils),
             $failureHandler,
             ['require_previous_session' => false]
         );

--- a/src/Symfony/Component/Security/Http/Tests/Logout/DefaultLogoutSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/DefaultLogoutSuccessHandlerTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Logout;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler;
 
 class DefaultLogoutSuccessHandlerTest extends TestCase
@@ -20,7 +20,7 @@ class DefaultLogoutSuccessHandlerTest extends TestCase
     public function testLogout()
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
-        $response = new Response();
+        $response = new RedirectResponse('/dashboard');
 
         $httpUtils = $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')->getMock();
         $httpUtils->expects($this->once())

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -39,6 +39,9 @@ class AbstractRememberMeServicesTest extends TestCase
         $this->assertNull($service->autoLogin(new Request()));
     }
 
+    /**
+     * @group legacy
+     */
     public function testAutoLoginThrowsExceptionWhenImplementationDoesNotReturnUserInterface()
     {
         $this->expectException('RuntimeException');

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -36,7 +36,7 @@ interface SerializerInterface
      * @param string $type
      * @param string $format
      *
-     * @return object
+     * @return object|array
      */
     public function deserialize($data, $type, $format, array $context = []);
 }

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -301,7 +301,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      * @param mixed  $value   A variable to escape
      * @param string $context The context name
      *
-     * @return string The escaped value
+     * @return mixed The escaped value
      */
     public function escape($value, $context = 'html')
     {

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -61,7 +61,7 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
     }
 
     /**
-     * @return array
+     * @return array|Data
      */
     public function getMessages()
     {

--- a/src/Symfony/Component/Translation/Extractor/AbstractFileExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/AbstractFileExtractor.php
@@ -21,9 +21,9 @@ use Symfony\Component\Translation\Exception\InvalidArgumentException;
 abstract class AbstractFileExtractor
 {
     /**
-     * @param string|array $resource Files, a file or a directory
+     * @param string|iterable $resource Files, a file or a directory
      *
-     * @return array
+     * @return iterable
      */
     protected function extractFiles($resource)
     {
@@ -79,7 +79,7 @@ abstract class AbstractFileExtractor
     /**
      * @param string|array $resource Files, a file or a directory
      *
-     * @return array files to be extracted
+     * @return iterable files to be extracted
      */
     abstract protected function extractFromDirectory($resource);
 }

--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -103,7 +103,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
      *
      * @param mixed $token
      *
-     * @return string
+     * @return string|null
      */
     protected function normalizeToken($token)
     {
@@ -257,9 +257,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
     }
 
     /**
-     * @param string|array $directory
-     *
-     * @return array
+     * {@inheritdoc}
      */
     protected function extractFromDirectory($directory)
     {

--- a/src/Symfony/Component/Translation/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/YamlFileLoader.php
@@ -52,6 +52,10 @@ class YamlFileLoader extends FileLoader
             restore_error_handler();
         }
 
-        return $messages;
+        if (null !== $messages && !\is_array($messages)) {
+            throw new InvalidResourceException(sprintf('Unable to load file "%s".', $resource));
+        }
+
+        return $messages ?: [];
     }
 }

--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -283,7 +283,7 @@ interface ExecutionContextInterface
     /**
      * Returns the validation group that is currently being validated.
      *
-     * @return string The current validation group
+     * @return string|null The current validation group
      */
     public function getGroup();
 

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -35,7 +35,7 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
     protected $indentPad = '  ';
     protected $flags;
 
-    private $charset;
+    private $charset = '';
 
     /**
      * @param callable|resource|string|null $output  A line dumper callable, an opened stream or an output path, defaults to static::$defaultOutput

--- a/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
@@ -8,6 +8,9 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Workflow\Event\GuardEvent;
 use Symfony\Component\Workflow\EventListener\ExpressionLanguage;
@@ -41,7 +44,8 @@ class GuardListenerTest extends TestCase
         $this->authenticationChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
         $trustResolver = $this->getMockBuilder(AuthenticationTrustResolverInterface::class)->getMock();
         $this->validator = $this->getMockBuilder(ValidatorInterface::class)->getMock();
-        $this->listener = new GuardListener($this->configuration, $expressionLanguage, $tokenStorage, $this->authenticationChecker, $trustResolver, null, $this->validator);
+        $roleHierarchy = new RoleHierarchy([]);
+        $this->listener = new GuardListener($this->configuration, $expressionLanguage, $tokenStorage, $this->authenticationChecker, $trustResolver, $roleHierarchy, $this->validator);
     }
 
     protected function tearDown()
@@ -170,7 +174,7 @@ class GuardListenerTest extends TestCase
         $this->validator
             ->expects($this->once())
             ->method('validate')
-            ->willReturn($valid ? [] : ['a violation'])
+            ->willReturn(new ConstraintViolationList($valid ? [] : [new ConstraintViolation('a violation', null, [], '', null, '')]))
         ;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is the subset of #33236 that applies to branch 3.4.
This PR ensures return types are correctly declared, and adjust some implementations that return incorrect types.