### PR TITLE
[Intl] Fix compile type errors

### DIFF
--- a/src/Symfony/Component/Intl/Data/Generator/FallbackTrait.php
+++ b/src/Symfony/Component/Intl/Data/Generator/FallbackTrait.php
@@ -25,23 +25,14 @@ trait FallbackTrait
     private $generatingFallback = false;
 
     /**
-     * @param string $tempDir
-     * @param string $displayLocale
-     *
-     * @return array|null
-     *
      * @see AbstractDataGenerator::generateDataForLocale()
      */
-    abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, $tempDir, $displayLocale);
+    abstract protected function generateDataForLocale(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale): ?array;
 
     /**
-     * @param string $tempDir
-     *
-     * @return array|null
-     *
      * @see AbstractDataGenerator::generateDataForRoot()
      */
-    abstract protected function generateDataForRoot(BundleEntryReaderInterface $reader, $tempDir);
+    abstract protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir): ?array;
 
     private function generateFallbackData(BundleEntryReaderInterface $reader, string $tempDir, string $displayLocale): array
     {

--- a/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
@@ -150,6 +150,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
      */
     protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir): ?array
     {
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
@@ -135,6 +135,7 @@ class LocaleDataGenerator extends AbstractDataGenerator
      */
     protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir): ?array
     {
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -133,6 +133,7 @@ class RegionDataGenerator extends AbstractDataGenerator
      */
     protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir): ?array
     {
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
@@ -86,6 +86,7 @@ class ScriptDataGenerator extends AbstractDataGenerator
      */
     protected function generateDataForRoot(BundleEntryReaderInterface $reader, string $tempDir): ?array
     {
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixes e.g. `TypeError: Return value of Symfony\Component\Intl\Data\Generator\LanguageDataGenerator::generateDataForRoot() must be of the type array or null, none returned`

Adding typehints in `FallbackTrait` seems forgotten, now added as all generator stuff is `@internal` anyway ran on latest PHP.