### PR TITLE
Updated parent::__constructor call

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -26,7 +26,7 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
         $this->statusCode = $statusCode;
         $this->headers = $headers;
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, $statusCode, $previous);
     }
 
     public function getStatusCode()


### PR DESCRIPTION
I ran into a case where I got a `InvalidArgumentException(code: 0)` with the message:
`The HTTP status code "0" is not valid` while building the response for an exception of the type HttpException. 

As you can see, at the moment, the parent is getting the $code variable, which is not set. 
The thing that is being used is `$statusCode`. 

This leads to the following:

`$exception->getCode` results in 0
`$exception->getStatusCode` results in a http-status code, like 404.

Expected was the following:

`$exception->getCode` results in 404
`$exception->getStatusCode` results 404.

This problem only happens when people have a custom exception handler that expects that the inherited `getCode` method form the extended parent `Exception` class can be called...which in this case is being set to `0`, even though it is a HttpException.

So my proposed solution is to change the constructor 
from:

```php
    public function __construct(int $statusCode, string $message = null, \Throwable $previous = null, array $headers = [], ?int $code = 0)
    {
        $this->statusCode = $statusCode;
        $this->headers = $headers;

        parent::__construct($message, $code, $previous);
    }
```

to: 

```php
    public function __construct(int $statusCode, string $message = null, \Throwable $previous = null, array $headers = [], ?int $code = 0)
    {
        $this->statusCode = $statusCode;
        $this->headers = $headers;

        parent::__construct($message, $statusCode, $previous);
    }
```

| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
