### PR TITLE
[DoctrineBridge] Auto-validation must work if no regex are passed

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -173,7 +173,7 @@ class DoctrineLoaderTest extends TestCase
     public function regexpProvider()
     {
         return [
-            [false, null],
+            [true, null],
             [true, '{^'.preg_quote(DoctrineLoaderEntity::class).'$|^'.preg_quote(Entity::class).'$}'],
             [false, '{^'.preg_quote(Entity::class).'$}'],
         ];

--- a/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
@@ -43,7 +43,7 @@ final class DoctrineLoader implements LoaderInterface
     public function loadClassMetadata(ClassMetadata $metadata): bool
     {
         $className = $metadata->getClassName();
-        if (null === $this->classValidatorRegexp || !preg_match($this->classValidatorRegexp, $className)) {
+        if (null !== $this->classValidatorRegexp && !preg_match($this->classValidatorRegexp, $className)) {
             return false;
         }
 

--- a/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
@@ -59,6 +59,10 @@ class AddAutoMappingConfigurationPass implements CompilerPassInterface
         $validatorBuilder = $container->getDefinition($this->validatorBuilderService);
         foreach ($container->findTaggedServiceIds($this->tag) as $id => $tags) {
             $regexp = $this->getRegexp(array_merge($globalNamespaces, $servicesToNamespaces[$id] ?? []));
+            if (null === $regexp) {
+                $container->removeDefinition($id);
+                continue;
+            }
 
             $container->getDefinition($id)->setArgument('$classValidatorRegexp', $regexp);
             $validatorBuilder->addMethodCall('addLoader', [new Reference($id)]);

--- a/src/Symfony/Component/Validator/Tests/DependencyInjection/AddAutoMappingConfigurationPassTest.php
+++ b/src/Symfony/Component/Validator/Tests/DependencyInjection/AddAutoMappingConfigurationPassTest.php
@@ -81,6 +81,6 @@ class AddAutoMappingConfigurationPassTest extends TestCase
 
         (new AddAutoMappingConfigurationPass())->process($container);
 
-        $this->assertNull($container->getDefinition('loader')->getArgument('$classValidatorRegexp'));
+        $this->assertFalse($container->hasDefinition('loader'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Backport of https://github.com/symfony/symfony/pull/32107/files#r295762928.
This behavior if faulty, if no regex are passed, autvalidation must be triggered, [as done in `PropertyInfoLoader`](https://github.com/symfony/symfony/blob/4.3/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php#L50).