### PR TITLE
[Mailer] rename SmtpEnvelope to Envelope

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Amazon\Transport;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -48,7 +48,7 @@ class SesApiTransport extends AbstractApiTransport
         return sprintf('ses+api://%s@%s', $this->accessKey, $this->getEndpoint());
     }
 
-    protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface
+    protected function doSendApi(Email $email, Envelope $envelope): ResponseInterface
     {
         $date = gmdate('D, d M Y H:i:s e');
         $auth = sprintf('AWS3-HTTPS AWSAccessKeyId=%s,Algorithm=HmacSHA256,Signature=%s', $this->accessKey, $this->getSignature($date));
@@ -81,7 +81,7 @@ class SesApiTransport extends AbstractApiTransport
         return base64_encode(hash_hmac('sha256', $string, $this->secretKey, true));
     }
 
-    private function getPayload(Email $email, SmtpEnvelope $envelope): array
+    private function getPayload(Email $email, Envelope $envelope): array
     {
         if ($email->getAttachments()) {
             return [

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Mailchimp\Transport;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -41,7 +41,7 @@ class MandrillApiTransport extends AbstractApiTransport
         return sprintf('mandrill+api://%s', $this->getEndpoint());
     }
 
-    protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface
+    protected function doSendApi(Email $email, Envelope $envelope): ResponseInterface
     {
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/1.0/messages/send.json', [
             'json' => $this->getPayload($email, $envelope),
@@ -64,7 +64,7 @@ class MandrillApiTransport extends AbstractApiTransport
         return ($this->host ?: self::HOST).($this->port ? ':'.$this->port : '');
     }
 
-    private function getPayload(Email $email, SmtpEnvelope $envelope): array
+    private function getPayload(Email $email, Envelope $envelope): array
     {
         $payload = [
             'key' => $this->key,
@@ -105,7 +105,7 @@ class MandrillApiTransport extends AbstractApiTransport
         return $payload;
     }
 
-    protected function getRecipients(Email $email, SmtpEnvelope $envelope): array
+    protected function getRecipients(Email $email, Envelope $envelope): array
     {
         $recipients = [];
         foreach ($envelope->getRecipients() as $recipient) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Mailgun\Transport;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
@@ -46,7 +46,7 @@ class MailgunApiTransport extends AbstractApiTransport
         return sprintf('mailgun+api://%s?domain=%s', $this->getEndpoint(), $this->domain);
     }
 
-    protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface
+    protected function doSendApi(Email $email, Envelope $envelope): ResponseInterface
     {
         $body = new FormDataPart($this->getPayload($email, $envelope));
         $headers = [];
@@ -72,7 +72,7 @@ class MailgunApiTransport extends AbstractApiTransport
         return $response;
     }
 
-    private function getPayload(Email $email, SmtpEnvelope $envelope): array
+    private function getPayload(Email $email, Envelope $envelope): array
     {
         $headers = $email->getHeaders();
         $html = $email->getHtmlBody();

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Postmark\Transport;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -41,7 +41,7 @@ class PostmarkApiTransport extends AbstractApiTransport
         return sprintf('postmark+api://%s', $this->getEndpoint());
     }
 
-    protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface
+    protected function doSendApi(Email $email, Envelope $envelope): ResponseInterface
     {
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/email', [
             'headers' => [
@@ -60,7 +60,7 @@ class PostmarkApiTransport extends AbstractApiTransport
         return $response;
     }
 
-    private function getPayload(Email $email, SmtpEnvelope $envelope): array
+    private function getPayload(Email $email, Envelope $envelope): array
     {
         $payload = [
             'From' => $envelope->getSender()->toString(),

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Sendgrid\Transport;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -42,7 +42,7 @@ class SendgridApiTransport extends AbstractApiTransport
         return sprintf('sendgrid+api://%s', $this->getEndpoint());
     }
 
-    protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface
+    protected function doSendApi(Email $email, Envelope $envelope): ResponseInterface
     {
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v3/mail/send', [
             'json' => $this->getPayload($email, $envelope),
@@ -58,7 +58,7 @@ class SendgridApiTransport extends AbstractApiTransport
         return $response;
     }
 
-    private function getPayload(Email $email, SmtpEnvelope $envelope): array
+    private function getPayload(Email $email, Envelope $envelope): array
     {
         $addressStringifier = function (Address $address) {return ['email' => $address->toString()]; };
 

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 4.4.0
 -----
 
+ * [BC BREAK] renamed `SmtpEnvelope` to `Envelope`, renamed `DelayedSmtpEnvelope` to
+   `DelayedEnvelope`
  * [BC BREAK] changed the syntax for failover and roundrobin DSNs
 
    Before:

--- a/src/Symfony/Component/Mailer/DelayedEnvelope.php
+++ b/src/Symfony/Component/Mailer/DelayedEnvelope.php
@@ -21,7 +21,7 @@ use Symfony\Component\Mime\Message;
  *
  * @internal
  */
-final class DelayedSmtpEnvelope extends SmtpEnvelope
+final class DelayedEnvelope extends Envelope
 {
     private $senderSet = false;
     private $recipientsSet = false;

--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -19,7 +19,7 @@ use Symfony\Component\Mime\RawMessage;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class SmtpEnvelope
+class Envelope
 {
     private $sender;
     private $recipients = [];
@@ -39,7 +39,7 @@ class SmtpEnvelope
             throw new LogicException('Cannot send a RawMessage instance without an explicit Envelope.');
         }
 
-        return new DelayedSmtpEnvelope($message);
+        return new DelayedEnvelope($message);
     }
 
     public function setSender(Address $sender): void

--- a/src/Symfony/Component/Mailer/Event/MessageEvent.php
+++ b/src/Symfony/Component/Mailer/Event/MessageEvent.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Mailer\Event;
 
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\Mailer\SmtpEnvelope;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mime\RawMessage;
 
 /**
@@ -27,7 +27,7 @@ final class MessageEvent extends Event
     private $transport;
     private $queued;
 
-    public function __construct(RawMessage $message, SmtpEnvelope $envelope, string $transport, bool $queued = false)
+    public function __construct(RawMessage $message, Envelope $envelope, string $transport, bool $queued = false)
     {
         $this->message = $message;
         $this->envelope = $envelope;

--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -34,7 +34,7 @@ final class Mailer implements MailerInterface
         $this->dispatcher = $dispatcher;
     }
 
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): void
+    public function send(RawMessage $message, Envelope $envelope = null): void
     {
         if (null === $this->bus) {
             $this->transport->send($message, $envelope);
@@ -44,7 +44,7 @@ final class Mailer implements MailerInterface
 
         if (null !== $this->dispatcher) {
             $message = clone $message;
-            $envelope = null !== $envelope ? clone $envelope : SmtpEnvelope::create($message);
+            $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
             $event = new MessageEvent($message, $envelope, (string) $this->transport, true);
             $this->dispatcher->dispatch($event);
         }

--- a/src/Symfony/Component/Mailer/MailerInterface.php
+++ b/src/Symfony/Component/Mailer/MailerInterface.php
@@ -26,5 +26,5 @@ interface MailerInterface
     /**
      * @throws TransportExceptionInterface
      */
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): void;
+    public function send(RawMessage $message, Envelope $envelope = null): void;
 }

--- a/src/Symfony/Component/Mailer/Messenger/SendEmailMessage.php
+++ b/src/Symfony/Component/Mailer/Messenger/SendEmailMessage.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Mailer\Messenger;
 
-use Symfony\Component\Mailer\SmtpEnvelope;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mime\RawMessage;
 
 /**
@@ -25,7 +25,7 @@ class SendEmailMessage
     /**
      * @internal
      */
-    public function __construct(RawMessage $message, SmtpEnvelope $envelope = null)
+    public function __construct(RawMessage $message, Envelope $envelope = null)
     {
         $this->message = $message;
         $this->envelope = $envelope;
@@ -36,7 +36,7 @@ class SendEmailMessage
         return $this->message;
     }
 
-    public function getEnvelope(): ?SmtpEnvelope
+    public function getEnvelope(): ?Envelope
     {
         return $this->envelope;
     }

--- a/src/Symfony/Component/Mailer/SentMessage.php
+++ b/src/Symfony/Component/Mailer/SentMessage.php
@@ -27,7 +27,7 @@ class SentMessage
     /**
      * @internal
      */
-    public function __construct(RawMessage $message, SmtpEnvelope $envelope)
+    public function __construct(RawMessage $message, Envelope $envelope)
     {
         $message->ensureValidity();
 
@@ -46,7 +46,7 @@ class SentMessage
         return $this->original;
     }
 
-    public function getEnvelope(): SmtpEnvelope
+    public function getEnvelope(): Envelope
     {
         return $this->envelope;
     }

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -12,43 +12,43 @@
 namespace Symfony\Component\Mailer\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\LogicException;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\RawMessage;
 
-class SmtpEnvelopeTest extends TestCase
+class EnvelopeTest extends TestCase
 {
     public function testConstructorWithAddressSender()
     {
-        $e = new SmtpEnvelope(new Address('fabien@symfony.com'), [new Address('thomas@symfony.com')]);
+        $e = new Envelope(new Address('fabien@symfony.com'), [new Address('thomas@symfony.com')]);
         $this->assertEquals(new Address('fabien@symfony.com'), $e->getSender());
     }
 
     public function testConstructorWithNamedAddressSender()
     {
-        $e = new SmtpEnvelope(new Address('fabien@symfony.com', 'Fabien'), [new Address('thomas@symfony.com')]);
+        $e = new Envelope(new Address('fabien@symfony.com', 'Fabien'), [new Address('thomas@symfony.com')]);
         $this->assertEquals(new Address('fabien@symfony.com'), $e->getSender());
     }
 
     public function testConstructorWithAddressRecipients()
     {
-        $e = new SmtpEnvelope(new Address('fabien@symfony.com'), [new Address('thomas@symfony.com'), new Address('lucas@symfony.com', 'Lucas')]);
+        $e = new Envelope(new Address('fabien@symfony.com'), [new Address('thomas@symfony.com'), new Address('lucas@symfony.com', 'Lucas')]);
         $this->assertEquals([new Address('thomas@symfony.com'), new Address('lucas@symfony.com')], $e->getRecipients());
     }
 
     public function testConstructorWithNoRecipients()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $e = new SmtpEnvelope(new Address('fabien@symfony.com'), []);
+        $e = new Envelope(new Address('fabien@symfony.com'), []);
     }
 
     public function testConstructorWithWrongRecipients()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $e = new SmtpEnvelope(new Address('fabien@symfony.com'), ['lucas@symfony.com']);
+        $e = new Envelope(new Address('fabien@symfony.com'), ['lucas@symfony.com']);
     }
 
     public function testSenderFromHeaders()
@@ -56,19 +56,19 @@ class SmtpEnvelopeTest extends TestCase
         $headers = new Headers();
         $headers->addPathHeader('Return-Path', new Address('return@symfony.com', 'return'));
         $headers->addMailboxListHeader('To', ['from@symfony.com']);
-        $e = SmtpEnvelope::create(new Message($headers));
+        $e = Envelope::create(new Message($headers));
         $this->assertEquals(new Address('return@symfony.com', 'return'), $e->getSender());
 
         $headers = new Headers();
         $headers->addMailboxHeader('Sender', new Address('sender@symfony.com', 'sender'));
         $headers->addMailboxListHeader('To', ['from@symfony.com']);
-        $e = SmtpEnvelope::create(new Message($headers));
+        $e = Envelope::create(new Message($headers));
         $this->assertEquals(new Address('sender@symfony.com', 'sender'), $e->getSender());
 
         $headers = new Headers();
         $headers->addMailboxListHeader('From', [new Address('from@symfony.com', 'from'), 'some@symfony.com']);
         $headers->addMailboxListHeader('To', ['from@symfony.com']);
-        $e = SmtpEnvelope::create(new Message($headers));
+        $e = Envelope::create(new Message($headers));
         $this->assertEquals(new Address('from@symfony.com', 'from'), $e->getSender());
     }
 
@@ -76,7 +76,7 @@ class SmtpEnvelopeTest extends TestCase
     {
         $headers = new Headers();
         $headers->addMailboxListHeader('To', ['from@symfony.com']);
-        $e = SmtpEnvelope::create($message = new Message($headers));
+        $e = Envelope::create($message = new Message($headers));
         $message->getHeaders()->addMailboxListHeader('From', [new Address('from@symfony.com', 'from')]);
         $this->assertEquals(new Address('from@symfony.com', 'from'), $e->getSender());
     }
@@ -88,7 +88,7 @@ class SmtpEnvelopeTest extends TestCase
         $headers->addMailboxListHeader('To', [new Address('to@symfony.com')]);
         $headers->addMailboxListHeader('Cc', [new Address('cc@symfony.com')]);
         $headers->addMailboxListHeader('Bcc', [new Address('bcc@symfony.com')]);
-        $e = SmtpEnvelope::create(new Message($headers));
+        $e = Envelope::create(new Message($headers));
         $this->assertEquals([new Address('to@symfony.com'), new Address('cc@symfony.com'), new Address('bcc@symfony.com')], $e->getRecipients());
     }
 
@@ -99,7 +99,7 @@ class SmtpEnvelopeTest extends TestCase
         $headers->addMailboxListHeader('To', [new Address('to@symfony.com', 'to')]);
         $headers->addMailboxListHeader('Cc', [new Address('cc@symfony.com', 'cc')]);
         $headers->addMailboxListHeader('Bcc', [new Address('bcc@symfony.com', 'bcc')]);
-        $e = SmtpEnvelope::create(new Message($headers));
+        $e = Envelope::create(new Message($headers));
         $this->assertEquals([new Address('to@symfony.com', 'to'), new Address('cc@symfony.com', 'cc'), new Address('bcc@symfony.com', 'bcc')], $e->getRecipients());
     }
 
