### PR TITLE
[Security] Make stateful firewalls turn responses private only when needed

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterTokenUsageTrackingPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterTokenUsageTrackingPass.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Bridge\Monolog\Processor\ProcessorInterface;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Injects the session tracker enabler in "security.context_listener" + binds "security.untracked_token_storage" to ProcessorInterface instances.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class RegisterTokenUsageTrackingPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('security.untracked_token_storage')) {
+            return;
+        }
+
+        $processorAutoconfiguration = $container->registerForAutoconfiguration(ProcessorInterface::class);
+        $processorAutoconfiguration->setBindings($processorAutoconfiguration->getBindings() + [
+            TokenStorageInterface::class => new BoundArgument(new Reference('security.untracked_token_storage'), false),
+        ]);
+
+        if (!$container->has('session')) {
+            $container->setAlias('security.token_storage', 'security.untracked_token_storage')->setPublic(true);
+        } elseif ($container->hasDefinition('security.context_listener')) {
+            $container->getDefinition('security.context_listener')
+                ->setArgument(6, [new Reference('security.token_storage'), 'enableUsageTracking']);
+        }
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
@@ -9,7 +9,7 @@
 
         <service id="data_collector.security" class="Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector">
             <tag name="data_collector" template="@Security/Collector/security.html.twig" id="security" priority="270" />
-            <argument type="service" id="security.token_storage" on-invalid="ignore" />
+            <argument type="service" id="security.untracked_token_storage" />
             <argument type="service" id="security.role_hierarchy" />
             <argument type="service" id="security.logout_url_generator" />
             <argument type="service" id="security.access.decision_manager" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -21,10 +21,17 @@
         </service>
         <service id="Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface" alias="security.authorization_checker" />
 
-        <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" public="true">
+        <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage" public="true">
+            <tag name="kernel.reset" method="disableUsageTracking" />
             <tag name="kernel.reset" method="setToken" />
+            <argument type="service" id="security.untracked_token_storage" />
+            <argument type="service_locator">
+                <argument key="session" type="service" id="session" />
+            </argument>
         </service>
         <service id="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface" alias="security.token_storage" />
+
+        <service id="security.untracked_token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" />
 
         <service id="security.helper" class="Symfony\Component\Security\Core\Security">
             <argument type="service_locator">
@@ -162,7 +169,7 @@
         <service id="security.logout_url_generator" class="Symfony\Component\Security\Http\Logout\LogoutUrlGenerator">
             <argument type="service" id="request_stack" on-invalid="null" />
             <argument type="service" id="router" on-invalid="null" />
-            <argument type="service" id="security.token_storage" on-invalid="null" />
+            <argument type="service" id="security.token_storage" />
         </service>
 
         <!-- Provisioning -->

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -9,7 +9,7 @@
 
         <service id="security.authentication.listener.anonymous" class="Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.untracked_token_storage" />
             <argument /> <!-- Key -->
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="security.authentication.manager" />
@@ -37,7 +37,7 @@
 
         <service id="security.context_listener" class="Symfony\Component\Security\Http\Firewall\ContextListener">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.untracked_token_storage" />
             <argument type="collection" />
             <argument /> <!-- Provider Key -->
             <argument type="service" id="logger" on-invalid="null" />
@@ -128,7 +128,7 @@
 
         <service id="security.authentication.listener.simple_preauth" class="Symfony\Component\Security\Http\Firewall\SimplePreAuthenticationListener" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.untracked_token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- Authenticator -->

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
@@ -9,7 +9,7 @@
 
         <service id="security.authentication.listener.rememberme" class="Symfony\Component\Security\Http\Firewall\RememberMeListener" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.untracked_token_storage" />
             <argument type="service" id="security.authentication.rememberme" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="logger" on-invalid="null" />

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddExpressionLang
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSessionDomainConstraintPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterCsrfTokenClearingLogoutHandlerPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterTokenUsageTrackingPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AnonymousFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginLdapFactory;
@@ -66,5 +67,6 @@ class SecurityBundle extends Bundle
         $container->addCompilerPass(new AddSecurityVotersPass());
         $container->addCompilerPass(new AddSessionDomainConstraintPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new RegisterCsrfTokenClearingLogoutHandlerPass());
+        $container->addCompilerPass(new RegisterTokenUsageTrackingPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -136,10 +136,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
         return \count($this->getAttributeBag()->all());
     }
 
