### PR TITLE
[HttpClient] fix support for 103 Early Hints and other informational status codes

### DIFF
--- a/src/Symfony/Component/HttpClient/Chunk/DataChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/DataChunk.php
@@ -20,8 +20,8 @@ use Symfony\Contracts\HttpClient\ChunkInterface;
  */
 class DataChunk implements ChunkInterface
 {
-    private $offset;
-    private $content;
+    private $offset = 0;
+    private $content = '';
 
     public function __construct(int $offset = 0, string $content = '')
     {
@@ -51,6 +51,14 @@ class DataChunk implements ChunkInterface
     public function isLast(): bool
     {
         return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInformationalStatus(): ?array
+    {
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
@@ -68,6 +68,15 @@ class ErrorChunk implements ChunkInterface
     /**
      * {@inheritdoc}
      */
+    public function getInformationalStatus(): ?array
+    {
+        $this->didThrow = true;
+        throw new TransportException($this->errorMessage, 0, $this->error);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getContent(): string
     {
         $this->didThrow = true;

--- a/src/Symfony/Component/HttpClient/Chunk/InformationalChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/InformationalChunk.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Chunk;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class InformationalChunk extends DataChunk
+{
+    private $status;
+
+    public function __construct(int $statusCode, array $headers)
+    {
+        $this->status = [$statusCode, $headers];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInformationalStatus(): ?array
+    {
+        return $this->status;
+    }
+}

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -45,7 +45,7 @@ class MockResponse implements ResponseInterface
     public function __construct($body = '', array $info = [])
     {
         $this->body = is_iterable($body) ? $body : (string) $body;
-        $this->info = $info + $this->info;
+        $this->info = $info + ['http_code' => 200] + $this->info;
 
         if (!isset($info['response_headers'])) {
             return;
@@ -59,7 +59,8 @@ class MockResponse implements ResponseInterface
             }
         }
 
-        $this->info['response_headers'] = $responseHeaders;
+        $this->info['response_headers'] = [];
+        self::addResponseHeaders($responseHeaders, $this->info, $this->headers);
     }
 
     /**

--- a/src/Symfony/Component/HttpClient/Response/ResponseStream.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseStream.php
@@ -17,8 +17,6 @@ use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
- *
- * @internal
  */
 final class ResponseStream implements ResponseStreamInterface
 {

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
+use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -122,6 +124,41 @@ class MockHttpClientTest extends HttpClientTestCase
                 $body = ['<1>', '', '<2>'];
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);
                 break;
+
+            case 'testInformationalResponseStream':
+                $client = $this->createMock(HttpClientInterface::class);
+                $response = new MockResponse('Here the body', ['response_headers' => [
+                    'HTTP/1.1 103 ',
+                    'Link: </style.css>; rel=preload; as=style',
+                    'HTTP/1.1 200 ',
+                    'Date: foo',
+                    'Content-Length: 13',
+                ]]);
+                $client->method('request')->willReturn($response);
+                $client->method('stream')->willReturn(new ResponseStream((function () use ($response) {
+                    $chunk = $this->createMock(ChunkInterface::class);
+                    $chunk->method('getInformationalStatus')
+                        ->willReturn([103, ['link' => ['</style.css>; rel=preload; as=style', '</script.js>; rel=preload; as=script']]]);
+
+                    yield $response => $chunk;
+
+                    $chunk = $this->createMock(ChunkInterface::class);
+                    $chunk->method('isFirst')->willReturn(true);
+
+                    yield $response => $chunk;
+
+                    $chunk = $this->createMock(ChunkInterface::class);
+                    $chunk->method('getContent')->willReturn('Here the body');
+
+                    yield $response => $chunk;
+
+                    $chunk = $this->createMock(ChunkInterface::class);
+                    $chunk->method('isLast')->willReturn(true);
+
+                    yield $response => $chunk;
+                })()));
+
+                return $client;
         }
 
         return new MockHttpClient($responses);

--- a/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
@@ -20,4 +20,9 @@ class NativeHttpClientTest extends HttpClientTestCase
     {
         return new NativeHttpClient();
     }
+
+    public function testInformationalResponseStream()
+    {
+        $this->markTestSkipped('NativeHttpClient doesn\'t support informational status codes.');
+    }
 }

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.1.3",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^1.1.6",
+        "symfony/http-client-contracts": "^1.1.7",
         "symfony/polyfill-php73": "^1.11"
     },
     "require-dev": {

--- a/src/Symfony/Contracts/HttpClient/ChunkInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ChunkInterface.php
@@ -48,6 +48,13 @@ interface ChunkInterface
     public function isLast(): bool;
 
     /**
+     * Returns a [status code, headers] tuple when a 1xx status code was just received.
+     *
+     * @throws TransportExceptionInterface on a network error or when the idle timeout is reached
+     */
+    public function getInformationalStatus(): ?array;
+
+    /**
      * Returns the content of the response chunk.
      *
      * @throws TransportExceptionInterface on a network error or when the idle timeout is reached


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I learned quite recently how 1xx status codes work in HTTP 1.1 when I discovered the [103 Early Hint](https://evertpot.com/http/103-early-hints) status code from [RFC8297](https://tools.ietf.org/html/rfc8297)
 
This PR fixes support for them by adding a new `getInformationalStatus()` method on `ChunkInterface`. This means that you can now know about 1xx status code by using the `$client->stream()` method:

```php

$response = $client->request('GET', '...');

foreach ($client->stream($response) as $chunk) {
    [$code, $headers] = $chunk->getInformationalStatus();
    if (103 === $code) {
        // $headers['link'] contains the early hints defined in RFC8297
    }

    // ...
}
```