### PR TITLE
Require exact match when reading from stdin with a dash

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -77,9 +77,9 @@ EOF
     {
         $io = new SymfonyStyle($input, $output);
         $filenames = $input->getArgument('filename');
-        $hasStdin = '-' === ($filenames[0] ?? '');
+        $hasStdin = ['-'] === $filenames;
 
-        if ($hasStdin || 0 === \count($filenames)) {
+        if ($hasStdin || !$filenames) {
             if ($hasStdin || 0 === ftell(STDIN)) { // remove 0 === ftell(STDIN) check in 5.0
                 if (!$hasStdin) {
                     @trigger_error('Calling to the "lint:twig" command providing pipe file content to STDIN without passing the dash symbol "-" explicitly is deprecated since Symfony 4.4.', E_USER_DEPRECATED);

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -83,9 +83,9 @@ EOF
         $filenames = (array) $input->getArgument('filename');
         $this->format = $input->getOption('format');
         $this->displayCorrectFiles = $output->isVerbose();
-        $hasStdin = '-' === ($filenames[0] ?? '');
+        $hasStdin = ['-'] === $filenames;
 
-        if ($hasStdin || 0 === \count($filenames)) {
+        if ($hasStdin || !$filenames) {
             if (!$hasStdin && 0 !== ftell(STDIN)) { // remove 0 !== ftell(STDIN) check in 5.0
                 throw new RuntimeException('Please provide a filename or pipe file content to STDIN.');
             }

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -86,9 +86,9 @@ EOF
         $this->format = $input->getOption('format');
         $this->displayCorrectFiles = $output->isVerbose();
         $flags = $input->getOption('parse-tags') ? Yaml::PARSE_CUSTOM_TAGS : 0;
-        $hasStdin = '-' === ($filenames[0] ?? '');
+        $hasStdin = ['-'] === $filenames;
 
-        if ($hasStdin || 0 === \count($filenames)) {
+        if ($hasStdin || !$filenames) {
             if (!$hasStdin && 0 !== ftell(STDIN)) { // remove 0 !== ftell(STDIN) check in 5.0
                 throw new RuntimeException('Please provide a filename or pipe file content to STDIN.');
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I think reading from stdin should happen only when the argument is exactly a dash, with no other files on the command line.

The alternative is to allow a dash at any position in the list of files, but I'm not sure that'd make sense.