### PR TITLE
[DoctrineBridge] Use VarCloner data instead of legacy array for query params

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -166,6 +166,8 @@ class DoctrineDataCollector extends DataCollector
             }
         }
 
+        $query['params'] = $this->cloneVar($query['params']);
+
         return $query;
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 class DoctrineDataCollectorTest extends TestCase
 {
@@ -96,9 +97,11 @@ class DoctrineDataCollectorTest extends TestCase
         $c->collect(new Request(), new Response());
 
         $collectedQueries = $c->getQueries();
-        $this->assertEquals([], $collectedQueries['default'][0]['params']);
+        $this->assertInstanceOf(Data::class, $collectedQueries['default'][0]['params']);
+        $this->assertEquals([], $collectedQueries['default'][0]['params']->getValue());
         $this->assertTrue($collectedQueries['default'][0]['explainable']);
-        $this->assertEquals([], $collectedQueries['default'][1]['params']);
+        $this->assertInstanceOf(Data::class, $collectedQueries['default'][1]['params']);
+        $this->assertEquals([], $collectedQueries['default'][1]['params']->getValue());
         $this->assertTrue($collectedQueries['default'][1]['explainable']);
     }
 

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -36,6 +36,7 @@
         "symfony/security-core": "^4.4|^5.0",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
         "symfony/validator": "^3.4.31|^4.3.4|^5.0",
+        "symfony/var-dumper": "^3.4|^4.0|^5.0",
         "symfony/translation": "^3.4|^4.0|^5.0",
         "doctrine/annotations": "~1.7",
         "doctrine/cache": "~1.6",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | 

When I implemented Symfony 4.0 support in DoctrineBundle, I have run into issue that DoctrineBridge does not return VarCloner instance here, so I had to introduce [conversion inside DoctrineBundle](https://github.com/doctrine/DoctrineBundle/blob/af8ac792c9b970ff2bc25b49ab9b31afd9e03dbf/DataCollector/DoctrineDataCollector.php#L135-L141). 

We need this because `WebProfilerBundle\Twig\WebProfilerExtension::dumpData()` requires this instance since Symfony 4.0. Not returning this instance here was oversight during work on Symfony 4.0. I did not contribute this sooner, because we can't remove code in DoctrineBundle until we drop Symfony 3.4 support anyways. But not doing this in Symfony 4.4 would mean having to keep transformation code not just during 3.4 LTS lifetime, but 4.4 LTS lifetime too.