### PR TITLE
[FrameworkBundle] conflict with VarDumper < 4.4

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -54,7 +54,7 @@
         "symfony/templating": "^3.4|^4.0|^5.0",
         "symfony/twig-bundle": "^4.4|^5.0",
         "symfony/validator": "^4.4|^5.0",
-        "symfony/var-dumper": "^4.3|^5.0",
+        "symfony/var-dumper": "^4.4|^5.0",
         "symfony/workflow": "^4.3|^5.0",
         "symfony/yaml": "^3.4|^4.0|^5.0",
         "symfony/property-info": "^3.4|^4.0|^5.0",
@@ -84,6 +84,7 @@
         "symfony/twig-bridge": "<4.1.1",
         "symfony/twig-bundle": "<4.4",
         "symfony/validator": "<4.4",
+        "symfony/var-dumper": "<4.4",
         "symfony/workflow": "<4.3"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While trying FrameworkBundle 4.4.x-dev I noticed that I was still using VarDumper 4.3 which leads to this error:

```
> app/console cache:clear

Fatal error: Uncaught Symfony\Component\ErrorHandler\Exception\ClassNotFoundException: Attempted to load class "ContextualizedDumper" from namespace "Symfony\Component\VarDumper\Dumper".
Did you forget a "use" statement for another namespace? in /var/www/x/symfony/app/cache/dev/ContainerB7mbdCh/getDebug_DumpListenerService.php:13
Stack trace:
#0 /var/www/x/symfony/app/cache/dev/ContainerB7mbdCh/appAppKernelDevDebugContainer.php(1357): require()
#1 /var/www/x/symfony/app/cache/dev/ContainerB7mbdCh/appAppKernelDevDebugContainer.php(2282): ContainerB7mbdCh\appAppKernelDevDebugContainer->load('getDebug_DumpLi...')
#2 /var/www/x/symfony/vendor/symfony/event-dispatcher/EventDispatcher.php(275): ContainerB7mbdCh\appAppKernelDevDebugContainer->ContainerB7mbdCh\{closure}()
#3 /var/www/x/symfony/vendor/symfony/event-dispatcher/EventDispatcher.php(90): Symfony\Component\EventDispatcher\EventDispatcher->sortListeners('console.command')
#4 /var/www/x in /var/www/x/symfony/app/cache/dev/ContainerB7mbdCh/getDebug_DumpListenerService.php on line 13
PHP Fatal error:  Uncaught Symfony\Component\ErrorHandler\Exception\ClassNotFoundException: Attempted to load class "ContextualizedDumper" from namespace "Symfony\Component\VarDumper\Dumper".
Did you forget a "use" statement for another namespace? in /var/www/x/symfony/app/cache/dev/ContainerB7mbdCh/getDebug_DumpListenerService.php:13
Stack trace:
#0 /var/www/x/symfony/app/cache/dev/ContainerB7mbdCh/appAppKernelDevDebugContainer.php(1357): require()
#1 /var/www/x/symfony/app/cache/dev/ContainerB7mbdCh/appAppKernelDevDebugContainer.php(2282): ContainerB7mbdCh\appAppKernelDevDebugContainer->load('getDebug_DumpLi...')
#2 /var/www/x/symfony/vendor/symfony/event-dispatcher/EventDispatcher.php(275): ContainerB7mbdCh\appAppKernelDevDebugContainer->ContainerB7mbdCh\{closure}()
#3 /var/www/x/symfony/vendor/symfony/event-dispatcher/EventDispatcher.php(90): Symfony\Component\EventDispatcher\EventDispatcher->sortListeners('console.command')
#4 /var/www/x in /var/www/x/symfony/app/cache/dev/ContainerB7mbdCh/getDebug_DumpListenerService.php on line 13
Script app/console cache:clear handling the post-update-cmd event returned with error code 255
```
So we need to use `symfony/var-dumper >= 4.4`