### PR TITLE
[HttpClient] fix throwing HTTP exceptions when the 1st chunk is emitted

### DIFF
--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -152,6 +152,16 @@ abstract class HttpClientTestCase extends TestCase
         $this->assertSame(404, $response->getStatusCode());
         $this->assertSame(['application/json'], $response->getHeaders(false)['content-type']);
         $this->assertNotEmpty($response->getContent(false));
+
+        $response = $client->request('GET', 'http://localhost:8057/404');
+
+        try {
+            foreach ($client->stream($response) as $chunk) {
+                $this->assertTrue($chunk->isFirst());
+            }
+            $this->fail(ClientExceptionInterface::class.' expected');
+        } catch (ClientExceptionInterface $e) {
+        }
     }
 
     public function testIgnoreErrors()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted while discussing the client with @Seldaek 
The current behavior is transient: depending on the speed of the network/server, the exception can be thrown, or not.

This forces one do deal with 3/4/5xx when the first chunk is yielded.
