### PR TITLE
[HttpKernel] drop support for retrieving container from non-booted kernels

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.0.0
 -----
 
+ * removed support for getting the container from a non-booted kernel
  * removed the first and second constructor argument of `ConfigDataCollector` 
  * removed `ConfigDataCollector::getApplicationName()` 
  * removed `ConfigDataCollector::getApplicationVersion()`

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -301,7 +301,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     public function getContainer()
     {
         if (!$this->booted) {
-            @trigger_error('Getting the container from a non-booted kernel is deprecated since Symfony 4.4.', E_USER_DEPRECATED);
+            throw new \LogicException('Cannot retrieve the container from a non-booted kernel.');
         }
 
         return $this->container;

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -47,18 +47,6 @@ class KernelTest extends TestCase
         $this->assertLessThanOrEqual(microtime(true), $kernel->getStartTime());
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Getting the container from a non-booted kernel is deprecated since Symfony 4.4.
-     */
-    public function testGetContainerForANonBootedKernel()
-    {
-        $kernel = new KernelForTest('test_env', true);
-
-        $this->assertFalse($kernel->isBooted());
-        $this->assertNull($kernel->getContainer());
-    }
-
     public function testClone()
     {
         $env = 'test_env';
@@ -405,18 +393,6 @@ EOF;
             ->method('getHttpKernel');
 
         $kernel->terminate(Request::create('/'), new Response());
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation Getting the container from a non-booted kernel is deprecated since Symfony 4.4.
-     */
-    public function testDeprecatedNullKernel()
-    {
-        $kernel = $this->getKernel();
-        $kernel->shutdown();
-
-        $this->assertNull($kernel->getContainer());
     }
 
     public function testTerminateDelegatesTerminationOnlyForTerminableInterface()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 