### PR TITLE
[Contracts] Don't remove object type declaration from PSR interface

### DIFF
--- a/src/Symfony/Contracts/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Contracts/EventDispatcher/EventDispatcherInterface.php
@@ -32,7 +32,7 @@ if (interface_exists(PsrEventDispatcherInterface::class)) {
          *
          * @return object The passed $event MUST be returned
          */
-        public function dispatch($event/*, string $eventName = null*/);
+        public function dispatch(object $event/*, string $eventName = null*/);
     }
 } else {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | #32179, prepares #33497
| License       | MIT
| Doc PR        | N/A

In the contracts package, when extending the PSR `EventDispatcherInterface`, we are removing the `object` parameter type declaration from the `dispatch()` method. This is how the interface looks like upstream:

https://github.com/php-fig/event-dispatcher/blob/1.0.0/src/EventDispatcherInterface.php#L20

I don't see a reason to do that. Keeping the declaration would allow implementers to keep the `object` type declaration when implementing our contracts interface together with the PSR one.