### PR TITLE
[Cache] Add types to constructors and private/final/internal methods

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -260,7 +260,7 @@ class ProxyAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
         }
     }
 
-    private function getId($key)
+    private function getId($key): string
     {
         CacheItem::validateKey($key);
 

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -185,7 +185,7 @@ final class CacheItem implements ItemInterface
      *
      * @internal
      */
-    public static function log(LoggerInterface $logger = null, $message, $context = [])
+    public static function log(?LoggerInterface $logger, string $message, array $context = [])
     {
         if ($logger) {
             $logger->warning($message, $context);

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -131,6 +131,8 @@ final class LockRegistry
                 $logger && $logger->info('Item "{key}" not found while lock was released, now retrying', ['key' => $item->getKey()]);
             }
         }
+
+        return null;
     }
 
     private static function open(int $key)

--- a/src/Symfony/Component/Cache/Simple/AbstractCache.php
+++ b/src/Symfony/Component/Cache/Simple/AbstractCache.php
@@ -177,7 +177,7 @@ abstract class AbstractCache implements Psr16CacheInterface, LoggerAwareInterfac
         throw new InvalidArgumentException(sprintf('Expiration date must be an integer, a DateInterval or null, "%s" given', \is_object($ttl) ? \get_class($ttl) : \gettype($ttl)));
     }
 
