### PR TITLE
[HttpKernel] Inherit Throwable in HttpExceptionInterface

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/HttpExceptionInterface.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpExceptionInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpKernel\Exception;
  *
  * @author Kris Wallsmith <kris@symfony.com>
  */
-interface HttpExceptionInterface
+interface HttpExceptionInterface extends \Throwable
 {
     /**
      * Returns the status code.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| **BC BREAKS?**| **YES**
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

When using a static analysis tools, it is not possible to do this:

```php
if ($exception instanceof HttpExceptionInterface) {
    $exception->getStatusCode();
    $exception->getHeaders();
    $exception->getMessage(); // ❌ Will fail here
}
```

This is due to `getMessage()` not being a method declared in `HttpExceptionInterface`. Since Symfony now requires PHP 7.1+ to run, it is safe to inherit from the `Throwable` interface (added in PHP 7.0).

### About backward compatibility

Adding new methods to `HttpExceptionInterface` [breaks BC](https://symfony.com/doc/current/contributing/code/bc.html#changing-interfaces), however this interface shouldn't be used on a class other than an exception, so this shouldn't affect much code.

### About tests

I'm not sure this really needs tests, but maybe I'm wrong? Tell me what to test if you think this is required.