### PR TITLE
[Mailer] Remove the default dispatcher in AbstractTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Mailer\Transport;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\DelayedSmtpEnvelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
@@ -37,7 +36,7 @@ abstract class AbstractTransport implements TransportInterface
 
     public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        $this->dispatcher = $dispatcher ?: new EventDispatcher();
+        $this->dispatcher = $dispatcher;
         $this->logger = $logger ?: new NullLogger();
     }
 
@@ -69,14 +68,18 @@ abstract class AbstractTransport implements TransportInterface
             }
         }
 
-        $event = new MessageEvent($message, $envelope);
-        $this->dispatcher->dispatch($event);
-        $envelope = $event->getEnvelope();
+        if (null !== $this->dispatcher) {
+            $event = new MessageEvent($message, $envelope);
+            $this->dispatcher->dispatch($event);
+            $envelope = $event->getEnvelope();
+            $message = $event->getMessage();
+        }
+
         if (!$envelope->getRecipients()) {
             return null;
         }
 
-        $message = new SentMessage($event->getMessage(), $envelope);
+        $message = new SentMessage($message, $envelope);
         $this->doSend($message);
 
         $this->checkThrottling();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n:a

Creating a default event dispatcher does not make sense as nobody can listen on it.
