### PR TITLE
Fix #33368 [Messenger] variable contentType in (de)serialization process

### DIFF
--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -31,9 +31,6 @@ final class Envelope
      */
     public function __construct($message, array $stamps = [])
     {
-        if (!\is_object($message)) {
-            throw new \TypeError(sprintf('Invalid argument provided to "%s()": expected object but got %s.', __METHOD__, \gettype($message)));
-        }
         $this->message = $message;
 
         foreach ($stamps as $stamp) {

--- a/src/Symfony/Component/Messenger/Handler/RawMessage.php
+++ b/src/Symfony/Component/Messenger/Handler/RawMessage.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+/**
+ * Handlers can implement this interface to handle multiple messages.
+ *
+ * @author Pierre Rineau <pierre.rineau@processus.org>
+ *
+ * @experimental in 4.3
+ */
+class RawMessage
+{
+    private $headers;
+    private $data;
+
+    public function __construct(string $data, array $headers = [])
+    {
+        $this->data = $data;
+        $this->headers = $headers;
+    }
+
+    /**
+     * Get raw data from transport
+     *
+     * @return string
+     */
+    public function getData(): string
+    {
+        return $this->data;
+    }
+
+    /**
+     * Get raw headers from transport
+     *
+     * @return string[]
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Get content type if exposed in headers
+     *
+     * @return string|null
+     */
+    public function getContentType(): ?string
+    {
+        return $this->headers['Content-Type'] ?? null;
+    }
+
+    /**
+     * Get message type if exposed in headers
+     *
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->headers['type'] ?? null;
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/ContentTypeStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ContentTypeStamp.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * @author Pierre Rineau <pierre.rineau@processus.org>
+ *
+ * @experimental in 4.3
+ */
+final class ContentTypeStamp implements StampInterface
+{
+    private $contentType;
+
+    public function __construct(string $contentType)
+    {
+        $this->contentType = $contentType;
+    }
+
+    public function getContentType(): string
+    {
+        return $this->contentType;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -31,6 +31,16 @@ class PhpSerializerTest extends TestCase
         $this->assertEquals($envelope, $serializer->decode($encoded));
     }
 
+    public function testIgnoresContentType()
+    {
+        $serializer = new PhpSerializer();
+
+        $envelope = new Envelope(new DummyMessage('Hello'));
+
+        $encoded = $serializer->encode($envelope, 'application/xml');
+        $this->assertEquals($envelope, $serializer->decode($encoded));
+    }
+
     public function testDecodingFailsWithMissingBodyKey()
     {
         $this->expectException(MessageDecodingFailedException::class);

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -25,7 +25,7 @@ class PhpSerializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function decode(array $encodedEnvelope): Envelope
+    public function decode(array $encodedEnvelope, ?string $contentType = null): Envelope
     {
         if (empty($encodedEnvelope['body'])) {
             throw new MessageDecodingFailedException('Encoded envelope should have at least a "body".');

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
@@ -33,7 +33,7 @@ interface SerializerInterface
      *
      * @throws MessageDecodingFailedException
      */
-    public function decode(array $encodedEnvelope, ?string $contentType = null): Envelope;
+    public function decode(array $encodedEnvelope): Envelope;
 
     /**
      * Encodes an envelope content (message & stamps) to a common format understandable by transports.

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
@@ -33,7 +33,7 @@ interface SerializerInterface
      *
      * @throws MessageDecodingFailedException
      */
-    public function decode(array $encodedEnvelope): Envelope;
+    public function decode(array $encodedEnvelope, ?string $contentType = null): Envelope;
 
     /**
      * Encodes an envelope content (message & stamps) to a common format understandable by transports.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33368
| License       | MIT

Make the serializer more robust by adding a contextual and variable content type that falls back on default format. See #33368.
