### PR TITLE
Fix test fixtures with deprecated method signatures

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/ClassThatInheritLogger.php
+++ b/src/Symfony/Bridge/Monolog/Tests/ClassThatInheritLogger.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests;
+
+use Symfony\Bridge\Monolog\Logger;
+
+class ClassThatInheritLogger extends Logger
+{
+    public function getLogs(): array
+    {
+        return parent::getLogs();
+    }
+
+    public function countErrors(): int
+    {
+        return parent::countErrors();
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -128,33 +128,12 @@ class LoggerTest extends TestCase
     /**
      * @group legacy
      * @expectedDeprecation The "Symfony\Bridge\Monolog\Logger::getLogs()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
+     * @expectedDeprecation The "Symfony\Bridge\Monolog\Logger::countErrors()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
      */
-    public function testInheritedClassCallGetLogsWithoutArgument()
+    public function testInheritedClassWithoutArgument()
     {
         $loggerChild = new ClassThatInheritLogger('test');
         $loggerChild->getLogs();
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation The "Symfony\Bridge\Monolog\Logger::countErrors()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
-     */
-    public function testInheritedClassCallCountErrorsWithoutArgument()
-    {
-        $loggerChild = new ClassThatInheritLogger('test');
         $loggerChild->countErrors();
-    }
-}
-
-class ClassThatInheritLogger extends Logger
-{
-    public function getLogs()
-    {
-        parent::getLogs();
-    }
-
-    public function countErrors()
-    {
-        parent::countErrors();
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/ClassThatInheritDebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/ClassThatInheritDebugProcessor.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Processor;
+
+use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+
+class ClassThatInheritDebugProcessor extends DebugProcessor
+{
+    public function getLogs(): array
+    {
+        return parent::getLogs();
+    }
+
+    public function countErrors(): int
+    {
+        return parent::countErrors();
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
@@ -66,20 +66,12 @@ class DebugProcessorTest extends TestCase
     /**
      * @group legacy
      * @expectedDeprecation The "Symfony\Bridge\Monolog\Processor\DebugProcessor::getLogs()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
+     * @expectedDeprecation The "Symfony\Bridge\Monolog\Processor\DebugProcessor::countErrors()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
      */
-    public function testInheritedClassCallGetLogsWithoutArgument()
+    public function testInheritedClassWithoutArgument()
     {
         $debugProcessorChild = new ClassThatInheritDebugProcessor();
         $debugProcessorChild->getLogs();
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation The "Symfony\Bridge\Monolog\Processor\DebugProcessor::countErrors()" method will have a new "Request $request = null" argument in version 5.0, not defining it is deprecated since Symfony 4.2.
-     */
-    public function testInheritedClassCallCountErrorsWithoutArgument()
-    {
-        $debugProcessorChild = new ClassThatInheritDebugProcessor();
         $debugProcessorChild->countErrors();
     }
 
@@ -94,18 +86,5 @@ class DebugProcessorTest extends TestCase
             'datetime' => new \DateTime(),
             'extra' => [],
         ];
-    }
-}
-
-class ClassThatInheritDebugProcessor extends DebugProcessor
-{
-    public function getLogs()
-    {
-        parent::getLogs();
-    }
-
-    public function countErrors()
-    {
-        parent::countErrors();
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -81,13 +81,16 @@ class AbstractControllerTest extends ControllerTraitTest
 
 class TestAbstractController extends AbstractController
 {
-    use TestControllerTrait;
-
     private $throwOnUnexpectedService;
 
     public function __construct($throwOnUnexpectedService = true)
     {
         $this->throwOnUnexpectedService = $throwOnUnexpectedService;
+    }
+
+    public function __call(string $method, array $arguments)
+    {
+        return $this->$method(...$arguments);
     }
 
     public function setContainer(ContainerInterface $container)
@@ -112,11 +115,6 @@ class TestAbstractController extends AbstractController
         }
 
         return parent::setContainer($container);
-    }
-
-    public function getParameter(string $name)
-    {
-        return parent::getParameter($name);
     }
 
     public function fooAction()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Fig\Link\Link;
-use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Form;
@@ -548,31 +547,5 @@ abstract class ControllerTraitTest extends TestCase
         $links = $request->attributes->get('_links')->getLinks();
         $this->assertContains($link1, $links);
         $this->assertContains($link2, $links);
-    }
-}
-
-trait TestControllerTrait
-{
-    use ControllerTrait {
-        generateUrl as public;
-        redirect as public;
-        forward as public;
-        getUser as public;
-        json as public;
-        file as public;
-        isGranted as public;
-        denyAccessUnlessGranted as public;
-        redirectToRoute as public;
-        addFlash as public;
-        isCsrfTokenValid as public;
-        renderView as public;
-        render as public;
-        stream as public;
-        createNotFoundException as public;
-        createAccessDeniedException as public;
-        createForm as public;
-        createFormBuilder as public;
-        getDoctrine as public;
-        addLink as public;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TestController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TestController.php
@@ -3,8 +3,30 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
 
 class TestController extends Controller
 {
-    use TestControllerTrait;
+    use ControllerTrait {
+        generateUrl as public;
+        redirect as public;
+        forward as public;
+        getUser as public;
+        json as public;
+        file as public;
+        isGranted as public;
+        denyAccessUnlessGranted as public;
+        redirectToRoute as public;
+        addFlash as public;
+        isCsrfTokenValid as public;
+        renderView as public;
+        render as public;
+        stream as public;
+        createNotFoundException as public;
+        createAccessDeniedException as public;
+        createForm as public;
+        createFormBuilder as public;
+        getDoctrine as public;
+        addLink as public;
+    }
 }

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -19,61 +19,6 @@ use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\DomCrawler\Form as DomCrawlerForm;
 
-class SpecialResponse extends Response
-{
-}
-
-class TestClient extends AbstractBrowser
-{
-    protected $nextResponse = null;
-    protected $nextScript = null;
-
-    public function setNextResponse(Response $response)
-    {
-        $this->nextResponse = $response;
-    }
-
-    public function setNextScript($script)
-    {
-        $this->nextScript = $script;
-    }
-
-    protected function doRequest($request)
-    {
-        if (null === $this->nextResponse) {
-            return new Response();
-        }
-
-        $response = $this->nextResponse;
-        $this->nextResponse = null;
-
-        return $response;
-    }
-
-    protected function filterResponse($response)
-    {
-        if ($response instanceof SpecialResponse) {
-            return new Response($response->getContent(), $response->getStatusCode(), $response->getHeaders());
-        }
-
-        return $response;
-    }
-
-    protected function getScript($request)
-    {
-        $r = new \ReflectionClass('Symfony\Component\BrowserKit\Response');
-        $path = $r->getFileName();
-
-        return <<<EOF
-<?php
-
-require_once('$path');
-
-echo serialize($this->nextScript);
-EOF;
-    }
-}
-
 class AbstractBrowserTest extends TestCase
 {
     public function getBrowser(array $server = [], History $history = null, CookieJar $cookieJar = null)
@@ -157,17 +102,6 @@ class AbstractBrowserTest extends TestCase
     {
         $client = $this->getBrowser();
         $this->assertNull($client->getResponse());
-    }
-
-    public function testGetInternalResponse()
-    {
-        $client = $this->getBrowser();
-        $client->setNextResponse(new SpecialResponse('foo'));
-        $client->request('GET', 'http://example.com/');
-
-        $this->assertInstanceOf('Symfony\Component\BrowserKit\Response', $client->getInternalResponse());
-        $this->assertNotInstanceOf('Symfony\Component\BrowserKit\Tests\SpecialResponse', $client->getInternalResponse());
-        $this->assertInstanceOf('Symfony\Component\BrowserKit\Tests\SpecialResponse', $client->getResponse());
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Tests/ClassThatInheritClient.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClassThatInheritClient.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\BrowserKit\Tests;
+
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Response;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\Form as DomCrawlerForm;
+
+class ClassThatInheritClient extends AbstractBrowser
+{
+    protected $nextResponse = null;
+
+    public function setNextResponse(Response $response)
+    {
+        $this->nextResponse = $response;
+    }
+
+    protected function doRequest($request): Response
+    {
+        if (null === $this->nextResponse) {
+            return new Response();
+        }
+
+        $response = $this->nextResponse;
+        $this->nextResponse = null;
+
+        return $response;
+    }
+
+    public function submit(DomCrawlerForm $form, array $values = []): Crawler
+    {
+        return parent::submit($form, $values);
+    }
+}

--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -14,105 +14,14 @@ namespace Symfony\Component\BrowserKit\Tests;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\HttpBrowser;
-use Symfony\Component\BrowserKit\Response;
-use Symfony\Component\HttpClient\MockHttpClient;
-use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
-
-class SpecialHttpResponse extends Response
-{
-}
-
-class TestHttpClient extends HttpBrowser
-{
-    protected $nextResponse = null;
-    protected $nextScript = null;
-
-    public function __construct(array $server = [], History $history = null, CookieJar $cookieJar = null)
-    {
-        $client = new MockHttpClient(function (string $method, string $url, array $options) {
-            if (null === $this->nextResponse) {
-                return new MockResponse();
-            }
-
-            return new MockResponse($this->nextResponse->getContent(), [
-                'http_code' => $this->nextResponse->getStatusCode(),
-                'response_headers' => $this->nextResponse->getHeaders(),
-            ]);
-        });
-        parent::__construct($client);
-
-        $this->setServerParameters($server);
-        $this->history = $history ?? new History();
-        $this->cookieJar = $cookieJar ?? new CookieJar();
-    }
-
-    public function setNextResponse(Response $response)
-    {
-        $this->nextResponse = $response;
-    }
-
-    public function setNextScript($script)
-    {
-        $this->nextScript = $script;
-    }
-
-    protected function filterResponse($response)
-    {
-        if ($response instanceof SpecialHttpResponse) {
-            return new Response($response->getContent(), $response->getStatusCode(), $response->getHeaders());
-        }
-
-        return $response;
-    }
-
-    protected function doRequest($request)
-    {
-        $response = parent::doRequest($request);
-
-        if (null === $this->nextResponse) {
-            return $response;
-        }
-
-        $class = \get_class($this->nextResponse);
-        $response = new $class($response->getContent(), $response->getStatusCode(), $response->getHeaders());
-        $this->nextResponse = null;
-
-        return $response;
-    }
-
-    protected function getScript($request)
-    {
-        $r = new \ReflectionClass('Symfony\Component\BrowserKit\Response');
-        $path = $r->getFileName();
-
-        return <<<EOF
-<?php
-
-require_once('$path');
-
-echo serialize($this->nextScript);
-EOF;
-    }
-}
 
 class HttpBrowserTest extends AbstractBrowserTest
 {
     public function getBrowser(array $server = [], History $history = null, CookieJar $cookieJar = null)
     {
         return new TestHttpClient($server, $history, $cookieJar);
-    }
-
-    public function testGetInternalResponse()
-    {
-        $client = $this->getBrowser();
-        $client->setNextResponse(new SpecialHttpResponse('foo'));
-        $client->request('GET', 'http://example.com/');
-
-        $this->assertInstanceOf('Symfony\Component\BrowserKit\Response', $client->getInternalResponse());
-        $this->assertNotInstanceOf('Symfony\Component\BrowserKit\Tests\SpecialHttpResponse', $client->getInternalResponse());
-        $this->assertInstanceOf('Symfony\Component\BrowserKit\Tests\SpecialHttpResponse', $client->getResponse());
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Tests/TestClient.php
+++ b/src/Symfony/Component/BrowserKit/Tests/TestClient.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\BrowserKit\Tests;
+
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Response;
+
+class TestClient extends AbstractBrowser
+{
+    protected $nextResponse = null;
+    protected $nextScript = null;
+
+    public function setNextResponse(Response $response)
+    {
+        $this->nextResponse = $response;
+    }
+
+    public function setNextScript($script)
+    {
+        $this->nextScript = $script;
+    }
+
+    protected function doRequest($request): Response
+    {
+        if (null === $this->nextResponse) {
+            return new Response();
+        }
+
+        $response = $this->nextResponse;
+        $this->nextResponse = null;
+
+        return $response;
+    }
+
+    protected function getScript($request)
+    {
+        $r = new \ReflectionClass('Symfony\Component\BrowserKit\Response');
+        $path = $r->getFileName();
+
+        return <<<EOF
+<?php
+
+require_once('$path');
+
+echo serialize($this->nextScript);
+EOF;
+    }
+}

--- a/src/Symfony/Component/BrowserKit/Tests/TestHttpClient.php
+++ b/src/Symfony/Component/BrowserKit/Tests/TestHttpClient.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\BrowserKit\Tests;
+
+use Symfony\Component\BrowserKit\CookieJar;
+use Symfony\Component\BrowserKit\History;
+use Symfony\Component\BrowserKit\HttpBrowser;
+use Symfony\Component\BrowserKit\Response;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class TestHttpClient extends HttpBrowser
+{
+    protected $nextResponse = null;
+    protected $nextScript = null;
+
+    public function __construct(array $server = [], History $history = null, CookieJar $cookieJar = null)
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options) {
+            if (null === $this->nextResponse) {
+                return new MockResponse();
+            }
+
+            return new MockResponse($this->nextResponse->getContent(), [
+                'http_code' => $this->nextResponse->getStatusCode(),
+                'response_headers' => $this->nextResponse->getHeaders(),
+            ]);
+        });
+        parent::__construct($client);
+
+        $this->setServerParameters($server);
+        $this->history = $history ?? new History();
+        $this->cookieJar = $cookieJar ?? new CookieJar();
+    }
+
+    public function setNextResponse(Response $response)
+    {
+        $this->nextResponse = $response;
+    }
+
+    public function setNextScript($script)
+    {
+        $this->nextScript = $script;
+    }
+
+    protected function doRequest($request): Response
+    {
+        if (null === $this->nextResponse) {
+            return parent::doRequest($request);
+        }
+
+        $response = $this->nextResponse;
+        $this->nextResponse = null;
+
+        return $response;
+    }
+
+    protected function getScript($request)
+    {
+        $r = new \ReflectionClass('Symfony\Component\BrowserKit\Response');
+        $path = $r->getFileName();
+
+        return <<<EOF
+<?php
+
+require_once('$path');
+
+echo serialize($this->nextScript);
+EOF;
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -1238,11 +1238,3 @@ HTML;
         return $domxpath->query('//div');
     }
 }
-
-class ClassThatInheritCrawler extends Crawler
-{
-    public function children()
-    {
-        parent::children();
-    }
-}

--- a/src/Symfony/Component/DomCrawler/Tests/ClassThatInheritCrawler.php
+++ b/src/Symfony/Component/DomCrawler/Tests/ClassThatInheritCrawler.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+class ClassThatInheritCrawler extends Crawler
+{
+    /**
+     * @return static
+     */
+    public function children()
+    {
+        return parent::children();
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/ClassThatInheritFinder.php
+++ b/src/Symfony/Component/Finder/Tests/ClassThatInheritFinder.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests;
+
+use Symfony\Component\Finder\Finder;
+
+class ClassThatInheritFinder extends Finder
+{
+    /**
+     * @return $this
+     */
+    public function sortByName()
+    {
+        parent::sortByName();
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -873,6 +873,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         $expected = [
             self::$tmpDir.\DIRECTORY_SEPARATOR.'test.php',
+            __DIR__.\DIRECTORY_SEPARATOR.'ClassThatInheritFinder.php',
             __DIR__.\DIRECTORY_SEPARATOR.'GitignoreTest.php',
             __DIR__.\DIRECTORY_SEPARATOR.'FinderTest.php',
             __DIR__.\DIRECTORY_SEPARATOR.'GlobTest.php',
@@ -1433,13 +1434,5 @@ class FinderTest extends Iterator\RealIteratorTestCase
     protected function buildFinder()
     {
         return Finder::create();
-    }
-}
-
-class ClassThatInheritFinder extends Finder
-{
-    public function sortByName()
-    {
-        parent::sortByName();
     }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTypeExtensionTest.php
@@ -12,12 +12,13 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 class AbstractTypeExtensionTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testImplementingNeitherGetExtendedTypeNorExtendsTypeThrowsException()
     {
         $this->expectException('Symfony\Component\Form\Exception\LogicException');
@@ -28,6 +29,7 @@ class AbstractTypeExtensionTest extends TestCase
 
     /**
      * @group legacy
+     * @expectedDeprecation The Symfony\Component\Form\Tests\MultipleTypesExtension::getExtendedType() method is deprecated since Symfony 4.2 and will be removed in 5.0. Use getExtendedTypes() instead.
      */
     public function testGetExtendedTypeReturnsFirstConfiguredExtension()
     {
@@ -35,17 +37,4 @@ class AbstractTypeExtensionTest extends TestCase
 
         $this->assertSame(DateTimeType::class, $extension->getExtendedType());
     }
-}
-
-class MultipleTypesExtension extends AbstractTypeExtension
-{
-    public static function getExtendedTypes(): iterable
-    {
-        yield DateTimeType::class;
-        yield DateType::class;
-    }
-}
-
-class TypeExtensionWithoutExtendedTypes extends AbstractTypeExtension
-{
 }

--- a/src/Symfony/Component/Form/Tests/MultipleTypesExtension.php
+++ b/src/Symfony/Component/Form/Tests/MultipleTypesExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+
+class MultipleTypesExtension extends AbstractTypeExtension
+{
+    public static function getExtendedTypes(): iterable
+    {
+        yield DateTimeType::class;
+        yield DateType::class;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/TypeExtensionWithoutExtendedTypes.php
+++ b/src/Symfony/Component/Form/Tests/TypeExtensionWithoutExtendedTypes.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+
+class TypeExtensionWithoutExtendedTypes extends AbstractTypeExtension
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -159,7 +159,7 @@ class ExceptionListenerTest extends TestCase
 
 class TestLogger extends Logger implements DebugLoggerInterface
 {
-    public function countErrors()
+    public function countErrors(Request $request = null)
     {
         return \count($this->logs['critical']);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -172,6 +172,10 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
+    public function getRoleNames(): array
+    {
+    }
+
     public function getCredentials()
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #33483 (partly)
| License       | MIT
| Doc PR        | N/A

This PR upgrades two fixtures that implemented deprecated method signatures. As far as I can tell, they are used in tests that do not specifically test legacy behavior, so the fixtures should be up to date. Currently, these fixtures cause failing tests on the 4.4 branch.