### PR TITLE
[Finder] Adjust regex to correctly match comments in gitignore contents

### DIFF
--- a/src/Symfony/Component/Finder/Gitignore.php
+++ b/src/Symfony/Component/Finder/Gitignore.php
@@ -27,7 +27,7 @@ class Gitignore
      */
     public static function toRegex(string $gitignoreFileContent): string
     {
-        $gitignoreFileContent = preg_replace('/^[^\\\\]*#.*/', '', $gitignoreFileContent);
+        $gitignoreFileContent = preg_replace('/^[^\\\r\n]*#.*/m', '', $gitignoreFileContent);
         $gitignoreLines = preg_split('/\r\n|\r|\n/', $gitignoreFileContent);
         $gitignoreLines = array_map('trim', $gitignoreLines);
         $gitignoreLines = array_filter($gitignoreLines);

--- a/src/Symfony/Component/Finder/Tests/GitignoreTest.php
+++ b/src/Symfony/Component/Finder/Tests/GitignoreTest.php
@@ -111,7 +111,31 @@ class GitignoreTest extends TestCase
                 #IamComment
                 /app/cache/',
                 ['app/cache/file.txt', 'app/cache/subdir/ile.txt'],
-                ['a/app/cache/file.txt'],
+                ['a/app/cache/file.txt', '#IamComment', 'IamComment'],
+            ],
+            [
+                '
+                /app/cache/
+                #LastLineIsComment',
+                ['app/cache/file.txt', 'app/cache/subdir/ile.txt'],
+                ['a/app/cache/file.txt', '#LastLineIsComment', 'LastLineIsComment'],
+            ],
+            [
+                '
+                /app/cache/
+                \#file.txt
+                #LastLineIsComment',
+                ['app/cache/file.txt', 'app/cache/subdir/ile.txt', '#file.txt'],
+                ['a/app/cache/file.txt', '#LastLineIsComment', 'LastLineIsComment'],
+            ],
+            [
+                '
+                /app/cache/
+                \#file.txt
+                #IamComment
+                another_file.txt',
+                ['app/cache/file.txt', 'app/cache/subdir/ile.txt', '#file.txt', 'another_file.txt'],
+                ['a/app/cache/file.txt', 'IamComment', '#IamComment'],
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32985
| License       | MIT


Description from issue:

When using `ignoreVCSIgnored`  as argument with the Symfony Finder, it will construct a regex equivalent of the gitignore pattern. However it seems that when a comment line (prefixed with `#`) is present in the `.gitignore`, the regex used to remove comment lines matches every line and thus returns `$gitignoreFileContent` as empty.
