### PR TITLE
[Mailer] Fix an error message

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -77,12 +77,12 @@ class DsnTest extends TestCase
 
         yield [
             '//sendmail',
-            'The "//sendmail" mailer DSN must contain a transport scheme.',
+            'The "//sendmail" mailer DSN must contain a scheme.',
         ];
 
         yield [
             'file:///some/path',
-            'The "file:///some/path" mailer DSN must contain a mailer name.',
+            'The "file:///some/path" mailer DSN must contain a host (use "default" by default).',
         ];
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -42,11 +42,11 @@ final class Dsn
         }
 
         if (!isset($parsedDsn['scheme'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a transport scheme.', $dsn));
+            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a scheme.', $dsn));
         }
 
         if (!isset($parsedDsn['host'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a mailer name.', $dsn));
+            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a host (use "default" by default).', $dsn));
         }
 
         $user = isset($parsedDsn['user']) ? urldecode($parsedDsn['user']) : null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Now  that the host is not the name anymore, the error message when not having a host is wrong.
