### PR TITLE
[Mailer] Change DSN syntax

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -4,6 +4,18 @@ CHANGELOG
 4.4.0
 -----
 
+ * [BC BREAK] changed the syntax for failover and roundrobin DSNs
+
+   Before:
+
+   dummy://a || dummy://b (for failover)
+   dummy://a && dummy://b (for roundrobin)
+
+   After:
+
+   failover(dummy://a dummy://b)
+   roundrobin(dummy://a dummy://b)
+
  * added support for multiple transports on a `Mailer` instance
  * [BC BREAK] removed the `auth_mode` DSN option (it is now always determined automatically)
  * STARTTLS cannot be enabled anymore (it is used automatically if TLS is disabled and the server supports STARTTLS)

--- a/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
@@ -36,7 +36,7 @@ class FailoverTransportTest extends TestCase
         $t2 = $this->createMock(TransportInterface::class);
         $t2->expects($this->once())->method('__toString')->willReturn('t2://local');
         $t = new FailoverTransport([$t1, $t2]);
-        $this->assertEquals('t1://local || t2://local', (string) $t);
+        $this->assertEquals('failover(t1://local t2://local)', (string) $t);
     }
 
     public function testSendFirstWork()

--- a/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
@@ -35,7 +35,7 @@ class RoundRobinTransportTest extends TestCase
         $t2 = $this->createMock(TransportInterface::class);
         $t2->expects($this->once())->method('__toString')->willReturn('t2://local');
         $t = new RoundRobinTransport([$t1, $t2]);
-        $this->assertEquals('t1://local && t2://local', (string) $t);
+        $this->assertEquals('roundrobin(t1://local t2://local)', (string) $t);
     }
 
     public function testSendAlternate()

--- a/src/Symfony/Component/Mailer/Transport/FailoverTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/FailoverTransport.php
@@ -31,6 +31,6 @@ class FailoverTransport extends RoundRobinTransport
 
     protected function getNameSymbol(): string
     {
-        return '||';
+        return 'failover';
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
@@ -58,9 +58,9 @@ class RoundRobinTransport implements TransportInterface
 
     public function __toString(): string
     {
-        return implode(' '.$this->getNameSymbol().' ', array_map(function (TransportInterface $transport) {
+        return $this->getNameSymbol().'('.implode(' ', array_map(function (TransportInterface $transport) {
             return (string) $transport;
-        }, $this->transports));
+        }, $this->transports)).')';
     }
 
     /**
@@ -99,7 +99,7 @@ class RoundRobinTransport implements TransportInterface
 
     protected function getNameSymbol(): string
     {
-        return '&&';
+        return 'roundrobin';
     }
 
     private function moveCursor(int $cursor): int


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | -

The current syntax for failover and roundrobin is confusing. `&&` and `||` do not really convey the right meaning. I realized that while working on a new transport that will send on more than one transport in parallel. `&&` would be a natural fit, but that's already taken.

So, this pull request changes the syntax to be more explicit.
