### PR TITLE
[Console] Do not leak hidden console commands

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -6,6 +6,11 @@ Cache
 
  * Added argument `$prefix` to `AdapterInterface::clear()`
 
+Console
+-------
+
+ * Deprecated finding hidden commands using an abbreviation, use the full name instead
+
 Debug
 -----
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -31,6 +31,7 @@ Config
 Console
 -------
 
+ * Removed support for finding hidden commands using an abbreviation, use the full name instead
  * Removed the `setCrossingChar()` method in favor of the `setDefaultCrossingChar()` method in `TableStyle`.
  * Removed the `setHorizontalBorderChar()` method in favor of the `setDefaultCrossingChars()` method in `TableStyle`.
  * Removed the `getHorizontalBorderChar()` method in favor of the `getBorderChars()` method in `TableStyle`.

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * deprecated finding hidden commands using an abbreviation, use the full name instead
  * added `Question::setTrimmable` default to true to allow the answer to be trimmed
  * added method `preventRedrawFasterThan()` and `forceRedrawSlowerThan()` on `ProgressBar`
  * `Application` implements `ResetInterface`

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -76,6 +76,7 @@ class ApplicationTest extends TestCase
         require_once self::$fixturesPath.'/TestAmbiguousCommandRegistering.php';
         require_once self::$fixturesPath.'/TestAmbiguousCommandRegistering2.php';
         require_once self::$fixturesPath.'/FooHiddenCommand.php';
+        require_once self::$fixturesPath.'/BarHiddenCommand.php';
     }
 
     protected function normalizeLineBreaks($text)
@@ -441,6 +442,16 @@ class ApplicationTest extends TestCase
         ];
     }
 
+    public function testFindWithAmbiguousAbbreviationsFindsCommandIfAlternativesAreHidden()
+    {
+        $application = new Application();
+
+        $application->add(new \FooCommand());
+        $application->add(new \FooHiddenCommand());
+
+        $this->assertInstanceOf('FooCommand', $application->find('foo:'));
+    }
+
     public function testFindCommandEqualNamespace()
     {
         $application = new Application();
@@ -706,6 +717,49 @@ class ApplicationTest extends TestCase
         $application->add(new \FooCommand());
         $application->add(new \Foo4Command());
         $application->find('foo::bar');
+    }
+
+    public function testFindHiddenWithExactName()
+    {
+        $application = new Application();
+        $application->add(new \FooHiddenCommand());
+
+        $this->assertInstanceOf('FooHiddenCommand', $application->find('foo:hidden'));
+        $this->assertInstanceOf('FooHiddenCommand', $application->find('afoohidden'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Command "%s:hidden" is hidden, finding it using an abbreviation is deprecated since Symfony 4.4, use its full name instead.
+     * @dataProvider provideAbbreviationsForHiddenCommands
+     */
+    public function testFindHiddenWithAbbreviatedName($name)
+    {
+        $application = new Application();
+
+        $application->add(new \FooHiddenCommand());
+        $application->add(new \BarHiddenCommand());
+
+        $application->find($name);
+    }
+
+    public function provideAbbreviationsForHiddenCommands()
+    {
+        return [
+            ['foo:hidde'],
+            ['afoohidd'],
+            ['bar:hidde'],
+        ];
+    }
+
+    public function testFindAmbiguousCommandsIfAllAlternativesAreHidden()
+    {
+        $application = new Application();
+
+        $application->add(new \FooCommand());
+        $application->add(new \FooHiddenCommand());
+
+        $this->assertInstanceOf('FooCommand', $application->find('foo:'));
     }
 
     public function testSetCatchExceptions()

--- a/src/Symfony/Component/Console/Tests/Fixtures/BarHiddenCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/BarHiddenCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BarHiddenCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('bar:hidden')
+            ->setAliases(['abarhidden'])
+            ->setHidden(true)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (updated)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33398 
| License       | MIT

This PR attempts to fix hidden console commands to be leaked when interacting with the console.

These are the changes:
* Hidden commands won't be shown anymore in the list of commands in a namespace as well as the list of  suggestions ("Did you mean...") for invalid or ambiguous commands.
* Hidden commands therefore now need to be always entered with their full name.
* If an abbreviated command is entered that was previously ambiguous with (only) hidden commands, it's now executed directly (not ambiguous anymore).

Side note: When implementing the tests & changes I realized that `Application->get()` isn't side effect free (when redirecting to the help command) and behaves differently when called multiple times. It therefore must not be used from inside `find()`. Maybe we should change this? Here are the relevant bits:
https://github.com/symfony/symfony/blob/f71f74b36a80227d3e68f1b65b1f1d9b42fa9952/src/Symfony/Component/Console/Application.php#L495-L502