### PR TITLE
Changed null coalesce to ternary for php 5.6 compatibility

### DIFF
--- a/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
@@ -78,8 +78,8 @@ class LocaleDataGenerator extends AbstractDataGenerator
         // Generate locale names for all locales that have translations in
         // at least the language or the region bundle
         $displayFormat = $reader->readEntry($tempDir.'/lang', $displayLocale, ['localeDisplayPattern']);
-        $pattern = $displayFormat['pattern'] ?? '{0} ({1})';
-        $separator = $displayFormat['separator'] ?? '{0}, {1}';
+        $pattern = isset($displayFormat['pattern']) ? $displayFormat['pattern'] : '{0} ({1})';
+        $separator = isset($displayFormat['separator']) ? $displayFormat['separator'] : '{0}, {1}';
         $localeNames = [];
         foreach ($this->locales as $locale) {
             // Ensure a normalized list of pure locales


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | n/a

I found a couple of null coalesce operators in 3.4 which I believe is meant to be compatible with php 5.6. I've changed them to ternary statements.