### PR TITLE
[DI] enable improved syntax for defining method calls in Yaml

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * added support for binding iterable and tagged services
  * made singly-implemented interfaces detection be scoped by file
  * added ability to define a static priority method for tagged service
+ * added support for improved syntax to define method calls in Yaml
 
 4.3.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/alt_call.yaml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/alt_call.yaml
@@ -1,0 +1,5 @@
+services:
+    foo:
+        calls:
+            - foo: [1, 2, 3]
+            - bar: !returns_clone [1, 2, 3]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -900,4 +900,19 @@ class YamlFileLoaderTest extends TestCase
 
         $this->assertSame(Prototype\SinglyImplementedInterface\Adapter\Adapter::class, (string) $alias);
     }
+
+    public function testAlternativeMethodCalls()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('alt_call.yaml');
+
+        $expected = [
+            ['foo', [1, 2, 3]],
+            ['bar', [1, 2, 3], true],
+        ];
+
+        $this->assertSame($expected, $container->getDefinition('foo')->getMethodCalls());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I've always found the syntax to write method calls in Yaml cumbersome. This PR allows a new syntax that is way easier to type and get (to me at least):

```yaml
services:
  App\MyService:
    calls:
      - addStuff: ['@App\Stuff']
```

for the case where a wither is to be declared, using the same wording as in XML:
```yaml
services:
  App\MyService:
    calls:
      - withStuff: !returns_clone ['@App\Stuff']
```

That's what this PR provides (+ additional syntax checks to guard against typos).

Note that deprecating the current syntax wouldn't be nice for the ecosystem in 4.4, but could be considered starting with 5.1.