### PR TITLE
[HttpClient] Add default value for Accept header

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -56,6 +56,10 @@ trait HttpClientTrait
             }
         }
 
+        if (!isset($options['normalized_headers']['accept'])) {
+            $options['normalized_headers']['accept'] = [$options['headers'][] = 'Accept: *'];
+        }
+
         if (isset($options['body'])) {
             $options['body'] = self::normalizeBody($options['body']);
         }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -172,7 +172,7 @@ class HttpClientTraitTest extends TestCase
     public function testAuthBearerOption()
     {
         [, $options] = self::prepareRequest('POST', 'http://example.com', ['auth_bearer' => 'foobar'], HttpClientInterface::OPTIONS_DEFAULTS);
-        $this->assertSame(['Authorization: Bearer foobar'], $options['headers']);
+        $this->assertSame(['Accept: *', 'Authorization: Bearer foobar'], $options['headers']);
         $this->assertSame(['Authorization: Bearer foobar'], $options['normalized_headers']['authorization']);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #33596 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT


This PR will add an "Accept: *" header when nothing is provided to stick with the behavior of a native curl query or postman query. 
