### PR TITLE
Allow version 2 of the contracts package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "psr/container": "^1.0",
         "psr/link": "^1.0",
         "psr/log": "~1.0",
-        "symfony/contracts": "^1.1.3",
+        "symfony/contracts": "^1.1.3|^2",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-intl-idn": "^1.10",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -21,7 +21,7 @@
         "doctrine/persistence": "~1.0",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/service-contracts": "^1.1"
+        "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
         "symfony/stopwatch": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "monolog/monolog": "^1.25.1",
-        "symfony/service-contracts": "^1.1",
+        "symfony/service-contracts": "^1.1|^2",
         "symfony/http-kernel": "^4.3"
     },
     "require-dev": {

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/translation-contracts": "^1.1",
+        "symfony/translation-contracts": "^1.1|^2",
         "twig/twig": "^1.41|^2.10"
     },
     "require-dev": {

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -24,8 +24,8 @@
         "php": "^7.1.3",
         "psr/cache": "~1.0",
         "psr/log": "~1.0",
-        "symfony/cache-contracts": "^1.1",
-        "symfony/service-contracts": "^1.1",
+        "symfony/cache-contracts": "^1.1|^2",
+        "symfony/service-contracts": "^1.1|^2",
         "symfony/var-exporter": "^4.2|^5.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -24,7 +24,7 @@
         "symfony/event-dispatcher": "^3.4|^4.0|^5.0",
         "symfony/finder": "^3.4|^4.0|^5.0",
         "symfony/messenger": "^4.1|^5.0",
-        "symfony/service-contracts": "^1.1",
+        "symfony/service-contracts": "^1.1|^2",
         "symfony/yaml": "^3.4|^4.0|^5.0"
     },
     "conflict": {

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1.3",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php73": "^1.8",
-        "symfony/service-contracts": "^1.1"
+        "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
         "symfony/config": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "psr/container": "^1.0",
-        "symfony/service-contracts": "^1.1.6"
+        "symfony/service-contracts": "^1.1.6|^2"
     },
     "require-dev": {
         "symfony/yaml": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/event-dispatcher-contracts": "^1.1"
+        "symfony/event-dispatcher-contracts": "^1.1|^2"
     },
     "require-dev": {
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
-        "symfony/service-contracts": "^1.1",
+        "symfony/service-contracts": "^1.1|^2",
         "symfony/stopwatch": "^3.4|^4.0|^5.0",
         "psr/log": "~1.0"
     },

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/cache": "^3.4|^4.0|^5.0",
-        "symfony/service-contracts": "^1.1"
+        "symfony/service-contracts": "^1.1|^2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\ExpressionLanguage\\": "" },

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.1.3",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^1.1.7",
+        "symfony/http-client-contracts": "^1.1.7|^2",
         "symfony/polyfill-php73": "^1.11"
     },
     "require-dev": {
@@ -32,7 +32,7 @@
         "symfony/dependency-injection": "^4.3|^5.0",
         "symfony/http-kernel": "^4.3|^5.0",
         "symfony/process": "^4.2|^5.0",
-        "symfony/service-contracts": "^1.0",
+        "symfony/service-contracts": "^1.0|^2",
         "symfony/var-dumper": "^4.3|^5.0"
     },
     "autoload": {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -39,7 +39,7 @@
         "symfony/stopwatch": "^3.4|^4.0|^5.0",
         "symfony/templating": "^3.4|^4.0|^5.0",
         "symfony/translation": "^4.2|^5.0",
-        "symfony/translation-contracts": "^1.1",
+        "symfony/translation-contracts": "^1.1|^2",
         "symfony/var-dumper": "^4.1.1|^5.0",
         "psr/cache": "~1.0",
         "twig/twig": "^1.34|^2.4"

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -21,12 +21,12 @@
         "psr/log": "~1.0",
         "symfony/event-dispatcher": "^4.3",
         "symfony/mime": "^4.4|^5.0",
-        "symfony/service-contracts": "^1.1"
+        "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
         "symfony/amazon-mailer": "^4.4|^5.0",
         "symfony/google-mailer": "^4.4|^5.0",
-        "symfony/http-client-contracts": "^1.1",
+        "symfony/http-client-contracts": "^1.1|^2",
         "symfony/mailgun-mailer": "^4.4|^5.0",
         "symfony/mailchimp-mailer": "^4.4|^5.0",
         "symfony/messenger": "^4.4|^5.0",

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -31,7 +31,7 @@
         "symfony/process": "^3.4|^4.0|^5.0",
         "symfony/property-access": "^3.4|^4.0|^5.0",
         "symfony/serializer": "^3.4|^4.0|^5.0",
-        "symfony/service-contracts": "^1.1",
+        "symfony/service-contracts": "^1.1|^2",
         "symfony/stopwatch": "^3.4|^4.0|^5.0",
         "symfony/validator": "^3.4|^4.0|^5.0",
         "symfony/var-dumper": "^3.4|^4.0|^5.0"

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/event-dispatcher-contracts": "^1.1",
-        "symfony/service-contracts": "^1.1"
+        "symfony/event-dispatcher-contracts": "^1.1|^2",
+        "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
         "psr/container": "^1.0",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/event-dispatcher-contracts": "^1.1",
+        "symfony/event-dispatcher-contracts": "^1.1|^2",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
         "symfony/http-kernel": "^4.3",
         "symfony/property-access": "^3.4|^4.0|^5.0",
-        "symfony/service-contracts": "^1.1"
+        "symfony/service-contracts": "^1.1|^2"
     },
     "replace": {
         "symfony/security-core": "self.version",

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/service-contracts": "^1.0"
+        "symfony/service-contracts": "^1.0|^2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Stopwatch\\": "" },

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^1.1.6"
+        "symfony/translation-contracts": "^1.1.6|^2"
     },
     "require-dev": {
         "symfony/config": "^3.4|^4.0|^5.0",
@@ -26,7 +26,7 @@
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
         "symfony/http-kernel": "^3.4|^4.0|^5.0",
         "symfony/intl": "^3.4|^4.0|^5.0",
-        "symfony/service-contracts": "^1.1.2",
+        "symfony/service-contracts": "^1.1.2|^2",
         "symfony/var-dumper": "^3.4|^4.0|^5.0",
         "symfony/yaml": "^3.4|^4.0|^5.0",
         "symfony/finder": "~2.8|~3.0|~4.0|^5.0",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1.3",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^1.1"
+        "symfony/translation-contracts": "^1.1|^2"
     },
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | prepares #33497
| License       | MIT
| Doc PR        | N/A

The plan is to release a version 2 of the contracts package that will require php 7.2 but remains compatible to Symfony 4.