### PR TITLE
[Mailer] Fix Mailgun support when a response is not JSON as expected

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/Api/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/Api/MailgunTransport.php
@@ -58,9 +58,11 @@ class MailgunTransport extends AbstractApiTransport
         ]);
 
         if (200 !== $response->getStatusCode()) {
-            $error = $response->toArray(false);
+            if ('application/json' === $response->getHeaders(false)['content-type'][0]) {
+                throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $response->toArray(false)['message'], $response->getStatusCode()));
+            }
 
-            throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $error['message'], $response->getStatusCode()));
+            throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $response->getContent(false), $response->getStatusCode()));
         }
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Http/MailgunTransport.php
@@ -59,9 +59,11 @@ class MailgunTransport extends AbstractHttpTransport
         ]);
 
         if (200 !== $response->getStatusCode()) {
-            $error = $response->toArray(false);
+            if ('application/json' === $response->getHeaders(false)['content-type'][0]) {
+                throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $response->toArray(false)['message'], $response->getStatusCode()));
+            }
 
-            throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $error['message'], $response->getStatusCode()));
+            throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $response->getContent(false), $response->getStatusCode()));
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #32043
| License       | MIT
| Doc PR        | n/a

Sometimes, like when getting a 401, the Mailgun API does not respond with JSON :(
