### PR TITLE
[Debug][BC Break] Fixed deserialization of FlattenException by the Serializer component

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -97,7 +97,7 @@ class FlattenException
         return $this->headers;
     }
 
-    public function setHeaders(array $headers)
+    public function setHeaders($headers)
     {
         $this->headers = $headers;
     }
@@ -157,7 +157,7 @@ class FlattenException
         return $this->previous;
     }
 
-    public function setPrevious(self $previous)
+    public function setPrevious($previous)
     {
         $this->previous = $previous;
     }
@@ -183,8 +183,13 @@ class FlattenException
         $this->setTrace($exception->getTrace(), $exception->getFile(), $exception->getLine());
     }
 
-    public function setTrace($trace, $file, $line)
+    public function setTrace($trace, $file = null, $line = null)
     {
+        if (null === $file && null === $line && (null === $trace || isset($trace[0], $trace[0]['namespace']))) {
+            $this->trace = $trace;
+
+            return;
+        }
         $this->trace = [];
         $this->trace[] = [
             'namespace' => '',

--- a/src/Symfony/Component/Debug/composer.json
+++ b/src/Symfony/Component/Debug/composer.json
@@ -23,7 +23,8 @@
         "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
     },
     "require-dev": {
-        "symfony/http-kernel": "~2.8|~3.0|~4.0"
+        "symfony/http-kernel": "~2.8|~3.0|~4.0",
+        "symfony/serializer": "~3.0|~4.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Debug\\": "" },

--- a/src/Symfony/Component/Debug/composer.json
+++ b/src/Symfony/Component/Debug/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "symfony/http-kernel": "~2.8|~3.0|~4.0",
+        "symfony/property-access": "~3.0|~4.0",
         "symfony/serializer": "~3.0|~4.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #32719 
| License       | MIT

As spotted in #32719, the Serializer component is unable to deserialize some `FlattenException` instances, which breaks the messenger component when used with the symfony serializer.

While this can't be fixed in `FlattenException` without breaking BC, as the main/sole purpose of this class is to be serialization friendly, I thought it was a real issue. 

Also, it should only break classes that extend `FlattenException` and I couldn't find a single project on Github that does this, nor imagine why anyone would want to (actually, I believe this class should have been marked final).

Here are all the issues I identified, and how they are fixed by this PR:

* `getHeaders` can return `null` or `array`, but `setHeaders` had an `array` type-hint: I removed the type hint
* `getPrevious` can return `null` or `self`, but `setPrevious` had a `self` type-hint: I removed the type-hint
* `setTrace` required 3 arguments, and added a new frame to the trace: the file and line arguments are now optional, and I try to detect whether the passed trace has already been processed or not. This may not be the best thing to do IMHO, but an attempt to limit the BC break to subclasses and ensure usage of the class doesn't get broken.

Note: The same issues affect the `FlattenException` class of the new ErrorRenderer component, but I will submit an new issue to discuss the best solution here, as I would also like to discuss #32873 and propose an alternate solution to #32473.