### PR TITLE
Create doctrine messenger transport table on send

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
@@ -40,7 +40,6 @@ class DoctrineIntegrationTest extends TestCase
         $dsn = getenv('MESSENGER_DOCTRINE_DSN') ?: 'sqlite:///'.sys_get_temp_dir().'/symfony.messenger.sqlite';
         $this->driverConnection = DriverManager::getConnection(['url' => $dsn]);
         $this->connection = new Connection([], $this->driverConnection);
-        // call send to auto-setup the table
         $this->connection->setup();
         // ensure the table is clean for tests
         $this->driverConnection->exec('DELETE FROM messenger_messages');

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
@@ -183,4 +183,15 @@ class DoctrineIntegrationTest extends TestCase
         $envelope = $this->connection->get();
         $this->assertEquals('the body', $envelope['body']);
     }
+
+    public function testTheTransportIsSetupOnSend()
+    {
+        // If the table does not exist and we call send the table must be setup
+        // so first delete the tables
+        $this->driverConnection->exec('DROP TABLE messenger_messages');
+
+        $this->connection->send('sent this', ['my' => 'header']);
+        $envelope = $this->connection->get();
+        $this->assertEquals('sent this', $envelope['body']);
+    }
 }

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -105,6 +105,9 @@ class Connection
      */
     public function send(string $body, array $headers, int $delay = 0): string
     {
+        if ($this->configuration['auto_setup']) {
+            $this->setup();
+        }
         $now = new \DateTime();
         $availableAt = (clone $now)->modify(sprintf('+%d seconds', $delay / 1000));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | aligns with existing docs

Create doctrine messenger transport table on send just like it is created on get to match the
documentation and expectations for auto_setup.

Existing documentation at https://symfony.com/doc/current/messenger.html#doctrine-transport includes:

auto_setup | Whether the table should be created automatically during send / get. | true
-- | -- | --

I think this is correct as I'd expect the table to be autocreated on set before get. 

Tests are added here, but they don't actually fail correctly and I'm not sure why. I wonder if sqlite or doctrine is auto creating this table on insert when it isn't present.  Maybe it's something else that you will see that I'm missing.

