### PR TITLE
[Yaml] don't dump a scalar tag value on its own line

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -115,15 +115,11 @@ class Dumper
                 if ($value instanceof TaggedValue) {
                     $output .= sprintf('%s%s !%s', $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', $value->getTag());
 
-                    if ($inline - 1 <= 0) {
+                    if ($inline - 1 <= 0 || null === $value->getValue() || is_scalar($value->getValue())) {
                         $output .= ' '.$this->dump($value->getValue(), $inline - 1, 0, $flags)."\n";
                     } else {
                         $output .= "\n";
                         $output .= $this->dump($value->getValue(), $inline - 1, $dumpAsMap ? $indent + $this->indentation : $indent + 2, $flags);
-
-                        if (is_scalar($value->getValue())) {
-                            $output .= "\n";
-                        }
                     }
 
                     continue;

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -532,10 +532,21 @@ YAML;
             'user2' => new TaggedValue('user', 'john'),
         ];
         $expected = <<<YAML
-user1: !user
-    jane
-user2: !user
-    john
+user1: !user jane
+user2: !user john
+
+YAML;
+
+        $this->assertSame($expected, $this->dumper->dump($data, 2));
+    }
+
+    public function testDumpingNotInlinedNullTaggedValue()
+    {
+        $data = [
+            'foo' => new TaggedValue('bar', null),
+        ];
+        $expected = <<<YAML
+foo: !bar null
 
 YAML;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This commit fine tunes the bugfix made in #33377 with the feedback provided in https://github.com/symfony/symfony/issues/33464#issuecomment-528290985.