### PR TITLE
[WebProfiler] Deprecated intercept_redirects in 4.4

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -323,6 +323,8 @@ WebProfilerBundle
 
  * Deprecated the `ExceptionController` class in favor of `ExceptionErrorController`
  * Deprecated the `TemplateManager::templateExists()` method
+ * Deprecated the `web_profiler.intercept_redirects` config option,
+   toolbar for the redirected resource contains a link to the redirect response profile instead.
 
 WebServerBundle
 ---------------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -577,6 +577,8 @@ WebProfilerBundle
 
  * Removed the `ExceptionController::templateExists()` method
  * Removed the `TemplateManager::templateExists()` method
+ * Removed the `web_profiler.intercept_redirects` config option,
+   toolbar for the redirected resource contains a link to the redirect response profile instead.
 
 Workflow
 --------

--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
  * deprecated the `ExceptionController` in favor of `ExceptionPanelController`
  * marked all classes of the WebProfilerBundle as internal
  * added a section with the stamps of a message after it is dispatched in the Messenger panel
+ * deprecated the `web_profiler.intercept_redirects` config option,
+   toolbar for the redirected resource contains a link to the redirect response profile instead.
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -36,7 +36,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder->getRootNode()
             ->children()
                 ->booleanNode('toolbar')->defaultFalse()->end()
-                ->booleanNode('intercept_redirects')->defaultFalse()->end()
+                ->booleanNode('intercept_redirects')->defaultFalse()->setDeprecated('The "intercept_redirects" option is deprecated since version 4.4 and will be removed in 5.0.')->end()
                 ->scalarNode('excluded_ajax_paths')->defaultValue('^/((index|app(_[\w]+)?)\.php/)?_wdt')->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -20,23 +20,78 @@ class ConfigurationTest extends TestCase
     /**
      * @dataProvider getDebugModes
      */
-    public function testConfigTree($options, $results)
+    public function testConfigTree(array $options, array $expectedResult)
     {
         $processor = new Processor();
         $configuration = new Configuration();
         $config = $processor->processConfiguration($configuration, [$options]);
 
-        $this->assertEquals($results, $config);
+        $this->assertEquals($expectedResult, $config);
     }
 
     public function getDebugModes()
     {
         return [
-            [[], ['intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt']],
-            [['intercept_redirects' => true], ['intercept_redirects' => true, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt']],
-            [['intercept_redirects' => false], ['intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt']],
-            [['toolbar' => true], ['intercept_redirects' => false, 'toolbar' => true, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt']],
-            [['excluded_ajax_paths' => 'test'], ['intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => 'test']],
+            [
+                'options' => [],
+                'expectedResult' => [
+                    'intercept_redirects' => false,
+                    'toolbar' => false,
+                    'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt',
+                ],
+            ],
+            [
+                'options' => ['toolbar' => true],
+                'expectedResult' => [
+                    'intercept_redirects' => false,
+                    'toolbar' => true,
+                    'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt',
+                ],
+            ],
+            [
+                'options' => ['excluded_ajax_paths' => 'test'],
+                'expectedResult' => [
+                    'intercept_redirects' => false,
+                    'toolbar' => false,
+                    'excluded_ajax_paths' => 'test',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider getInterceptRedirectsConfiguration
+     */
+    public function testConfigTreeUsingInterceptRedirects(bool $interceptRedirects, array $expectedResult)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $config = $processor->processConfiguration($configuration, [['intercept_redirects' => $interceptRedirects]]);
+
+        $this->assertEquals($expectedResult, $config);
+    }
+
+    public function getInterceptRedirectsConfiguration()
+    {
+        return [
+            [
+                'interceptRedirects' => true,
+                'expectedResult' => [
+                    'intercept_redirects' => true,
+                    'toolbar' => false,
+                    'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt',
+                ],
+            ],
+            [
+                'interceptRedirects' => false,
+                'expectedResult' => [
+                    'intercept_redirects' => false,
+                    'toolbar' => false,
+                    'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt',
+                ],
+            ],
         ];
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -99,13 +99,21 @@ class WebProfilerExtensionTest extends TestCase
         self::assertSaneContainer($this->getCompiledContainer());
     }
 
+    public function getDebugModes()
+    {
+        return [
+            ['debug' => false],
+            ['debug' => true],
+        ];
+    }
+
     /**
-     * @dataProvider getDebugModes
+     * @dataProvider getToolbarConfig
      */
-    public function testToolbarConfig($toolbarEnabled, $interceptRedirects, $listenerInjected, $listenerEnabled)
+    public function testToolbarConfig(bool $toolbarEnabled, bool $listenerInjected, bool $listenerEnabled)
     {
         $extension = new WebProfilerExtension();
-        $extension->load([['toolbar' => $toolbarEnabled, 'intercept_redirects' => $interceptRedirects]], $this->container);
+        $extension->load([['toolbar' => $toolbarEnabled]], $this->container);
         $this->container->removeDefinition('web_profiler.controller.exception');
 
         $this->assertSame($listenerInjected, $this->container->has('web_profiler.debug_toolbar'));
@@ -117,13 +125,70 @@ class WebProfilerExtensionTest extends TestCase
         }
     }
 
-    public function getDebugModes()
+    public function getToolbarConfig()
     {
         return [
-            [false, false, false, false],
-            [true,  false, true,  true],
-            [false, true,  true,  false],
-            [true,  true,  true,  true],
+            [
+                'toolbarEnabled' => false,
+                'listenerInjected' => false,
+                'listenerEnabled' => false,
+            ],
+            [
+                'toolbarEnabled' => true,
+                'listenerInjected' => true,
+                'listenerEnabled' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider getInterceptRedirectsToolbarConfig
+     */
+    public function testToolbarConfigUsingInterceptRedirects(
+        bool $toolbarEnabled,
+        bool $interceptRedirects,
+        bool $listenerInjected,
+        bool $listenerEnabled
+    ) {
+        $extension = new WebProfilerExtension();
+        $extension->load(
+            [['toolbar' => $toolbarEnabled, 'intercept_redirects' => $interceptRedirects]],
+            $this->container
+        );
+        $this->container->removeDefinition('web_profiler.controller.exception');
+
+        $this->assertSame($listenerInjected, $this->container->has('web_profiler.debug_toolbar'));
+
+        self::assertSaneContainer($this->getCompiledContainer(), '', ['web_profiler.csp.handler']);
+
+        if ($listenerInjected) {
+            $this->assertSame($listenerEnabled, $this->container->get('web_profiler.debug_toolbar')->isEnabled());
+        }
+    }
+
+    public function getInterceptRedirectsToolbarConfig()
+    {
+        return [
+             [
+                 'toolbarEnabled' => false,
+                 'interceptRedirects' => true,
+                 'listenerInjected' => true,
+                 'listenerEnabled' => false,
+            ],
+            [
+                'toolbarEnabled' => false,
+                'interceptRedirects' => false,
+                'listenerInjected' => false,
+                'listenerEnabled' => false,
+            ],
+            [
+                'toolbarEnabled' => true,
+                'interceptRedirects' => true,
+                'listenerInjected' => true,
+                'listenerEnabled' => true,
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #33467 
| License       | MIT
| Doc PR        | -

Deprecated `web_profiler.intercept_redirects` config option in symfony 4.4.