### PR TITLE
[Validator] Only handle numeric values in DivisibleBy

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DivisibleByValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DivisibleByValidator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
 /**
  * Validates that values are a multiple of the given number.
  *
@@ -23,6 +25,14 @@ class DivisibleByValidator extends AbstractComparisonValidator
      */
     protected function compareValues($value1, $value2)
     {
+        if (!is_numeric($value1)) {
+            throw new UnexpectedValueException($value1, 'numeric');
+        }
+
+        if (!is_numeric($value2)) {
+            throw new UnexpectedValueException($value2, 'numeric');
+        }
+
         if (!$value2 = abs($value2)) {
             return false;
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\DivisibleBy;
 use Symfony\Component\Validator\Constraints\DivisibleByValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 /**
  * @author Colin O'Dell <colinodell@gmail.com>
@@ -73,6 +74,27 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
             [42, '42', INF, 'INF', 'double'],
             [4.15, '4.15', 0.1, '0.1', 'double'],
             ['22', '"22"', '10', '"10"', 'string'],
+        ];
+    }
+
+    /**
+     * @dataProvider throwsOnNonNumericValuesProvider
+     */
+    public function testThrowsOnNonNumericValues(string $expectedGivenType, $value, $comparedValue)
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf('Expected argument of type "numeric", "%s" given', $expectedGivenType));
+
+        $this->validator->validate($value, $this->createConstraint([
+            'value' => $comparedValue,
+        ]));
+    }
+
+    public function throwsOnNonNumericValuesProvider()
+    {
+        return [
+            [\stdClass::class, 2, new \stdClass()],
+            [\ArrayIterator::class, new \ArrayIterator(), 12],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Currently it probably breaks because `abs` throws a notice on objects.