### PR TITLE
[HttpClient] do not perform string operations on null

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -506,7 +506,9 @@ trait HttpClientTrait
 
     private static function shouldBuffer(array $headers): bool
     {
-        $contentType = $headers['content-type'][0] ?? null;
+        if (null === $contentType = $headers['content-type'][0] ?? null) {
+            return false;
+        }
 
         if (false !== $i = strpos($contentType, ';')) {
             $contentType = substr($contentType, 0, $i);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 