### PR TITLE
[Serializer] Add note about deprecating the XmlEncoder::TYPE_CASE_ATTRIBUTES constant in upgrade

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -219,6 +219,11 @@ Security
    ) {}
    ```
 
+Serializer
+----------
+
+ * Deprecated the `XmlEncoder::TYPE_CASE_ATTRIBUTES` constant. Use `XmlEncoder::TYPE_CAST_ATTRIBUTES` instead.
+
 Stopwatch
 ---------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -536,6 +536,11 @@ Serializer
  * The `AbstractNormalizer::handleCircularReference()` method has two new `$format` and `$context` arguments.
  * Removed support for instantiating a `DataUriNormalizer` with a default MIME type guesser when the `symfony/mime` component isn't installed.
 
+Serializer
+----------
+
+* Removed the `XmlEncoder::TYPE_CASE_ATTRIBUTES` constant. Use `XmlEncoder::TYPE_CAST_ATTRIBUTES` instead.
+
 Stopwatch
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | N/A
| New feature?  | N/A
| Deprecations? | N/A
| Tickets       | https://github.com/symfony/symfony/pull/33789#issuecomment-537392407
| License       | MIT
| Doc PR        | N/A
