### PR TITLE
[DependencyInjection] Fixed the `getServiceIds` implementation to always return aliases

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -405,7 +405,7 @@ class Container implements ResettableContainerInterface
         }
         $ids[] = 'service_container';
 
-        return array_map('strval', array_unique(array_merge($ids, array_keys($this->methodMap), array_keys($this->fileMap), array_keys($this->services))));
+        return array_map('strval', array_unique(array_merge($ids, array_keys($this->methodMap), array_keys($this->fileMap), array_keys($this->aliases), array_keys($this->services))));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -156,7 +156,7 @@ class ContainerTest extends TestCase
 
         $sc = new ProjectServiceContainer();
         $sc->set('foo', $obj = new \stdClass());
-        $this->assertEquals(['service_container', 'internal', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'internal_dependency', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by factory methods in the method map, followed by service ids defined by set()');
+        $this->assertEquals(['service_container', 'internal', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'internal_dependency', 'alias', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by factory methods in the method map, followed by service ids defined by set()');
     }
 
     /**
@@ -168,7 +168,7 @@ class ContainerTest extends TestCase
         $sc = new LegacyProjectServiceContainer();
         $sc->set('foo', $obj = new \stdClass());
 
-        $this->assertEquals(['internal', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'service_container', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods, followed by service ids defined by set()');
+        $this->assertEquals(['internal', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'service_container', 'alias', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods, followed by service ids defined by set()');
     }
 
     public function testSet()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1141,28 +1141,29 @@ class PhpDumperTest extends TestCase
         $this->assertSame('some value', $container->get('foo'));
     }
 
-	public function testAliasCanBeFoundInTheDumpedContainerWhenBothTheAliasAndTheServiceArePublic() {
-		$container = new ContainerBuilder();
+    public function testAliasCanBeFoundInTheDumpedContainerWhenBothTheAliasAndTheServiceArePublic()
+    {
+        $container = new ContainerBuilder();
 
-		$container->register('foo', stdClass::class)->setPublic(true);
-		$container->setAlias('bar', 'foo')->setPublic(true);
+        $container->register('foo', stdClass::class)->setPublic(true);
+        $container->setAlias('bar', 'foo')->setPublic(true);
 
-		$container->compile();
+        $container->compile();
 
-		// Bar is found in the compiled container
-		$service_ids = $container->getServiceIds();
-		$this->assertContains("bar", $service_ids);
+        // Bar is found in the compiled container
+        $service_ids = $container->getServiceIds();
+        $this->assertContains('bar', $service_ids);
 
-		$dumper = new PhpDumper($container);
-		$dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_AliasesCanBeFoundInTheDumpedContainer']);
-		eval('?>'.$dump);
+        $dumper = new PhpDumper($container);
+        $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_AliasesCanBeFoundInTheDumpedContainer']);
+        eval('?>'.$dump);
 
-		$container = new \Symfony_DI_PhpDumper_AliasesCanBeFoundInTheDumpedContainer();
+        $container = new \Symfony_DI_PhpDumper_AliasesCanBeFoundInTheDumpedContainer();
 
-		// Bar should still be found in the compiled container
-		$service_ids = $container->getServiceIds();
-		$this->assertContains("bar", $service_ids);
-	}
+        // Bar should still be found in the compiled container
+        $service_ids = $container->getServiceIds();
+        $this->assertContains('bar', $service_ids);
+    }
 }
 
 class Rot13EnvVarProcessor implements EnvVarProcessorInterface

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
+use MyProject\Proxies\__CG__\stdClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\FileLocator;
@@ -1139,6 +1140,29 @@ class PhpDumperTest extends TestCase
         $this->assertTrue($container->has('foo'));
         $this->assertSame('some value', $container->get('foo'));
     }
+
+	public function testAliasCanBeFoundInTheDumpedContainerWhenBothTheAliasAndTheServiceArePublic() {
+		$container = new ContainerBuilder();
+
+		$container->register('foo', stdClass::class)->setPublic(true);
+		$container->setAlias('bar', 'foo')->setPublic(true);
+
+		$container->compile();
+
+		// Bar is found in the compiled container
+		$service_ids = $container->getServiceIds();
+		$this->assertContains("bar", $service_ids);
+
+		$dumper = new PhpDumper($container);
+		$dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_AliasesCanBeFoundInTheDumpedContainer']);
+		eval('?>'.$dump);
+
+		$container = new \Symfony_DI_PhpDumper_AliasesCanBeFoundInTheDumpedContainer();
+
+		// Bar should still be found in the compiled container
+		$service_ids = $container->getServiceIds();
+		$this->assertContains("bar", $service_ids);
+	}
 }
 
 class Rot13EnvVarProcessor implements EnvVarProcessorInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33307
| License       | MIT
| Doc PR        | -

Changed the `getServiceIds` implementation in the `Container` base class to include aliases. Modified existing tests. Added test which uses the PhpDumper.
Fixes https://github.com/symfony/symfony/issues/33307

Without this patch the implementations of the container are inconsistent in whether or not they return aliases (see issue). Fixing this could be considered a BC break for the affected `Container` class. 

As an alternative to keep the behaviour in `Container` unchanged, the dumped container could be patched instead. And then only apply this version of the patch to master. This however keeps the inconsistency between `Container` and `ContainerBuilder`. 