### PR TITLE
Fix exceptions (PDOException) error code type

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
@@ -29,7 +29,7 @@ class HandlerFailedException extends RuntimeException
             1 === \count($exceptions)
                 ? $firstFailure->getMessage()
                 : sprintf('%d handlers failed. First failure is: "%s"', \count($exceptions), $firstFailure->getMessage()),
-            $firstFailure->getCode(),
+            (int) $firstFailure->getCode(),
             $firstFailure
         );
 

--- a/src/Symfony/Component/Messenger/Tests/Exception/HandlerFailedExceptionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Exception/HandlerFailedExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+
+class HandlerFailedExceptionTest extends TestCase
+{
+    public function testThatStringErrorCodeConvertsToInteger()
+    {
+        $envelope = new Envelope(new \stdClass());
+
+        $exception = new class() extends \RuntimeException {
+            public function __construct()
+            {
+                $this->code = 'HY000';
+                $this->message = 'test';
+                // no to call parent constructor, it will fail with string error code
+            }
+        };
+
+        $handlerException = new HandlerFailedException($envelope, [$exception]);
+        $originalException = $handlerException->getNestedExceptions()[0];
+
+        $this->assertIsInt($handlerException->getCode(), 'Exception codes must converts to int');
+
+        $this->assertSame(0, $handlerException->getCode(), 'String code (HY000) converted to int must be 0');
+
+        $this->assertIsString($originalException->getCode(), 'Original exception code still with original type (string)');
+
+        $this->assertSame($exception->getCode(), $originalException->getCode(), 'Original exception code is not modified');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33704
| License       | MIT

From the [php.net docs](https://www.php.net/manual/en/exception.getcode.php) `Exception::getCode()` description:

> Returns the exception code as integer in Exception but possibly as other type in Exception descendants (for example as **string** in PDOException).

So if can be string, we convert it to the int in the `HandlerFailedException` but it still string in `nestedExceptiions`.


