### PR TITLE
[HttpFoundation] Add 'video/avi' MIME type

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php
@@ -768,6 +768,7 @@ class MimeTypeExtensionGuesser implements ExtensionGuesserInterface
         'text/x-uuencode' => 'uu',
         'text/x-vcalendar' => 'vcs',
         'text/x-vcard' => 'vcf',
+        'video/avi' => 'avi',
         'video/3gpp' => '3gp',
         'video/3gpp2' => '3g2',
         'video/h261' => 'h261',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

`$file->guessClientExtension()` returns null on 'video/avi' MIME type.

![image](https://user-images.githubusercontent.com/22893424/64486823-e39a7f00-d23a-11e9-8e4f-b1615fadddee.png)
