### PR TITLE
[Serializer] Add FlattenExceptionNormalizer / Fix messenger used with the serializer component

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -31,6 +31,11 @@
         <service id="Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface" alias="serializer.mapping.class_discriminator_resolver" />
 
         <!-- Normalizer -->
+        <service id="serializer.normalizer.flatten_exception" class="Symfony\Component\Serializer\Normalizer\FlattenExceptionNormalizer">
+            <!-- Run before serializer.normalizer.object -->
+            <tag name="serializer.normalizer" priority="-915" />
+        </service>
+
         <service id="serializer.normalizer.constraint_violation_list" class="Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer">
             <argument type="collection" />
             <argument type="service" id="serializer.name_converter.metadata_aware" />

--- a/src/Symfony/Component/Serializer/Normalizer/FlattenExceptionNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/FlattenExceptionNormalizer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
  * Normalizes FlattenException instances.
  *
  * @author Pascal Luna <skalpa@zetareticuli.org>
+ *
+ * @experimental
  */
 class FlattenExceptionNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/FlattenExceptionNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/FlattenExceptionNormalizer.php
@@ -34,10 +34,9 @@ class FlattenExceptionNormalizer implements NormalizerInterface, DenormalizerInt
         }
         /* @var FlattenException $object */
 
-        return [
-            'message' => $object->getMessage(),
+        $normalized = [
+            'detail' => $object->getMessage(),
             'code' => $object->getCode(),
-            'status_code' => $object->getStatusCode(),
             'headers' => $object->getHeaders(),
             'class' => $object->getClass(),
             'file' => $object->getFile(),
@@ -46,6 +45,11 @@ class FlattenExceptionNormalizer implements NormalizerInterface, DenormalizerInt
             'trace' => $object->getTrace(),
             'trace_as_string' => $object->getTraceAsString(),
         ];
+        if (null !== $status = $object->getStatusCode()) {
+            $normalized['status'] = $status;
+        }
+
+        return $normalized;
     }
 
     /**
@@ -70,9 +74,9 @@ class FlattenExceptionNormalizer implements NormalizerInterface, DenormalizerInt
 
         $object = new FlattenException();
 
-        $object->setMessage($data['message'] ?? null);
+        $object->setMessage($data['detail'] ?? null);
         $object->setCode($data['code'] ?? null);
-        $object->setStatusCode($data['status_code'] ?? null);
+        $object->setStatusCode($data['status'] ?? null);
         $object->setClass($data['class'] ?? null);
         $object->setFile($data['file'] ?? null);
         $object->setLine($data['line'] ?? null);

--- a/src/Symfony/Component/Serializer/Normalizer/FlattenExceptionNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/FlattenExceptionNormalizer.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+
+/**
+ * Normalizes FlattenException instances.
+ *
+ * @author Pascal Luna <skalpa@zetareticuli.org>
+ */
+class FlattenExceptionNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws InvalidArgumentException
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        if (!$object instanceof FlattenException) {
+            throw new InvalidArgumentException(sprintf('The object must be an instance of %s.', FlattenException::class));
+        }
+        /* @var FlattenException $object */
+
+        return [
+            'message' => $object->getMessage(),
+            'code' => $object->getCode(),
+            'status_code' => $object->getStatusCode(),
+            'headers' => $object->getHeaders(),
+            'class' => $object->getClass(),
+            'file' => $object->getFile(),
+            'line' => $object->getLine(),
+            'previous' => null === $object->getPrevious() ? null : $this->normalize($object->getPrevious(), $format, $context),
+            'trace' => $object->getTrace(),
+            'trace_as_string' => $object->getTraceAsString(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof FlattenException;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $type, $format = null, array $context = [])
+    {
+        if (!\is_array($data)) {
+            throw new NotNormalizableValueException(sprintf(
+                'The normalized data must be an array, got %s.',
+                \is_object($data) ? \get_class($data) : \gettype($data)
+            ));
+        }
+
+        $object = new FlattenException();
+
+        $object->setMessage($data['message'] ?? null);
+        $object->setCode($data['code'] ?? null);
+        $object->setStatusCode($data['status_code'] ?? null);
+        $object->setClass($data['class'] ?? null);
+        $object->setFile($data['file'] ?? null);
+        $object->setLine($data['line'] ?? null);
+
+        if (isset($data['headers'])) {
+            $object->setHeaders((array) $data['headers']);
+        }
+        if (isset($data['previous'])) {
+            $object->setPrevious($this->denormalize($data['previous'], $type, $format, $context));
+        }
+        if (isset($data['trace'])) {
+            $property = new \ReflectionProperty(FlattenException::class, 'trace');
+            $property->setAccessible(true);
+            $property->setValue($object, (array) $data['trace']);
+        }
+        if (isset($data['trace_as_string'])) {
+            $property = new \ReflectionProperty(FlattenException::class, 'traceAsString');
+            $property->setAccessible(true);
+            $property->setValue($object, $data['trace_as_string']);
+        }
+
+        return $object;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null, array $context = [])
+    {
+        return FlattenException::class === $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return __CLASS__ === \get_class($this);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/FlattenExceptionNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/FlattenExceptionNormalizerTest.php
@@ -46,9 +46,13 @@ class FlattenExceptionNormalizerTest extends TestCase
         $normalized = $this->normalizer->normalize($exception);
         $previous = null === $exception->getPrevious() ? null : $this->normalizer->normalize($exception->getPrevious());
 
-        $this->assertSame($exception->getMessage(), $normalized['message']);
+        $this->assertSame($exception->getMessage(), $normalized['detail']);
         $this->assertSame($exception->getCode(), $normalized['code']);
-        $this->assertSame($exception->getStatusCode(), $normalized['status_code']);
+        if (null !== $exception->getStatusCode()) {
+            $this->assertSame($exception->getStatusCode(), $normalized['status']);
+        } else {
+            $this->assertArrayNotHasKey('status', $normalized);
+        }
         $this->assertSame($exception->getHeaders(), $normalized['headers']);
         $this->assertSame($exception->getClass(), $normalized['class']);
         $this->assertSame($exception->getFile(), $normalized['file']);
@@ -98,15 +102,15 @@ class FlattenExceptionNormalizerTest extends TestCase
         $this->assertNull($exception->getTraceAsString());
 
         $normalized = [
-            'message' => 'Something went foobar.',
+            'detail' => 'Something went foobar.',
             'code' => 42,
-            'status_code' => 404,
+            'status' => 404,
             'headers' => ['Content-Type' => 'application/json'],
             'class' => \get_class($this),
             'file' => 'foo.php',
             'line' => 123,
             'previous' => [
-                'message' => 'Previous exception',
+                'detail' => 'Previous exception',
                 'code' => 0,
             ],
             'trace' => [
@@ -119,9 +123,9 @@ class FlattenExceptionNormalizerTest extends TestCase
         $exception = $this->normalizer->denormalize($normalized, FlattenException::class);
 
         $this->assertInstanceOf(FlattenException::class, $exception);
-        $this->assertSame($normalized['message'], $exception->getMessage());
+        $this->assertSame($normalized['detail'], $exception->getMessage());
         $this->assertSame($normalized['code'], $exception->getCode());
-        $this->assertSame($normalized['status_code'], $exception->getStatusCode());
+        $this->assertSame($normalized['status'], $exception->getStatusCode());
         $this->assertSame($normalized['headers'], $exception->getHeaders());
         $this->assertSame($normalized['class'], $exception->getClass());
         $this->assertSame($normalized['file'], $exception->getFile());
@@ -130,7 +134,7 @@ class FlattenExceptionNormalizerTest extends TestCase
         $this->assertSame($normalized['trace_as_string'], $exception->getTraceAsString());
 
         $this->assertInstanceOf(FlattenException::class, $previous = $exception->getPrevious());
-        $this->assertSame($normalized['previous']['message'], $previous->getMessage());
+        $this->assertSame($normalized['previous']['detail'], $previous->getMessage());
         $this->assertSame($normalized['previous']['code'], $previous->getCode());
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/FlattenExceptionNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/FlattenExceptionNormalizerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\FlattenExceptionNormalizer;
+
+/**
+ * @author Pascal Luna <skalpa@zetareticuli.org>
+ */
+class FlattenExceptionNormalizerTest extends TestCase
+{
+    /**
+     * @var FlattenExceptionNormalizer
+     */
+    private $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new FlattenExceptionNormalizer();
+    }
+
+    public function testSupportsNormalization(): void
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new FlattenException()));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    /**
+     * @dataProvider provideFlattenException
+     */
+    public function testNormalize(FlattenException $exception): void
+    {
+        $normalized = $this->normalizer->normalize($exception);
+        $previous = null === $exception->getPrevious() ? null : $this->normalizer->normalize($exception->getPrevious());
+
+        $this->assertSame($exception->getMessage(), $normalized['message']);
+        $this->assertSame($exception->getCode(), $normalized['code']);
+        $this->assertSame($exception->getStatusCode(), $normalized['status_code']);
+        $this->assertSame($exception->getHeaders(), $normalized['headers']);
+        $this->assertSame($exception->getClass(), $normalized['class']);
+        $this->assertSame($exception->getFile(), $normalized['file']);
+        $this->assertSame($exception->getLine(), $normalized['line']);
+        $this->assertSame($previous, $normalized['previous']);
+        $this->assertSame($exception->getTrace(), $normalized['trace']);
+        $this->assertSame($exception->getTraceAsString(), $normalized['trace_as_string']);
+    }
+
+    public function provideFlattenException(): array
+    {
+        return [
+            'instance from constructor' => [new FlattenException()],
+            'instance from exception' => [FlattenException::createFromThrowable(new \RuntimeException('foo', 42))],
+            'instance with previous exception' => [FlattenException::createFromThrowable(new \RuntimeException('foo', 42, new \Exception()))],
+            'instance with headers' => [FlattenException::createFromThrowable(new \RuntimeException('foo', 42), 404, ['Foo' => 'Bar'])],
+        ];
+    }
+
+    public function testNormalizeBadObjectTypeThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->normalizer->normalize(new \stdClass());
+    }
+
+    public function testSupportsDenormalization(): void
+    {
+        $this->assertTrue($this->normalizer->supportsDenormalization(null, FlattenException::class));
+        $this->assertFalse($this->normalizer->supportsDenormalization(null, \stdClass::class));
+    }
+
+    public function testDenormalizeValidData(): void
+    {
+        $normalized = [];
+        $exception = $this->normalizer->denormalize($normalized, FlattenException::class);
+
+        $this->assertInstanceOf(FlattenException::class, $exception);
+        $this->assertNull($exception->getMessage());
+        $this->assertNull($exception->getCode());
+        $this->assertNull($exception->getStatusCode());
+        $this->assertNull($exception->getHeaders());
+        $this->assertNull($exception->getClass());
+        $this->assertNull($exception->getFile());
+        $this->assertNull($exception->getLine());
+        $this->assertNull($exception->getPrevious());
+        $this->assertNull($exception->getTrace());
+        $this->assertNull($exception->getTraceAsString());
+
+        $normalized = [
+            'message' => 'Something went foobar.',
+            'code' => 42,
+            'status_code' => 404,
+            'headers' => ['Content-Type' => 'application/json'],
+            'class' => \get_class($this),
+            'file' => 'foo.php',
+            'line' => 123,
+            'previous' => [
+                'message' => 'Previous exception',
+                'code' => 0,
+            ],
+            'trace' => [
+                [
+                    'namespace' => '', 'short_class' => '', 'class' => '', 'type' => '', 'function' => '', 'file' => 'foo.php', 'line' => 123, 'args' => [],
+                ],
+            ],
+            'trace_as_string' => '#0 foo.php(123): foo()'.PHP_EOL.'#1 bar.php(456): bar()',
+        ];
+        $exception = $this->normalizer->denormalize($normalized, FlattenException::class);
+
+        $this->assertInstanceOf(FlattenException::class, $exception);
+        $this->assertSame($normalized['message'], $exception->getMessage());
+        $this->assertSame($normalized['code'], $exception->getCode());
+        $this->assertSame($normalized['status_code'], $exception->getStatusCode());
+        $this->assertSame($normalized['headers'], $exception->getHeaders());
+        $this->assertSame($normalized['class'], $exception->getClass());
+        $this->assertSame($normalized['file'], $exception->getFile());
+        $this->assertSame($normalized['line'], $exception->getLine());
+        $this->assertSame($normalized['trace'], $exception->getTrace());
+        $this->assertSame($normalized['trace_as_string'], $exception->getTraceAsString());
+
+        $this->assertInstanceOf(FlattenException::class, $previous = $exception->getPrevious());
+        $this->assertSame($normalized['previous']['message'], $previous->getMessage());
+        $this->assertSame($normalized['previous']['code'], $previous->getCode());
+    }
+
+    /**
+     * @dataProvider provideInvalidNormalizedData
+     */
+    public function testDenormalizeInvalidDataThrowsException($normalized): void
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->normalizer->denormalize($normalized, FlattenException::class);
+    }
+
+    public function provideInvalidNormalizedData(): array
+    {
+        return [
+            'null' => [null],
+            'string' => ['foo'],
+            'integer' => [42],
+            'object' => [new \stdClass()],
+        ];
+    }
+}

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -25,6 +25,7 @@
         "symfony/property-access": "~3.4|~4.0",
         "symfony/http-foundation": "~3.4|~4.0",
         "symfony/cache": "~3.4|~4.0",
+        "symfony/debug": "~3.4|~4.0",
         "symfony/property-info": "^3.4.13|~4.0",
         "symfony/validator": "~3.4|~4.0",
         "doctrine/annotations": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #32719 
| License       | MIT

This adds a new normalizer for `FlattenException` objects.

It is against 4.3 and marked as a bug fix, because the Serializer component's current inability to deserialize `FlattenException` objects breaks Messenger when used with the component (see #32719 for details).

The new FlattenException class of the ErrorRenderer component suffers from the same problem, so once merged it will probably have to be amended on 4.4 to support the ErrorRenderer as well.

