### PR TITLE
[Validator][4.3] Sync string to date behavior and throw a better exception

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -65,14 +65,14 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
         // This allows to compare with any date/time value supported by
         // the DateTime constructor:
         // https://php.net/datetime.formats
-        if (\is_string($comparedValue)) {
-            if ($value instanceof \DateTimeImmutable) {
-                // If $value is immutable, convert the compared value to a
-                // DateTimeImmutable too
-                $comparedValue = new \DateTimeImmutable($comparedValue);
-            } elseif ($value instanceof \DateTimeInterface) {
-                // Otherwise use DateTime
-                $comparedValue = new \DateTime($comparedValue);
+        if (\is_string($comparedValue) && $value instanceof \DateTimeInterface) {
+            // If $value is immutable, convert the compared value to a DateTimeImmutable too, otherwise use DateTime
+            $dateTimeClass = $value instanceof \DateTimeImmutable ? \DateTimeImmutable::class : \DateTime::class;
+
+            try {
+                $comparedValue = new $dateTimeClass($comparedValue);
+            } catch (\Exception $e) {
+                throw new ConstraintDefinitionException(sprintf('The compared value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $comparedValue, $dateTimeClass, \get_class($constraint)));
             }
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\AbstractComparison;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
@@ -209,6 +210,31 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
             ->setParameter('{{ compared_value_type }}', $comparedValueType)
             ->setCode($this->getErrorCode())
             ->assertRaised();
+    }
+
+    /**
+     * @dataProvider throwsOnInvalidStringDatesProvider
+     */
+    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->validator->validate($value, $constraint);
+    }
+
+    public function throwsOnInvalidStringDatesProvider()
+    {
+        $constraint = $this->createConstraint([
+            'value' => 'foo',
+        ]);
+
+        $constraintClass = \get_class($constraint);
+
+        return [
+            [$constraint, sprintf('The compared value "foo" could not be converted to a "DateTimeImmutable" instance in the "%s" constraint.', $constraintClass), new \DateTimeImmutable()],
+            [$constraint, sprintf('The compared value "foo" could not be converted to a "DateTime" instance in the "%s" constraint.', $constraintClass), new \DateTime()],
+        ];
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraints\AbstractComparison;
 use Symfony\Component\Validator\Constraints\PositiveOrZero;
 
 /**
@@ -98,10 +99,10 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
     }
 
     /**
-     * @dataProvider provideValidComparisonsToPropertyPath
+     * @dataProvider throwsOnInvalidStringDatesProvider
      */
-    public function testValidComparisonToPropertyPathOnArray($comparedValue)
+    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
     {
-        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraints\AbstractComparison;
 use Symfony\Component\Validator\Constraints\Positive;
 
 /**
@@ -101,10 +102,10 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
     }
 
     /**
-     * @dataProvider provideValidComparisonsToPropertyPath
+     * @dataProvider throwsOnInvalidStringDatesProvider
      */
-    public function testValidComparisonToPropertyPathOnArray($comparedValue)
+    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
     {
-        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraints\AbstractComparison;
 use Symfony\Component\Validator\Constraints\NegativeOrZero;
 
 /**
@@ -101,10 +102,10 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
     }
 
     /**
-     * @dataProvider provideValidComparisonsToPropertyPath
+     * @dataProvider throwsOnInvalidStringDatesProvider
      */
-    public function testValidComparisonToPropertyPathOnArray($comparedValue)
+    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
     {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Validator\Constraints\AbstractComparison;
 use Symfony\Component\Validator\Constraints\Negative;
 
 /**
@@ -101,10 +102,10 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
     }
 
     /**
-     * @dataProvider provideValidComparisonsToPropertyPath
+     * @dataProvider throwsOnInvalidStringDatesProvider
      */
-    public function testValidComparisonToPropertyPathOnArray($comparedValue)
+    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
     {
-        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\RangeValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class RangeValidatorTest extends ConstraintValidatorTestCase
@@ -388,5 +389,30 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ value }}', '"abcd"')
             ->setCode(Range::INVALID_CHARACTERS_ERROR)
             ->assertRaised();
+    }
+
+    /**
+     * @dataProvider throwsOnInvalidStringDatesProvider
+     */
+    public function testThrowsOnInvalidStringDates($expectedMessage, $value, $min, $max)
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->validator->validate($value, new Range([
+            'min' => $min,
+            'max' => $max,
+        ]));
+    }
+
+    public function throwsOnInvalidStringDatesProvider()
+    {
+        return [
+            ['The min value "foo" could not be converted to a "DateTimeImmutable" instance in the "Symfony\Component\Validator\Constraints\Range" constraint.', new \DateTimeImmutable(), 'foo', null],
+            ['The min value "foo" could not be converted to a "DateTime" instance in the "Symfony\Component\Validator\Constraints\Range" constraint.', new \DateTime(), 'foo', null],
+            ['The max value "foo" could not be converted to a "DateTimeImmutable" instance in the "Symfony\Component\Validator\Constraints\Range" constraint.', new \DateTimeImmutable(), null, 'foo'],
+            ['The max value "foo" could not be converted to a "DateTime" instance in the "Symfony\Component\Validator\Constraints\Range" constraint.', new \DateTime(), null, 'foo'],
+            ['The min value "bar" could not be converted to a "DateTimeImmutable" instance in the "Symfony\Component\Validator\Constraints\Range" constraint.', new \DateTimeImmutable(), 'bar', 'ccc'],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/33439#issuecomment-527604946
| License       | MIT
| Doc PR        | -

As asked by @nicolas-grekas 