### PR TITLE
Casting getInt to integer

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -142,7 +142,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function getInt(string $key, int $default = 0)
     {
-        return $this->get($key, $default);
+        return (int) $this->get($key, $default);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Until two months ago (until here https://github.com/symfony/symfony/commit/ead419b77b3a41cd7e5955a7c7811989434cca1e ) getInt was casting the returned value to integer however this was removed.
