### PR TITLE
[Finder] Prevent unintentional file locks in Windows 

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -38,11 +38,11 @@ class SortableIterator implements \IteratorAggregate
         $this->iterator = $iterator;
 
         if (self::SORT_BY_NAME === $sort) {
-            $this->sort = function ($a, $b) {
+            $this->sort = static function ($a, $b) {
                 return strcmp($a->getRealPath() ?: $a->getPathname(), $b->getRealPath() ?: $b->getPathname());
             };
         } elseif (self::SORT_BY_TYPE === $sort) {
-            $this->sort = function ($a, $b) {
+            $this->sort = static function ($a, $b) {
                 if ($a->isDir() && $b->isFile()) {
                     return -1;
                 } elseif ($a->isFile() && $b->isDir()) {
@@ -52,15 +52,15 @@ class SortableIterator implements \IteratorAggregate
                 return strcmp($a->getRealPath() ?: $a->getPathname(), $b->getRealPath() ?: $b->getPathname());
             };
         } elseif (self::SORT_BY_ACCESSED_TIME === $sort) {
-            $this->sort = function ($a, $b) {
+            $this->sort = static function ($a, $b) {
                 return $a->getATime() - $b->getATime();
             };
         } elseif (self::SORT_BY_CHANGED_TIME === $sort) {
-            $this->sort = function ($a, $b) {
+            $this->sort = static function ($a, $b) {
                 return $a->getCTime() - $b->getCTime();
             };
         } elseif (self::SORT_BY_MODIFIED_TIME === $sort) {
-            $this->sort = function ($a, $b) {
+            $this->sort = static function ($a, $b) {
                 return $a->getMTime() - $b->getMTime();
             };
         } elseif (\is_callable($sort)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes <!-- please add some, will be required by reviewers -->
| Fixed tickets | #33400   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |

~~This replaces the constructor behavior for `SortableIterator`. Instead of storing the sort strategy as a property, causing the object to hold references to the files being sorted and thus locking them in Windows, it uses a method to determine the sort strategy when calling `getIterator`.~~

Change stored `$sort` closure to a static closure. This removes the instance context that causes the file lock. This doesn't change any intended behavior.

I, unfortunately, did not provided tests for 2 reasons. The first being that I've never written tests for the Symfony framework so I do not know the nuances. ~~The second is that in order for the test to actually fail it would need to be run in the Windows OS.~~ AppVeyor tests with a Windows instance, but it appears the `Finder` tests get skipped.