### PR TITLE
Fix gmail relay

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
@@ -35,7 +35,7 @@ abstract class AbstractStream
         $bytesToWrite = \strlen($bytes);
         $totalBytesWritten = 0;
         while ($totalBytesWritten < $bytesToWrite) {
-            $bytesWritten = fwrite($this->in, substr($bytes, $totalBytesWritten));
+            $bytesWritten = @fwrite($this->in, substr($bytes, $totalBytesWritten));
             if (false === $bytesWritten || 0 === $bytesWritten) {
                 throw new TransportException('Unable to write bytes on the wire.');
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32148 
| License       | MIT

This tiny PR fixes #32148 by removing the emission of a notice which prevented a `TransportException` to be thrown when something wrong occured.
