### PR TITLE
[Serializer] Allows the DateTimeNormalizer to use the FORMAT_KEY used in construct…

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -27,6 +27,8 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
 
     private $defaultContext;
 
+    private $defaultDenormalizationFormat;
+
     private static $supportedTypes = [
         \DateTimeInterface::class => true,
         \DateTimeImmutable::class => true,
@@ -49,6 +51,8 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
             $defaultContext = [self::FORMAT_KEY => (string) $defaultContext];
             $defaultContext[self::TIMEZONE_KEY] = $timezone;
         }
+
+        $this->defaultDenormalizationFormat = $defaultContext[self::FORMAT_KEY] ?? null;
 
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
@@ -90,7 +94,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {
-        $dateTimeFormat = $context[self::FORMAT_KEY] ?? null;
+        $dateTimeFormat = $context[self::FORMAT_KEY] ?? $this->defaultDenormalizationFormat;
         $timezone = $this->getTimezone($context);
 
         if ('' === $data || null === $data) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -242,6 +242,16 @@ class DateTimeNormalizerTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testDenormalizeUsingFormatPassedInConstructor()
+    {
+        $format = 'd/m/Y';
+        $string = '01/10/2018';
+        $date = \DateTime::createFromFormat($format, $string);
+        $normalizer = new DateTimeNormalizer([DateTimeNormalizer::FORMAT_KEY => $format]);
+        $denormalizedDate = $normalizer->denormalize($date->format($format), \DateTimeInterface::class);
+        $this->assertEquals($date->diff($denormalizedDate)->days, 0);
+    }
+
     public function denormalizeUsingTimezonePassedInContextProvider()
     {
         yield 'with timezone' => [


### PR DESCRIPTION
 Allows the DateTimeNormalizer to use the FORMAT_KEY used in construct or in the denormalize method

| Q             | A
| ------------- | ---
| Branch?       |  4.3 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #29030
| License       | MIT

The default format, passed to the constructor, wasn't considered when denormalizing a DateTime. 

I needed to store it in a different property, as the format from defaultContext, \DateTime::RFC3339, was causing a BC Break and making it a hassle to denormalize simpler formats, and was failing a bunch of other tests.
