### PR TITLE
[HttpKernel] compress files generated by the profiler

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -119,6 +119,10 @@ class FileProfilerStorage implements ProfilerStorageInterface
             return null;
         }
 
+        if (\function_exists('gzcompress')) {
+            $file = 'compress.zlib://'.$file;
+        }
+
         return $this->createProfileFromData($token, unserialize(file_get_contents($file)));
     }
 
@@ -161,7 +165,14 @@ class FileProfilerStorage implements ProfilerStorageInterface
             'status_code' => $profile->getStatusCode(),
         ];
 
-        if (false === file_put_contents($file, serialize($data))) {
+        $context = stream_context_create();
+
+        if (\function_exists('gzcompress')) {
+            $file = 'compress.zlib://'.$file;
+            stream_context_set_option($context, 'zlib', 'level', 3);
+        }
+
+        if (false === file_put_contents($file, serialize($data), 0, $context)) {
             return false;
         }
 
@@ -280,6 +291,10 @@ class FileProfilerStorage implements ProfilerStorageInterface
         foreach ($data['children'] as $token) {
             if (!$token || !file_exists($file = $this->getFilename($token))) {
                 continue;
+            }
+
+            if (\function_exists('gzcompress')) {
+                $file = 'compress.zlib://'.$file;
             }
 
             $profile->addChild($this->createProfileFromData($token, unserialize(file_get_contents($file)), $profile));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #33006
| License       | MIT
| Doc PR        | -

I've recently seen several reports of fastly growing profiler storages. Let's compress them when possible.

Locally for the skeleton homepage, a single profile goes from 150k to 15k. Level 3 is producing significant compression ratio while being measurably faster than level 6 (the default), that's why I'm using it.