### PR TITLE
[Form] Added CountryType option for using alpha3 country codes

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -42,16 +42,19 @@ class CountryType extends AbstractType implements ChoiceLoaderInterface
         $resolver->setDefaults([
             'choice_loader' => function (Options $options) {
                 $choiceTranslationLocale = $options['choice_translation_locale'];
+                $alpha3 = $options['alpha3'];
 
-                return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale) {
-                    return array_flip(Countries::getNames($choiceTranslationLocale));
+                return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale, $alpha3) {
+                    return array_flip($alpha3 ? Countries::getAlpha3Names($choiceTranslationLocale) : Countries::getNames($choiceTranslationLocale));
                 });
             },
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
+            'alpha3' => false,
         ]);
 
         $resolver->setAllowedTypes('choice_translation_locale', ['null', 'string']);
+        $resolver->setAllowedTypes('alpha3', 'bool');
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -42,16 +42,19 @@ class LanguageType extends AbstractType implements ChoiceLoaderInterface
         $resolver->setDefaults([
             'choice_loader' => function (Options $options) {
                 $choiceTranslationLocale = $options['choice_translation_locale'];
+                $alpha3 = $options['alpha3'];
 
-                return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale) {
-                    return array_flip(Languages::getNames($choiceTranslationLocale));
+                return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale, $alpha3) {
+                    return array_flip($alpha3 ? Languages::getAlpha3Names($choiceTranslationLocale) : Languages::getNames($choiceTranslationLocale));
                 });
             },
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
+            'alpha3' => false,
         ]);
 
         $resolver->setAllowedTypes('choice_translation_locale', ['null', 'string']);
+        $resolver->setAllowedTypes('alpha3', 'bool');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -58,6 +58,42 @@ class CountryTypeTest extends BaseTypeTest
         $this->assertContainsEquals(new ChoiceView('MY', 'MY', 'Малайзія'), $choices);
     }
 
+    public function testAlpha3Option()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'alpha3' => true,
+            ])
+            ->createView()->vars['choices'];
+
+        // Don't check objects for identity
+        $this->assertContainsEquals(new ChoiceView('DEU', 'DEU', 'Germany'), $choices);
+        $this->assertContainsEquals(new ChoiceView('GBR', 'GBR', 'United Kingdom'), $choices);
+        $this->assertContainsEquals(new ChoiceView('USA', 'USA', 'United States'), $choices);
+        $this->assertContainsEquals(new ChoiceView('FRA', 'FRA', 'France'), $choices);
+        $this->assertContainsEquals(new ChoiceView('MYS', 'MYS', 'Malaysia'), $choices);
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testChoiceTranslationLocaleAndAlpha3Option()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'uk',
+                'alpha3' => true,
+            ])
+            ->createView()->vars['choices'];
+
+        // Don't check objects for identity
+        $this->assertContainsEquals(new ChoiceView('DEU', 'DEU', 'Німеччина'), $choices);
+        $this->assertContainsEquals(new ChoiceView('GBR', 'GBR', 'Велика Британія'), $choices);
+        $this->assertContainsEquals(new ChoiceView('USA', 'USA', 'Сполучені Штати'), $choices);
+        $this->assertContainsEquals(new ChoiceView('FRA', 'FRA', 'Франція'), $choices);
+        $this->assertContainsEquals(new ChoiceView('MYS', 'MYS', 'Малайзія'), $choices);
+    }
+
     public function testUnknownCountryIsNotIncluded()
     {
         $choices = $this->factory->create(static::TESTED_TYPE, 'country')

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -53,6 +53,40 @@ class LanguageTypeTest extends BaseTypeTest
         $this->assertContainsEquals(new ChoiceView('my', 'my', 'бірманська'), $choices);
     }
 
+    public function testAlpha3Option()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'alpha3' => true,
+            ])
+            ->createView()->vars['choices'];
+
+        // Don't check objects for identity
+        $this->assertContainsEquals(new ChoiceView('eng', 'eng', 'English'), $choices);
+        $this->assertContainsEquals(new ChoiceView('fra', 'fra', 'French'), $choices);
+        // Burmese has no three letter language code
+        $this->assertNotContainsEquals(new ChoiceView('my', 'my', 'Burmese'), $choices);
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testChoiceTranslationLocaleAndAlpha3Option()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'uk',
+                'alpha3' => true,
+            ])
+            ->createView()->vars['choices'];
+
+        // Don't check objects for identity
+        $this->assertContainsEquals(new ChoiceView('eng', 'eng', 'англійська'), $choices);
+        $this->assertContainsEquals(new ChoiceView('fra', 'fra', 'французька'), $choices);
+        // Burmese has no three letter language code
+        $this->assertNotContainsEquals(new ChoiceView('my', 'my', 'бірманська'), $choices);
+    }
+
     public function testMultipleLanguagesIsNotIncluded()
     {
         $choices = $this->factory->create(static::TESTED_TYPE, 'language')

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/event-dispatcher": "^4.3",
-        "symfony/intl": "^4.3|^5.0",
+        "symfony/intl": "^4.4|^5.0",
         "symfony/options-resolver": "~4.3|^5.0",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fixes #20313
| License       | MIT
| Doc PR        | -

In the linked issue #20313 was a proposal to add an alpha3 option to the country type.
Here it is..
Hopefully I've made no mistake, so when the code is fine, I will create a documentation PR.. :-)