### PR TITLE
[WebProfilerBundle] Try to display the most useful panel by default

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag;
+use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\ExceptionDataCollector;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -78,7 +80,7 @@ class ProfilerController
             $this->cspHandler->disableCsp();
         }
 
-        $panel = $request->query->get('panel', 'request');
+        $panel = $request->query->get('panel');
         $page = $request->query->get('page', 'home');
 
         if ('latest' === $token && $latest = current($this->profiler->find(null, null, 1, null, null, null))) {
@@ -87,6 +89,22 @@ class ProfilerController
 
         if (!$profile = $this->profiler->loadProfile($token)) {
             return new Response($this->twig->render('@WebProfiler/Profiler/info.html.twig', ['about' => 'no_token', 'token' => $token, 'request' => $request]), 200, ['Content-Type' => 'text/html']);
+        }
+
+        if (null === $panel) {
+            $panel = 'request';
+
+            foreach ($profile->getCollectors() as $collector) {
+                if ($collector instanceof ExceptionDataCollector && $collector->hasException()) {
+                    $panel = $collector->getName();
+
+                    break;
+                }
+
+                if ($collector instanceof DumpDataCollector && $collector->getDumpsCount() > 0) {
+                    $panel = $collector->getName();
+                }
+            }
         }
 
         if (!$profile->hasCollector($panel)) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -267,7 +267,7 @@
             if (request.profilerUrl) {
                 profilerCell.textContent = '';
                 var profilerLink = document.createElement('a');
-                profilerLink.setAttribute('href', request.statusCode < 400 ? request.profilerUrl : request.profilerUrl + '?panel=exception');
+                profilerLink.setAttribute('href', request.profilerUrl);
                 profilerLink.textContent = request.profile;
                 profilerCell.appendChild(profilerLink);
             }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -15,7 +15,8 @@ use Symfony\Bundle\WebProfilerBundle\Profiler\TemplateManager;
 use Symfony\Bundle\WebProfilerBundle\Tests\TestCase;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Twig\Environment;
-use Twig\Source;
+use Twig\Loader\LoaderInterface;
+use Twig\Loader\SourceContextLoaderInterface;
 
 /**
  * Test for TemplateManager class.
@@ -104,11 +105,14 @@ class TemplateManagerTest extends TestCase
     {
         $this->twigEnvironment = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
 
-        if (interface_exists('Twig\Loader\SourceContextLoaderInterface')) {
-            $loader = $this->getMockBuilder('Twig\Loader\SourceContextLoaderInterface')->getMock();
+        if (Environment::MAJOR_VERSION > 1) {
+            $loader = $this->createMock(LoaderInterface::class);
+            $loader
+                ->expects($this->any())
+                ->method('exists')
+                ->willReturn(true);
         } else {
-            $loader = $this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock();
-            $loader->method('getSourceContext')->willReturn(new Source('source-code', 'source-name'));
+            $loader = $this->createMock(SourceContextLoaderInterface::class);
         }
 
         $this->twigEnvironment->expects($this->any())->method('getLoader')->willReturn($loader);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Alternative to https://github.com/symfony/symfony/pull/32491, the goal stays the same.

I think reserving a data collector name is fine, isn'it ? It's not likely that end users use this name (that's why I added an underscore) + shouldn't be hard for them to just rename it.

I don't think adding a configuration option to toggle the "_best" behavior is useful, should be by default for DX IMHO.

Not adding an extension point for now (for end users to set their panel as the "best"), maybe later if someone request it?