### PR TITLE
[Mailer] Added messenger to dev dependencies

### DIFF
--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -29,6 +29,7 @@
         "symfony/http-client-contracts": "^1.1",
         "symfony/mailgun-mailer": "^4.4|^5.0",
         "symfony/mailchimp-mailer": "^4.4|^5.0",
+        "symfony/messenger": "^4.4|^5.0",
         "symfony/postmark-mailer": "^4.4|^5.0",
         "symfony/sendgrid-mailer": "^4.4|^5.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

PR #33454 introduced a new test case that mocks the `MessageBusInterface` from the messenger component. This makes the tests suite fail on travis because PHPUnit refuses to create a mock for an interface that does not exist.

```
There was 1 failure:

1) Symfony\Component\Mailer\Tests\MailerTest::testSendingRawMessages

Failed asserting that exception of type "PHPUnit\Framework\MockObject\RuntimeException" matches expected exception "Symfony\Component\Mailer\Exception\LogicException". Message was: "Cannot stub or mock class or interface "Symfony\Component\Messenger\MessageBusInterface" which does not exist" at

/home/travis/build/symfony/symfony/src/Symfony/Component/Mailer/Tests/MailerTest.php:28
```

This PR fixes the test by adding the Messenger component to Mailer's dev dependencies.