### PR TITLE
Fixed cache pools affecting each other due to an overwritten seed variable

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -78,11 +78,12 @@ class CachePoolPass implements CompilerPassInterface
             }
             $name = $tags[0]['name'] ?? $id;
             if (!isset($tags[0]['namespace'])) {
+                $namespaceSeed = $seed;
                 if (null !== $class) {
-                    $seed .= '.'.$class;
+                    $namespaceSeed .= '.'.$class;
                 }
 
-                $tags[0]['namespace'] = $this->getNamespace($seed, $name);
+                $tags[0]['namespace'] = $this->getNamespace($namespaceSeed, $name);
             }
             if (isset($tags[0]['clearer'])) {
                 $clearer = $tags[0]['clearer'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Closes #33561
| License       | MIT

Due to the fact the adapter was added to the cache seed calculation for cache pools, multiple pool definitions could affect each other. The how and why is described in #33561. This PR resolves that issue by using a copy of the seed and mutating only that copy. 