### PR TITLE
[Messenger] Add doctrine transport to services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -83,6 +83,10 @@
             <tag name="kernel.reset" method="reset" />
         </service>
 
+        <service id="messenger.transport.doctrine.factory" class="Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory">
+            <tag name="messenger.transport_factory" />
+        </service>
+
         <!-- retry -->
         <service id="messenger.retry_strategy_locator">
             <tag name="container.service_locator" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Doctrine Transport was added in Messenger 4.3, but it's not added to the container. This means that in order to use Doctrine transport, e.g. for `failure_transport`, you should add it to the container yourself. 
If it's done intentionally (e.g. performance) then there should be info in documentation. 
