### PR TITLE
[DI] cascade preloading only to public parameters/properties

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
@@ -67,14 +67,14 @@ class Preloader
             $r->getDefaultProperties();
 
             if (\PHP_VERSION_ID >= 70400) {
-                foreach ($r->getProperties() as $p) {
+                foreach ($r->getProperties(\ReflectionProperty::IS_PUBLIC) as $p) {
                     if (($t = $p->getType()) && !$t->isBuiltin()) {
                         self::doPreload($t->getName(), $preloaded);
                     }
                 }
             }
 
-            foreach ($r->getMethods() as $m) {
+            foreach ($r->getMethods(\ReflectionMethod::IS_PUBLIC) as $m) {
                 foreach ($m->getParameters() as $p) {
                     if ($p->isDefaultValueAvailable() && $p->isDefaultValueConstant()) {
                         $c = $p->getDefaultValueConstantName();

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
@@ -15,7 +15,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
 
 if (!class_exists(BaseExpressionLanguage::class)) {
-    throw new \ReflectionException(BaseExpressionLanguage::class.' not found.');
+    return;
 }
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This removes `ContainerBuilder`, `RouteCollectionBuilder`, etc. coming from `App\Kernel`