### PR TITLE
Fixed a minor typo in the UPGRADE to 5.0 guide

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -56,7 +56,7 @@ Debug
 
  * Removed the `Debug` class, use the one from the `ErrorRenderer` component instead
  * Removed the `FlattenException` class, use the one from the `ErrorRenderer` component instead
- * Removed the component component in favor of the `ErrorHandler` component
+ * Removed the component in favor of the `ErrorHandler` component
 
 DependencyInjection
 -------------------
@@ -122,7 +122,7 @@ DoctrineBridge
  * Passing an `IdReader` to the `DoctrineChoiceLoader` when the query cannot be optimized with single id field will throw an exception, pass `null` instead
  * Not passing an `IdReader` to the `DoctrineChoiceLoader` when the query can be optimized with single id field will not apply any optimization
  * The `RegistryInterface` has been removed.
- * Added a new `getMetadataDriverClass` method in `AbstractDoctrineExtension` to replace class parameters. 
+ * Added a new `getMetadataDriverClass` method in `AbstractDoctrineExtension` to replace class parameters.
 
 DomCrawler
 ----------
@@ -332,7 +332,7 @@ HttpKernel
     }
     ```
 
-   As many bundles must be compatible with a range of Symfony versions, the current 
+   As many bundles must be compatible with a range of Symfony versions, the current
    directory convention is not deprecated yet, but it will be in the future.
  * Removed the second and third argument of `KernelInterface::locateResource`
  * Removed the second and third argument of `FileLocator::__construct`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I tried to fix this in the 4.3 branch too ... but the `UPGRADE-5.0.md` is quite different. Should these two files be exactly the same?

* https://github.com/symfony/symfony/blob/4.3/UPGRADE-5.0.md
* https://github.com/symfony/symfony/blob/4.4/UPGRADE-5.0.md
