### PR TITLE
[Cache] bump required symfony/contracts version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "psr/container": "^1.0",
         "psr/link": "^1.0",
         "psr/log": "~1.0",
-        "symfony/contracts": "^1.1.3|^2",
+        "symfony/contracts": "^1.1.7|^2",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-intl-idn": "^1.10",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33593
| License       | MIT
| Doc PR        | 

make the changes from #33516 work when `symfony/symfony` is required instead of `symfony/cache`