-    /**
-     * @internal
-     */
-    public function getUsageIndex(): int
+    public function &getUsageIndex(): int
     {
         return $this->usageIndex;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token\Storage;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+/**
+ * A token storage that increments the session usage index when the token is accessed.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class UsageTrackingTokenStorage implements TokenStorageInterface, ServiceSubscriberInterface
+{
+    private $storage;
+    private $sessionLocator;
+    private $enableUsageTracking = false;
+
+    public function __construct(TokenStorageInterface $storage, ContainerInterface $sessionLocator)
+    {
+        $this->storage = $storage;
+        $this->sessionLocator = $sessionLocator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getToken(): ?TokenInterface
+    {
+        if ($this->enableUsageTracking) {
+            // increments the internal session usage index
+            $this->sessionLocator->get('session')->getMetadataBag();
+        }
+
+        return $this->storage->getToken();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setToken(TokenInterface $token = null): void
+    {
+        $this->storage->setToken($token);
+    }
+
+    public function enableUsageTracking(): void
+    {
+        $this->enableUsageTracking = true;
+    }
+
+    public function disableUsageTracking(): void
+    {
+        $this->enableUsageTracking = false;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            'session' => SessionInterface::class,
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authentication\Token\Storage;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Contracts\Service\ServiceLocatorTrait;
+
+class UsageTrackingTokenStorageTest extends TestCase
+{
+    public function testGetSetToken()
+    {
+        $sessionAccess = 0;
+        $sessionLocator = new class(['session' => function () use (&$sessionAccess) {
+            ++$sessionAccess;
+
+            $session = $this->createMock(SessionInterface::class);
+            $session->expects($this->once())
+                    ->method('getMetadataBag');
+
+            return $session;
+        }]) implements ContainerInterface {
+            use ServiceLocatorTrait;
+        };
+        $tokenStorage = new TokenStorage();
+        $trackingStorage = new UsageTrackingTokenStorage($tokenStorage, $sessionLocator);
+
+        $this->assertNull($trackingStorage->getToken());
+        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
+
+        $trackingStorage->setToken($token);
+        $this->assertSame($token, $trackingStorage->getToken());
+        $this->assertSame($token, $tokenStorage->getToken());
+        $this->assertSame(0, $sessionAccess);
+
+        $trackingStorage->enableUsageTracking();
+        $this->assertSame($token, $trackingStorage->getToken());
+        $this->assertSame(1, $sessionAccess);
+
+        $trackingStorage->disableUsageTracking();
+        $this->assertSame($token, $trackingStorage->getToken());
+        $this->assertSame(1, $sessionAccess);
+    }
+}

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/event-dispatcher-contracts": "^1.1|^2",
-        "symfony/service-contracts": "^1.1|^2"
+        "symfony/service-contracts": "^1.1.6|^2"
     },
     "require-dev": {
         "psr/container": "^1.0",

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -51,16 +51,16 @@ class AccessListener implements ListenerInterface
      */
     public function __invoke(RequestEvent $event)
     {
-        if (null === $token = $this->tokenStorage->getToken()) {
-            throw new AuthenticationCredentialsNotFoundException('A Token was not found in the TokenStorage.');
-        }
-
         $request = $event->getRequest();
 
         list($attributes) = $this->map->getPatterns($request);
 
-        if (null === $attributes) {
+        if (!$attributes) {
             return;
+        }
+
+        if (null === $token = $this->tokenStorage->getToken()) {
+            throw new AuthenticationCredentialsNotFoundException('A Token was not found in the TokenStorage.');
         }
 
         if (!$token->isAuthenticated()) {

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -12,7 +12,12 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Http\Firewall\AccessListener;
 
 class AccessListenerTest extends TestCase
@@ -182,6 +187,41 @@ class AccessListenerTest extends TestCase
         $listener($event);
     }
 
+    public function testHandleWhenAccessMapReturnsEmptyAttributes()
+    {
+        $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->disableOriginalClone()->getMock();
+
+        $accessMap = $this->getMockBuilder(AccessMapInterface::class)->getMock();
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->willReturn([[], null])
+        ;
+
+        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
+        $tokenStorage
+            ->expects($this->never())
+            ->method('getToken')
+        ;
+
+        $listener = new AccessListener(
+            $tokenStorage,
+            $this->getMockBuilder(AccessDecisionManagerInterface::class)->getMock(),
+            $accessMap,
+            $this->getMockBuilder(AuthenticationManagerInterface::class)->getMock()
+        );
+
+        $event = $this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock();
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($request)
+        ;
+
+        $listener($event);
+    }
+
     public function testHandleWhenTheSecurityTokenStorageHasNoToken()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException');
@@ -192,14 +232,29 @@ class AccessListenerTest extends TestCase
             ->willReturn(null)
         ;
 
+        $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->disableOriginalClone()->getMock();
+
+        $accessMap = $this->getMockBuilder(AccessMapInterface::class)->getMock();
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->willReturn([['foo' => 'bar'], null])
+        ;
+
         $listener = new AccessListener(
             $tokenStorage,
             $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock(),
-            $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock(),
+            $accessMap,
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock()
         );
 
         $event = $this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock();
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($request)
+        ;
 
         $listener($event);
     }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/security-core": "^4.3",
+        "symfony/security-core": "^4.4",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
         "symfony/http-kernel": "^4.3",
         "symfony/property-access": "^3.4|^4.0|^5.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26769 *et al.*
| License       | MIT
| Doc PR        | -

Replaces #28089

By taking over session usage tracking and replacing it with token usage tracking, we can prevent responses that don't actually use the token from turning responses private without changing anything to the lifecycle of security listeners. This makes the behavior much more seamless, allowing to still log the user with the monolog processor, and display it in the profiler toolbar.

This works by using two separate token storage services:
- `security.token_storage` now tracks access to the token and increments the session usage tracker when needed. This is the service that is injected in userland.
- `security.untracked_token_storage` is a raw token storage that just stores the token and is disconnected from the session. This service is injected in places where reading the session doesn't impact the generated output in any way (as e.g. in Monolog processors, etc.)