### PR TITLE
[AnnotationCacheWarmer] add RedirectController to annotation cache

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -37,7 +37,7 @@
             <argument type="service" id="annotations.reader" />
             <argument>%kernel.cache_dir%/annotations.php</argument>
             <argument type="service" id="cache.annotations" />
-            <argument>#^Symfony\\(?:Component\\HttpKernel\\|Bundle\\FrameworkBundle\\Controller\\(?!AbstractController$|Controller$))#</argument>
+            <argument>#^Symfony\\(?:Component\\HttpKernel\\|Bundle\\FrameworkBundle\\Controller\\(?!.*Controller$))#</argument>
             <argument>%kernel.debug%</argument>
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #29357
| License       | MIT

This prevents to exclude the RedirectController from the warmed annotation cache which would lead to warnings when trying to use the warmed cache on read only file systems
