### PR TITLE
Copy phpunit.xsd to a predictable path

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -78,6 +78,7 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
         passthru(sprintf('\\' === DIRECTORY_SEPARATOR ? 'rmdir /S /Q %s': 'rm -rf %s', "phpunit-$PHPUNIT_VERSION.old"));
     }
     passthru("$COMPOSER create-project --no-install --prefer-dist --no-scripts --no-plugins --no-progress --ansi phpunit/phpunit phpunit-$PHPUNIT_VERSION \"$PHPUNIT_VERSION.*\"");
+    @copy("phpunit-$PHPUNIT_VERSION/phpunit.xsd", 'phpunit.xsd');
     chdir("phpunit-$PHPUNIT_VERSION");
     if ($SYMFONY_PHPUNIT_REMOVE) {
         passthru("$COMPOSER remove --no-update ".$SYMFONY_PHPUNIT_REMOVE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes-ish
| Deprecations? | no
| Tickets       | https://github.com/symfony/recipes/pull/652#discussion_r329446277
| License       | MIT
| Doc PR        | -

In symfony/recipes#652 I would like to make Flex create the `phpunit.xml.dist` file with a local URI for the `phpunit.xsd`. This is doable when using `phpunit/phpunit` standalone because the path to the XSD file is known. This PR aims to allow doing this when using the PHPUnit Bridge, which installs PHPUnit in a path that might change.

Is is simple `@copy()` call ok? Should I add some error handling?