### PR TITLE
[Inflector] add support 'see' to 'ee' for singularize 'fees' to 'fee'

### DIFF
--- a/src/Symfony/Component/Inflector/Inflector.php
+++ b/src/Symfony/Component/Inflector/Inflector.php
@@ -124,6 +124,9 @@ final class Inflector
         // bureaus (bureau)
         ['suae', 4, false, true, 'eau'],
 
+        // fees (fee), trees (tree), employees (employee)
+        ['see', 3, true, true, 'ee'],
+
         // roses (rose), garages (garage), cassettes (cassette),
         // waltzes (waltz), heroes (hero), bushes (bush), arches (arch),
         // shoes (shoe)

--- a/src/Symfony/Component/Inflector/Tests/InflectorTest.php
+++ b/src/Symfony/Component/Inflector/Tests/InflectorTest.php
@@ -38,7 +38,7 @@ class InflectorTest extends TestCase
             ['bases', ['bas', 'base', 'basis']],
             ['batches', ['batch', 'batche']],
             ['beaux', 'beau'],
-            ['bees', ['be', 'bee']],
+            ['bees', 'bee'],
             ['boxes', 'box'],
             ['boys', 'boy'],
             ['bureaus', 'bureau'],
@@ -68,7 +68,9 @@ class InflectorTest extends TestCase
             ['echoes', ['echo', 'echoe']],
             ['elves', ['elf', 'elve', 'elff']],
             ['emphases', ['emphas', 'emphase', 'emphasis']],
+            ['employees', 'employee'],
             ['faxes', 'fax'],
+            ['fees', 'fee'],
             ['feet', 'foot'],
             ['feedback', 'feedback'],
             ['foci', 'focus'],
@@ -139,14 +141,14 @@ class InflectorTest extends TestCase
             ['teeth', 'tooth'],
             ['theses', ['thes', 'these', 'thesis']],
             ['thieves', ['thief', 'thieve', 'thieff']],
-            ['trees', ['tre', 'tree']],
+            ['trees', 'tree'],
             ['waltzes', ['waltz', 'waltze']],
             ['wives', 'wife'],
 
             // test casing: if the first letter was uppercase, it should remain so
             ['Men', 'Man'],
             ['GrandChildren', 'GrandChild'],
-            ['SubTrees', ['SubTre', 'SubTree']],
+            ['SubTrees', 'SubTree'],
 
             // Known issues
             //['insignia', 'insigne'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
I don't know if this is considered a bug or a new feature ? Tell me if I need to change target branch

This PR improves the singularization of words such as "trees", "employees" or "fees"
