### PR TITLE
[Cache] fix known tag versions ttl check

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -350,7 +350,7 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
                 continue;
             }
             $version -= $this->knownTagVersions[$tag][1];
-            if ((0 !== $version && 1 !== $version) || $this->knownTagVersionsTtl > $now - $this->knownTagVersions[$tag][0]) {
+            if ((0 !== $version && 1 !== $version) || $now - $this->knownTagVersions[$tag][0] >= $this->knownTagVersionsTtl) {
                 // reuse previously fetched tag versions up to the ttl, unless we are storing items or a potential miss arises
                 $fetchTagVersions = true;
             } else {

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
@@ -158,6 +159,39 @@ class TagAwareAdapterTest extends AdapterTestCase
 
         $cache = new TagAwareAdapter($this->getFailingPruneableMock());
         $this->assertFalse($cache->prune());
+    }
+
+    public function testKnownTagVersionsTtl()
+    {
+        $itemsPool = new FilesystemAdapter('', 10);
+        $tagsPool = $this
+            ->getMockBuilder(AdapterInterface::class)
+            ->getMock();
+
+        $pool = new TagAwareAdapter($itemsPool, $tagsPool, 10);
+
+        $item = $pool->getItem('foo');
+        $item->tag(['baz']);
+        $item->expiresAfter(100);
+
+        $tag = $this->getMockBuilder(CacheItemInterface::class)->getMock();
+        $tag->expects(self::exactly(2))->method('get')->willReturn(10);
+
+        $tagsPool->expects(self::exactly(2))->method('getItems')->willReturn([
+            'baz'.TagAwareAdapter::TAGS_PREFIX => $tag,
+        ]);
+
+        $pool->save($item);
+        $this->assertTrue($pool->getItem('foo')->isHit());
+        $this->assertTrue($pool->getItem('foo')->isHit());
+
+        sleep(20);
+
+        $this->assertTrue($pool->getItem('foo')->isHit());
+
+        sleep(5);
+
+        $this->assertTrue($pool->getItem('foo')->isHit());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT

The introduced changes from PR #27007 came with a knownTagVersionTtl property defaulted to 0.15 microseconds. The if statement defined on line 353 checks if the ttl is higher then the already known tag versions. This results in the opposite of the wanted behavior. Instead of waiting for the ttl to expire the if statement is only true if the known versions are lower than the version ttl.

So if this Adapter stays in memory the tag versions are never checked again if the ttl is already lower then the passed time.

The unit test I've added tests once if the version is changed and another time it doesn't get checked cause the ttl hasn't been expired yet.