### PR TITLE
[Mailer] Renamed getName() to toString()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
@@ -43,7 +43,7 @@ class MailerTest extends AbstractWebTestCase
                 $this->onDoSend = $onDoSend;
             }
 
-            public function getName(): string
+            public function __toString(): string
             {
                 return 'dummy://local';
             }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
@@ -43,7 +43,7 @@ class SesApiTransport extends AbstractApiTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('api://%s@ses?region=%s', $this->accessKey, $this->region);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpTransport.php
@@ -42,7 +42,7 @@ class SesHttpTransport extends AbstractHttpTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('http://%s@ses?region=%s', $this->accessKey, $this->region);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -36,7 +36,7 @@ class MandrillApiTransport extends AbstractApiTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('api://mandrill');
     }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
@@ -34,7 +34,7 @@ class MandrillHttpTransport extends AbstractHttpTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('http://mandrill');
     }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -41,7 +41,7 @@ class MailgunApiTransport extends AbstractApiTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('api://%s@mailgun?region=%s', $this->domain, $this->region);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
@@ -40,7 +40,7 @@ class MailgunHttpTransport extends AbstractHttpTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('http://%s@mailgun?region=%s', $this->domain, $this->region);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -36,7 +36,7 @@ class PostmarkApiTransport extends AbstractApiTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('api://postmark');
     }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridTransportFactoryTest.php
@@ -76,4 +76,9 @@ class SendgridTransportFactoryTest extends TransportFactoryTestCase
             'The "foo" scheme is not supported for mailer "sendgrid". Supported schemes are: "api", "smtp", "smtps".',
         ];
     }
+
+    public function incompleteDsnProvider(): iterable
+    {
+        yield [new Dsn('api', 'sendgrid')];
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -37,7 +37,7 @@ class SendgridApiTransport extends AbstractApiTransport
         parent::__construct($client, $dispatcher, $logger);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('api://sendgrid');
     }

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -11,7 +11,7 @@ CHANGELOG
  * Added PHPUnit constraints
  * Added `MessageDataCollector`
  * Added `MessageEvents` and `MessageLoggerListener` to allow collecting sent emails
- * [BC BREAK] `TransportInterface` has a new `getName()` method
+ * [BC BREAK] `TransportInterface` has a new `__toString()` method
  * [BC BREAK] Classes `AbstractApiTransport` and `AbstractHttpTransport` moved under `Transport` sub-namespace.
  * [BC BREAK] Transports depend on `Symfony\Contracts\EventDispatcher\EventDispatcherInterface`
    instead of `Symfony\Component\EventDispatcher\EventDispatcherInterface`.

--- a/src/Symfony/Component/Mailer/Event/MessageEvent.php
+++ b/src/Symfony/Component/Mailer/Event/MessageEvent.php
@@ -24,14 +24,14 @@ final class MessageEvent extends Event
 {
     private $message;
     private $envelope;
-    private $transportName;
+    private $transport;
     private $queued;
 
-    public function __construct(RawMessage $message, SmtpEnvelope $envelope, string $transportName, bool $queued = false)
+    public function __construct(RawMessage $message, SmtpEnvelope $envelope, string $transport, bool $queued = false)
     {
         $this->message = $message;
         $this->envelope = $envelope;
-        $this->transportName = $transportName;
+        $this->transport = $transport;
         $this->queued = $queued;
     }
 
@@ -55,9 +55,9 @@ final class MessageEvent extends Event
         $this->envelope = $envelope;
     }
 
-    public function getTransportName(): string
+    public function getTransport(): string
     {
-        return $this->transportName;
+        return $this->transport;
     }
 
     public function isQueued(): bool

--- a/src/Symfony/Component/Mailer/Event/MessageEvents.php
+++ b/src/Symfony/Component/Mailer/Event/MessageEvents.php
@@ -24,7 +24,7 @@ class MessageEvents
     public function add(MessageEvent $event): void
     {
         $this->events[] = $event;
-        $this->transports[$event->getTransportName()] = true;
+        $this->transports[$event->getTransport()] = true;
     }
 
     public function getTransports(): array
