### PR TITLE
Adding .gitattributes to remove Tests directory from "dist"

### DIFF
--- a/src/Symfony/Bridge/Doctrine/.gitattributes
+++ b/src/Symfony/Bridge/Doctrine/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Monolog/.gitattributes
+++ b/src/Symfony/Bridge/Monolog/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/ProxyManager/.gitattributes
+++ b/src/Symfony/Bridge/ProxyManager/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Twig/.gitattributes
+++ b/src/Symfony/Bridge/Twig/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/DebugBundle/.gitattributes
+++ b/src/Symfony/Bundle/DebugBundle/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/FrameworkBundle/.gitattributes
+++ b/src/Symfony/Bundle/FrameworkBundle/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/SecurityBundle/.gitattributes
+++ b/src/Symfony/Bundle/SecurityBundle/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/TwigBundle/.gitattributes
+++ b/src/Symfony/Bundle/TwigBundle/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
+++ b/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/WebServerBundle/.gitattributes
+++ b/src/Symfony/Bundle/WebServerBundle/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Asset/.gitattributes
+++ b/src/Symfony/Component/Asset/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/BrowserKit/.gitattributes
+++ b/src/Symfony/Component/BrowserKit/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Cache/.gitattributes
+++ b/src/Symfony/Component/Cache/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Config/.gitattributes
+++ b/src/Symfony/Component/Config/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Console/.gitattributes
+++ b/src/Symfony/Component/Console/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/CssSelector/.gitattributes
+++ b/src/Symfony/Component/CssSelector/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Debug/.gitattributes
+++ b/src/Symfony/Component/Debug/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/DependencyInjection/.gitattributes
+++ b/src/Symfony/Component/DependencyInjection/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/DomCrawler/.gitattributes
+++ b/src/Symfony/Component/DomCrawler/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Dotenv/.gitattributes
+++ b/src/Symfony/Component/Dotenv/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/ErrorHandler/.gitattributes
+++ b/src/Symfony/Component/ErrorHandler/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/ErrorRenderer/.gitattributes
+++ b/src/Symfony/Component/ErrorRenderer/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/EventDispatcher/.gitattributes
+++ b/src/Symfony/Component/EventDispatcher/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/ExpressionLanguage/.gitattributes
+++ b/src/Symfony/Component/ExpressionLanguage/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Filesystem/.gitattributes
+++ b/src/Symfony/Component/Filesystem/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Finder/.gitattributes
+++ b/src/Symfony/Component/Finder/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Form/.gitattributes
+++ b/src/Symfony/Component/Form/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/HttpClient/.gitattributes
+++ b/src/Symfony/Component/HttpClient/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/HttpFoundation/.gitattributes
+++ b/src/Symfony/Component/HttpFoundation/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/HttpKernel/.gitattributes
+++ b/src/Symfony/Component/HttpKernel/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Inflector/.gitattributes
+++ b/src/Symfony/Component/Inflector/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Intl/.gitattributes
+++ b/src/Symfony/Component/Intl/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Ldap/.gitattributes
+++ b/src/Symfony/Component/Ldap/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Lock/.gitattributes
+++ b/src/Symfony/Component/Lock/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Mailer/.gitattributes
+++ b/src/Symfony/Component/Mailer/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Google/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Google/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Messenger/.gitattributes
+++ b/src/Symfony/Component/Messenger/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Mime/.gitattributes
+++ b/src/Symfony/Component/Mime/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/OptionsResolver/.gitattributes
+++ b/src/Symfony/Component/OptionsResolver/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Process/.gitattributes
+++ b/src/Symfony/Component/Process/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/PropertyAccess/.gitattributes
+++ b/src/Symfony/Component/PropertyAccess/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/PropertyInfo/.gitattributes
+++ b/src/Symfony/Component/PropertyInfo/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Routing/.gitattributes
+++ b/src/Symfony/Component/Routing/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Security/Core/.gitattributes
+++ b/src/Symfony/Component/Security/Core/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Security/Csrf/.gitattributes
+++ b/src/Symfony/Component/Security/Csrf/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Security/Guard/.gitattributes
+++ b/src/Symfony/Component/Security/Guard/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Security/Http/.gitattributes
+++ b/src/Symfony/Component/Security/Http/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Serializer/.gitattributes
+++ b/src/Symfony/Component/Serializer/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Stopwatch/.gitattributes
+++ b/src/Symfony/Component/Stopwatch/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Templating/.gitattributes
+++ b/src/Symfony/Component/Templating/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Translation/.gitattributes
+++ b/src/Symfony/Component/Translation/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Validator/.gitattributes
+++ b/src/Symfony/Component/Validator/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/VarDumper/.gitattributes
+++ b/src/Symfony/Component/VarDumper/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/VarExporter/.gitattributes
+++ b/src/Symfony/Component/VarExporter/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/WebLink/.gitattributes
+++ b/src/Symfony/Component/WebLink/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Workflow/.gitattributes
+++ b/src/Symfony/Component/Workflow/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Yaml/.gitattributes
+++ b/src/Symfony/Component/Yaml/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no?
| Tickets       | 
| License       | MIT
| Doc PR        |

This is a controversial topic that have been mentioned before. We recently had some discussions on Slack about it and the community not in an agreement. This was asked back in 2014 already. 

Im making this PR again, because I think this will help more people than it hurts to keep the tests in the "dist" version. 

### Reasons for keeping the tests with the source

* You can look at the tests to understand how the code works
* It is convenient

In the past there were an argument of people might depend on Symfony's classes in Tests. That is no longer the case since we moved reusable classes from Tests to Test. 

### Reasons for removing them (merging this PR)

* There should be difference between `composer update --prefer-source` and `composer update --prefer-dist`
* Smaller packages when deploying with Docker or on Serverless. 
* Static analysis tools will not complain on PHP syntax errors in our tests ([example](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/xml_with_wrong_ext.php))

## How to decide?

Merging this PR or not is tricky because no side has a solid technical argument. It is basically just personal preference. Please give this PR a 👍 or 👎 if you want to give your opinion. 


## Other PRs and issues related to this: 

Add .gitattributes file (https://github.com/symfony/symfony/pull/29277)
Added .gitattributes files to root and all components (https://github.com/symfony/symfony/pull/26472)
Exclude non-essential files from Composer package (https://github.com/symfony/symfony/issues/25414)
[HttpFoundation] optimize files for distribution (https://github.com/symfony/symfony/pull/24427)
Add .gitattributes files (https://github.com/symfony/symfony/pull/23926)
[Suggestion] Adding .gitattributes to ignore unnecessary folders and files for production env (https://github.com/symfony/symfony/issues/20057)
Add lightweight and root only .gitattributes (https://github.com/symfony/symfony/pull/18004)
Add .gitattributes to exclude tests from ZIPs (https://github.com/symfony/symfony/pull/17995)
[RFC] Move tests out of the source and source out of the tests (https://github.com/symfony/symfony/issues/17749)
Removal of development & testing files using .gitattributes (https://github.com/symfony/symfony/issues/16174)
Please add .gitattributes files and fix line endings (https://github.com/symfony/symfony/issues/13521)
making use of .gitattributes (https://github.com/symfony/symfony/issues/11810)

## Workarounds

There are workarounds for both sides. Example: 

### Workaround if merged

* `composer update --prefer-source`

### Workaround if closed

* `find vendor/symfony -name "Tests" -type d -exec rm -r "{}" \;`
* https://github.com/editorconfig/editorconfig/issues/228
* https://github.com/dg/composer-cleaner