### PR TITLE
[FrameworkBundle][ErrorRenderer] Use FileLinkFormatter service when possible

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.xml
@@ -13,7 +13,7 @@
             <tag name="error_renderer.renderer" />
             <argument>%kernel.debug%</argument>
             <argument>%kernel.charset%</argument>
-            <argument>%debug.file_link_format%</argument>
+            <argument type="service" id="debug.file_link_formatter" on-invalid="null" />
             <argument>%kernel.project_dir%</argument>
             <argument type="service" id="request_stack" />
             <argument type="service" id="logger" on-invalid="null" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Consistent the way TwigBundle defines the `Symfony\Bridge\Twig\Extension\CodeExtension` service:
https://github.com/symfony/symfony/blob/789448b65ced6e59fd1b9e7339c069051b5f08c1/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml#L88