### PR TITLE
 Fixing 'TypeError' in LdapUser::getSalt()

### DIFF
--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -67,6 +67,7 @@ class LdapUser implements UserInterface, EquatableInterface
      */
     public function getSalt(): ?string
     {
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The following TypeError is returned as LdapUser::getSalt() returns no value.

Return value of Symfony\Component\Ldap\Security\LdapUser::getSalt() must be of the type string or null, none returned
