### PR TITLE
[FrameworkBundle] Fix wrong returned status code in ConfigDebugCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -104,7 +104,7 @@ EOF
         } catch (LogicException $e) {
             $errorIo->error($e->getMessage());
 
-            return;
+            return 1;
         }
 
         $io->title(sprintf('Current configuration for "%s.%s"', $extensionAlias, $path));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #33747<!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | -

This is a follow-up PR caused by https://github.com/symfony/symfony/pull/33775#discussion_r330463216