### PR TITLE
[Security] use LegacyEventDispatcherProxy

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -63,7 +64,7 @@ class ContextListener implements ListenerInterface
         $this->userProviders = $userProviders;
         $this->sessionKey = '_security_'.$contextKey;
         $this->logger = $logger;
-        $this->dispatcher = $dispatcher;
+        $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
         $this->trustResolver = $trustResolver ?: new AuthenticationTrustResolver(AnonymousToken::class, RememberMeToken::class);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I ran into an issue on one of my apps that has its own event dispatcher class using the old dispatch method signature

```php
public function dispatch($eventName, Event $event = null)
```

This leads to

```
TypeError: Argument 2 passed to X\Tests\Base\TestEventDispatcher::dispatch() must be an instance of Symfony\Component\EventDispatcher\Event or null, string given, called in /var/www/x/symfony/vendor/symfony/security/Http/Firewall/ContextListener.php on line 230

/var/www/x/symfony/tests/Base/TestEventDispatcher.php:20
/var/www/x/symfony/vendor/symfony/security/Http/Firewall/ContextListener.php:230
/var/www/x/symfony/vendor/symfony/security/Http/Firewall/ContextListener.php:111
```

since the event here is dispatched using the new signature:

https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L259