@@ -43,7 +43,7 @@ class MessageEvents
 
         $events = [];
         foreach ($this->events as $event) {
-            if ($name === $event->getTransportName()) {
+            if ($name === $event->getTransport()) {
                 $events[] = $event;
             }
         }

--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -54,7 +54,7 @@ class Mailer implements MailerInterface
                     throw new TransportException('Cannot send message without a valid envelope.', 0, $e);
                 }
             }
-            $event = new MessageEvent($message, $envelope, $this->transport->getName(), true);
+            $event = new MessageEvent($message, $envelope, (string) $this->transport, true);
             $this->dispatcher->dispatch($event);
         }
 

--- a/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
@@ -70,7 +70,7 @@ abstract class TransportFactoryTestCase extends TestCase
 
         $this->assertEquals($transport, $factory->create($dsn));
         if ('smtp' !== $dsn->getScheme() && 'smtps' !== $dsn->getScheme()) {
-            $this->assertStringMatchesFormat($dsn->getScheme().'://%S'.$dsn->getHost().'%S', $transport->getName());
+            $this->assertStringMatchesFormat($dsn->getScheme().'://%S'.$dsn->getHost().'%S', (string) $transport);
         }
     }
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
@@ -29,14 +29,14 @@ class FailoverTransportTest extends TestCase
         new FailoverTransport([]);
     }
 
-    public function testGetName()
+    public function testToString()
     {
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->expects($this->once())->method('getName')->willReturn('t1://local');
+        $t1->expects($this->once())->method('__toString')->willReturn('t1://local');
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->expects($this->once())->method('getName')->willReturn('t2://local');
+        $t2->expects($this->once())->method('__toString')->willReturn('t2://local');
         $t = new FailoverTransport([$t1, $t2]);
-        $this->assertEquals('t1://local || t2://local', $t->getName());
+        $this->assertEquals('t1://local || t2://local', (string) $t);
     }
 
     public function testSendFirstWork()

