### PR TITLE
[Validator] Support \DateInterval in comparison constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added option `alpha3` to `Country` constraint
  * allow to define a reusable set of constraints by extending the `Compound` constraint
  * added `Sequentially` constraint, to sequentially validate a set of constraints (any violation raised will prevent further validation of the nested constraints)
+ * added support to validate `\DateInterval` instances with relative string date formats in the `Range` and all comparisons constraints
 
 5.0.0
 -----

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -32,6 +32,12 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     const OBJECT_TO_STRING = 2;
 
     /**
+     * Whether to format {@link \DateInterval} objects as human readable strings
+     * eg: 6 hours, 1 minute and 2 seconds.
+     */
+    const PRETTY_DATE_INTERVAL = 4;
+
+    /**
      * @var ExecutionContextInterface
      */
     protected $context;
@@ -96,6 +102,37 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
             }
 
             return $value->format('Y-m-d H:i:s');
+        }
+
+        if (($format & self::PRETTY_DATE_INTERVAL) && $value instanceof \DateInterval) {
+            $formattedValueParts = [];
+            foreach ([
+                'y' => 'year',
+                'm' => 'month',
+                'd' => 'day',
+                'h' => 'hour',
+                'i' => 'minute',
+                's' => 'second',
+                'f' => 'microsecond',
+            ] as $p => $label) {
+                if (!$formattedValue = $value->format('%'.$p)) {
+                    continue;
+                }
+
+                if ($formattedValue > 1) {
+                    $label .= 's';
+                }
+
+                $formattedValueParts[] = $formattedValue.' '.$label;
+            }
+
+            if (!$formattedValueParts) {
+                return '0';
+            }
+
+            $lastFormattedValuePart = array_pop($formattedValueParts);
+
+            return $value->format('%r').(!$formattedValueParts ? $lastFormattedValuePart : implode(', ', $formattedValueParts).' and '.$lastFormattedValuePart);
         }
 
         if (\is_object($value)) {

--- a/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
@@ -30,6 +30,9 @@ final class ConstraintValidatorTest extends TestCase
         $defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('Europe/Moscow'); // GMT+3
 
+        $negativeDateInterval = new \DateInterval('PT30S');
+        $negativeDateInterval->invert = 1;
+
         $data = [
             ['true', true],
             ['false', false],
@@ -44,6 +47,13 @@ final class ConstraintValidatorTest extends TestCase
             [class_exists(\IntlDateFormatter::class) ? 'Feb 2, 1971, 8:00 AM' : '1971-02-02 08:00:00', $dateTime, ConstraintValidator::PRETTY_DATE],
             [class_exists(\IntlDateFormatter::class) ? 'Jan 1, 1970, 6:00 AM' : '1970-01-01 06:00:00', new \DateTimeImmutable('1970-01-01T06:00:00Z'), ConstraintValidator::PRETTY_DATE],
             [class_exists(\IntlDateFormatter::class) ? 'Jan 1, 1970, 3:00 PM' : '1970-01-01 15:00:00', (new \DateTimeImmutable('1970-01-01T23:00:00'))->setTimezone(new \DateTimeZone('America/New_York')), ConstraintValidator::PRETTY_DATE],
+            ['object', new \DateInterval('PT30S')],
+            ['1 year, 1 month, 1 day, 1 hour, 1 minute and 1 second', new \DateInterval('P1Y1M1DT1H1M1S'), ConstraintValidator::PRETTY_DATE_INTERVAL],
+            ['3 months and 4 seconds', new \DateInterval('P3MT4S'), ConstraintValidator::PRETTY_DATE_INTERVAL],
+            ['0', new \DateInterval('PT0S'), ConstraintValidator::PRETTY_DATE_INTERVAL],
+            ['0', ($dateTime = new \DateTimeImmutable())->diff($dateTime), ConstraintValidator::PRETTY_DATE_INTERVAL],
+            ['7 days', new \DateInterval('P1W'), ConstraintValidator::PRETTY_DATE_INTERVAL],
+            ['-30 seconds', $negativeDateInterval, ConstraintValidator::PRETTY_DATE_INTERVAL],
         ];
 
         date_default_timezone_set($defaultTimezone);

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -40,6 +40,9 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT1H');
+        $negativeDateInterval->invert = 1;
+
         return [
             [3, 3],
             [3, '3'],
@@ -49,6 +52,9 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2000-01-01 UTC'), '2000-01-01 UTC'],
             [new ComparisonTest_Class(5), new ComparisonTest_Class(5)],
             [null, 1],
+            ['1 == 1 (string)' => new \DateInterval('PT1H'), '+1 hour'],
+            ['1 == 1 (\DateInterval instance)' => new \DateInterval('PT1H'), new \DateInterval('PT1H')],
+            ['-1 == -1' => $negativeDateInterval, '-1 hour'],
         ];
     }
 
