### PR TITLE
Fix lint commands frozen on empty stdin

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
@@ -35,29 +35,12 @@ class XliffLintCommandTest extends TestCase
     {
         $command = new XliffLintCommand();
         $expected = <<<EOF
-The <info>%command.name%</info> command lints a XLIFF file and outputs to STDOUT
-the first encountered syntax error.
-
-You can validates XLIFF contents passed from STDIN:
-
-  <info>cat filename | php %command.full_name%</info>
-
-You can also validate the syntax of a file:
-
-  <info>php %command.full_name% filename</info>
-
-Or of a whole directory:
-
-  <info>php %command.full_name% dirname</info>
-  <info>php %command.full_name% dirname --format=json</info>
-
 Or find all files in a bundle:
 
   <info>php %command.full_name% @AcmeDemoBundle</info>
-
 EOF;
 
-        $this->assertEquals($expected, $command->getHelp());
+        $this->assertStringContainsString($expected, $command->getHelp());
     }
 
     public function testLintFilesFromBundleDirectory()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -72,29 +72,12 @@ bar';
     {
         $command = new YamlLintCommand();
         $expected = <<<EOF
-The <info>%command.name%</info> command lints a YAML file and outputs to STDOUT
-the first encountered syntax error.
-
-You can validates YAML contents passed from STDIN:
-
-  <info>cat filename | php %command.full_name%</info>
-
-You can also validate the syntax of a file:
-
-  <info>php %command.full_name% filename</info>
-
-Or of a whole directory:
-
-  <info>php %command.full_name% dirname</info>
-  <info>php %command.full_name% dirname --format=json</info>
-
 Or find all files in a bundle:
 
   <info>php %command.full_name% @AcmeDemoBundle</info>
-
 EOF;
 
-        $this->assertEquals($expected, $command->getHelp());
+        $this->assertStringContainsString($expected, $command->getHelp());
     }
 
     public function testLintFilesFromBundleDirectory()

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -61,7 +61,7 @@ the first encountered syntax error.
 
 You can validates XLIFF contents passed from STDIN:
 
-  <info>cat filename | php %command.full_name%</info>
+  <info>cat filename | php %command.full_name% -</info>
 
 You can also validate the syntax of a file:
 
@@ -83,16 +83,18 @@ EOF
         $filenames = (array) $input->getArgument('filename');
         $this->format = $input->getOption('format');
         $this->displayCorrectFiles = $output->isVerbose();
-        $hasStdin = ['-'] === $filenames;
 
-        if ($hasStdin || !$filenames) {
-            if (!$hasStdin && 0 !== ftell(STDIN)) { // remove 0 !== ftell(STDIN) check in 5.0
+        if (['-'] === $filenames) {
+            return $this->display($io, [$this->validate($this->getStdin())]);
+        }
+
+        // @deprecated to be removed in 5.0
+        if (!$filenames) {
+            if (0 !== ftell(STDIN)) {
                 throw new RuntimeException('Please provide a filename or pipe file content to STDIN.');
             }
 
-            if (!$hasStdin) {
-                @trigger_error('Calling to the "lint:xliff" command providing pipe file content to STDIN without passing the dash symbol "-" explicitly is deprecated since Symfony 4.4.', E_USER_DEPRECATED);
-            }
+            @trigger_error('Piping content from STDIN to the "lint:xliff" command without passing the dash symbol "-" as argument is deprecated since Symfony 4.4.', E_USER_DEPRECATED);
 
             return $this->display($io, [$this->validate($this->getStdin())]);
         }

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -124,7 +124,7 @@ the first encountered syntax error.
 
 You can validates XLIFF contents passed from STDIN:
 
-  <info>cat filename | php %command.full_name%</info>
+  <info>cat filename | php %command.full_name% -</info>
 
 You can also validate the syntax of a file:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Running e.g. `lint:yaml -` with no piped content makes the command hangs currently, this makes it fail instead. Also fixes the command help which we forgot to update