### PR TITLE
[FrameworkBundle] Fix about command not showing .env vars

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -130,9 +130,9 @@ EOT
     private static function getDotenvVars(): array
     {
         $vars = [];
-        foreach (explode(',', getenv('SYMFONY_DOTENV_VARS')) as $name) {
-            if ('' !== $name && false !== $value = getenv($name)) {
-                $vars[$name] = $value;
+        foreach (explode(',', $_SERVER['SYMFONY_DOTENV_VARS'] ?? $_ENV['SYMFONY_DOTENV_VARS'] ?? '') as $name) {
+            if ('' !== $name && isset($_ENV[$name])) {
+                $vars[$name] = $_ENV[$name];
             }
         }
 


### PR DESCRIPTION
Before this fix, `bin/console about` can't properly show `Environment (.env)` section because:
`SYMFONY_DOTENV_VARS` which stores all keys of Dotenv-set env vars, is being fetched via `getenv()`.

However, in Symfony Dotenv 4.3, usage of `putenv()` is deprecated:
https://github.com/symfony/dotenv/commit/d2fa94d2590be2e640f4d91aad3209618f0ba062#diff-a6967492da82dce9ba93bcba3eee0334
so we can get env vars via `getenv()` only when `new Dotenv(true)`.
In the default shipped `config/bootstrap.php`, there is `new Dotenv(false)` set.

(Maybe related #29131)

| Q             | A
| ------------- | ---
| Branch?       | 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
