### PR TITLE
[Cache] Fixed Redis Sentinel usage when only one Sentinel specified

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -271,7 +271,7 @@ trait RedisTrait
             if (null !== $auth) {
                 $params['parameters']['password'] = $auth;
             }
-            if (1 === \count($hosts) && !$params['redis_cluster']) {
+            if (1 === \count($hosts) && !($params['redis_cluster'] || $params['redis_sentinel'])) {
                 $hosts = $hosts[0];
             } elseif (\in_array($params['failover'], ['slaves', 'distribute'], true) && !isset($params['replication'])) {
                 $params['replication'] = true;


### PR DESCRIPTION
Added check for $params['redis_sentinel'] to line 274, as by converting the array of hosts to a single host configuration (as you might in a test environment), this causes the class to initialise incorrectly.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33796 
| License       | MIT
| Doc PR        | 

As from Issue #33796 
In a Redis Sentinel setup, if only a single Redis Sentinel, or multiple Sentinels with the same host/port are specified (as we're currently doing in a test environment), then the call to `setSentinelTimeout` in `RedisTrait.php` throws an exception, as the wrong interface appears to be initialised as a result.

Adding a check for the `redis_sentinel` parameter, as was done with a check for the `redis_cluster` parameter, avoids this, and the Redis Client is initialised correctly.