### PR TITLE
[HttpFoundation] Call AssertEquals with proper parameters

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -52,7 +52,7 @@ class JsonResponseTest extends TestCase
         $this->assertSame('0', $response->getContent());
 
         $response = new JsonResponse(0.1);
-        $this->assertEquals('0.1', $response->getContent());
+        $this->assertEquals(0.1, $response->getContent());
         $this->assertIsString($response->getContent());
 
         $response = new JsonResponse(true);
@@ -141,7 +141,7 @@ class JsonResponseTest extends TestCase
 
         $response = JsonResponse::create(0.1);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
-        $this->assertEquals('0.1', $response->getContent());
+        $this->assertEquals(0.1, $response->getContent());
         $this->assertIsString($response->getContent());
 
         $response = JsonResponse::create(true);


### PR DESCRIPTION
Since `$response->getContent()` returns string and our first parameter is already string as well, in some cases (with different precisions) it may "compare strings" as "strings" and this is not what the test wants.
By changing the first parameter to actual number we force `AssertEquals` to compare them numerically rather than literally by string content.

| Q             | A
| ------------- | ---
| Branch?       | 3.4, 4.3, master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is yet another catch of this type: https://github.com/symfony/symfony/pull/31612