### PR TITLE
[Draft][WebProfiler] Removed intercept_redirects config option

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -36,7 +36,6 @@ class Configuration implements ConfigurationInterface
         $treeBuilder->getRootNode()
             ->children()
                 ->booleanNode('toolbar')->defaultFalse()->end()
-                ->booleanNode('intercept_redirects')->defaultFalse()->setDeprecated('The "intercept_redirects" option is deprecated since version 4.4 and will be removed in 5.0.')->end()
                 ->scalarNode('excluded_ajax_paths')->defaultValue('^/((index|app(_[\w]+)?)\.php/)?_wdt')->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -46,10 +46,9 @@ class WebProfilerExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('profiler.xml');
 
-        if ($config['toolbar'] || $config['intercept_redirects']) {
+        if ($config['toolbar']) {
             $loader->load('toolbar.xml');
-            $container->getDefinition('web_profiler.debug_toolbar')->replaceArgument(4, $config['excluded_ajax_paths']);
-            $container->setParameter('web_profiler.debug_toolbar.intercept_redirects', $config['intercept_redirects']);
+            $container->getDefinition('web_profiler.debug_toolbar')->replaceArgument(3, $config['excluded_ajax_paths']);
             $container->setParameter('web_profiler.debug_toolbar.mode', $config['toolbar'] ? WebDebugToolbarListener::ENABLED : WebDebugToolbarListener::DISABLED);
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
@@ -10,7 +10,6 @@
         <service id="web_profiler.debug_toolbar" class="Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="twig" />
-            <argument>%web_profiler.debug_toolbar.intercept_redirects%</argument>
             <argument>%web_profiler.debug_toolbar.mode%</argument>
             <argument type="service" id="router" on-invalid="ignore" />
             <argument /> <!-- paths that should be excluded from the AJAX requests shown in the toolbar -->

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -35,7 +35,6 @@ class ConfigurationTest extends TestCase
             [
                 'options' => [],
                 'expectedResult' => [
-                    'intercept_redirects' => false,
                     'toolbar' => false,
                     'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt',
                 ],
@@ -43,7 +42,6 @@ class ConfigurationTest extends TestCase
             [
                 'options' => ['toolbar' => true],
                 'expectedResult' => [
-                    'intercept_redirects' => false,
                     'toolbar' => true,
                     'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt',
                 ],
@@ -51,45 +49,8 @@ class ConfigurationTest extends TestCase
             [
                 'options' => ['excluded_ajax_paths' => 'test'],
                 'expectedResult' => [
-                    'intercept_redirects' => false,
                     'toolbar' => false,
                     'excluded_ajax_paths' => 'test',
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * @group legacy
-     *
-     * @dataProvider getInterceptRedirectsConfiguration
-     */
-    public function testConfigTreeUsingInterceptRedirects(bool $interceptRedirects, array $expectedResult)
-    {
-        $processor = new Processor();
-        $configuration = new Configuration();
-        $config = $processor->processConfiguration($configuration, [['intercept_redirects' => $interceptRedirects]]);
-
-        $this->assertEquals($expectedResult, $config);
-    }
-
-    public function getInterceptRedirectsConfiguration()
-    {
-        return [
-            [
-                'interceptRedirects' => true,
-                'expectedResult' => [
-                    'intercept_redirects' => true,
-                    'toolbar' => false,
-                    'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt',
-                ],
-            ],
-            [
-                'interceptRedirects' => false,
-                'expectedResult' => [
-                    'intercept_redirects' => false,
-                    'toolbar' => false,
-                    'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt',
                 ],
             ],
         ];

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -141,57 +141,6 @@ class WebProfilerExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @group legacy
-     *
-     * @dataProvider getInterceptRedirectsToolbarConfig
-     */
-    public function testToolbarConfigUsingInterceptRedirects(
-        bool $toolbarEnabled,
-        bool $interceptRedirects,
-        bool $listenerInjected,
-        bool $listenerEnabled
-    ) {
-        $extension = new WebProfilerExtension();
-        $extension->load(
-            [['toolbar' => $toolbarEnabled, 'intercept_redirects' => $interceptRedirects]],
-            $this->container
-        );
-        $this->container->removeDefinition('web_profiler.controller.exception');
-
-        $this->assertSame($listenerInjected, $this->container->has('web_profiler.debug_toolbar'));
-
-        self::assertSaneContainer($this->getCompiledContainer(), '', ['web_profiler.csp.handler']);
-
-        if ($listenerInjected) {
-            $this->assertSame($listenerEnabled, $this->container->get('web_profiler.debug_toolbar')->isEnabled());
-        }
-    }
-
-    public function getInterceptRedirectsToolbarConfig()
-    {
-        return [
-             [
-                 'toolbarEnabled' => false,
-                 'interceptRedirects' => true,
-                 'listenerInjected' => true,
-                 'listenerEnabled' => false,
-            ],
-            [
-                'toolbarEnabled' => false,
-                'interceptRedirects' => false,
-                'listenerInjected' => false,
-                'listenerEnabled' => false,
-            ],
-            [
-                'toolbarEnabled' => true,
-                'interceptRedirects' => true,
-                'listenerInjected' => true,
-                'listenerEnabled' => true,
-            ],
-        ];
-    }
-
     private function getCompiledContainer()
     {
         if ($this->container->has('web_profiler.debug_toolbar')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | #33467 
| License       | MIT
| Doc PR        | -

As a follow up of https://github.com/symfony/symfony/pull/33507, where `intercept_redirects` config option was deprecated, removing it in master.
