### PR TITLE
[Cache] Added reserved characters constant for CacheItem

### DIFF
--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -129,8 +129,8 @@ final class CacheItem implements ItemInterface
             if ('' === $tag) {
                 throw new InvalidArgumentException('Cache tag length must be greater than zero');
             }
-            if (false !== strpbrk($tag, '{}()/\@:')) {
-                throw new InvalidArgumentException(sprintf('Cache tag "%s" contains reserved characters {}()/\@:', $tag));
+            if (false !== strpbrk($tag, self::RESERVED_CHARACTERS)) {
+                throw new InvalidArgumentException(sprintf('Cache tag "%s" contains reserved characters %s', $tag, self::RESERVED_CHARACTERS));
             }
             $this->newMetadata[self::METADATA_TAGS][$tag] = $tag;
         }
@@ -173,8 +173,8 @@ final class CacheItem implements ItemInterface
         if ('' === $key) {
             throw new InvalidArgumentException('Cache key length must be greater than zero');
         }
-        if (false !== strpbrk($key, '{}()/\@:')) {
-            throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters {}()/\@:', $key));
+        if (false !== strpbrk($key, self::RESERVED_CHARACTERS)) {
+            throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters %s', $key, self::RESERVED_CHARACTERS));
         }
 
         return $key;

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.1.3",
         "psr/cache": "~1.0",
         "psr/log": "~1.0",
-        "symfony/cache-contracts": "^1.1|^2",
+        "symfony/cache-contracts": "^1.1.7|^2",
         "symfony/service-contracts": "^1.1|^2",
         "symfony/var-exporter": "^4.2|^5.0"
     },

--- a/src/Symfony/Contracts/Cache/ItemInterface.php
+++ b/src/Symfony/Contracts/Cache/ItemInterface.php
@@ -38,6 +38,11 @@ interface ItemInterface extends CacheItemInterface
     const METADATA_TAGS = 'tags';
 
     /**
+     * Reserved characters that cannot be used in a key or tag.
+     */
+    const RESERVED_CHARACTERS = '{}()/\@:';
+
+    /**
      * Adds a tag to a cache item.
      *
      * Tags are strings that follow the same validation rules as keys.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

This PR introduces a `RESERVED_CHARACTERS` constant to the `CacheItem` class to keep things DRY.

The rationale for making the constant public is so that developers can access the list of reserved characters so they could - for example - sanitise keys before passing them to the Cache component.
