### PR TITLE
[Mailer] Added support for whitelisting recipients

### DIFF
--- a/src/Symfony/Component/Mailer/EventListener/EnvelopeWhitelistListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/EnvelopeWhitelistListener.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mime\Address;
+
+/**
+ * Manipulates the Envelope of a Message.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class EnvelopeWhitelistListener implements EventSubscriberInterface
+{
+    private $sender;
+    private $recipients;
+    private $whitelist;
+
+    /**
+     * @param Address|string     $sender
+     * @param (Address|string)[] $recipients
+     * @param (Address|string)[] $whitelist
+     */
+    public function __construct($sender = null, array $recipients = null, array $whitelist = null)
+    {
+        if (null !== $sender) {
+            $this->sender = Address::create($sender);
+        }
+        if (null !== $recipients) {
+            $this->recipients = Address::createArray($recipients);
+        }
+        if (null !== $whitelist) {
+            $this->whitelist = Address::createArray($whitelist);
+        }
+    }
+
+    public function onMessage(MessageEvent $event): void
+    {
+        if ($this->sender) {
+            $event->getEnvelope()->setSender($this->sender);
+        }
+
+        if ($this->whitelist) {
+            array_push(
+                $this->recipients, 
+                array_intersect(
+                    $event->getEnvelope()->getRecipients(), 
+                    $this->whitelist
+                )
+            );
+        }
+
+        if ($this->recipients) {
+            $event->getEnvelope()->setRecipients($this->recipients);
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            // should be the last one to allow header changes by other listeners first
+            MessageEvent::class => ['onMessage', -255],
+        ];
+    }
+}

--- a/src/Symfony/Component/Mailer/EventListener/EnvelopeWhitelistListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/EnvelopeWhitelistListener.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mime\Address;
+
+/**
+ * Manipulates the Envelope of a Message.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class EnvelopeWhitelistListener implements EventSubscriberInterface
+{
+    private $sender;
+    private $recipients;
+    private $whitelist;
+
+    /**
+     * @param Address|string     $sender
+     * @param (Address|string)[] $recipients
+     * @param (Address|string)[] $whitelist
+     */
+    public function __construct($sender = null, array $recipients = null, array $whitelist = null)
+    {
+        if (null !== $sender) {
+            $this->sender = Address::create($sender);
+        }
+        if (null !== $recipients) {
+            $this->recipients = Address::createArray($recipients);
+        }
+        if (null !== $whitelist) {
+            $this->whitelist = Address::createArray($whitelist);
+        }
+    }
+
+    public function onMessage(MessageEvent $event): void
+    {
+        if ($this->sender) {
+            $event->getEnvelope()->setSender($this->sender);
+        }
+
+        if ($this->whitelist) {
+            array_push(
+                $this->recipients,
+                array_intersect(
+                    $event->getEnvelope()->getRecipients(),
+                    $this->whitelist
+                )
+            );
+        }
+
+        if ($this->recipients) {
+            $event->getEnvelope()->setRecipients($this->recipients);
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            // should be the last one to allow header changes by other listeners first
+            MessageEvent::class => ['onMessage', -255],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--

To whitelist recipients replace the EnvelopeListener with EnvelopeWhitelistListener class and add whitelist to the arguments. Whitelisted recipients won't be deleted from the envelope recipients list.

```yaml
# config/services_dev.yaml
services:
    mailer.dev.set_recipients:
        class: Symfony\Component\Mailer\EventListener\EnvelopeWhitelistListener
        tags: ['kernel.event_subscriber']
        arguments:
            $sender: null
            $recipients: ['youremail@example.com']
            $whitelist: ['whitelisted.recipient@example.com']
```
-->
