### PR TITLE
Add twig template to toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * deprecated the `ExceptionController` in favor of `ExceptionPanelController`
  * marked all classes of the WebProfilerBundle as internal
  * added a section with the stamps of a message after it is dispatched in the Messenger panel
+ * added the template used in the toolbar
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -25,6 +25,15 @@
             <b>Macro Calls</b>
             <span class="sf-toolbar-status">{{ collector.macrocount }}</span>
         </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Template</b>
+            <span>
+                {% for template, count in collector.templates|slice(0,1) %}
+                    {%- set file = collector.templatePaths[template]|default(false) -%}
+                    {{ file|file_relative|default(file) }}
+                {% endfor %}
+            </span>
+        </div>
     {% endset %}
 
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hi,

When I'm working on an already existing symfony project for a client, I'm usually given an URL and asked "add this to this page, remove this" etc...

The toolbar has almost everything I need : the controller, the action and the route name. But it doesn't have the twig template to modify. I need to open the profiler to have this information.

I propose this small modification so we can have the template name directly in the toolbar, in the twig section.

![image](https://user-images.githubusercontent.com/35108257/64239090-dcecce80-ceff-11e9-9157-427c0fbe1433.png)