### PR TITLE
Deprecated not passing dash symbol (-) to STDIN commands

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -207,12 +207,14 @@ Translation
 -----------
 
  * Deprecated support for using `null` as the locale in `Translator`.
+ * Deprecated accepting STDIN implicitly when using the `lint:xliff` command, use `lint:xliff -` (append a dash) instead to make it explicit.
 
 TwigBridge
 ----------
 
  * Deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the
    `DebugCommand::__construct()` method, swap the variables position.
+ * Deprecated accepting STDIN implicitly when using the `lint:twig` command, use `lint:twig -` (append a dash) instead to make it explicit.
    
 TwigBundle
 ----------
@@ -326,3 +328,8 @@ WebServerBundle
 ---------------
 
  * The bundle is deprecated and will be removed in 5.0.
+ 
+Yaml
+----
+
+* Deprecated accepting STDIN implicitly when using the `lint:yaml` command, use `lint:yaml -` (append a dash) instead to make it explicit.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -531,6 +531,7 @@ Translation
  * The `MessageSelector`, `Interval` and `PluralizationRules` classes have been removed, use `IdentityTranslator` instead
  * The `Translator::getFallbackLocales()` and `TranslationDataCollector::getFallbackLocales()` method are now internal
  * The `Translator::transChoice()` method has been removed in favor of using `Translator::trans()` with "%count%" as the parameter driving plurals
+ * Removed support for implicit STDIN usage in the `lint:xliff` command, use `lint:xliff -` (append a dash) instead to make it explicit.
 
 TwigBundle
 ----------
@@ -548,6 +549,7 @@ TwigBridge
  * removed the `$requestStack` and `$requestContext` arguments of the
    `HttpFoundationExtension`, pass a `Symfony\Component\HttpFoundation\UrlHelper`
    instance as the only argument instead
+ * Removed support for implicit STDIN usage in the `lint:twig` command, use `lint:twig -` (append a dash) instead to make it explicit.
 
 Validator
 --------
@@ -653,6 +655,7 @@ Yaml
 
  * The parser is now stricter and will throw a `ParseException` when a
    mapping is found inside a multi-line string.
+ * Removed support for implicit STDIN usage in the `lint:yaml` command, use `lint:yaml -` (append a dash) instead to make it explicit.
 
 WebProfilerBundle
 -----------------

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
    `DebugCommand::__construct()` method, swap the variables position.
  * the `LintCommand` lints all the templates stored in all configured Twig paths if none argument is provided
+ * deprecated accepting STDIN implicitly when using the `lint:twig` command, use `lint:twig -` (append a dash) instead to make it explicit.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * deprecated support for using `null` as the locale in `Translator`
+ * deprecated accepting STDIN implicitly when using the `lint:xliff` command, use `lint:xliff -` (append a dash) instead to make it explicit.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added support to dump `null` as `~` by using the `Yaml::DUMP_NULL_AS_TILDE` flag.
+ * deprecated accepting STDIN implicitly when using the `lint:yaml` command, use `lint:yaml -` (append a dash) instead to make it explicit.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -54,7 +54,7 @@ class LintCommand extends Command
     {
         $this
             ->setDescription('Lints a file and outputs encountered errors')
-            ->addArgument('filename', InputArgument::IS_ARRAY, 'A file or a directory or STDIN')
+            ->addArgument('filename', InputArgument::IS_ARRAY, 'A file, a directory or "-" for reading from STDIN')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'txt')
             ->addOption('parse-tags', null, InputOption::VALUE_NONE, 'Parse custom tags')
             ->setHelp(<<<EOF
@@ -86,13 +86,18 @@ EOF
         $this->format = $input->getOption('format');
         $this->displayCorrectFiles = $output->isVerbose();
         $flags = $input->getOption('parse-tags') ? Yaml::PARSE_CUSTOM_TAGS : 0;
+        $hasStdin = '-' === ($filenames[0] ?? '');
 
-        if (0 === \count($filenames)) {
-            if (!$stdin = $this->getStdin()) {
+        if ($hasStdin || 0 === \count($filenames)) {
+            if (!$hasStdin && 0 !== ftell(STDIN)) { // remove 0 !== ftell(STDIN) check in 5.0
                 throw new RuntimeException('Please provide a filename or pipe file content to STDIN.');
             }
 
-            return $this->display($io, [$this->validate($stdin, $flags)]);
+            if (!$hasStdin) {
+                @trigger_error('Calling to the "lint:yaml" command providing pipe file content to STDIN without passing the dash symbol "-" explicitly is deprecated since Symfony 4.4.', E_USER_DEPRECATED);
+            }
+
+            return $this->display($io, [$this->validate($this->getStdin(), $flags)]);
         }
 
         $filesInfo = [];
@@ -199,18 +204,14 @@ EOF
         }
     }
 
-    private function getStdin(): ?string
+    private function getStdin(): string
     {
-        if (0 !== ftell(STDIN)) {
-            return null;
-        }
-
-        $inputs = '';
+        $yaml = '';
         while (!feof(STDIN)) {
-            $inputs .= fread(STDIN, 1024);
+            $yaml .= fread(STDIN, 1024);
         }
 
-        return $inputs;
+        return $yaml;
     }
 
     private function getParser()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/33446#issuecomment-528276646
| License       | MIT
| Doc PR        | -

Follow-up https://github.com/symfony/symfony/pull/33446

> There's a conflict here: when no argument was provided, the command also reads from STDIN.
So now, it reads from STDIN, and if there is nothing there, reads from the default template.
This has been caught in php/php-src#4672

> This creates an ambiguous situation - maybe one did pipe nothing but doesn't expect the default template dir to be linted.

> I'd suggest resolving the ambiguity by reading from STDIN only when explicitly asked for. Passing - as argument could the way. And we could trigger a deprecation for now.

For consistency, the other 2 lint commands (`lint:yaml` and `lint:xliff`) have been touched as well.

The plan for 5.0 is read from the STDIN only when `-` is given.

/cc @nicolas-grekas 