### PR TITLE
[ErrorRenderer] fix Cannot use object of type ErrorException as array exception #33631

### DIFF
--- a/src/Symfony/Component/ErrorRenderer/Resources/views/logs.html.php
+++ b/src/Symfony/Component/ErrorRenderer/Resources/views/logs.html.php
@@ -16,7 +16,10 @@
         } elseif ($log['priority'] >= 300) {
             $status = 'warning';
         } else {
-            $severity = $log['context']['exception']['severity'] ?? false;
+            $severity = 0;
+            if (($exception = $log['context']['exception'] ?? null) instanceof \ErrorException) {
+                $severity = $exception->getSeverity();
+            }
             $status = E_DEPRECATED === $severity || E_USER_DEPRECATED === $severity ? 'warning' : 'normal';
         } ?>
         <tr class="status-<?= $status; ?>" data-filter-level="<?= strtolower($this->escape($log['priorityName'])); ?>"<?php if ($channelIsDefined) { ?> data-filter-channel="<?= $this->escape($log['channel']); ?>"<?php } ?>>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33631 
| License       | MIT

This fixes exception thrown when trying to render ErrorException as an array
