### PR TITLE
[PropertyInfo] Give precedence to constructor arguments over mutators

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -133,19 +133,18 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      */
     public function getTypes($class, $property, array $context = [])
     {
+        $useConstructor = $context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction;
+
+        if ($useConstructor && $fromConstructor = $this->extractFromConstructor($class, $property)) {
+            return $fromConstructor;
+        }
+
         if ($fromMutator = $this->extractFromMutator($class, $property)) {
             return $fromMutator;
         }
 
         if ($fromAccessor = $this->extractFromAccessor($class, $property)) {
             return $fromAccessor;
-        }
-
-        if (
-            ($context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction) &&
-            $fromConstructor = $this->extractFromConstructor($class, $property)
-        ) {
-            return $fromConstructor;
         }
 
         if ($fromDefaultValue = $this->extractFromDefaultValue($class, $property)) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\ImmutableTest;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended2;
@@ -338,6 +339,7 @@ class ReflectionExtractorTest extends TestCase
 
     /**
      * @dataProvider constructorTypesProvider
+     * @dataProvider constructorOnlyTypesProvider
      */
     public function testExtractTypeConstructor(string $class, string $property, array $type = null)
     {
@@ -345,10 +347,24 @@ class ReflectionExtractorTest extends TestCase
            Check that null is returned if constructor extraction is disabled */
         $this->assertEquals($type, $this->extractor->getTypes($class, $property, []));
         $this->assertEquals($type, $this->extractor->getTypes($class, $property, ['enable_constructor_extraction' => true]));
+    }
+
+    /**
+     * @dataProvider constructorOnlyTypesProvider
+     */
+    public function testExtractTypeConstructorOnly(string $class, string $property, array $type = null)
+    {
         $this->assertNull($this->extractor->getTypes($class, $property, ['enable_constructor_extraction' => false]));
     }
 
     public function constructorTypesProvider(): array
+    {
+        return [
+            [ImmutableTest::class, 'test', [new Type(Type::BUILTIN_TYPE_INT, true)]],
+        ];
+    }
+
+    public function constructorOnlyTypesProvider(): array
     {
         return [
             // php71 dummy has following constructor: __construct(string $string, int $intPrivate)

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php71Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php71Dummy.php
@@ -51,3 +51,14 @@ class Php71DummyExtended2 extends Php71Dummy
     {
     }
 }
+
+class ImmutableTest
+{
+    public function __construct(int $test = null)
+    {
+    }
+
+    public function getTest(): int
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33415
| License       | MIT
| Doc PR        | --
