### PR TITLE
[Console] Console output formatter upgrade

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ max_line_length = 80
 
 [COMMIT_EDITMSG]
 max_line_length = 0
+
+[*.txt]
+trim_trailing_whitespace = false

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
  * added method `preventRedrawFasterThan()` and `forceRedrawSlowerThan()` on `ProgressBar`
  * `Application` implements `ResetInterface`
  * marked all dispatched event classes as `@final`
+ * added `OutputWrapperInterface` and `OutputWrapper` to allow modifying your
+   wrapping strategy in `SymfonyStyle` or in other `OutputStyle`. Eg: you can
+   switch off to wrap URLs.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Formatter;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Helper\OutputWrapperInterface;
 
 /**
  * Formatter class for console output.
@@ -136,7 +137,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
     {
         $offset = 0;
         $output = '';
-        $tagRegex = '[a-z][^<>]*+';
+        $tagRegex = OutputWrapperInterface::TAG_INNER_REGEX;
         $currentLineLength = 0;
         preg_match_all("#<(($tagRegex) | /($tagRegex)?)>#ix", $message, $matches, PREG_OFFSET_CAPTURE);
         foreach ($matches[0] as $i => $match) {

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 /*
  * This file is part of the Symfony package.
@@ -48,19 +48,11 @@ class OutputWrapper implements OutputWrapperInterface
 
     private $keepUrlsTogether = true;
 
-    /**
-     * @return bool
-     */
     public function isKeepUrlsTogether(): bool
     {
         return $this->keepUrlsTogether;
     }
 
