### PR TITLE
[HttpClient] workaround bad Content-Length sent by old libcurl

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -245,7 +245,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
             if ('POST' !== $method) {
                 $curlopts[CURLOPT_UPLOAD] = true;
             }
-        } elseif ('' !== $body) {
+        } elseif ('' !== $body || 'POST' === $method) {
             $curlopts[CURLOPT_POSTFIELDS] = $body;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Issue described in https://curl.haxx.se/mail/lib-2014-01/0106.html, happens with curl 7.29 at least.