### PR TITLE
[Messenger] Fix exception message of failed message is dropped on retry

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -13,12 +13,15 @@ namespace Symfony\Component\Messenger\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
-use Symfony\Component\Messenger\Worker;
 
 class FailedMessagesRetryCommandTest extends TestCase
 {
@@ -34,15 +37,51 @@ class FailedMessagesRetryCommandTest extends TestCase
         // the bus should be called in the worker
         $bus->expects($this->exactly(2))->method('dispatch')->willReturn(new Envelope(new \stdClass()));
 
-        $command = new FailedMessagesRetryCommand(
-            'failure_receiver',
-            $receiver,
-            $bus,
-            $dispatcher
-        );
+        $command = new FailedMessagesRetryCommand('failure_receiver', $receiver, $bus, $dispatcher);
 
         $tester = new CommandTester($command);
         $tester->execute(['id' => [10, 12]]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testExceptionOnRetry()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->with(10)->willReturn(new Envelope(new \stdClass()));
+        // message will eventually be ack'ed in Worker
+        $receiver->expects($this->once())->method('ack');
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $bus = $this->createMock(MessageBusInterface::class);
+        // the bus should be called in the worker
+        $bus->expects($this->at(0))
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $envelope) {
+                $lastReceivedStamp = $envelope->last(ReceivedStamp::class);
+
+                return $lastReceivedStamp instanceof ReceivedStamp && \is_string($lastReceivedStamp->getTransportName());
+            }))
+            ->will($this->throwException(new \Exception('Mock test exception')));
+
+        $bus->expects($this->at(1))
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $envelope) {
+                $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
+
+                return $lastRedeliveryStamp instanceof RedeliveryStamp &&
+                    \is_string($lastRedeliveryStamp->getExceptionMessage()) &&
+                    $lastRedeliveryStamp->getFlattenException() instanceof FlattenException;
+            }))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStrategy->expects($this->once())->method('isRetryable')->with($this->isInstanceOf(Envelope::class))->willReturn(true);
+
+        $command = new FailedMessagesRetryCommand('failure_receiver', $receiver, $bus, $dispatcher, $retryStrategy);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => [10]]);
 
         $this->assertStringContainsString('[OK]', $tester->getDisplay());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #32311
| License       | MIT
| Doc PR        | NA <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
