### PR TITLE
Add missing row_attr option to FormType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -101,6 +101,7 @@ abstract class BaseType extends AbstractType
             'attr' => $options['attr'],
             'block_prefixes' => $blockPrefixes,
             'unique_block_prefix' => $uniqueBlockPrefix,
+            'row_attr' => $options['row_attr'],
             'translation_domain' => $translationDomain,
             'label_translation_parameters' => $labelTranslationParameters,
             'attr_translation_parameters' => $attrTranslationParameters,
@@ -125,6 +126,7 @@ abstract class BaseType extends AbstractType
             'disabled' => false,
             'label' => null,
             'label_format' => null,
+            'row_attr' => [],
             'label_translation_parameters' => [],
             'attr_translation_parameters' => [],
             'attr' => [],
@@ -134,5 +136,6 @@ abstract class BaseType extends AbstractType
 
         $resolver->setAllowedTypes('block_prefix', ['null', 'string']);
         $resolver->setAllowedTypes('attr', 'array');
+        $resolver->setAllowedTypes('row_attr', 'array');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -51,6 +51,7 @@
                 "post_max_size_message",
                 "property_path",
                 "required",
+                "row_attr",
                 "translation_domain",
                 "upload_max_size_message"
             ]

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -31,6 +31,7 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
                                                    post_max_size_message                                 
                                                    property_path                                         
                                                    required                                              
+                                                   row_attr                                              
                                                    translation_domain                                    
                                                    upload_max_size_message                               
  --------------------------- -------------------- ------------------------------ ----------------------- 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
@@ -31,6 +31,7 @@
             "post_max_size_message",
             "property_path",
             "required",
+            "row_attr",
             "translation_domain",
             "trim",
             "upload_max_size_message"

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
@@ -33,6 +33,7 @@ Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")
   post_max_size_message         
   property_path                 
   required                      
+  row_attr                      
   translation_domain            
   trim                          
   upload_max_size_message       


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix: #33682 - related issue #33573 
| License       | MIT

The #33573 modified Symfony's form themes. But the [FormType](https://github.com/symfony/form/blob/master/Extension/Core/Type/FormType.php) don't allow the option `row_attr` so the OptionResolver throw an exception that the option is unknown. 

This PR basically add the option and give it to the form view (like `label_attr` do)