### PR TITLE
[Security] Removed unused argument in Test

### DIFF
--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -83,7 +83,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
     /**
      * @dataProvider getTokenClearingTests
      */
-    public function testHandleAuthenticationClearsToken($tokenClass, $tokenProviderKey, $actualProviderKey)
+    public function testHandleAuthenticationClearsToken($tokenProviderKey, $actualProviderKey)
     {
         $this->tokenStorage->expects($this->never())
             ->method('setToken')
@@ -104,10 +104,10 @@ class GuardAuthenticatorHandlerTest extends TestCase
     public function getTokenClearingTests()
     {
         $tests = [];
-        // correct token class and matching firewall => clear the token
-        $tests[] = ['Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken', 'the_firewall_key', 'the_firewall_key'];
-        $tests[] = ['Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken', 'the_firewall_key', 'different_key'];
-        $tests[] = ['Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', 'the_firewall_key', 'the_firewall_key'];
+        // matching firewall => clear the token
+        $tests[] = ['the_firewall_key', 'the_firewall_key'];
+        $tests[] = ['the_firewall_key', 'different_key'];
+        $tests[] = ['the_firewall_key', 'the_firewall_key'];
 
         return $tests;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

After #32998 there was a minor left over, the `testHandleAuthenticationClearsToken` `$tokenClass` argument is no longer used and can be safely removed.
