### PR TITLE
[Mailer] Remove line breaks in email attachment content with Sendgrid API

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Http/Api/SendgridTransport.php
@@ -115,7 +115,7 @@ class SendgridTransport extends AbstractApiTransport
             $disposition = $headers->getHeaderBody('Content-Disposition');
 
             $att = [
-                'content' => $attachment->bodyToString(),
+                'content' => str_replace("\r\n", '', $attachment->bodyToString()),
                 'type' => $headers->get('Content-Type')->getBody(),
                 'filename' => $filename,
                 'disposition' => $disposition,

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Http/Api/SendgridTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Http/Api/SendgridTransportTest.php
@@ -58,4 +58,52 @@ class SendgridTransportTest extends TestCase
 
         $mailer->send($email);
     }
+
+    public function testLineBreaksInEncodedAttachment()
+    {
+        $email = new Email();
+        $email->from('foo@example.com')
+            ->to('bar@example.com')
+            // even if content doesn't include new lines, the base64 encoding performed later may add them
+            ->attach('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod', 'lorem.txt');
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(202);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://api.sendgrid.com/v3/mail/send', [
+                'json' => [
+                    'personalizations' => [
+                        [
+                            'to' => [['email' => 'bar@example.com']],
+                            'subject' => null,
+                        ],
+                    ],
+                    'from' => ['email' => 'foo@example.com'],
+                    'content' => [],
+                    'attachments' => [
+                        [
+                            'content' => 'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2Q=',
+                            'filename' => 'lorem.txt',
+                            'type' => 'application/octet-stream',
+                            'disposition' => 'attachment',
+                        ],
+                    ],
+                ],
+                'auth_bearer' => 'foo',
+            ])
+            ->willReturn($response);
+
+        $mailer = new SendgridTransport('foo', $httpClient);
+
+        $mailer->send($email);
+    }
 }


### PR DESCRIPTION
Line breaks are not allowed in attachment content when sending over the
API.

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33671, Closes #32645
| License       | MIT
| Doc PR        |

This is a fix for #33671. Send grid's API throws a 400 error when sending email attachments with default base64 encoding.
Removing the line breaks resolves this issue.