### PR TITLE
[Serializer] Remove XmlEncoder::TYPE_CASE_ATTRIBUTES constant

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * removed `XmlEncoder::setRootNodeName()` & `XmlEncoder::getRootNodeName()`, use the default context instead.
  * removed individual encoders/normalizers options as constructor arguments.
  * removed support for instantiating a `DataUriNormalizer` with a default MIME type guesser when the `symfony/mime` component isn't installed.
+ * removed the `XmlEncoder::TYPE_CASE_ATTRIBUTES` constant. Use `XmlEncoder::TYPE_CAST_ATTRIBUTES` instead.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -51,7 +51,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     const REMOVE_EMPTY_TAGS = 'remove_empty_tags';
     const ROOT_NODE_NAME = 'xml_root_node_name';
     const STANDALONE = 'xml_standalone';
-    const TYPE_CASE_ATTRIBUTES = 'xml_type_cast_attributes';
+    const TYPE_CAST_ATTRIBUTES = 'xml_type_cast_attributes';
     const VERSION = 'xml_version';
 
     private $defaultContext = [
@@ -61,7 +61,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::LOAD_OPTIONS => LIBXML_NONET | LIBXML_NOBLANKS,
         self::REMOVE_EMPTY_TAGS => false,
         self::ROOT_NODE_NAME => 'response',
-        self::TYPE_CASE_ATTRIBUTES => true,
+        self::TYPE_CAST_ATTRIBUTES => true,
     ];
 
     /**
@@ -293,7 +293,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         }
 
         $data = [];
-        $typeCastAttributes = (bool) ($context[self::TYPE_CASE_ATTRIBUTES] ?? $this->defaultContext[self::TYPE_CASE_ATTRIBUTES]);
+        $typeCastAttributes = (bool) ($context[self::TYPE_CAST_ATTRIBUTES] ?? $this->defaultContext[self::TYPE_CAST_ATTRIBUTES]);
 
         foreach ($node->attributes as $attr) {
             if (!is_numeric($attr->nodeValue) || !$typeCastAttributes || (isset($attr->nodeValue[1]) && '0' === $attr->nodeValue[0])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | not really
| Deprecations? | yes (well, sort of)
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

There is a small typo in the `XmlEncoder` constant. This can only be fixed in the master branch for Symfony 5 as it is a breaking change. I'm not sure if it's possible to deprecate the usage of the old constant name in 4.4? As the constant just resolves to a string, there is no way of determining if someone used the constant or not (a quick search on Github, I can't find any direct usages of the constant outside of this class)