--- a/src/Symfony/Component/Mailer/Tests/Transport/NullTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/NullTransportTest.php
@@ -16,9 +16,9 @@ use Symfony\Component\Mailer\Transport\NullTransport;
 
 class NullTransportTest extends TestCase
 {
-    public function testName()
+    public function testToString()
     {
         $t = new NullTransport();
-        $this->assertEquals('smtp://null', $t->getName());
+        $this->assertEquals('smtp://null', (string) $t);
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
@@ -28,14 +28,14 @@ class RoundRobinTransportTest extends TestCase
         new RoundRobinTransport([]);
     }
 
-    public function testGetName()
+    public function testToString()
     {
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->expects($this->once())->method('getName')->willReturn('t1://local');
+        $t1->expects($this->once())->method('__toString')->willReturn('t1://local');
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->expects($this->once())->method('getName')->willReturn('t2://local');
+        $t2->expects($this->once())->method('__toString')->willReturn('t2://local');
         $t = new RoundRobinTransport([$t1, $t2]);
-        $this->assertEquals('t1://local && t2://local', $t->getName());
+        $this->assertEquals('t1://local && t2://local', (string) $t);
     }
 
     public function testSendAlternate()

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
@@ -16,9 +16,9 @@ use Symfony\Component\Mailer\Transport\SendmailTransport;
 
 class SendmailTransportTest extends TestCase
 {
-    public function testName()
+    public function testToString()
     {
         $t = new SendmailTransport();
-        $this->assertEquals('smtp://sendmail', $t->getName());
+        $this->assertEquals('smtp://sendmail', (string) $t);
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -16,28 +16,28 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 
 class EsmtpTransportTest extends TestCase
 {
-    public function testName()
+    public function testToString()
     {
         $t = new EsmtpTransport();
-        $this->assertEquals('smtp://localhost', $t->getName());
+        $this->assertEquals('smtp://localhost', (string) $t);
 
         $t = new EsmtpTransport('example.com');
         if (\defined('OPENSSL_VERSION_NUMBER')) {
-            $this->assertEquals('smtps://example.com', $t->getName());
+            $this->assertEquals('smtps://example.com', (string) $t);
         } else {
-            $this->assertEquals('smtp://example.com', $t->getName());
+            $this->assertEquals('smtp://example.com', (string) $t);
         }
 
         $t = new EsmtpTransport('example.com', 2525);
-        $this->assertEquals('smtp://example.com:2525', $t->getName());
+        $this->assertEquals('smtp://example.com:2525', (string) $t);
 
         $t = new EsmtpTransport('example.com', 0, true);
-        $this->assertEquals('smtps://example.com', $t->getName());
+        $this->assertEquals('smtps://example.com', (string) $t);
 
         $t = new EsmtpTransport('example.com', 0, false);
-        $this->assertEquals('smtp://example.com', $t->getName());
+        $this->assertEquals('smtp://example.com', (string) $t);
 
         $t = new EsmtpTransport('example.com', 466, true);
-        $this->assertEquals('smtps://example.com:466', $t->getName());
+        $this->assertEquals('smtps://example.com:466', (string) $t);
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -17,12 +17,12 @@ use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
 
 class SmtpTransportTest extends TestCase
 {
-    public function testName()
+    public function testToString()
     {
         $t = new SmtpTransport();
-        $this->assertEquals('smtps://localhost', $t->getName());
+        $this->assertEquals('smtps://localhost', (string) $t);
 
         $t = new SmtpTransport((new SocketStream())->setHost('127.0.0.1')->setPort(2525)->disableTls());
-        $this->assertEquals('smtp://127.0.0.1:2525', $t->getName());
+        $this->assertEquals('smtp://127.0.0.1:2525', (string) $t);
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -69,7 +69,7 @@ class DummyTransport implements Transport\TransportInterface
         throw new \BadMethodCallException('This method newer should be called.');
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return sprintf('dummy://local');
     }

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -67,7 +67,7 @@ abstract class AbstractTransport implements TransportInterface
             }
         }
 
-        $event = new MessageEvent($message, $envelope, $this->getName());
+        $event = new MessageEvent($message, $envelope, (string) $this);
         $this->dispatcher->dispatch($event);
         $envelope = $event->getEnvelope();
         if (!$envelope->getRecipients()) {

--- a/src/Symfony/Component/Mailer/Transport/NullTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/NullTransport.php
@@ -24,7 +24,7 @@ final class NullTransport extends AbstractTransport
     {
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return 'smtp://null';
     }

--- a/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
@@ -56,10 +56,10 @@ class RoundRobinTransport implements TransportInterface
         throw new TransportException('All transports failed.');
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         return implode(' '.$this->getNameSymbol().' ', array_map(function (TransportInterface $transport) {
-            return $transport->getName();
+            return (string) $transport;
         }, $this->transports));
     }
 

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -73,10 +73,10 @@ class SendmailTransport extends AbstractTransport
         return parent::send($message, $envelope);
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         if ($this->transport) {
-            return $this->transport->getName();
+            return (string) $this->transport;
         }
 
         return 'smtp://sendmail';

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -126,7 +126,7 @@ class SmtpTransport extends AbstractTransport
         return $message;
     }
 
-    public function getName(): string
+    public function __toString(): string
     {
         if ($this->stream instanceof SocketStream) {
             $name = sprintf('smtp%s://%s', ($tls = $this->stream->isTLS()) ? 's' : '', $this->stream->getHost());

--- a/src/Symfony/Component/Mailer/Transport/TransportInterface.php
+++ b/src/Symfony/Component/Mailer/Transport/TransportInterface.php
@@ -31,5 +31,5 @@ interface TransportInterface
      */
     public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage;
 
-    public function getName(): string;
+    public function __toString(): string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The `getName()` method on a Transport was introduced in 4.4. We rename it here as this method is mainly used by the profiler to display useful information about which mailer is used. This is more a string representation than a name (which is going to be introduced in the PR about multiple mailer support).