@@ -67,6 +73,9 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT1H');
+        $negativeDateInterval->invert = 1;
+
         return [
             [1, '1', 2, '2', 'integer'],
             ['22', '"22"', '333', '"333"', 'string'],
@@ -74,6 +83,9 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new \DateTime('2001-01-01 UTC'), 'Jan 1, 2001, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
+            ['1 != 2 (string)' => new \DateInterval('PT1H'), '1 hour', '+2 hour', '2 hours', \DateInterval::class],
+            ['1 != 2 (\DateInterval instance)' => new \DateInterval('PT1H'), '1 hour', new \DateInterval('PT2H'), '2 hours', \DateInterval::class],
+            ['-1 != -2' => $negativeDateInterval, '-1 hour', '-2 hours', '-2 hours', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -40,6 +40,9 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [3, 2],
             [1, 1],
@@ -52,6 +55,12 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
             ['a', 'a'],
             ['z', 'a'],
             [null, 1],
+            ['30 > 29 (string)' => new \DateInterval('PT30S'), '+29 seconds'],
+            ['30 > 29 (\DateInterval instance)' => new \DateInterval('PT30S'), new \DateInterval('PT29S')],
+            ['30 = 30 (string)' => new \DateInterval('PT30S'), '+30 seconds'],
+            ['30 = 30 (\DateInterval instance)' => new \DateInterval('PT30S'), new \DateInterval('PT30S')],
+            ['-30 > -31' => $negativeDateInterval, '-31 seconds'],
+            ['-30 = -30' => $negativeDateInterval, '-30 seconds'],
         ];
     }
 
@@ -71,12 +80,18 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [1, '1', 2, '2', 'integer'],
             [new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2005/01/01'), 'Jan 1, 2005, 12:00 AM', 'DateTime'],
             [new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', '2005/01/01', 'Jan 1, 2005, 12:00 AM', 'DateTime'],
             [new \DateTime('2000/01/01 UTC'), 'Jan 1, 2000, 12:00 AM', '2005/01/01 UTC', 'Jan 1, 2005, 12:00 AM', 'DateTime'],
             ['b', '"b"', 'c', '"c"', 'string'],
+            ['30 < 31 (string)' => new \DateInterval('PT30S'), '30 seconds', '+31 seconds', '31 seconds', \DateInterval::class],
+            ['30 < 31 (\DateInterval instance)' => new \DateInterval('PT30S'), '30 seconds', new \DateInterval('PT31S'), '31 seconds', \DateInterval::class],
+            ['-30 < -29' => $negativeDateInterval, '-30 seconds', '-29 seconds', '-29 seconds', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -38,6 +38,8 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
             ['0', '0'],
             ['333', '0'],
             [null, 0],
+            ['30 >= 0' => new \DateInterval('PT30S'), 0],
+            ['0 >= 0' => new \DateInterval('PT0S'), 0],
         ];
     }
 
@@ -46,10 +48,14 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT45S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [-1, '-1', 0, '0', 'integer'],
             [-2, '-2', 0, '0', 'integer'],
             [-2.5, '-2.5', 0, '0', 'integer'],
+            ['-45 < 0' => $negativeDateInterval, '-45 seconds', 0, '0', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -40,6 +40,9 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [2, 1],
             [new \DateTime('2005/01/01'), new \DateTime('2001/01/01')],
@@ -48,6 +51,9 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             [new ComparisonTest_Class(5), new ComparisonTest_Class(4)],
             ['333', '22'],
             [null, 1],
+            ['30 > 29 (string)' => new \DateInterval('PT30S'), '+29 seconds'],
+            ['30 > 29 (\DateInterval instance)' => new \DateInterval('PT30S'), new \DateInterval('PT29S')],
+            ['-30 > -31' => $negativeDateInterval, '-31 seconds'],
         ];
     }
 
