### PR TITLE
[Serializer] fix denormalization of string-arrays with only one element

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -244,15 +244,17 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 return null;
             }
 
-            if ($type->isCollection() && null !== ($collectionValueType = $type->getCollectionValueType()) && Type::BUILTIN_TYPE_OBJECT === $collectionValueType->getBuiltinType()) {
+            $collectionValueType = $type->isCollection() ? $type->getCollectionValueType() : null;
+
+            // Fix a collection that contains the only one element
+            // This is special to xml format only
+            if ('xml' === $format && null !== $collectionValueType && (!\is_array($data) || !\is_int(key($data)))) {
+                $data = [$data];
+            }
+
+            if (null !== $collectionValueType && Type::BUILTIN_TYPE_OBJECT === $collectionValueType->getBuiltinType()) {
                 $builtinType = Type::BUILTIN_TYPE_OBJECT;
                 $class = $collectionValueType->getClassName().'[]';
-
-                // Fix a collection that contains the only one element
-                // This is special to xml format only
-                if ('xml' === $format && !\is_int(key($data))) {
-                    $data = [$data];
-                }
 
                 if (null !== $collectionKeyType = $type->getCollectionKeyType()) {
                     $context['key_type'] = $collectionKeyType;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -121,16 +121,54 @@ class AbstractObjectNormalizerTest extends TestCase
         $extractor = $this->getMockBuilder(PhpDocExtractor::class)->getMock();
         $extractor->method('getTypes')
             ->will($this->onConsecutiveCalls(
-                [
-                    new Type(
-                        'array',
-                        false,
-                        null,
-                        true,
-                        new Type('int'),
-                        new Type('object', false, DummyChild::class)
-                    ),
-                ],
+                [new Type('array', false, null, true, new Type('int'), new Type('object', false, DummyChild::class))],
+                null
+            ));
+
+        $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
+        $arrayDenormalizer = new ArrayDenormalizerDummy();
+        $serializer = new SerializerCollectionDummy([$arrayDenormalizer, $denormalizer]);
+        $arrayDenormalizer->setSerializer($serializer);
+        $denormalizer->setSerializer($serializer);
+
+        return $denormalizer;
+    }
+
+    public function testDenormalizeStringCollectionDecodedFromXmlWithOneChild()
+    {
+        $denormalizer = $this->getDenormalizerForStringCollection();
+
+        // if an xml-node can have children which should be deserialized as string[]
+        // and only one child exists
+        $stringCollection = $denormalizer->denormalize(['children' => 'foo'], StringCollection::class, 'xml');
+
+        $this->assertInstanceOf(StringCollection::class, $stringCollection);
+        $this->assertIsArray($stringCollection->children);
+        $this->assertCount(1, $stringCollection->children);
+        $this->assertEquals('foo', $stringCollection->children[0]);
+    }
+
+    public function testDenormalizeStringCollectionDecodedFromXmlWithTwoChildren()
+    {
+        $denormalizer = $this->getDenormalizerForStringCollection();
+
+        // if an xml-node can have children which should be deserialized as string[]
+        // and only one child exists
+        $stringCollection = $denormalizer->denormalize(['children' => ['foo', 'bar']], StringCollection::class, 'xml');
+
+        $this->assertInstanceOf(StringCollection::class, $stringCollection);
+        $this->assertIsArray($stringCollection->children);
+        $this->assertCount(2, $stringCollection->children);
+        $this->assertEquals('foo', $stringCollection->children[0]);
+        $this->assertEquals('bar', $stringCollection->children[1]);
+    }
+
+    private function getDenormalizerForStringCollection()
+    {
+        $extractor = $this->getMockBuilder(PhpDocExtractor::class)->getMock();
+        $extractor->method('getTypes')
+            ->will($this->onConsecutiveCalls(
+                [new Type('array', false, null, true, new Type('int'), new Type('string'))],
                 null
             ));
 
@@ -210,6 +248,12 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
     {
         $object->$attribute = $value;
     }
+}
+
+class StringCollection
+{
+    /** @var string[] */
+    public $children;
 }
 
 class DummyCollection


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? |no
| Tickets       | Fix #33731
| License       | MIT
| Doc PR        | 

This PR does almost the same as https://github.com/symfony/symfony/commit/ac70edf8cd6e63919129584108dadf327c18669a, just not only for arrays of objects.