-    private function generateValues(iterable $values, array &$keys, $default)
+    private function generateValues(iterable $values, array &$keys, $default): iterable
     {
         try {
             foreach ($values as $id => $value) {

--- a/src/Symfony/Component/Cache/Simple/ChainCache.php
+++ b/src/Symfony/Component/Cache/Simple/ChainCache.php
@@ -92,7 +92,7 @@ class ChainCache implements Psr16CacheInterface, PruneableInterface, ResettableI
         return $this->generateItems($this->caches[0]->getMultiple($keys, $miss), 0, $miss, $default);
     }
 
-    private function generateItems(iterable $values, int $cacheIndex, $miss, $default)
+    private function generateItems(iterable $values, int $cacheIndex, $miss, $default): iterable
     {
         $missing = [];
         $nextCacheIndex = $cacheIndex + 1;

--- a/src/Symfony/Component/Cache/Simple/PhpArrayCache.php
+++ b/src/Symfony/Component/Cache/Simple/PhpArrayCache.php
@@ -229,7 +229,7 @@ class PhpArrayCache implements Psr16CacheInterface, PruneableInterface, Resettab
         return $saved;
     }
 
-    private function generateItems(array $keys, $default)
+    private function generateItems(array $keys, $default): iterable
     {
         $fallbackKeys = [];
 

--- a/src/Symfony/Component/Cache/Simple/TraceableCache.php
+++ b/src/Symfony/Component/Cache/Simple/TraceableCache.php
@@ -236,7 +236,7 @@ class TraceableCache implements Psr16CacheInterface, PruneableInterface, Resetta
         }
     }
 
-    private function start(string $name)
+    private function start(string $name): TraceableCacheEvent
     {
         $this->calls[] = $event = new TraceableCacheEvent();
         $event->name = $name;

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -24,7 +24,7 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
 
     protected static $redis;
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new RedisAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
@@ -23,7 +23,7 @@ class ApcuAdapterTest extends AdapterTestCase
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
     ];
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         if (!\function_exists('apcu_fetch') || !filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN)) {
             $this->markTestSkipped('APCu extension is required.');

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -25,7 +25,7 @@ class ArrayAdapterTest extends AdapterTestCase
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayAdapter is not.',
     ];
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new ArrayAdapter($defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -26,7 +25,7 @@ use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
  */
 class ChainAdapterTest extends AdapterTestCase
 {
-    public function createCachePool($defaultLifetime = 0, $testMethod = null): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0, string $testMethod = null): CacheItemPoolInterface
     {
         if ('testGetMetadata' === $testMethod) {
             return new ChainAdapter([new FilesystemAdapter('', $defaultLifetime)], $defaultLifetime);
@@ -70,14 +69,9 @@ class ChainAdapterTest extends AdapterTestCase
         $this->assertFalse($cache->prune());
     }
 
-    /**
-     * @return MockObject|PruneableCacheInterface
-     */
-    private function getPruneableMock()
+    private function getPruneableMock(): AdapterInterface
     {
-        $pruneable = $this
-            ->getMockBuilder(PruneableCacheInterface::class)
-            ->getMock();
+        $pruneable = $this->createMock([PruneableInterface::class, AdapterInterface::class]);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -87,14 +81,9 @@ class ChainAdapterTest extends AdapterTestCase
         return $pruneable;
     }
 
-    /**
-     * @return MockObject|PruneableCacheInterface
-     */
-    private function getFailingPruneableMock()
+    private function getFailingPruneableMock(): AdapterInterface
     {
-        $pruneable = $this
-            ->getMockBuilder(PruneableCacheInterface::class)
-            ->getMock();
+        $pruneable = $this->createMock([PruneableInterface::class, AdapterInterface::class]);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -104,17 +93,8 @@ class ChainAdapterTest extends AdapterTestCase
         return $pruneable;
     }
 
-    /**
-     * @return MockObject|AdapterInterface
-     */
-    private function getNonPruneableMock()
+    private function getNonPruneableMock(): AdapterInterface
     {
-        return $this
-            ->getMockBuilder(AdapterInterface::class)
-            ->getMock();
+        return $this->createMock(AdapterInterface::class);
     }
-}
-
-interface PruneableCacheInterface extends PruneableInterface, AdapterInterface
-{
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
@@ -27,7 +27,7 @@ class DoctrineAdapterTest extends AdapterTestCase
         'testClearPrefix' => 'Doctrine cannot clear by prefix',
     ];
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new DoctrineAdapter(new ArrayCache($defaultLifetime), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/FilesystemAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/FilesystemAdapterTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  */
 class FilesystemAdapterTest extends AdapterTestCase
 {
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new FilesystemAdapter('', $defaultLifetime);
     }
@@ -29,7 +29,7 @@ class FilesystemAdapterTest extends AdapterTestCase
         self::rmdir(sys_get_temp_dir().'/symfony-cache');
     }
 
-    public static function rmdir($dir)
+    public static function rmdir(string $dir)
     {
         if (!file_exists($dir)) {
             return;
@@ -51,7 +51,7 @@ class FilesystemAdapterTest extends AdapterTestCase
         rmdir($dir);
     }
 
-    protected function isPruned(CacheItemPoolInterface $cache, $name)
+    protected function isPruned(CacheItemPoolInterface $cache, string $name): bool
     {
         $getFileMethod = (new \ReflectionObject($cache))->getMethod('getFile');
         $getFileMethod->setAccessible(true);

--- a/src/Symfony/Component/Cache/Tests/Adapter/FilesystemTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/FilesystemTagAwareAdapterTest.php
@@ -22,7 +22,7 @@ class FilesystemTagAwareAdapterTest extends FilesystemAdapterTest
 {
     use TagAwareTestTrait;
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new FilesystemTagAwareAdapter('', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -80,7 +80,7 @@ abstract class MaxIdLengthAdapter extends AbstractAdapter
 {
     protected $maxIdLength = 50;
 
-    public function __construct($ns)
+    public function __construct(string $ns)
     {
         parent::__construct($ns);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -39,7 +39,7 @@ class MemcachedAdapterTest extends AdapterTestCase
         }
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $client = $defaultLifetime ? AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST')) : self::$client;
 
@@ -73,7 +73,7 @@ class MemcachedAdapterTest extends AdapterTestCase
         MemcachedAdapter::createConnection([], [$name => $value]);
     }
 
-    public function provideBadOptions()
+    public function provideBadOptions(): array
     {
         return [
             ['foo', 'bar'],
@@ -109,7 +109,7 @@ class MemcachedAdapterTest extends AdapterTestCase
     /**
      * @dataProvider provideServersSetting
      */
-    public function testServersSetting($dsn, $host, $port)
+    public function testServersSetting(string $dsn, string $host, int $port)
     {
         $client1 = MemcachedAdapter::createConnection($dsn);
         $client2 = MemcachedAdapter::createConnection([$dsn]);
@@ -125,7 +125,7 @@ class MemcachedAdapterTest extends AdapterTestCase
         $this->assertSame([$expect], array_map($f, $client3->getServerList()));
     }
 
-    public function provideServersSetting()
+    public function provideServersSetting(): iterable
     {
         yield [
             'memcached://127.0.0.1/50',
@@ -166,7 +166,7 @@ class MemcachedAdapterTest extends AdapterTestCase
     /**
      * @dataProvider provideDsnWithOptions
      */
-    public function testDsnWithOptions($dsn, array $options, array $expectedOptions)
+    public function testDsnWithOptions(string $dsn, array $options, array $expectedOptions)
     {
         $client = MemcachedAdapter::createConnection($dsn, $options);
 
@@ -175,7 +175,7 @@ class MemcachedAdapterTest extends AdapterTestCase
         }
     }
 
-    public function provideDsnWithOptions()
+    public function provideDsnWithOptions(): iterable
     {
         if (!class_exists('\Memcached')) {
             self::markTestSkipped('Extension memcached required.');

--- a/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Cache\Adapter\ProxyAdapter;
  */
 class NamespacedProxyAdapterTest extends ProxyAdapterTest
 {
-    public function createCachePool($defaultLifetime = 0, $testMethod = null): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0, string $testMethod = null): CacheItemPoolInterface
     {
         if ('testGetMetadata' === $testMethod) {
             return new ProxyAdapter(new FilesystemAdapter(), 'foo', $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -41,7 +41,7 @@ class PdoAdapterTest extends AdapterTestCase
         @unlink(self::$dbFile);
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new PdoAdapter('sqlite:'.self::$dbFile, 'ns', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
@@ -41,7 +41,7 @@ class PdoDbalAdapterTest extends AdapterTestCase
         @unlink(self::$dbFile);
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new PdoAdapter(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -71,7 +71,7 @@ class PhpArrayAdapterTest extends AdapterTestCase
         }
     }
 
-    public function createCachePool($defaultLifetime = 0, $testMethod = null): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0, string $testMethod = null): CacheItemPoolInterface
     {
         if ('testGetMetadata' === $testMethod || 'testClearPrefix' === $testMethod) {
             return new PhpArrayAdapter(self::$file, new FilesystemAdapter());

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
@@ -43,7 +43,7 @@ class PhpArrayAdapterWithFallbackTest extends AdapterTestCase
         }
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new PhpArrayAdapter(self::$file, new FilesystemAdapter('php-array-fallback', $defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
@@ -33,7 +33,7 @@ class PhpFilesAdapterTest extends AdapterTestCase
         FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');
     }
 
-    protected function isPruned(CacheItemPoolInterface $cache, $name)
+    protected function isPruned(CacheItemPoolInterface $cache, string $name): bool
     {
         $getFileMethod = (new \ReflectionObject($cache))->getMethod('getFile');
         $getFileMethod->setAccessible(true);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
@@ -25,7 +25,7 @@ class PredisTagAwareAdapterTest extends PredisAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(\Predis\Client::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
@@ -25,7 +25,7 @@ class PredisTagAwareClusterAdapterTest extends PredisClusterAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(\Predis\Client::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareRedisClusterAdapterTest.php
@@ -25,7 +25,7 @@ class PredisTagAwareRedisClusterAdapterTest extends PredisRedisClusterAdapterTes
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(\Predis\Client::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
@@ -29,7 +29,7 @@ class ProxyAdapterTest extends AdapterTestCase
         'testPrune' => 'ProxyAdapter just proxies',
     ];
 
-    public function createCachePool($defaultLifetime = 0, $testMethod = null): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0, string $testMethod = null): CacheItemPoolInterface
     {
         if ('testGetMetadata' === $testMethod) {
             return new ProxyAdapter(new FilesystemAdapter(), '', $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
@@ -27,7 +27,7 @@ class Psr16AdapterTest extends AdapterTestCase
         'testClearPrefix' => 'SimpleCache cannot clear by prefix',
     ];
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new Psr16Adapter(new Psr16Cache(new FilesystemAdapter()), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -24,7 +24,7 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
         self::$redis = AbstractAdapter::createConnection('redis://'.getenv('REDIS_HOST'), ['lazy' => true]);
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $adapter = parent::createCachePool($defaultLifetime);
         $this->assertInstanceOf(RedisProxy::class, self::$redis);
@@ -35,7 +35,7 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
     /**
      * @dataProvider provideValidSchemes
      */
-    public function testCreateConnection($dsnScheme)
+    public function testCreateConnection(string $dsnScheme)
     {
         $redis = RedisAdapter::createConnection($dsnScheme.':?host[h1]&host[h2]&host[/foo:]');
         $this->assertInstanceOf(\RedisArray::class, $redis);
@@ -65,14 +65,14 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
     /**
      * @dataProvider provideFailedCreateConnection
      */
-    public function testFailedCreateConnection($dsn)
+    public function testFailedCreateConnection(string $dsn)
     {
         $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('Redis connection failed');
         RedisAdapter::createConnection($dsn);
     }
 
-    public function provideFailedCreateConnection()
+    public function provideFailedCreateConnection(): array
     {
         return [
             ['redis://localhost:1234'],
@@ -84,14 +84,14 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
     /**
      * @dataProvider provideInvalidCreateConnection
      */
-    public function testInvalidCreateConnection($dsn)
+    public function testInvalidCreateConnection(string $dsn)
     {
         $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('Invalid Redis DSN');
         RedisAdapter::createConnection($dsn);
     }
 
-    public function provideValidSchemes()
+    public function provideValidSchemes(): array
     {
         return [
             ['redis'],
@@ -99,7 +99,7 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
         ];
     }
 
-    public function provideInvalidCreateConnection()
+    public function provideInvalidCreateConnection(): array
     {
         return [
             ['foo://localhost'],

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
@@ -30,7 +30,7 @@ class RedisClusterAdapterTest extends AbstractRedisAdapterTest
         self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['lazy' => true, 'redis_cluster' => true]);
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(RedisClusterProxy::class, self::$redis);
         $adapter = new RedisAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
@@ -41,14 +41,14 @@ class RedisClusterAdapterTest extends AbstractRedisAdapterTest
     /**
      * @dataProvider provideFailedCreateConnection
      */
-    public function testFailedCreateConnection($dsn)
+    public function testFailedCreateConnection(string $dsn)
     {
         $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('Redis connection failed');
         RedisAdapter::createConnection($dsn);
     }
 
-    public function provideFailedCreateConnection()
+    public function provideFailedCreateConnection(): array
     {
         return [
             ['redis://localhost:1234?redis_cluster=1'],

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
@@ -26,7 +26,7 @@ class RedisTagAwareAdapterTest extends RedisAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(RedisProxy::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
@@ -25,7 +25,7 @@ class RedisTagAwareArrayAdapterTest extends RedisArrayAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(\RedisArray::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
@@ -26,7 +26,7 @@ class RedisTagAwareClusterAdapterTest extends RedisClusterAdapterTest
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
     }
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         $this->assertInstanceOf(RedisClusterProxy::class, self::$redis);
         $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);

--- a/src/Symfony/Component/Cache/Tests/Adapter/SimpleCacheAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/SimpleCacheAdapterTest.php
@@ -27,7 +27,7 @@ class SimpleCacheAdapterTest extends AdapterTestCase
         'testClearPrefix' => 'SimpleCache cannot clear by prefix',
     ];
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new SimpleCacheAdapter(new FilesystemCache(), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -16,6 +16,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
 /**
@@ -66,14 +67,9 @@ class TagAwareAdapterTest extends AdapterTestCase
         $this->assertFalse($cache->prune());
     }
 
-    /**
-     * @return MockObject|PruneableCacheInterface
-     */
-    private function getPruneableMock()
+    private function getPruneableMock(): AdapterInterface
     {
-        $pruneable = $this
-            ->getMockBuilder(PruneableCacheInterface::class)
-            ->getMock();
+        $pruneable = $this->createMock([PruneableInterface::class, AdapterInterface::class]);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -83,14 +79,9 @@ class TagAwareAdapterTest extends AdapterTestCase
         return $pruneable;
     }
 
-    /**
-     * @return MockObject|PruneableCacheInterface
-     */
-    private function getFailingPruneableMock()
+    private function getFailingPruneableMock(): AdapterInterface
     {
-        $pruneable = $this
-            ->getMockBuilder(PruneableCacheInterface::class)
-            ->getMock();
+        $pruneable = $this->createMock([PruneableInterface::class, AdapterInterface::class]);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -100,13 +91,8 @@ class TagAwareAdapterTest extends AdapterTestCase
         return $pruneable;
     }
 
-    /**
-     * @return MockObject|AdapterInterface
-     */
-    private function getNonPruneableMock()
+    private function getNonPruneableMock(): AdapterInterface
     {
-        return $this
-            ->getMockBuilder(AdapterInterface::class)
-            ->getMock();
+        return $this->createMock(AdapterInterface::class);
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAndProxyAdapterIntegrationTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAndProxyAdapterIntegrationTest.php
@@ -26,7 +26,7 @@ class TagAwareAndProxyAdapterIntegrationTest extends TestCase
         $this->assertSame('bar', $cache->getItem('foo')->get());
     }
 
-    public function dataProvider()
+    public function dataProvider(): array
     {
         return [
             [new ArrayAdapter()],

--- a/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
@@ -24,7 +24,7 @@ class TraceableAdapterTest extends AdapterTestCase
         'testPrune' => 'TraceableAdapter just proxies',
     ];
 
-    public function createCachePool($defaultLifetime = 0): CacheItemPoolInterface
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new TraceableAdapter(new FilesystemAdapter('', $defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -31,7 +31,7 @@ class CacheItemTest extends TestCase
         CacheItem::validateKey($key);
     }
 
-    public function provideInvalidKey()
+    public function provideInvalidKey(): array
     {
         return [
             [''],

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -40,7 +40,7 @@ class Psr16CacheTest extends SimpleCacheTest
         }
     }
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new Psr16Cache(new FilesystemAdapter('', $defaultLifetime));
     }
@@ -146,7 +146,7 @@ class Psr16CacheTest extends SimpleCacheTest
         $cache->clear();
     }
 
-    protected function isPruned($cache, $name)
+    protected function isPruned(CacheInterface $cache, string $name): bool
     {
         if (Psr16Cache::class !== \get_class($cache)) {
             $this->fail('Test classes for pruneable caches must implement `isPruned($cache, $name)` method.');

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -27,7 +27,7 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
 
     protected static $redis;
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new RedisCache(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/ApcuCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ApcuCacheTest.php
@@ -25,7 +25,7 @@ class ApcuCacheTest extends CacheTestCase
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
     ];
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         if (!\function_exists('apcu_fetch') || !filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) || ('cli' === \PHP_SAPI && !filter_var(ini_get('apc.enable_cli'), FILTER_VALIDATE_BOOLEAN))) {
             $this->markTestSkipped('APCu extension is required.');

--- a/src/Symfony/Component/Cache/Tests/Simple/ArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ArrayCacheTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Cache\Simple\ArrayCache;
  */
 class ArrayCacheTest extends CacheTestCase
 {
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new ArrayCache($defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Simple\ArrayCache;
@@ -24,7 +23,7 @@ use Symfony\Component\Cache\Simple\FilesystemCache;
  */
 class ChainCacheTest extends CacheTestCase
 {
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new ChainCache([new ArrayCache($defaultLifetime), new FilesystemCache('', $defaultLifetime)], $defaultLifetime);
     }
@@ -64,14 +63,9 @@ class ChainCacheTest extends CacheTestCase
         $this->assertFalse($cache->prune());
     }
 
-    /**
-     * @return MockObject|PruneableCacheInterface
-     */
-    private function getPruneableMock()
+    private function getPruneableMock(): CacheInterface
     {
-        $pruneable = $this
-            ->getMockBuilder(PruneableCacheInterface::class)
-            ->getMock();
+        $pruneable = $this->createMock([CacheInterface::class, PruneableInterface::class]);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -81,14 +75,9 @@ class ChainCacheTest extends CacheTestCase
         return $pruneable;
     }
 
-    /**
-     * @return MockObject|PruneableCacheInterface
-     */
-    private function getFailingPruneableMock()
+    private function getFailingPruneableMock(): CacheInterface
     {
-        $pruneable = $this
-            ->getMockBuilder(PruneableCacheInterface::class)
-            ->getMock();
+        $pruneable = $this->createMock([CacheInterface::class, PruneableInterface::class]);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -98,17 +87,8 @@ class ChainCacheTest extends CacheTestCase
         return $pruneable;
     }
 
-    /**
-     * @return MockObject|CacheInterface
-     */
-    private function getNonPruneableMock()
+    private function getNonPruneableMock(): CacheInterface
     {
-        return $this
-            ->getMockBuilder(CacheInterface::class)
-            ->getMock();
+        return $this->createMock(CacheInterface::class);
     }
-}
-
-interface PruneableCacheInterface extends PruneableInterface, CacheInterface
-{
 }

--- a/src/Symfony/Component/Cache/Tests/Simple/DoctrineCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/DoctrineCacheTest.php
@@ -26,7 +26,7 @@ class DoctrineCacheTest extends CacheTestCase
         'testNotUnserializable' => 'ArrayCache does not use serialize/unserialize',
     ];
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new DoctrineCache(new ArrayCache($defaultLifetime), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/FilesystemCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/FilesystemCacheTest.php
@@ -20,12 +20,12 @@ use Symfony\Component\Cache\Simple\FilesystemCache;
  */
 class FilesystemCacheTest extends CacheTestCase
 {
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new FilesystemCache('', $defaultLifetime);
     }
 
-    protected function isPruned(CacheInterface $cache, $name)
+    protected function isPruned(CacheInterface $cache, string $name): bool
     {
         $getFileMethod = (new \ReflectionObject($cache))->getMethod('getFile');
         $getFileMethod->setAccessible(true);

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -42,7 +42,7 @@ class MemcachedCacheTest extends CacheTestCase
         }
     }
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         $client = $defaultLifetime ? AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), ['binary_protocol' => false]) : self::$client;
 
@@ -78,14 +78,14 @@ class MemcachedCacheTest extends CacheTestCase
     /**
      * @dataProvider provideBadOptions
      */
-    public function testBadOptions($name, $value)
+    public function testBadOptions(string $name, $value)
     {
         $this->expectException('ErrorException');
         $this->expectExceptionMessage('constant(): Couldn\'t find constant Memcached::');
         MemcachedCache::createConnection([], [$name => $value]);
     }
 
-    public function provideBadOptions()
+    public function provideBadOptions(): array
     {
         return [
             ['foo', 'bar'],
@@ -120,7 +120,7 @@ class MemcachedCacheTest extends CacheTestCase
     /**
      * @dataProvider provideServersSetting
      */
-    public function testServersSetting($dsn, $host, $port)
+    public function testServersSetting(string $dsn, string $host, int $port)
     {
         $client1 = MemcachedCache::createConnection($dsn);
         $client2 = MemcachedCache::createConnection([$dsn]);
@@ -136,7 +136,7 @@ class MemcachedCacheTest extends CacheTestCase
         $this->assertSame([$expect], array_map($f, $client3->getServerList()));
     }
 
-    public function provideServersSetting()
+    public function provideServersSetting(): iterable
     {
         yield [
             'memcached://127.0.0.1/50',

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Cache\Simple\MemcachedCache;
  */
 class MemcachedCacheTextModeTest extends MemcachedCacheTest
 {
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         $client = AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), ['binary_protocol' => false]);
 

--- a/src/Symfony/Component/Cache/Tests/Simple/NullCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/NullCacheTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Cache\Simple\NullCache;
  */
 class NullCacheTest extends TestCase
 {
-    public function createCachePool()
+    public function createCachePool(): NullCache
     {
         return new NullCache();
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
@@ -42,7 +42,7 @@ class PdoCacheTest extends CacheTestCase
         @unlink(self::$dbFile);
     }
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new PdoCache('sqlite:'.self::$dbFile, 'ns', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
@@ -43,7 +43,7 @@ class PdoDbalCacheTest extends CacheTestCase
         @unlink(self::$dbFile);
     }
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new PdoCache(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]), '', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWithFallbackTest.php
@@ -50,7 +50,7 @@ class PhpArrayCacheWithFallbackTest extends CacheTestCase
         }
     }
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new PhpArrayCache(self::$file, new FilesystemCache('php-array-fallback', $defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpFilesCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpFilesCacheTest.php
@@ -24,12 +24,12 @@ class PhpFilesCacheTest extends CacheTestCase
         'testDefaultLifeTime' => 'PhpFilesCache does not allow configuring a default lifetime.',
     ];
 
-    public function createSimpleCache(): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new PhpFilesCache('sf-cache');
     }
 
-    protected function isPruned(CacheInterface $cache, $name)
+    protected function isPruned(CacheInterface $cache, string $name): bool
     {
         $getFileMethod = (new \ReflectionObject($cache))->getMethod('getFile');
         $getFileMethod->setAccessible(true);

--- a/src/Symfony/Component/Cache/Tests/Simple/Psr6CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/Psr6CacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\Psr6Cache;
 
@@ -23,10 +24,10 @@ abstract class Psr6CacheTest extends CacheTestCase
         'testPrune' => 'Psr6Cache just proxies',
     ];
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new Psr6Cache($this->createCacheItemPool($defaultLifetime));
     }
 
-    abstract protected function createCacheItemPool($defaultLifetime = 0);
+    abstract protected function createCacheItemPool(int $defaultLifetime = 0): CacheItemPoolInterface;
 }

--- a/src/Symfony/Component/Cache/Tests/Simple/Psr6CacheWithAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/Psr6CacheWithAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  */
 class Psr6CacheWithAdapterTest extends Psr6CacheTest
 {
-    protected function createCacheItemPool($defaultLifetime = 0)
+    protected function createCacheItemPool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new FilesystemAdapter('', $defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/Psr6CacheWithoutAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/Psr6CacheWithoutAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
  */
 class Psr6CacheWithoutAdapterTest extends Psr6CacheTest
 {
-    protected function createCacheItemPool($defaultLifetime = 0)
+    protected function createCacheItemPool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new ExternalAdapter($defaultLifetime);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
@@ -49,14 +49,14 @@ class RedisCacheTest extends AbstractRedisCacheTest
     /**
      * @dataProvider provideFailedCreateConnection
      */
-    public function testFailedCreateConnection($dsn)
+    public function testFailedCreateConnection(string $dsn)
     {
         $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('Redis connection failed');
         RedisCache::createConnection($dsn);
     }
 
-    public function provideFailedCreateConnection()
+    public function provideFailedCreateConnection(): array
     {
         return [
             ['redis://localhost:1234'],
@@ -68,14 +68,14 @@ class RedisCacheTest extends AbstractRedisCacheTest
     /**
      * @dataProvider provideInvalidCreateConnection
      */
-    public function testInvalidCreateConnection($dsn)
+    public function testInvalidCreateConnection(string $dsn)
     {
         $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
         $this->expectExceptionMessage('Invalid Redis DSN');
         RedisCache::createConnection($dsn);
     }
 
-    public function provideInvalidCreateConnection()
+    public function provideInvalidCreateConnection(): array
     {
         return [
             ['foo://localhost'],

--- a/src/Symfony/Component/Cache/Tests/Simple/TraceableCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/TraceableCacheTest.php
@@ -25,7 +25,7 @@ class TraceableCacheTest extends CacheTestCase
         'testPrune' => 'TraceableCache just proxies',
     ];
 
-    public function createSimpleCache($defaultLifetime = 0): CacheInterface
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
     {
         return new TraceableCache(new FilesystemCache('', $defaultLifetime));
     }

--- a/src/Symfony/Component/Cache/Tests/Traits/PdoPruneableTrait.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/PdoPruneableTrait.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Cache\Tests\Traits;
 
 trait PdoPruneableTrait
 {
-    protected function isPruned($cache, $name)
+    protected function isPruned($cache, string $name): bool
     {
         $o = new \ReflectionObject($cache);
 

--- a/src/Symfony/Component/Cache/Tests/Traits/TagAwareTestTrait.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/TagAwareTestTrait.php
@@ -16,7 +16,7 @@ use Symfony\Component\Cache\CacheItem;
 /**
  * Common assertions for TagAware adapters.
  *
- * @method \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface createCachePool() Must be implemented by TestCase
+ * @method \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface createCachePool(int $defaultLifetime = 0) Must be implemented by TestCase
  */
 trait TagAwareTestTrait
 {

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -119,7 +119,7 @@ trait AbstractAdapterTrait
         }
     }
 
-    private function generateItems(iterable $items, array &$keys)
+    private function generateItems(iterable $items, array &$keys): iterable
     {
         $f = $this->createCacheItem;
 

--- a/src/Symfony/Component/Cache/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractTrait.php
@@ -250,7 +250,7 @@ trait AbstractTrait
         }
     }
 
-    private function getId($key)
+    private function getId($key): string
     {
         if ($this->versioningIsEnabled && '' === $this->namespaceVersion) {
             $this->ids = [];

--- a/src/Symfony/Component/Cache/Traits/ArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ArrayTrait.php
@@ -113,7 +113,7 @@ trait ArrayTrait
         $this->clear();
     }
 
-    private function generateItems(array $keys, float $now, callable $f)
+    private function generateItems(array $keys, float $now, callable $f): iterable
     {
         foreach ($keys as $i => $key) {
             if (!$isHit = isset($this->expiries[$key]) && ($this->expiries[$key] > $now || !$this->deleteItem($key))) {

--- a/src/Symfony/Component/Cache/Traits/PhpFilesTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PhpFilesTrait.php
@@ -289,7 +289,7 @@ class LazyValue
 {
     public $file;
 
-    public function __construct($file)
+    public function __construct(string $file)
     {
         $this->file = $file;
     }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -423,7 +423,7 @@ trait RedisTrait
         return $failed;
     }
 
-    private function pipeline(\Closure $generator)
+    private function pipeline(\Closure $generator): \Generator
     {
         $ids = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #32179, #33228
| License       | MIT
| Doc PR        | N/A

I'm currently preparing a large PR collecting changes like these. However, the changeset for the Cache component was large enough to justify a dedicated PR, imho.