@@ -66,6 +72,9 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [1, '1', 2, '2', 'integer'],
             [2, '2', 2, '2', 'integer'],
@@ -79,6 +88,9 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             ['22', '"22"', '333', '"333"', 'string'],
             ['22', '"22"', '22', '"22"', 'string'],
+            ['30 < 31 (string)' => new \DateInterval('PT30S'), '30 seconds', '+31 seconds', '31 seconds', \DateInterval::class],
+            ['30 < 31 (\DateInterval instance)' => new \DateInterval('PT30S'), '30 seconds', new \DateInterval('PT31S'), '31 seconds', \DateInterval::class],
+            ['-30 < -29' => $negativeDateInterval, '-30 seconds', '-29 seconds', '-29 seconds', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -35,6 +35,7 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
             [2.5, 0],
             ['333', '0'],
             [null, 0],
+            ['1 > 0' => new \DateInterval('P1W'), 0],
         ];
     }
 
@@ -43,11 +44,15 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('P1W');
+        $negativeDateInterval->invert = 1;
+
         return [
             [0, '0', 0, '0', 'integer'],
             [-1, '-1', 0, '0', 'integer'],
             [-2, '-2', 0, '0', 'integer'],
             [-2.5, '-2.5', 0, '0', 'integer'],
+            ['-1 < 0' => $negativeDateInterval, '-7 days', 0, '0', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -67,6 +67,12 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         $immutableDate = new \DateTimeImmutable('2000-01-01');
         $comparisons[] = [$immutableDate, $immutableDate];
 
+        $comparisons['\DateInterval instance === \DateInterval instance'] = [$dateInterval = new \DateInterval('P2Y'), $dateInterval];
+
+        $negativeDateInterval = new \DateInterval('P2Y');
+        $negativeDateInterval->invert = 1;
+        $comparisons['negative \DateInterval instance === negative \DateInterval instance'] = [$negativeDateInterval, $negativeDateInterval];
+
         return $comparisons;
     }
 
@@ -85,6 +91,9 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('P2Y');
+        $negativeDateInterval->invert = 1;
+
         return [
             [1, '1', 2, '2', 'integer'],
             [2, '2', '2', '"2"', 'string'],
@@ -92,6 +101,8 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', 'DateTime'],
             [new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('1999-01-01'), 'Jan 1, 1999, 12:00 AM', 'DateTime'],
             [new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
+            ['\DateInterval instance !== same string' => new \DateInterval('P22M'), '22 months', '+22 months', '1 year and 10 months', \DateInterval::class],
+            ['negative \DateInterval instance !== same negative string' => $negativeDateInterval, '-2 years', '-2 years', '-2 years', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -40,6 +40,9 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30H');
+        $negativeDateInterval->invert = 1;
+
         return [
             [1, 2],
             [1, 1],
@@ -54,6 +57,12 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
             ['a', 'a'],
             ['a', 'z'],
             [null, 1],
+            ['30 < 31 (string)' => new \DateInterval('PT30H'), '+31 hours'],
+            ['30 < 31 (\DateInterval instance)' => new \DateInterval('PT30H'), new \DateInterval('PT31H')],
+            ['30 = 30' => new \DateInterval('PT30H'), '+30 hours'],
+            ['30 = 30' => new \DateInterval('PT30H'), new \DateInterval('PT30H')],
+            ['-30 < -29' => $negativeDateInterval, '-29 hours'],
+            ['-30 = -30' => $negativeDateInterval, '-30 hours'],
         ];
     }
 
@@ -73,6 +82,9 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30H');
+        $negativeDateInterval->invert = 1;
+
         return [
             [2, '2', 1, '1', 'integer'],
             [new \DateTime('2010-01-01'), 'Jan 1, 2010, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'],
@@ -80,6 +92,9 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2010-01-01 UTC'), 'Jan 1, 2010, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', __NAMESPACE__.'\ComparisonTest_Class'],
             ['c', '"c"', 'b', '"b"', 'string'],
+            ['30 > 29 (string)' => new \DateInterval('PT30H'), '30 hours', '+29 hours', '1 day and 5 hours', \DateInterval::class],
+            ['30 > 29 (\DateInterval instance)' => new \DateInterval('PT30H'), '30 hours', new \DateInterval('PT29H'), '1 day and 5 hours', \DateInterval::class],
+            ['-30 > -31' => $negativeDateInterval, '-30 hours', '-31 hours', '-1 day and 7 hours', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -30,12 +30,17 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [0, 0],
             [-1, 0],
             [-2, 0],
             [-2.5, 0],
             [null, 0],
+            ['-30 <= 0' => $negativeDateInterval, 0],
+            ['0 <= 0' => new \DateInterval('PT0S'), 0],
         ];
     }
 
@@ -48,6 +53,7 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
             [2, '2', 0, '0', 'integer'],
             [2.5, '2.5', 0, '0', 'integer'],
             [333, '333', 0, '0', 'integer'],
+            ['1 > 0' => new \DateInterval('P1Y'), '1 year', 0, '0', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -40,6 +40,9 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [1, 2],
             [new \DateTime('2000-01-01'), new \DateTime('2010-01-01')],
@@ -48,6 +51,9 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
             [new ComparisonTest_Class(4), new ComparisonTest_Class(5)],
             ['22', '333'],
             [null, 1],
+            ['30 < 31 (string)' => new \DateInterval('PT30S'), '+31 seconds'],
+            ['30 < 31 (\DateInterval instance)' => new \DateInterval('PT30S'), new \DateInterval('PT31S')],
+            ['-30 < -29' => $negativeDateInterval, '-29 seconds'],
         ];
     }
 
@@ -66,6 +72,9 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT30S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [3, '3', 2, '2', 'integer'],
             [2, '2', 2, '2', 'integer'],
@@ -78,6 +87,9 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             [new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             ['333', '"333"', '22', '"22"', 'string'],
+            ['30 > 29 (string)' => new \DateInterval('PT30S'), '30 seconds', '+29 seconds', '29 seconds', \DateInterval::class],
+            ['30 > 29 (\DateInterval instance)' => new \DateInterval('PT30S'), '30 seconds', new \DateInterval('PT29S'), '29 seconds', \DateInterval::class],
+            ['-30 > -31' => $negativeDateInterval, '-30 seconds', '-31 seconds', '-31 seconds', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -30,11 +30,15 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT440S');
+        $negativeDateInterval->invert = 1;
+
         return [
             [-1, 0],
             [-2, 0],
             [-2.5, 0],
             [null, 0],
+            ['-440 < 0' => $negativeDateInterval, 0],
         ];
     }
 
@@ -48,6 +52,7 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
             [2, '2', 0, '0', 'integer'],
             [2.5, '2.5', 0, '0', 'integer'],
             [333, '333', 0, '0', 'integer'],
+            ['1 > 0' => new \DateInterval('P1D'), '1 day', 0, '0', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -40,6 +40,9 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT1H');
+        $negativeDateInterval->invert = 1;
+
         return [
             [1, 2],
             ['22', '333'],
@@ -48,6 +51,9 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2001-01-01 UTC'), '2000-01-01 UTC'],
             [new ComparisonTest_Class(6), new ComparisonTest_Class(5)],
             [null, 1],
+            ['1 != 2 (string)' => new \DateInterval('PT1H'), '+2 hours'],
+            ['1 != 2 (\DateInterval instance)' => new \DateInterval('PT1H'), new \DateInterval('PT2H')],
+            ['-1 != -2' => $negativeDateInterval, '-2 hours'],
         ];
     }
 
@@ -66,6 +72,9 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideInvalidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('PT1H');
+        $negativeDateInterval->invert = 1;
+
         return [
             [3, '3', 3, '3', 'integer'],
             ['2', '"2"', 2, '2', 'integer'],
@@ -74,6 +83,9 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new \DateTime('2000-01-01 UTC'), 'Jan 1, 2000, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
+            ['1 == 1 (string)' => new \DateInterval('PT1H'), '1 hour', '+1 hour', '1 hour', \DateInterval::class],
+            ['1 == 1 (\DateInterval instance)' => new \DateInterval('PT1H'), '1 hour', new \DateInterval('PT1H'), '1 hour', \DateInterval::class],
+            ['-1 == -1' => $negativeDateInterval, '-1 hour', '-1 hour', '-1 hour', \DateInterval::class],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -40,6 +40,9 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
      */
     public function provideValidComparisons(): array
     {
+        $negativeDateInterval = new \DateInterval('P2Y');
+        $negativeDateInterval->invert = 1;
+
         return [
             [1, 2],
             ['2', 2],
@@ -51,6 +54,8 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2001-01-01'), '2000-01-01'],
             [new \DateTime('2000-01-01 UTC'), '2000-01-01 UTC'],
             [null, 1],
+            ['\DateInterval instance !== same string' => new \DateInterval('P22M'), '22 months', '+22 months', '1 year and 10 months', \DateInterval::class],
+            ['negative \DateInterval instance !== same negative string' => $negativeDateInterval, '-2 years', '-2 years', '-2 years', \DateInterval::class],
         ];
     }
 
@@ -85,11 +90,16 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         $date = new \DateTime('2000-01-01');
         $object = new ComparisonTest_Class(2);
 
+        $negativeDateInterval = new \DateInterval('P2Y');
+        $negativeDateInterval->invert = 1;
+
         $comparisons = [
             [3, '3', 3, '3', 'integer'],
             ['a', '"a"', 'a', '"a"', 'string'],
             [$date, 'Jan 1, 2000, 12:00 AM', $date, 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [$object, '2', $object, '2', __NAMESPACE__.'\ComparisonTest_Class'],
+            '\DateInterval instance === \DateInterval instance' => [$dateInterval = new \DateInterval('P1W'), '7 days', $dateInterval, '7 days', \DateInterval::class],
+            'negative \DateInterval instance === negative \DateInterval instance' => [$negativeDateInterval, '-2 years', $negativeDateInterval, '-2 years', \DateInterval::class],
         ];
 
         return $comparisons;

--- a/src/Symfony/Component/Validator/Tests/Util/DateIntervalComparisonHelperTest.php
+++ b/src/Symfony/Component/Validator/Tests/Util/DateIntervalComparisonHelperTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Util\DateIntervalComparisonHelper;
+
+final class DateIntervalComparisonHelperTest extends TestCase
+{
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(bool $expected, $value, $comparedValue)
+    {
+        $this->assertSame($expected, DateIntervalComparisonHelper::supports($value, $comparedValue));
+    }
+
+    public function supportsProvider()
+    {
+        return [
+            [false, 'foo', 'bar'],
+            [false, $dateInterval = new \DateInterval('PT30S'), new \stdClass()],
+            [false, $dateInterval, $dateInterval],
+            [false, $dateInterval, 2],
+            [true, $dateInterval, 'foo'],
+            [true, $dateInterval, new \DateInterval('PT2S')],
+            [true, $dateInterval, 0],
+        ];
+    }
+
+    public function testConvertValue()
+    {
+        $this->assertEquals(new \DateTimeImmutable('@0'), DateIntervalComparisonHelper::convertValue(new \DateTimeImmutable('@0-30 seconds'), new \DateInterval('PT30S')));
+    }
+
+    public function testConvertComparedValueWhenTheStringComparedValueIsInvalid()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DateIntervalComparisonHelper::convertComparedValue(new \DateTimeImmutable(), 'foo');
+    }
+
+    /**
+     * @dataProvider convertComparedValueProvider
+     */
+    public function testConvertComparedValue($expected, \DateTimeImmutable $reference, $comparedValue, bool $strict = false)
+    {
+        $convertedComparedValue = DateIntervalComparisonHelper::convertComparedValue($reference, $comparedValue);
+
+        if (!$strict) {
+            $this->assertEquals($expected, $convertedComparedValue);
+        } else {
+            $this->assertSame($expected, $convertedComparedValue);
+        }
+    }
+
+    public function convertComparedValueProvider()
+    {
+        return [
+            [new \DateTimeImmutable('@0-45 minutes'), new \DateTimeImmutable('@0'), '-45 minutes'],
+            [new \DateTimeImmutable('@0'), new \DateTimeImmutable('@0-1 year'), new \DateInterval('P1Y')],
+            [$reference = new \DateTimeImmutable(), $reference, 0],
+        ];
+    }
+}

--- a/src/Symfony/Component/Validator/Util/DateIntervalComparisonHelper.php
+++ b/src/Symfony/Component/Validator/Util/DateIntervalComparisonHelper.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Util;
+
+/**
+ * @internal
+ */
+final class DateIntervalComparisonHelper
+{
+    private function __construct()
+    {
+    }
+
+    public static function supports($value, $comparedValue): bool
+    {
+        return $value instanceof \DateInterval && (
+            \is_string($comparedValue) ||
+            ($comparedValue instanceof \DateInterval && $value !== $comparedValue) ||
+            0 === $comparedValue
+        );
+    }
+
+    public static function convertValue(\DateTimeImmutable $reference, \DateInterval $value): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromMutable(self::getMutableReference($reference))->add($value);
+    }
+
+    public static function convertComparedValue(\DateTimeImmutable $reference, $comparedValue): \DateTimeImmutable
+    {
+        if (\is_string($comparedValue)) {
+            $reference = \DateTimeImmutable::createFromMutable(self::getMutableReference($reference));
+
+            set_error_handler(function (int $errno, string $errstr): void {
+                throw new \InvalidArgumentException($errstr);
+            });
+
+            try {
+                return $reference->modify($comparedValue);
+            } finally {
+                restore_error_handler();
+            }
+        }
+
+        if ($comparedValue instanceof \DateInterval) {
+            return \DateTimeImmutable::createFromMutable(self::getMutableReference($reference)->add($comparedValue));
+        }
+
+        if (0 === $comparedValue) {
+            return $reference;
+        }
+
+        throw new \LogicException();
+    }
+
+    private static function getMutableReference(\DateTimeImmutable $reference): \DateTime
+    {
+        if (\PHP_VERSION_ID >= 70300) {
+            return \DateTime::createFromImmutable($reference);
+        }
+
+        return \DateTime::createFromFormat($format = 'U.u', $reference->format($format));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | TODO

That feature allows to use the `Range` and all comparisons constraints on `\DateInterval` values.

```php
/**
 * @GreaterThan("+30 seconds")
 */
private $foo;

/**
 * @Range(min="6 months", max="10 years")
 */
private $bar;
```

TODO : 
- [x] Update CHANGELOG
- [x] Test `ConstraintValidator::formatValue()` with `PRETTY_DATE_INTERVAL`
- [x] Test `ComparisonValidatorDateIntervalHelper`
- [x] Check `DivisibleBy` - this constraint is a comparison and there is no test with dates, so I guess a proper exception needs to be thrown. - see https://github.com/symfony/symfony/pull/33435

~Edit : waiting for other related PRs to be treated before resynchronizing everything on this one.~