### PR TITLE
[Messenger] fix empty amqp body returned as false

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -60,9 +60,11 @@ class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
             return;
         }
 
+        $body = $amqpEnvelope->getBody();
+
         try {
             $envelope = $this->serializer->decode([
-                'body' => $amqpEnvelope->getBody(),
+                'body' => false === $body ? '' : $body, // workaround https://github.com/pdezwart/php-amqp/issues/351
                 'headers' => $amqpEnvelope->getHeaders(),
             ]);
         } catch (MessageDecodingFailedException $exception) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |
| License       | MIT
| Doc PR        | 

Having `false` in the body breaks typehints in the serializer and is not consistent with other transports like doctrine. See https://github.com/pdezwart/php-amqp/issues/351