### PR TITLE
[Ldap] Add LDAP error codes to exceptions

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Ldap\Adapter\ExtLdap;
 
 use Symfony\Component\Ldap\Adapter\AdapterInterface;
-use Symfony\Component\Ldap\Exception\LdapException;
+use Symfony\Component\Ldap\Exception\ExtensionNotLoadedException;
 
 /**
  * @author Charles Sarrazin <charles@sarraz.in>
@@ -26,7 +26,7 @@ class Adapter implements AdapterInterface
     public function __construct(array $config = [])
     {
         if (!\extension_loaded('ldap')) {
-            throw new LdapException('The LDAP PHP extension is not enabled.');
+            throw new ExtensionNotLoadedException('The LDAP PHP extension is not enabled.');
         }
 
         $this->config = $config;

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Collection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Collection.php
@@ -51,9 +51,9 @@ class Collection implements CollectionInterface
         $searches = $this->search->getResources();
         $count = 0;
         foreach ($searches as $search) {
-            $searchCount = ldap_count_entries($con, $search);
+            $searchCount = @ldap_count_entries($con, $search);
             if (false === $searchCount) {
-                throw new LdapException(sprintf('Error while retrieving entry count: %s.', ldap_error($con)));
+                throw LdapException::create('Error while retrieving entry count: [{errorCode}] {errorMsg}.', ldap_errno($con));
             }
             $count += $searchCount;
         }
@@ -73,10 +73,10 @@ class Collection implements CollectionInterface
         $con = $this->connection->getResource();
         $searches = $this->search->getResources();
         foreach ($searches as $search) {
-            $current = ldap_first_entry($con, $search);
+            $current = @ldap_first_entry($con, $search);
 
             if (false === $current) {
-                throw new LdapException(sprintf('Could not rewind entries array: %s.', ldap_error($con)));
+                throw LdapException::create('Could not rewind entries array: [{errorCode}] {errorMsg}.', ldap_errno($con));
             }
 
             yield $this->getSingleEntry($con, $current);
@@ -120,18 +120,18 @@ class Collection implements CollectionInterface
 
     private function getSingleEntry($con, $current): Entry
     {
-        $attributes = ldap_get_attributes($con, $current);
+        $attributes = @ldap_get_attributes($con, $current);
 
         if (false === $attributes) {
-            throw new LdapException(sprintf('Could not fetch attributes: %s.', ldap_error($con)));
+            throw LdapException::create('Could not fetch attributes: [{errorCode}] {errorMsg}.', ldap_errno($con));
         }
 
         $attributes = $this->cleanupAttributes($attributes);
 
-        $dn = ldap_get_dn($con, $current);
+        $dn = @ldap_get_dn($con, $current);
 
         if (false === $dn) {
-            throw new LdapException(sprintf('Could not fetch DN: %s.', ldap_error($con)));
+            throw LdapException::create('Could not fetch DN: [{errorCode}] {errorMsg}.', ldap_errno($con));
         }
 
         return new Entry($dn, $attributes);

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/ConnectionOptions.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/ConnectionOptions.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Ldap\Adapter\ExtLdap;
 
-use Symfony\Component\Ldap\Exception\LdapException;
+use Symfony\Component\Ldap\Exception\UnexpectedValueException;
 
 /**
  * A class representing the Ldap extension's options, which can be used with
@@ -71,7 +71,7 @@ final class ConnectionOptions
      * Fetches an option's corresponding constant value from an option name.
      * The option name can either be in snake or camel case.
      *
-     * @throws LdapException
+     * @throws UnexpectedValueException
      */
     public static function getOption(string $name): int
     {
@@ -79,7 +79,7 @@ final class ConnectionOptions
         $constantName = self::getOptionName($name);
 
         if (!\defined($constantName)) {
-            throw new LdapException(sprintf('Unknown option "%s".', $name));
+            throw new UnexpectedValueException(sprintf('Unknown option "%s".', $name));
         }
 
         return \constant($constantName);

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/EntryManager.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/EntryManager.php
@@ -116,7 +116,7 @@ class EntryManager implements EntryManagerInterface
      *
      * @throws NotBoundException                   if the connection has not been previously bound
      * @throws LdapException                       if an error is thrown during the rename operation
-     * @throws MalformedDistinguishedNameException if entry contains a malformed DN.
+     * @throws MalformedDistinguishedNameException if entry contains a malformed DN
      */
     public function move(Entry $entry, string $newParent)
     {

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/UpdateOperation.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/UpdateOperation.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Ldap\Adapter\ExtLdap;
 
-use Symfony\Component\Ldap\Exception\UpdateOperationException;
+use Symfony\Component\Ldap\Exception\UnexpectedValueException;
 
 class UpdateOperation
 {
@@ -30,15 +30,15 @@ class UpdateOperation
      * @param int    $operationType An LDAP_MODIFY_BATCH_* constant
      * @param string $attribute     The attribute to batch modify on
      *
-     * @throws UpdateOperationException on consistency errors during construction
+     * @throws UnexpectedValueException on consistency errors during construction
      */
     public function __construct(int $operationType, string $attribute, ?array $values)
     {
         if (!\in_array($operationType, $this->validOperationTypes, true)) {
-            throw new UpdateOperationException(sprintf('"%s" is not a valid modification type.', $operationType));
+            throw new UnexpectedValueException(sprintf('"%s" is not a valid modification type.', $operationType));
         }
         if (LDAP_MODIFY_BATCH_REMOVE_ALL === $operationType && null !== $values) {
-            throw new UpdateOperationException(sprintf('$values must be null for LDAP_MODIFY_BATCH_REMOVE_ALL operation, "%s" given.', \gettype($values)));
+            throw new UnexpectedValueException(sprintf('$values must be null for LDAP_MODIFY_BATCH_REMOVE_ALL operation, "%s" given.', \gettype($values)));
         }
 
         $this->operationType = $operationType;

--- a/src/Symfony/Component/Ldap/Exception/DomainException.php
+++ b/src/Symfony/Component/Ldap/Exception/DomainException.php
@@ -11,11 +11,6 @@
 
 namespace Symfony\Component\Ldap\Exception;
 
-/**
- * ConnectionException is thrown if binding to ldap can not be established.
- *
- * @author Grégoire Pineau <lyrixx@lyrixx.info>
- */
-class ConnectionException extends LdapException implements ExceptionInterface
+class DomainException extends \DomainException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/DriverNotFoundException.php
+++ b/src/Symfony/Component/Ldap/Exception/DriverNotFoundException.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Ldap\Exception;
 
 /**
- * LdapException is thrown if php ldap module is not loaded.
+ * DriverNotFoundException is thrown if adapter is not found in adapter map.
  *
  * @author Charles Sarrazin <charles@sarraz.in>
  */

--- a/src/Symfony/Component/Ldap/Exception/ExtensionNotLoadedException.php
+++ b/src/Symfony/Component/Ldap/Exception/ExtensionNotLoadedException.php
@@ -12,10 +12,18 @@
 namespace Symfony\Component\Ldap\Exception;
 
 /**
- * ExtensionNotLoadedException is thrown is a required PHP extension is not loaded.
+ * ExtensionNotLoadedException is thrown if a required PHP extension is not loaded.
+ *
+ * This class should extend \RuntimeException, but extends LdapException for BC
+ * compatibility.
  *
  * @author Dominic Tubach <dominic.tubach@to.com>
  */
-class ExtensionNotLoadedException extends \RuntimeException implements ExceptionInterface
+class ExtensionNotLoadedException extends LdapException implements ExceptionInterface
 {
+    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+    {
+        // avoid deprecation error
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Symfony/Component/Ldap/Exception/ExtensionNotLoadedException.php
+++ b/src/Symfony/Component/Ldap/Exception/ExtensionNotLoadedException.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Ldap\Exception;
 
 /**
- * ConnectionException is thrown if binding to ldap can not be established.
+ * ExtensionNotLoadedException is thrown is a required PHP extension is not loaded.
  *
- * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Dominic Tubach <dominic.tubach@to.com>
  */
-class ConnectionException extends LdapException implements ExceptionInterface
+class ExtensionNotLoadedException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/LdapException.php
+++ b/src/Symfony/Component/Ldap/Exception/LdapException.php
@@ -30,7 +30,7 @@ class LdapException extends \RuntimeException implements ExceptionInterface
      */
     public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
     {
-        if (2 > func_num_args()) {
+        if (2 > \func_num_args()) {
             @trigger_error(sprintf('Not specifying the LDAP error code in "%s::__construct()" is deprecated since Symfony 4.4.', __CLASS__), E_USER_DEPRECATED);
         }
 

--- a/src/Symfony/Component/Ldap/Exception/LdapException.php
+++ b/src/Symfony/Component/Ldap/Exception/LdapException.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Ldap\Exception;
 
 /**
- * LdapException is thrown if an LDAP operation fails.
+ * LdapException is thrown if an LDAP operation fails. For BC compatibility
+ * the classes ExtensionNotLoadedException, MalformedDistinguishedNameException,
+ * and UnexpectedValueException extend this class, though they are not thrown
+ * because of a failed LDAP operation.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Dominic Tubach <dominic.tubach@to.com>
@@ -22,12 +25,15 @@ class LdapException extends \RuntimeException implements ExceptionInterface
     /**
      * This constructor ensures that an error code is specified.
      *
-     * @param string     $message
-     * @param int        $code     The LDAP error code.
+     * @param int        $code     the LDAP error code
      * @param \Throwable $previous
      */
-    public function __construct(string $message, int $code, \Throwable $previous = null)
+    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
     {
+        if (2 > func_num_args()) {
+            @trigger_error(sprintf('Not specifying the LDAP error code in "%s::__construct()" is deprecated since Symfony 4.4.', __CLASS__), E_USER_DEPRECATED);
+        }
+
         parent::__construct($message, $code, $previous);
     }
 
@@ -36,7 +42,7 @@ class LdapException extends \RuntimeException implements ExceptionInterface
      *                              are {errorCode} and {errorMsg} that will be
      *                              replaced by the LDAP error code and the LDAP
      *                              error message, respectively.
-     * @param int    $errorCode     The LDAP error code.
+     * @param int    $errorCode     the LDAP error code
      *
      * @return static
      */
@@ -44,7 +50,7 @@ class LdapException extends \RuntimeException implements ExceptionInterface
     {
         $message = strtr($messageFormat, [
             '{errorCode}' => $errorCode,
-            '{errorMsg}'  => ldap_err2str($errorCode),
+            '{errorMsg}' => ldap_err2str($errorCode),
         ]);
 
         return new static($message, $errorCode);

--- a/src/Symfony/Component/Ldap/Exception/LdapException.php
+++ b/src/Symfony/Component/Ldap/Exception/LdapException.php
@@ -12,10 +12,41 @@
 namespace Symfony\Component\Ldap\Exception;
 
 /**
- * LdapException is thrown if php ldap module is not loaded.
+ * LdapException is thrown if an LDAP operation fails.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Dominic Tubach <dominic.tubach@to.com>
  */
 class LdapException extends \RuntimeException implements ExceptionInterface
 {
+    /**
+     * This constructor ensures that an error code is specified.
+     *
+     * @param string     $message
+     * @param int        $code     The LDAP error code.
+     * @param \Throwable $previous
+     */
+    public function __construct(string $message, int $code, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @param string $messageFormat The exception message. Possible placeholders
+     *                              are {errorCode} and {errorMsg} that will be
+     *                              replaced by the LDAP error code and the LDAP
+     *                              error message, respectively.
+     * @param int    $errorCode     The LDAP error code.
+     *
+     * @return static
+     */
+    public static function create(string $messageFormat, int $errorCode)
+    {
+        $message = strtr($messageFormat, [
+            '{errorCode}' => $errorCode,
+            '{errorMsg}'  => ldap_err2str($errorCode),
+        ]);
+
+        return new static($message, $errorCode);
+    }
 }

--- a/src/Symfony/Component/Ldap/Exception/MalformedDistinguishedNameException.php
+++ b/src/Symfony/Component/Ldap/Exception/MalformedDistinguishedNameException.php
@@ -14,8 +14,16 @@ namespace Symfony\Component\Ldap\Exception;
 /**
  * MalformedDistinguishedNameException is thrown in case of an malformed DN.
  *
+ * This class should extend \RuntimeException, but extends LdapException for BC
+ * compatibility.
+ *
  * @author Dominic Tubach <dominic.tubach@to.com>
  */
-class MalformedDistinguishedNameException extends \RuntimeException implements ExceptionInterface
+class MalformedDistinguishedNameException extends LdapException implements ExceptionInterface
 {
+    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+    {
+        // avoid deprecation error
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Symfony/Component/Ldap/Exception/MalformedDistinguishedNameException.php
+++ b/src/Symfony/Component/Ldap/Exception/MalformedDistinguishedNameException.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Ldap\Exception;
 
 /**
- * ConnectionException is thrown if binding to ldap can not be established.
+ * MalformedDistinguishedNameException is thrown in case of an malformed DN.
  *
- * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Dominic Tubach <dominic.tubach@to.com>
  */
-class ConnectionException extends LdapException implements ExceptionInterface
+class MalformedDistinguishedNameException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/UnexpectedValueException.php
+++ b/src/Symfony/Component/Ldap/Exception/UnexpectedValueException.php
@@ -11,11 +11,6 @@
 
 namespace Symfony\Component\Ldap\Exception;
 
-/**
- * ConnectionException is thrown if binding to ldap can not be established.
- *
- * @author Grégoire Pineau <lyrixx@lyrixx.info>
- */
-class ConnectionException extends LdapException implements ExceptionInterface
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/UnexpectedValueException.php
+++ b/src/Symfony/Component/Ldap/Exception/UnexpectedValueException.php
@@ -11,6 +11,17 @@
 
 namespace Symfony\Component\Ldap\Exception;
 
-class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+/**
+ * This class should extend \UnexpectedValueException, but extends LdapException
+ * for BC compatibility.
+ *
+ * @author Dominic Tubach <dominic.tubach@to.com>
+ */
+class UnexpectedValueException extends LdapException implements ExceptionInterface
 {
+    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+    {
+        // avoid deprecation error
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
@@ -14,12 +14,13 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Connection;
 use Symfony\Component\Ldap\Adapter\ExtLdap\EntryManager;
 use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\MalformedDistinguishedNameException;
 
 class EntryManagerTest extends TestCase
 {
     public function testMove()
     {
-        $this->expectException('Symfony\Component\Ldap\Exception\LdapException');
+        $this->expectException(MalformedDistinguishedNameException::class);
         $this->expectExceptionMessage('Entry "$$$$$$" malformed, could not parse RDN.');
         $connection = $this->createMock(Connection::class);
         $connection

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -33,7 +33,7 @@ class LdapUserProviderTest extends TestCase
         $ldap
             ->expects($this->once())
             ->method('bind')
-            ->willThrowException(new ConnectionException())
+            ->willThrowException(new ConnectionException('Test', 80))
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
@@ -67,7 +67,7 @@ class LdapBindAuthenticationProviderTest extends TestCase
         $ldap
             ->expects($this->once())
             ->method('bind')
-            ->willThrowException(new ConnectionException())
+            ->willThrowException(new ConnectionException('Test', 80))
         ;
         $userChecker = $this->getMockBuilder(UserCheckerInterface::class)->getMock();
 

--- a/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
@@ -32,7 +32,7 @@ class LdapUserProviderTest extends TestCase
         $ldap
             ->expects($this->once())
             ->method('bind')
-            ->willThrowException(new ConnectionException())
+            ->willThrowException(new ConnectionException('Test', 80))
         ;
 
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com');


### PR DESCRIPTION
This PR ensures that an LdapException is only used when an LDAP
operations fails. In cases an LdapException was used for non LDAP
operations it is replaced by an appropriate exception.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | `LdapException` requires error code now. (I wouldn't expect it to be relevant for any component user.)
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #28677
| License       | MIT

This PR ensures that an `LdapException` is only used when an LDAP operations fails. The constructor of `LdapException` enforces that an error code is specified. In cases an `LdapException` was used for non LDAP operations it is replaced by an appropriate exception.

Additionally silencing is added to ldap functions where missing.
