### PR TITLE
[ErrorHandler] make DebugClassLoader turn multi-types declarations to "object"

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisArraySessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisArraySessionHandlerTest.php
@@ -13,7 +13,10 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 class RedisArraySessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
-    protected function createRedisClient(string $host): \RedisArray
+    /**
+     * @return \RedisArray|object
+     */
+    protected function createRedisClient(string $host)
     {
         return new \RedisArray([$host]);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
@@ -24,7 +24,10 @@ class RedisClusterSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
         }
     }
 
-    protected function createRedisClient(string $host): \RedisCluster
+    /**
+     * @return \RedisCluster|object
+     */
+    protected function createRedisClient(string $host)
     {
         return new \RedisCluster(null, explode(' ', getenv('REDIS_CLUSTER_HOSTS')));
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -13,7 +13,10 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 class RedisSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
-    protected function createRedisClient(string $host): \Redis
+    /**
+     * @return \Redis|object
+     */
+    protected function createRedisClient(string $host)
     {
         $client = new \Redis();
         $client->connect($host);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When `@return Foo|Bar` is found, this makes DebugClassLoader generate an `object` return type.
When all classes in the combo type contain `Iterator`, it generates an `iterable` type instead.