### PR TITLE
[Security] Fix isGranted with object attribute

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -58,6 +58,6 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
             throw new InvalidArgumentException(sprintf('Passing an array of Security attributes to %s() is not supported.', __METHOD__));
         }
 
-        return $this->accessDecisionManager->decide($token, (array) $attributes, $subject);
+        return $this->accessDecisionManager->decide($token, [$attributes], $subject);
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -92,4 +92,19 @@ class AuthorizationCheckerTest extends TestCase
     {
         return [[true], [false]];
     }
+
+    public function testIsGrantedWithObjectAttribute()
+    {
+        $attribute = new \stdClass();
+
+        $token = new UsernamePasswordToken('username', 'password', 'provider', ['ROLE_USER']);
+
+        $this->accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($this->identicalTo($token), $this->identicalTo([$attribute]))
+            ->willReturn(true);
+        $this->tokenStorage->setToken($token);
+        $this->assertTrue($this->authorizationChecker->isGranted($attribute));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (the added test could be backported to older branches)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/33697#discussion_r328466135
| License       | MIT
| Doc PR        |

Fix calls to isGranted with `$attribute` beeing an object.