### PR TITLE
[PhpUnit] Fix usleep mock return value

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -52,12 +52,10 @@ class ClockMock
     public static function usleep($us)
     {
         if (null === self::$now) {
-            return \usleep($us);
+            \usleep($us);
+        } else {
+            self::$now += $us / 1000000;
         }
-
-        self::$now += $us / 1000000;
-
-        return null;
     }
 
     public static function microtime($asFloat = false)
@@ -108,7 +106,7 @@ function sleep(\$s)
 
 function usleep(\$us)
 {
-    return \\$self::usleep(\$us);
+    \\$self::usleep(\$us);
 }
 
 EOPHP


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a| License       | MIT
| Doc PR        | n/a

`usleep` does not return anything.