@@ -107,6 +107,6 @@ class SmtpEnvelopeTest extends TestCase
     {
         $this->expectException(LogicException::class);
 
-        SmtpEnvelope::create(new RawMessage('Some raw email message'));
+        Envelope::create(new RawMessage('Some raw email message'));
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/SentMessageTest.php
+++ b/src/Symfony/Component/Mailer/Tests/SentMessageTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\RawMessage;
@@ -22,7 +22,7 @@ class SentMessageTest extends TestCase
 {
     public function test()
     {
-        $m = new SentMessage($r = new RawMessage('Email'), $e = new SmtpEnvelope(new Address('fabien@example.com'), [new Address('helene@example.com')]));
+        $m = new SentMessage($r = new RawMessage('Email'), $e = new Envelope(new Address('fabien@example.com'), [new Address('helene@example.com')]));
         $this->assertSame($r, $m->getOriginalMessage());
         $this->assertSame($r, $m->getMessage());
         $this->assertSame($e, $m->getEnvelope());

--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\LogicException;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\NullTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\RawMessage;
@@ -28,7 +28,7 @@ class AbstractTransportTest extends TestCase
         $transport = new NullTransport();
         $transport->setMaxPerSecond(2 / 10);
         $message = new RawMessage('');
-        $envelope = new SmtpEnvelope(new Address('fabien@example.com'), [new Address('helene@example.com')]);
+        $envelope = new Envelope(new Address('fabien@example.com'), [new Address('helene@example.com')]);
 
         $start = time();
         $transport->send($message, $envelope);

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -12,9 +12,9 @@
 namespace Symfony\Component\Mailer\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\FailoverTransport;
@@ -93,7 +93,7 @@ class DummyTransport implements Transport\TransportInterface
         $this->host = $host;
     }
 
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         throw new \BadMethodCallException('This method newer should be called.');
     }

--- a/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Mailer\Transport;
 
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\RuntimeException;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\MessageConverter;
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 abstract class AbstractApiTransport extends AbstractHttpTransport
 {
-    abstract protected function doSendApi(Email $email, SmtpEnvelope $envelope): ResponseInterface;
+    abstract protected function doSendApi(Email $email, Envelope $envelope): ResponseInterface;
 
     protected function doSendHttp(SentMessage $message): ResponseInterface
     {
@@ -37,7 +37,7 @@ abstract class AbstractApiTransport extends AbstractHttpTransport
         return $this->doSendApi($email, $message->getEnvelope());
     }
 
-    protected function getRecipients(Email $email, SmtpEnvelope $envelope): array
+    protected function getRecipients(Email $email, Envelope $envelope): array
     {
         return array_filter($envelope->getRecipients(), function (Address $address) use ($email) {
             return false === \in_array($address, array_merge($email->getCc(), $email->getBcc()), true);

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -13,9 +13,9 @@ namespace Symfony\Component\Mailer\Transport;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -51,10 +51,10 @@ abstract class AbstractTransport implements TransportInterface
         return $this;
     }
 
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         $message = clone $message;
-        $envelope = null !== $envelope ? clone $envelope : SmtpEnvelope::create($message);
+        $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
 
         if (null !== $this->dispatcher) {
             $event = new MessageEvent($message, $envelope, (string) $this);

--- a/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Mailer\Transport;
 
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mime\RawMessage;
 
 /**
@@ -43,7 +43,7 @@ class RoundRobinTransport implements TransportInterface
         $this->retryPeriod = $retryPeriod;
     }
 
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         while ($transport = $this->getNextTransport()) {
             try {

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Mailer\Transport;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\AbstractStream;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\ProcessStream;
@@ -64,7 +64,7 @@ class SendmailTransport extends AbstractTransport
         }
     }
 
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         if ($this->transport) {
             return $this->transport->send($message, $envelope);

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\Mailer\Transport\Smtp;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\AbstractStream;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
@@ -102,7 +102,7 @@ class SmtpTransport extends AbstractTransport
         return $this->domain;
     }
 
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         try {
             $message = parent::send($message, $envelope);

--- a/src/Symfony/Component/Mailer/Transport/TransportInterface.php
+++ b/src/Symfony/Component/Mailer/Transport/TransportInterface.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Mailer\Transport;
 
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mime\RawMessage;
 
 /**
@@ -29,7 +29,7 @@ interface TransportInterface
     /**
      * @throws TransportExceptionInterface
      */
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage;
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage;
 
     public function __toString(): string;
 }

--- a/src/Symfony/Component/Mailer/Transport/Transports.php
+++ b/src/Symfony/Component/Mailer/Transport/Transports.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Mailer\Transport;
 
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\SentMessage;
-use Symfony\Component\Mailer\SmtpEnvelope;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\RawMessage;
 
@@ -44,7 +44,7 @@ class Transports implements TransportInterface
         }
     }
 
-    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         /** @var Message $message */
         if (RawMessage::class === \get_class($message) || !$message->getHeaders()->has('X-Transport')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Drop the Smtp prefix so that arbitrary transports do not have to depend
on SMTP specific concepts.