### PR TITLE
[DependencyInjection] Accept existing interfaces as valid named args

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -53,7 +53,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
                     $parameters = $r->getParameters();
                 }
 
-                if (isset($key[0]) && '$' !== $key[0] && !class_exists($key)) {
+                if (isset($key[0]) && '$' !== $key[0] && !class_exists($key) && !interface_exists($key, false)) {
                     throw new InvalidArgumentException(sprintf('Invalid service "%s": did you forget to add the "$" prefix to argument "%s"?', $this->currentId, $key));
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Compiler\ResolveNamedArgumentsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -150,6 +151,19 @@ class ResolveNamedArgumentsPassTest extends TestCase
 
         $pass = new ResolveNamedArgumentsPass();
         $pass->process($container);
+    }
+
+    public function testInterfaceTypedArgument()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
+        $definition->setArgument(ContainerInterface::class, $expected = new Reference('foo'));
+
+        $pass = new ResolveNamedArgumentsPass();
+        $pass->process($container);
+
+        $this->assertSame($expected, $definition->getArgument(3));
     }
 
     public function testResolvesMultipleArgumentsOfTheSameType()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedArgumentsDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedArgumentsDummy.php
@@ -2,12 +2,14 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
+use Psr\Container\ContainerInterface;
+
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 class NamedArgumentsDummy
 {
-    public function __construct(CaseSensitiveClass $c, $apiKey, $hostName)
+    public function __construct(CaseSensitiveClass $c, $apiKey, $hostName, ContainerInterface $interface)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/33531
| License       | MIT
| Doc PR        | -
