### PR TITLE
[TwigBridge] lint all templates from configured Twig paths if no argument was provided

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * marked all classes extending twig as `@final`
  * deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
    `DebugCommand::__construct()` method, swap the variables position.
+ * the `LintCommand` lints all the templates stored in all configured Twig paths if none argument is provided
 
 4.3.0
 -----

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -66,9 +66,18 @@ class LintCommandTest extends TestCase
         $this->assertRegExp('/ERROR  in \S+ \(line /', trim($tester->getDisplay()));
     }
 
+    public function testLintDefaultPaths()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]);
+
+        $this->assertEquals(0, $ret, 'Returns 0 in case of success');
+        self::assertStringContainsString('OK in', trim($tester->getDisplay()));
+    }
+
     private function createCommandTester(): CommandTester
     {
-        $command = new LintCommand(new Environment(new FilesystemLoader()));
+        $command = new LintCommand(new Environment(new FilesystemLoader(\dirname(__DIR__).'/Fixtures/templates/')));
 
         $application = new Application();
         $application->add($command);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/33443
| License       | MIT
| Doc PR        | -

All details in PR title and related issue https://github.com/symfony/symfony/issues/33443.