### PR TITLE
[Bridge/Twig] use tty group on testLintDefaultPaths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -289,7 +289,7 @@ install:
               fi
 
               echo "$COMPONENTS" | parallel --gnu "tfold {} $PHPUNIT_X {}"
-              tfold src/Symfony/Component/Console.tty $PHPUNIT src/Symfony/Component/Console --group tty
+              tfold src/Symfony/Component/Console.tty $PHPUNIT --group tty
               if [[ $PHP = ${MIN_PHP%.*} ]]; then
                   export PHP=$MIN_PHP
                   tfold src/Symfony/Component/Process.sigchild SYMFONY_DEPRECATIONS_HELPER=weak php-$MIN_PHP/sapi/cli/php ./phpunit --colors=always src/Symfony/Component/Process/

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -66,6 +66,9 @@ class LintCommandTest extends TestCase
         $this->assertRegExp('/ERROR  in \S+ \(line /', trim($tester->getDisplay()));
     }
 
+    /**
+     * @group tty
+     */
     public function testLintDefaultPaths()
     {
         $tester = $this->createCommandTester();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/33446#issuecomment-528811376
| License       | MIT
| Doc PR        | -

Note that I still think we should deprecate reading from STDIN when not explicitly asked for, as explained in https://github.com/symfony/symfony/pull/33446#issuecomment-528276646