### PR TITLE
[Console] Rename some methods related to redraw frequency

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * added `Question::setTrimmable` default to true to allow the answer to be trimmed
- * added method `preventRedrawFasterThan()` and `forceRedrawSlowerThan()` on `ProgressBar`
+ * added method `minSecondsBetweenRedraws()` and `maxSecondsBetweenRedraws()` on `ProgressBar`
  * `Application` implements `ResetInterface`
  * marked all dispatched event classes as `@final`
  * added support for displaying table horizontally

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -256,14 +256,14 @@ final class ProgressBar
         $this->redrawFreq = null !== $freq ? max(1, $freq) : null;
     }
 
-    public function preventRedrawFasterThan(float $intervalInSeconds): void
+    public function minSecondsBetweenRedraws(float $seconds): void
     {
-        $this->minSecondsBetweenRedraws = $intervalInSeconds;
+        $this->minSecondsBetweenRedraws = $seconds;
     }
 
-    public function forceRedrawSlowerThan(float $intervalInSeconds): void
+    public function maxSecondsBetweenRedraws(float $seconds): void
     {
-        $this->maxSecondsBetweenRedraws = $intervalInSeconds;
+        $this->maxSecondsBetweenRedraws = $seconds;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In #26339 we added `preventRedrawFasterThan()` and `forceRedrawSlowerThan()`. While merging the docs for them (https://github.com/symfony/symfony-docs/pull/12364) I thought that the method names are a bit hard to understand.

In this PR I propose a renaming for your consideration. Thanks!

In the following example, we want to update the progress bar every 100 iterations, but not faster than 100ms or slower than 200ms.

**Before**

```php
$progressBar = new ProgressBar($output, 50000);
$progressBar->start();

$progressBar->setRedrawFrequency(100);
$progressBar->preventRedrawFasterThan(0.1);
$progressBar->forceRedrawSlowerThan(0.2);
```

**After**

```php
$progressBar = new ProgressBar($output, 50000);
$progressBar->start();

$progressBar->setRedrawFrequency(100);
$progressBar->maxRefreshInterval(0.1);
$progressBar->minRefreshInterval(0.2);
```
