### PR TITLE
[Security] drop support for non-boolean return values from checkCredentials()

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 5.0.0
 -----
 
+ * Implementations of `Guard\AuthenticatorInterface::checkCredentials()` must return
+   a boolean value now. Please explicitly return `false` to indicate invalid credentials.
  * The `LdapUserProvider` class has been removed, use `Symfony\Component\Ldap\Security\LdapUserProvider` instead.
  * The `FirewallMapInterface::getListeners()` method must return an array of 3 elements.
  * Removed the `ContextListener::setLogoutOnUserChange()` method.

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -115,7 +115,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         $this->userChecker->checkPreAuth($user);
         if (true !== $checkCredentialsResult = $guardAuthenticator->checkCredentials($token->getCredentials(), $user)) {
             if (false !== $checkCredentialsResult) {
-                @trigger_error(sprintf('%s::checkCredentials() must return a boolean value. You returned %s. This behavior is deprecated in Symfony 4.4 and will trigger a TypeError in Symfony 5.', \get_class($guardAuthenticator), \is_object($checkCredentialsResult) ? \get_class($checkCredentialsResult) : \gettype($checkCredentialsResult)), E_USER_DEPRECATED);
+                throw new \TypeError(sprintf('%s::checkCredentials() must return a boolean value.', \get_class($guardAuthenticator)));
             }
 
             throw new BadCredentialsException(sprintf('Authentication failed because %s::checkCredentials() did not return true.', \get_class($guardAuthenticator)));

--- a/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
@@ -119,41 +119,6 @@ class GuardAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->preAuthenticationToken);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation %s::checkCredentials() must return a boolean value. You returned NULL. This behavior is deprecated in Symfony 4.4 and will trigger a TypeError in Symfony 5.
-     */
-    public function testCheckCredentialsReturningNonTrueFailsAuthentication()
-    {
-        $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');
-        $providerKey = 'my_uncool_firewall';
-
-        $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
-
-        // make sure the authenticator is used
-        $this->preAuthenticationToken->expects($this->any())
-            ->method('getGuardProviderKey')
-            // the 0 index, to match the only authenticator
-            ->willReturn('my_uncool_firewall_0');
-
-        $this->preAuthenticationToken->expects($this->atLeastOnce())
-            ->method('getCredentials')
-            ->willReturn('non-null-value');
-
-        $mockedUser = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
-        $authenticator->expects($this->once())
-            ->method('getUser')
-            ->willReturn($mockedUser);
-        // checkCredentials is called
-        $authenticator->expects($this->once())
-            ->method('checkCredentials')
-            // authentication fails :(
-            ->willReturn(null);
-
-        $provider = new GuardAuthenticationProvider([$authenticator], $this->userProvider, $providerKey, $this->userChecker);
-        $provider->authenticate($this->preAuthenticationToken);
-    }
-
     public function testGuardWithNoLongerAuthenticatedTriggersLogout()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationExpiredException');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 