### PR TITLE
Add an envvar processor for YAML

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -38,6 +38,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'float' => ['float'],
             'int' => ['int'],
             'json' => ['array'],
+            'yaml' => ['array'],
             'key' => ['bool', 'int', 'float', 'string', 'array'],
             'url' => ['array'],
             'query_string' => ['array'],

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -625,6 +625,27 @@ class PhpDumperTest extends TestCase
         $this->assertNull($container->getParameter('hello-bar'));
     }
 
+    public function testDumpedYamlEnvParameters()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('env(foo)', '["foo","bar"]');
+        $container->setParameter('env(bar)', 'null');
+        $container->setParameter('hello', '%env(yaml:foo)%');
+        $container->setParameter('hello-bar', '%env(yaml:bar)%');
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dumper->dump();
+
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_yaml_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_YamlParameters']));
+
+        putenv('foobar="hello"');
+        require self::$fixturesPath.'/php/services_yaml_env.php';
+        $container = new \Symfony_DI_PhpDumper_Test_YamlParameters();
+        $this->assertSame(['foo', 'bar'], $container->getParameter('hello'));
+        $this->assertNull($container->getParameter('hello-bar'));
+    }
+
     public function testCustomEnvParameters()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -311,6 +311,45 @@ class EnvVarProcessorTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider validYaml
+     */
+    public function testGetEnvYaml($value, $processed)
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $result = $processor->getEnv('yaml', 'foo', function ($name) use ($value) {
+            $this->assertSame('foo', $name);
+
+            return $value;
+        });
+
+        $this->assertSame($processed, $result);
+    }
+
+    public function validYaml()
+    {
+        return [
+            ['[1]', [1]],
+            ['{"key": "value"}', ['key' => 'value']],
+            ['~', null],
+            [null, null],
+        ];
+    }
+
+    public function testGetEnvInvalidYaml()
+    {
+        $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');
+        $this->expectExceptionMessage('Malformed inline YAML');
+        $processor = new EnvVarProcessor(new Container());
+
+        $processor->getEnv('yaml', 'foo', function ($name) {
+            $this->assertSame('foo', $name);
+
+            return '\'';
+        });
+    }
+
     public function testGetEnvUnknown()
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_yaml_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_yaml_env.php
@@ -1,0 +1,114 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+/**
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final
+ */
+class Symfony_DI_PhpDumper_Test_YamlParameters extends Container
+{
+    private $parameters = [];
+    private $targetDirs = [];
+
+    public function __construct()
+    {
+        $this->parameters = $this->getDefaultParameters();
+
+        $this->services = $this->privates = [];
+
+        $this->aliases = [];
+    }
+
+    public function compile(): void
+    {
+        throw new LogicException('You cannot compile a dumped container that was already compiled.');
+    }
+
+    public function isCompiled(): bool
+    {
+        return true;
+    }
+
+    public function getRemovedIds(): array
+    {
+        return [
+            'Psr\\Container\\ContainerInterface' => true,
+            'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
+        ];
+    }
+
+    public function getParameter($name)
+    {
+        $name = (string) $name;
+
+        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || array_key_exists($name, $this->parameters))) {
+            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
+        }
+        if (isset($this->loadedDynamicParameters[$name])) {
+            return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        return $this->parameters[$name];
+    }
+
+    public function hasParameter($name): bool
+    {
+        $name = (string) $name;
+
+        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || array_key_exists($name, $this->parameters);
+    }
+
+    public function setParameter($name, $value): void
+    {
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    public function getParameterBag(): ParameterBagInterface
+    {
+        if (null === $this->parameterBag) {
+            $parameters = $this->parameters;
+            foreach ($this->loadedDynamicParameters as $name => $loaded) {
+                $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+            }
+            $this->parameterBag = new FrozenParameterBag($parameters);
+        }
+
+        return $this->parameterBag;
+    }
+
+    private $loadedDynamicParameters = [
+        'hello' => false,
+        'hello-bar' => false,
+    ];
+    private $dynamicParameters = [];
+
+    private function getDynamicParameter(string $name)
+    {
+        switch ($name) {
+            case 'hello': $value = $this->getEnv('yaml:foo'); break;
+            case 'hello-bar': $value = $this->getEnv('yaml:bar'); break;
+            default: throw new InvalidArgumentException(sprintf('The dynamic parameter "%s" must be defined.', $name));
+        }
+        $this->loadedDynamicParameters[$name] = true;
+
+        return $this->dynamicParameters[$name] = $value;
+    }
+
+    protected function getDefaultParameters(): array
+    {
+        return [
+            'env(foo)' => '["foo","bar"]',
+            'env(bar)' => 'null',
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Adds a simple envvar processor prefix for YAML. 

Remember it's not just about sticking YAML strings into envvars, possible, maybe not very pretty :) . but also combined with the `file:` prefix it becomes pretty useful as a way of getting config into your app.
