### PR TITLE
Use the monotonic hrtime function

### DIFF
--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -85,7 +85,7 @@ class Section
     public function open($id)
     {
         if (null === $id || null === $session = $this->get($id)) {
-            $session = $this->children[] = new self(microtime(true) * 1000, $this->morePrecision);
+            $session = $this->children[] = new self(\hrtime(true) / 1e6, $this->morePrecision);
         }
 
         return $session;

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -85,7 +85,7 @@ class Section
     public function open($id)
     {
         if (null === $id || null === $session = $this->get($id)) {
-            $session = $this->children[] = new self(\hrtime(true) / 1e6, $this->morePrecision);
+            $session = $this->children[] = new self(hrtime(true) / 1e6, $this->morePrecision);
         }
 
         return $session;

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -217,7 +217,7 @@ class StopwatchEvent
      */
     protected function getNow()
     {
-        return $this->formatTime(\hrtime(true) / 1e6 - $this->origin);
+        return $this->formatTime(hrtime(true) / 1e6 - $this->origin);
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -217,7 +217,7 @@ class StopwatchEvent
      */
     protected function getNow()
     {
-        return $this->formatTime(microtime(true) * 1000 - $this->origin);
+        return $this->formatTime(\hrtime(true) / 1e6 - $this->origin);
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/service-contracts": "^1.0"
+        "symfony/service-contracts": "^1.0",
+        "symfony/polyfill-php73": "^1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Stopwatch\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The `microtime` function is not monotonic, which can lead to incorrect timing results. Instead, `hrtime` should be used. This function is new in PHP 7.3, but Symfony has polyfilled it.