### PR TITLE
[Serializer] Adapt max depth calculation acccording to documentation

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/MaxDepthDummyChild1.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/MaxDepthDummyChild1.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class MaxDepthDummyChild1 extends MaxDepthDummy
+{
+}
+

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/MaxDepthDummyChild2.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/MaxDepthDummyChild2.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class MaxDepthDummyChild2 extends MaxDepthDummy
+{
+}
+

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/MaxDepthTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/MaxDepthTestTrait.php
@@ -72,10 +72,6 @@ trait MaxDepthTestTrait
         $level4->bar = 'level4';
         $level3->child = $level4;
 
-        $level5 = new MaxDepthDummyChild2();
-        $level5->bar = 'level5';
-        $level4->child = $level5;
-
         $result = $normalizer->normalize($level1, null, ['enable_max_depth' => true]);
 
         $expected = [

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/MaxDepthTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/MaxDepthTestTrait.php
@@ -4,6 +4,8 @@ namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummyChild1;
+use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummyChild2;
 
 /**
  * Covers AbstractObjectNormalizer::ENABLE_MAX_DEPTH and AbstractObjectNormalizer::MAX_DEPTH_HANDLER.
@@ -30,6 +32,49 @@ trait MaxDepthTestTrait
         $level4 = new MaxDepthDummy();
         $level4->bar = 'level4';
         $level3->child = $level4;
+
+        $result = $normalizer->normalize($level1, null, ['enable_max_depth' => true]);
+
+        $expected = [
+            'bar' => 'level1',
+            'child' => [
+                'bar' => 'level2',
+                'child' => [
+                    'bar' => 'level3',
+                    'child' => [
+                        'child' => null,
+                    ],
+                ],
+                'foo' => null,
+            ],
+            'foo' => null,
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testMaxDepthWithDifferentClasses()
+    {
+        $normalizer = $this->getNormalizerForMaxDepth();
+
+        $level1 = new MaxDepthDummy();
+        $level1->bar = 'level1';
+
+        $level2 = new MaxDepthDummyChild1();
+        $level2->bar = 'level2';
+        $level1->child = $level2;
+
+        $level3 = new MaxDepthDummyChild2();
+        $level3->bar = 'level3';
+        $level2->child = $level3;
+
+        $level4 = new MaxDepthDummyChild1();
+        $level4->bar = 'level4';
+        $level3->child = $level4;
+
+        $level5 = new MaxDepthDummyChild2();
+        $level5->bar = 'level5';
+        $level4->child = $level5;
 
         $result = $normalizer->normalize($level1, null, ['enable_max_depth' => true]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33466 
| License       | MIT
| Doc PR        | n/a

Context:
- [Current documentation](https://symfony.com/doc/current/components/serializer.html#handling-serialization-depth)  
- [Current code](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php#L552)

The documentation is ambiguous in the way the MaxDepth() attribute will be used during serialization.  
The issue #33466 shows that some understand it as a max depth for a property where the depth is calculated relative to the root of the serialized tree.  
The actual implementation calculates the number of passes through an object of the same class instead.

This PR is an implementation of the former. A discussion is to be had if this is an implementation issue or a documentation issue.

This is a fix but also a BC break (codewise; not for the documentation).
This new implementation passes the tests written for the previous one (since it's "stricter") so I didn't write new ones: should I ?