### PR TITLE
Make legacy "wrong" RFC2047 encoding apply only to one header

### DIFF
--- a/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
+++ b/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
@@ -38,7 +38,7 @@ final class ParameterizedHeader extends UnstructuredHeader
             $this->setParameter($k, $v);
         }
 
-        if ('content-disposition' === strtolower($name)) {
+        if ('content-type' !== strtolower($name)) {
             $this->encoder = new Rfc2231Encoder();
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

It says in a comment in the code that "We have to go against RFC 2183/2231 in some areas for interoperability". But I would like that to be the exception and not the rule. As the code was, all parameterized headers except from "Content-Disposition" was not encoded according to RFC 2231. 

This change is to make it so that the exception (to not follow the RFC) is for the header "Content-Type" only, and all other parameterized headers will follow the rule of RFC 2231.

The code kind of worked before, because in emails we generally only have two parameterized headers; "Content-Disposition" and "Content-Type". But I think it is a good thing that if another  parameterized header would happen to be added, by default it should follow the rule of the RFC and not by default be an exception.
