### PR TITLE
[Router] Fix DumpedUrlMatcher behaviour with trailing slash

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -50,13 +50,12 @@ class TraceableUrlMatcher extends UrlMatcher
         return $traces;
     }
 
-    protected function matchCollection($pathinfo, RouteCollection $routes)
+    protected function matchCollection($pathinfo, RouteCollection $routes, $supportsTrailingSlash)
     {
         // HEAD and GET are equivalent as per RFC
         if ('HEAD' === $method = $this->context->getMethod()) {
             $method = 'GET';
         }
-        $supportsTrailingSlash = '/' !== $pathinfo && '' !== $pathinfo && $this instanceof RedirectableUrlMatcherInterface;
 
         foreach ($routes as $name => $route) {
             $compiledRoute = $route->compile();

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -71,8 +71,9 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     public function match($pathinfo)
     {
         $this->allow = [];
+        $supportsTrailingSlash = '/' !== $pathinfo && '' !== $pathinfo && $this instanceof RedirectableUrlMatcherInterface;
 
-        if ($ret = $this->matchCollection(rawurldecode($pathinfo), $this->routes)) {
+        if ($ret = $this->matchCollection(rawurldecode($pathinfo), $this->routes, $supportsTrailingSlash)) {
             return $ret;
         }
 
@@ -116,13 +117,12 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
      * @throws ResourceNotFoundException If the resource could not be found
      * @throws MethodNotAllowedException If the resource was found but the request method is not allowed
      */
-    protected function matchCollection($pathinfo, RouteCollection $routes)
+    protected function matchCollection($pathinfo, RouteCollection $routes, $supportsTrailingSlash)
     {
         // HEAD and GET are equivalent as per RFC
         if ('HEAD' === $method = $this->context->getMethod()) {
             $method = 'GET';
         }
-        $supportsTrailingSlash = '/' !== $pathinfo && '' !== $pathinfo && $this instanceof RedirectableUrlMatcherInterface;
 
         foreach ($routes as $name => $route) {
             $compiledRoute = $route->compile();

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -115,17 +115,6 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $this->assertSame(['_route' => 'foo'], $matcher->match('/foo'));
     }
 
-    public function testFallbackPage()
-    {
-        $coll = new RouteCollection();
-        $coll->add('foo', new Route('/foo/'));
-        $coll->add('bar', new Route('/{name}'));
-
-        $matcher = $this->getUrlMatcher($coll);
-        $matcher->expects($this->once())->method('redirect')->with('/foo/')->willReturn(['_route' => 'foo']);
-        $this->assertSame(['_route' => 'foo'], $matcher->match('/foo'));
-    }
-
     public function testSlashAndVerbPrecedenceWithRedirection()
     {
         $coll = new RouteCollection();

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -609,6 +609,28 @@ class UrlMatcherTest extends TestCase
         $this->assertEquals(['_route' => 'a', 'a' => 'foo/'], $matcher->match('/foo/'));
     }
 
+    public function testRouteWithAndWithoutTrailingSlash()
+    {
+        $coll = new RouteCollection();
+        $coll->add('hard_route_with_trailing_slash', new Route('/a/'));
+        $coll->add('dynamic_route_without_trailing_slash', new Route('/{b}', [], ['b' => '.+']));
+
+        $matcher = $this->getUrlMatcher($coll);
+
+        $this->assertEquals(['_route' => 'hard_route_with_trailing_slash'], $matcher->match('/a/'), 'truc3');
+        $this->assertEquals(['_route' => 'dynamic_route_without_trailing_slash', 'b' => 'a'], $matcher->match('/a'), 'truc4');
+
+        // Order of definitions matters
+        $coll = new RouteCollection();
+        $coll->add('dynamic_route_without_trailing_slash', new Route('/{b}', [], ['b' => '.+']));
+        $coll->add('hard_route_with_trailing_slash', new Route('/a/'));
+
+        $matcher = $this->getUrlMatcher($coll);
+
+        $this->assertEquals(['_route' => 'dynamic_route_without_trailing_slash', 'b' => 'a/'], $matcher->match('/a/'), 'truc1');
+        $this->assertEquals(['_route' => 'dynamic_route_without_trailing_slash', 'b' => 'a'], $matcher->match('/a'), 'truc2');
+    }
+
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
     {
         return new UrlMatcher($routes, $context ?: new RequestContext());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32996
| License       | MIT
| Doc PR        | ¤

The trailing slash management seems not to be quite consistant across matchers. This pull request fixes the behaviour with the current state of mind: when you have an exact route, you should always use it, not trying to redirect request.

Things are a little bit tricky here, specially when it comes to the DumpedUrlMatcher, but it was adding a lot of complexity than trying to keep things in a single function.
