### PR TITLE
[String] renamed core classes to Byte/CodePoint/UnicodeString

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -543,9 +543,9 @@ abstract class AbstractString implements \JsonSerializable
      */
     abstract public function title(bool $allWords = false): self;
 
-    public function toBinary(string $toEncoding = null): BinaryString
+    public function toByteString(string $toEncoding = null): ByteString
     {
-        $b = new BinaryString();
+        $b = new ByteString();
 
         $toEncoding = \in_array($toEncoding, ['utf8', 'utf-8', 'UTF8'], true) ? 'UTF-8' : $toEncoding;
 
@@ -574,14 +574,14 @@ abstract class AbstractString implements \JsonSerializable
         return $b;
     }
 
-    public function toGrapheme(): GraphemeString
+    public function toCodePointString(): CodePointString
     {
-        return new GraphemeString($this->string);
+        return new CodePointString($this->string);
     }
 
-    public function toUtf8(): Utf8String
+    public function toUnicodeString(): UnicodeString
     {
-        return new Utf8String($this->string);
+        return new UnicodeString($this->string);
     }
 
     /**

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -25,7 +25,7 @@ use Symfony\Component\String\Exception\RuntimeException;
  *
  * @experimental in 5.0
  */
-class BinaryString extends AbstractString
+class ByteString extends AbstractString
 {
     public function __construct(string $string = '')
     {
@@ -371,14 +371,14 @@ class BinaryString extends AbstractString
         return $str;
     }
 
-    public function toGrapheme(string $fromEncoding = null): GraphemeString
+    public function toUnicodeString(string $fromEncoding = null): UnicodeString
     {
-        return new GraphemeString($this->toUtf8($fromEncoding)->string);
+        return new UnicodeString($this->toCodePointString($fromEncoding)->string);
     }
 
-    public function toUtf8(string $fromEncoding = null): Utf8String
+    public function toCodePointString(string $fromEncoding = null): CodePointString
     {
-        $u = new Utf8String();
+        $u = new CodePointString();
 
         if (\in_array($fromEncoding, [null, 'utf8', 'utf-8', 'UTF8', 'UTF-8'], true) && preg_match('//u', $this->string)) {
             $u->string = $this->string;

--- a/src/Symfony/Component/String/CodePointString.php
+++ b/src/Symfony/Component/String/CodePointString.php
@@ -24,7 +24,7 @@ use Symfony\Component\String\Exception\InvalidArgumentException;
  *
  * @experimental in 5.0
  */
-class Utf8String extends AbstractUnicodeString
+class CodePointString extends AbstractUnicodeString
 {
     public function __construct(string $string = '')
     {

--- a/src/Symfony/Component/String/Resources/functions.php
+++ b/src/Symfony/Component/String/Resources/functions.php
@@ -14,15 +14,15 @@ namespace Symfony\Component\String;
 /**
  * @experimental in 5.0
  */
-function u(string $string = ''): GraphemeString
+function u(string $string = ''): UnicodeString
 {
-    return new GraphemeString($string);
+    return new UnicodeString($string);
 }
 
 /**
  * @experimental in 5.0
  */
-function b(string $string = ''): BinaryString
+function b(string $string = ''): ByteString
 {
-    return new BinaryString($string);
+    return new ByteString($string);
 }

--- a/src/Symfony/Component/String/Slugger/AsciiSlugger.php
+++ b/src/Symfony/Component/String/Slugger/AsciiSlugger.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\String\Slugger;
 
 use Symfony\Component\String\AbstractUnicodeString;
-use Symfony\Component\String\GraphemeString;
+use Symfony\Component\String\UnicodeString;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 
 /**
@@ -91,13 +91,13 @@ class AsciiSlugger implements SluggerInterface, LocaleAwareInterface
 
         $transliterator = [];
         if ('de' === $locale || 0 === strpos($locale, 'de_')) {
-            // Use the shortcut for German in GraphemeString::ascii() if possible (faster and no requirement on intl)
+            // Use the shortcut for German in UnicodeString::ascii() if possible (faster and no requirement on intl)
             $transliterator = ['de-ASCII'];
         } elseif (\function_exists('transliterator_transliterate') && $locale) {
             $transliterator = (array) $this->createTransliterator($locale);
         }
 
-        return (new GraphemeString($string))
+        return (new UnicodeString($string))
             ->ascii($transliterator)
             ->replace('@', $separator.'at'.$separator)
             ->replaceMatches('/[^A-Za-z0-9]++/', $separator)

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -4,10 +4,10 @@ namespace Symfony\Component\String\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\String\AbstractString;
-use Symfony\Component\String\BinaryString;
+use Symfony\Component\String\ByteString;
+use Symfony\Component\String\CodePointString;
 use Symfony\Component\String\Exception\InvalidArgumentException;
-use Symfony\Component\String\GraphemeString;
-use Symfony\Component\String\Utf8String;
+use Symfony\Component\String\UnicodeString;
 
 abstract class AbstractAsciiTestCase extends TestCase
 {
@@ -875,9 +875,9 @@ abstract class AbstractAsciiTestCase extends TestCase
             [false, "\nfoo", 'f'],
             [true, 'foo', 'f'],
             [true, 'foo', 'fo'],
-            [true, 'foo', new BinaryString('f')],
-            [true, 'foo', new Utf8String('f')],
-            [true, 'foo', new GraphemeString('f')],
+            [true, 'foo', new ByteString('f')],
+            [true, 'foo', new CodePointString('f')],
+            [true, 'foo', new UnicodeString('f')],
             [true, 'foo', ['e', 'f', 'g']],
         ];
     }
@@ -900,9 +900,9 @@ abstract class AbstractAsciiTestCase extends TestCase
             [false, "\nfoo", 'f'],
             [true, 'foo', 'F'],
             [true, 'FoO', 'foo'],
-            [true, 'foo', new BinaryString('F')],
-            [true, 'foo', new Utf8String('F')],
-            [true, 'foo', new GraphemeString('F')],
+            [true, 'foo', new ByteString('F')],
+            [true, 'foo', new CodePointString('F')],
+            [true, 'foo', new UnicodeString('F')],
             [true, 'foo', ['E', 'F', 'G']],
         ];
     }
@@ -926,9 +926,9 @@ abstract class AbstractAsciiTestCase extends TestCase
             [false, "foo\n", 'o'],
             [true, 'foo', 'o'],
             [true, 'foo', 'foo'],
-            [true, 'foo', new BinaryString('o')],
-            [true, 'foo', new Utf8String('o')],
-            [true, 'foo', new GraphemeString('o')],
+            [true, 'foo', new ByteString('o')],
+            [true, 'foo', new CodePointString('o')],
+            [true, 'foo', new UnicodeString('o')],
             [true, 'foo', ['a', 'o', 'u']],
         ];
     }
@@ -951,9 +951,9 @@ abstract class AbstractAsciiTestCase extends TestCase
             [false, "foo\n", 'o'],
             [true, 'foo', 'O'],
             [true, 'Foo', 'foo'],
-            [true, 'foo', new BinaryString('O')],
-            [true, 'foo', new Utf8String('O')],
-            [true, 'foo', new GraphemeString('O')],
+            [true, 'foo', new ByteString('O')],
+            [true, 'foo', new CodePointString('O')],
+            [true, 'foo', new UnicodeString('O')],
             [true, 'foo', ['A', 'O', 'U']],
         ];
     }
@@ -1098,9 +1098,9 @@ abstract class AbstractAsciiTestCase extends TestCase
             [false, 'foo', 'Foo'],
             [false, "foo\n", 'foo'],
             [true, 'Foo bar', 'Foo bar'],
-            [true, 'Foo bar', new BinaryString('Foo bar')],
-            [true, 'Foo bar', new Utf8String('Foo bar')],
-            [true, 'Foo bar', new GraphemeString('Foo bar')],
+            [true, 'Foo bar', new ByteString('Foo bar')],
+            [true, 'Foo bar', new CodePointString('Foo bar')],
+            [true, 'Foo bar', new UnicodeString('Foo bar')],
             [false, '', []],
             [false, 'foo', ['bar', 'baz']],
             [true, 'foo', ['bar', 'foo', 'baz']],
@@ -1123,9 +1123,9 @@ abstract class AbstractAsciiTestCase extends TestCase
             [false, 'foo', ''],
             [false, "foo\n", 'foo'],
             [true, 'foo Bar', 'FOO bar'],
-            [true, 'foo Bar', new BinaryString('FOO bar')],
-            [true, 'foo Bar', new Utf8String('FOO bar')],
-            [true, 'foo Bar', new GraphemeString('FOO bar')],
+            [true, 'foo Bar', new ByteString('FOO bar')],
+            [true, 'foo Bar', new CodePointString('FOO bar')],
+            [true, 'foo Bar', new UnicodeString('FOO bar')],
             [false, '', []],
             [false, 'Foo', ['bar', 'baz']],
             [true, 'Foo', ['bar', 'foo', 'baz']],

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\String\Tests;
 
 use Symfony\Component\String\Exception\InvalidArgumentException;
 
-abstract class AbstractUtf8TestCase extends AbstractAsciiTestCase
+abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
 {
     public function testCreateFromStringWithInvalidUtf8Input()
     {

--- a/src/Symfony/Component/String/Tests/ByteStringTest.php
+++ b/src/Symfony/Component/String/Tests/ByteStringTest.php
@@ -12,13 +12,13 @@
 namespace Symfony\Component\String\Tests;
 
 use Symfony\Component\String\AbstractString;
-use Symfony\Component\String\BinaryString;
+use Symfony\Component\String\ByteString;
 
-class BinaryStringTest extends AbstractAsciiTestCase
+class ByteStringTest extends AbstractAsciiTestCase
 {
     protected static function createFromString(string $string): AbstractString
     {
-        return new BinaryString($string);
+        return new ByteString($string);
     }
 
     public static function provideLength(): array

--- a/src/Symfony/Component/String/Tests/CodePointStringTest.php
+++ b/src/Symfony/Component/String/Tests/CodePointStringTest.php
@@ -12,13 +12,13 @@
 namespace Symfony\Component\String\Tests;
 
 use Symfony\Component\String\AbstractString;
-use Symfony\Component\String\Utf8String;
+use Symfony\Component\String\CodePointString;
 
-class Utf8StringTest extends AbstractUtf8TestCase
+class CodePointStringTest extends AbstractUnicodeTestCase
 {
     protected static function createFromString(string $string): AbstractString
     {
-        return new Utf8String($string);
+        return new CodePointString($string);
     }
 
     public static function provideLength(): array

--- a/src/Symfony/Component/String/Tests/UnicodeStringTest.php
+++ b/src/Symfony/Component/String/Tests/UnicodeStringTest.php
@@ -12,13 +12,13 @@
 namespace Symfony\Component\String\Tests;
 
 use Symfony\Component\String\AbstractString;
-use Symfony\Component\String\GraphemeString;
+use Symfony\Component\String\UnicodeString;
 
-class GraphemeStringTest extends AbstractUtf8TestCase
+class UnicodeStringTest extends AbstractUnicodeTestCase
 {
     protected static function createFromString(string $string): AbstractString
     {
-        return new GraphemeString($string);
+        return new UnicodeString($string);
     }
 
     public static function provideLength(): array

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -17,7 +17,7 @@ use Symfony\Component\String\Exception\InvalidArgumentException;
 /**
  * Represents a string of Unicode grapheme clusters encoded as UTF-8.
  *
- * A letter followed by combining characters (accents typically) forms what Unicode defines
+ * A letter followed by combining characters (accents typically) form what Unicode defines
  * as a grapheme cluster: a character as humans mean it in written texts. This class knows
  * about the concept and won't split a letter apart from its combining accents. It also
  * ensures all string comparisons happen on their canonically-composed representation,
@@ -32,7 +32,7 @@ use Symfony\Component\String\Exception\InvalidArgumentException;
  *
  * @experimental in 5.0
  */
-class GraphemeString extends AbstractUnicodeString
+class UnicodeString extends AbstractUnicodeString
 {
     public function __construct(string $string = '')
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In #33553 there have been discussions about the naming of the classes - eg. "what's a grapheme", "why `Utf8String`", "lowercase on binary is weird", etc.

What about these names? Would they get your votes *vs* the current ones?
- `BinaryString` -> `ByteString`
- `Utf8String` -> `CodePointString`
- `GraphemeString` -> `UnicodeString`

