### PR TITLE
Fix #33427

### DIFF
--- a/src/Symfony/Component/Translation/Formatter/IntlFormatter.php
+++ b/src/Symfony/Component/Translation/Formatter/IntlFormatter.php
@@ -28,6 +28,11 @@ class IntlFormatter implements IntlFormatterInterface
      */
     public function formatIntl(string $message, string $locale, array $parameters = []): string
     {
+        // MessageFormatter constructor throws an exception if the message is empty
+        if ('' === $message) {
+            return '';
+        }
+
         if (!$formatter = $this->cache[$locale][$message] ?? null) {
             if (!($this->hasMessageFormatter ?? $this->hasMessageFormatter = class_exists(\MessageFormatter::class))) {
                 throw new LogicException('Cannot parse message translation: please install the "intl" PHP extension or the "symfony/polyfill-intl-messageformatter" package.');

--- a/src/Symfony/Component/Translation/Tests/Formatter/IntlFormatterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/IntlFormatterTest.php
@@ -82,6 +82,11 @@ _MSG_;
                 '{0,number,integer} monkeys on {1,number,integer} trees make {2,number} monkeys per tree',
                 [4560, 123, 4560 / 123],
             ],
+            [
+                '',
+                '',
+                [],
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33427
| License       | MIT
| Doc PR        | none

Fix #33427 by checking if the message returned by the intl-icu catalog is empty. If yes then the translator returns an empty string instead of running `formatIntl()` which uses the constructor of `MessageFormatter` which throws an exception with empty strings.