-    /**
-     * @param bool $keepUrlsTogether
-     *
-     * @return $this
-     */
     public function setKeepUrlsTogether(bool $keepUrlsTogether)
     {
         $this->keepUrlsTogether = $keepUrlsTogether;
@@ -84,8 +76,8 @@ class OutputWrapper implements OutputWrapperInterface
         $blocks = implode('|', $patternBlocks);
         $rowPattern = "(?:$blocks)$limitPattern";
         $pattern = sprintf('#(?:((?>(%1$s)((?<=[^\S\r\n])[^\S\r\n]?|(?=\r?\n)|$|[^\S\r\n]))|(%1$s))(?:\r?\n)?|(?:\r?\n|$))#imux', $rowPattern);
-        $output = rtrim(preg_replace($pattern, '\\1' . $break, $text), $break);
+        $output = rtrim(preg_replace($pattern, '\\1'.$break, $text), $break);
 
-        return str_replace(' ' . $break, $break, $output);
+        return str_replace(' '.$break, $break, $output);
     }
 }

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -46,16 +46,16 @@ class OutputWrapper implements OutputWrapperInterface
 {
     const URL_PATTERN = 'https?://[^ ]+';
 
-    private $keepUrlsTogether = true;
+    private $allowCutUrls = false;
 
-    public function isKeepUrlsTogether(): bool
+    public function isAllowCutUrls(): bool
     {
-        return $this->keepUrlsTogether;
+        return $this->allowCutUrls;
     }
 
-    public function setKeepUrlsTogether(bool $keepUrlsTogether)
+    public function setAllowCutUrls(bool $allowCutUrls)
     {
-        $this->keepUrlsTogether = $keepUrlsTogether;
+        $this->allowCutUrls = $allowCutUrls;
 
         return $this;
     }
@@ -69,7 +69,7 @@ class OutputWrapper implements OutputWrapperInterface
         $tagPattern = sprintf('<(?:(?:%1$s)|/(?:%1$s)?)>', '[a-z][^<>]*+');
         $limitPattern = "{1,$width}";
         $patternBlocks = [$tagPattern];
-        if ($this->keepUrlsTogether) {
+        if (!$this->allowCutUrls) {
             $patternBlocks[] = self::URL_PATTERN;
         }
         $patternBlocks[] = '.';

--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+/**
+ * Simple output wrapper for "tagged outputs" instead of wordwrap(). This solution is based on a StackOverflow
+ * answer: https://stackoverflow.com/a/20434776/1476819 from SLN.
+ *
+ *  (?:
+ *       # -- Words/Characters
+ *       (                       # (1 start)
+ *            (?>                     # Atomic Group - Match words with valid breaks
+ *                 .{1,16}                 #  1-N characters
+ *                                         #  Followed by one of 4 prioritized, non-linebreak whitespace
+ *                 (?:                     #  break types:
+ *                      (?<= [^\S\r\n] )        # 1. - Behind a non-linebreak whitespace
+ *                      [^\S\r\n]?              #      ( optionally accept an extra non-linebreak whitespace )
+ *                   |  (?= \r? \n )            # 2. - Ahead a linebreak
+ *                   |  $                       # 3. - EOS
+ *                   |  [^\S\r\n]               # 4. - Accept an extra non-linebreak whitespace
+ *                 )
+ *            )                       # End atomic group
+ *         |
+ *            .{1,16}                 # No valid word breaks, just break on the N'th character
+ *       )                       # (1 end)
+ *       (?: \r? \n )?           # Optional linebreak after Words/Characters
+ *    |
+ *       # -- Or, Linebreak
+ *       (?: \r? \n | $ )        # Stand alone linebreak or at EOS
+ *  )
+ *
+ * @author Krisztián Ferenczi <ferenczi.krisztian@gmail.com>
+ *
+ * @see https://stackoverflow.com/a/20434776/1476819
+ */
+class OutputWrapper implements OutputWrapperInterface
+{
+    const URL_PATTERN = 'https?://[^ ]+';
+
+    private $keepUrlsTogether = true;
+
+    /**
+     * @return bool
+     */
+    public function isKeepUrlsTogether(): bool
+    {
+        return $this->keepUrlsTogether;
+    }
+
+    /**
+     * @param bool $keepUrlsTogether
+     *
+     * @return $this
+     */
+    public function setKeepUrlsTogether(bool $keepUrlsTogether)
+    {
+        $this->keepUrlsTogether = $keepUrlsTogether;
+
+        return $this;
+    }
+
+    public function wrap(string $text, int $width, string $break = "\n"): string
+    {
+        if (0 === $width) {
+            return $text;
+        }
+
+        $tagPattern = sprintf('<(?:(?:%1$s)|/(?:%1$s)?)>', '[a-z][^<>]*+');
+        $limitPattern = "{1,$width}";
+        $patternBlocks = [$tagPattern];
+        if ($this->keepUrlsTogether) {
+            $patternBlocks[] = self::URL_PATTERN;
+        }
+        $patternBlocks[] = '.';
+        $blocks = implode('|', $patternBlocks);
+        $rowPattern = "(?:$blocks)$limitPattern";
+        $pattern = sprintf('#(?:((?>(%1$s)((?<=[^\S\r\n])[^\S\r\n]?|(?=\r?\n)|$|[^\S\r\n]))|(%1$s))(?:\r?\n)?|(?:\r?\n|$))#imux', $rowPattern);
+        $output = rtrim(preg_replace($pattern, '\\1' . $break, $text), $break);
+
+        return str_replace(' ' . $break, $break, $output);
+    }
+}

--- a/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
@@ -1,4 +1,13 @@
-<?php declare(strict_types=1);
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Symfony\Component\Console\Helper;
 

--- a/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapperInterface.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Symfony\Component\Console\Helper;
+
+interface OutputWrapperInterface
+{
+    const TAG_INNER_REGEX = '[a-z][^<>]*+';
+
+    public function wrap(string $text, int $width, string $break = "\n"): string;
+}

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -104,7 +104,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
     /**
      * {@inheritdoc}
      */
-    public function getArgument($name)
+    public function getArgument(string $name)
     {
         if (!$this->definition->hasArgument($name)) {
             throw new InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));
@@ -116,7 +116,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
     /**
      * {@inheritdoc}
      */
-    public function setArgument($name, $value)
+    public function setArgument(string $name, $value)
     {
         if (!$this->definition->hasArgument($name)) {
             throw new InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -57,19 +57,11 @@ class SymfonyStyle extends OutputStyle
         parent::__construct($output);
     }
 
-    /**
-     * @return OutputWrapperInterface
-     */
     public function getOutputWrapper(): OutputWrapperInterface
     {
         return $this->outputWrapper;
     }
 
-    /**
-     * @param OutputWrapperInterface $outputWrapper
-     *
-     * @return $this
-     */
     public function setOutputWrapper(OutputWrapperInterface $outputWrapper)
     {
         $this->outputWrapper = $outputWrapper;

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
@@ -9,6 +9,6 @@ return function (InputInterface $input, OutputInterface $output) {
     $output->setDecorated(true);
     $output = new SymfonyStyle($input, $output);
     $output->comment(
-        'Lorem ipsum dolor sit <comment>amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
+        'Árvíztűrőtükörfúrógép Lorem ipsum dolor sit <comment>amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
     );
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_18.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_18.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+// ensure that nested tags have no effect on the color of the '//' prefix
+return function (InputInterface $input, OutputInterface $output) {
+    $output->setDecorated(true);
+    $output = new SymfonyStyle($input, $output);
+    $output->block(
+        'Árvíztűrőtükörfúrógép Lorem ipsum dolor sit <comment>amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
+        '★', // UTF-8 star!
+        null,
+        '<fg=default;bg=default> ║ </>', // UTF-8 double line!
+        false,
+        false
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
@@ -1,7 +1,7 @@
 
-[39;49m // [39;49mLorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et             [39m
-[39;49m // [39;49m[33mdolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea       [39m
-[39;49m // [39;49m[33mcommodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla     [39m
-[39;49m // [39;49m[33mpariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim            
-[39;49m // [39;49mid est laborum                                                                                                      
+[39;49m // [39;49mÁrvíztűrőtükörfúrógép Lorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut [39m
+[39;49m // [39;49m[33mlabore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex[39m
+[39;49m // [39;49m[33mea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla  [39m
+[39;49m // [39;49m[33mpariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est     
+[39;49m // [39;49mlaborum                                                                                                             
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_18.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_18.txt
@@ -1,0 +1,7 @@
+
+[39;49m ║ [39;49m[★] Árvíztűrőtükörfúrógép Lorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt [39m
+[39;49m ║ [39;49m[33m    ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut     [39m
+[39;49m ║ [39;49m[33m    aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu [39m
+[39;49m ║ [39;49m[33m    fugiat nulla pariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit 
+[39;49m ║ [39;49m    anim id est laborum                                                                                              
+

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -20,7 +20,7 @@ class OutputWrapperTest extends TestCase
     {
         $wrapper = new OutputWrapper();
         // Test UTF-8 chars + URL
-        $text = "Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.";
+        $text = 'Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.';
         $baseExpected = <<<EOS
 Árvíztűrőtükörfúrógé
 p https://github.com/symfony/symfony Lorem ipsum

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\OutputWrapper;
+
+class OutputWrapperTest extends TestCase
+{
+    public function testBasicWrap()
+    {
+        $wrapper = new OutputWrapper();
+        // Test UTF-8 chars + URL
+        $text = "Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.";
+        $baseExpected = <<<EOS
+Árvíztűrőtükörfúrógé
+p https://github.com/symfony/symfony Lorem ipsum
+<comment>dolor</comment> sit amet,
+consectetur
+adipiscing elit.
+Praesent vestibulum
+nulla quis urna
+maximus porttitor.
+Donec ullamcorper
+risus at <error>libero
+ornare</error> efficitur.
+EOS;
+        $result = $wrapper->wrap($text, 20);
+        $this->assertEquals($baseExpected, $result);
+
+        $URLwrappedExpected = <<<EOS
+Árvíztűrőtükörfúrógé
+p
+https://github.com/s
+ymfony/symfony Lorem
+ipsum <comment>dolor</comment> sit
+amet, consectetur
+adipiscing elit.
+Praesent vestibulum
+nulla quis urna
+maximus porttitor.
+Donec ullamcorper
+risus at <error>libero
+ornare</error> efficitur.
+EOS;
+        $wrapper->setKeepUrlsTogether(false);
+        $result = $wrapper->wrap($text, 20);
+        $this->assertEquals($URLwrappedExpected, $result);
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -52,7 +52,7 @@ Donec ullamcorper
 risus at <error>libero
 ornare</error> efficitur.
 EOS;
-        $wrapper->setKeepUrlsTogether(false);
+        $wrapper->setAllowCutUrls(false);
         $result = $wrapper->wrap($text, 20);
         $this->assertEquals($URLwrappedExpected, $result);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30920
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/12248

Current `SymfonyStyle` can cause some problem:
- cut format tags
- wrong formatting if there are multibyte characters
- cut URLs, user can't click on it in the terminal

I fixed the problem and added or modified some tests. This is a simple, fast and working solution with regular expression.