### PR TITLE
[Cache] skip igbinary on PHP 7.4.0

### DIFF
--- a/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
@@ -25,9 +25,9 @@ class DefaultMarshaller implements MarshallerInterface
     public function __construct(bool $useIgbinarySerialize = null)
     {
         if (null === $useIgbinarySerialize) {
-            $useIgbinarySerialize = \extension_loaded('igbinary');
-        } elseif ($useIgbinarySerialize && !\extension_loaded('igbinary')) {
-            throw new CacheException('The "igbinary" PHP extension is not loaded.');
+            $useIgbinarySerialize = \extension_loaded('igbinary') && \PHP_VERSION_ID !== 70400;
+        } elseif ($useIgbinarySerialize && (!\extension_loaded('igbinary') || \PHP_VERSION_ID === 70400)) {
+            throw new CacheException('The "igbinary" PHP extension is not '.(\PHP_VERSION_ID === 70400 ? 'compatible with PHP 7.4.0.' : 'loaded.'));
         }
         $this->useIgbinarySerialize = $useIgbinarySerialize;
     }
@@ -66,7 +66,7 @@ class DefaultMarshaller implements MarshallerInterface
             return null;
         }
         static $igbinaryNull;
-        if ($value === ($igbinaryNull ?? $igbinaryNull = \extension_loaded('igbinary') ? igbinary_serialize(null) : false)) {
+        if ($value === ($igbinaryNull ?? $igbinaryNull = \extension_loaded('igbinary') && \PHP_VERSION_ID !== 70400 ? igbinary_serialize(null) : false)) {
             return null;
         }
         $unserializeCallbackHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');

--- a/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
@@ -24,7 +24,7 @@ class DefaultMarshallerTest extends TestCase
             'b' => function () {},
         ];
 
-        $expected = ['a' => \extension_loaded('igbinary') ? igbinary_serialize(123) : serialize(123)];
+        $expected = ['a' => \extension_loaded('igbinary') && \PHP_VERSION_ID !== 70400 ? igbinary_serialize(123) : serialize(123)];
         $this->assertSame($expected, $marshaller->marshall($values, $failed));
         $this->assertSame(['b'], $failed);
     }
@@ -43,6 +43,10 @@ class DefaultMarshallerTest extends TestCase
      */
     public function testIgbinaryUnserialize()
     {
+        if (\PHP_VERSION_ID === 70400) {
+            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.0.');
+        }
+
         $marshaller = new DefaultMarshaller();
         $this->assertNull($marshaller->unmarshall(igbinary_serialize(null)));
         $this->assertFalse($marshaller->unmarshall(igbinary_serialize(false)));
@@ -63,6 +67,10 @@ class DefaultMarshallerTest extends TestCase
      */
     public function testIgbinaryUnserializeNotFoundClass()
     {
+        if (\PHP_VERSION_ID === 70400) {
+            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.0.');
+        }
+
         $this->expectException('DomainException');
         $this->expectExceptionMessage('Class not found: NotExistingClass');
         $marshaller = new DefaultMarshaller();
@@ -87,6 +95,10 @@ class DefaultMarshallerTest extends TestCase
      */
     public function testIgbinaryUnserializeInvalid()
     {
+        if (\PHP_VERSION_ID === 70400) {
+            $this->markTestSkipped('igbinary is not compatible with PHP 7.4.0');
+        }
+
         $this->expectException('DomainException');
         $this->expectExceptionMessage('igbinary_unserialize_zval: unknown type \'61\', position 5');
         $marshaller = new DefaultMarshaller();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Our CI currently fails because of that. I'm blacklisting 7.4.0 exactly so that we don't have to maintain these lines, betting on the issue being resolved before 7.4.1 is released.

See https://github.com/igbinary/igbinary/issues/237