### PR TITLE
[Validator] Add "is_valid" function to the Expression constraint

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * Added the `ExpressionLanguage::hasFunction()` method.
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -132,6 +132,11 @@ class ExpressionLanguage
         }
     }
 
+    public function hasFunction(string $name): bool
+    {
+        return isset($this->functions[$name]);
+    }
+
     protected function registerFunctions()
     {
         $this->addFunction(ExpressionFunction::fromPhp('constant'));

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -256,4 +256,15 @@ class ExpressionLanguageTest extends TestCase
             ],
         ];
     }
+
+    public function testHasFunction()
+    {
+        $el = new ExpressionLanguage();
+
+        $this->assertFalse($el->hasFunction('foo'));
+
+        $el->register('foo', function () {}, function () {});
+
+        $this->assertTrue($el->hasFunction('foo'));
+    }
 }

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
  * Overriding the methods `ConstraintValidatorTestCase::setUp()` and `ConstraintValidatorTestCase::tearDown()` without the `void` return-type is deprecated.
  * deprecated `Symfony\Component\Validator\Mapping\Cache\CacheInterface` in favor of PSR-6.
  * deprecated `ValidatorBuilder::setMetadataCache`, use `ValidatorBuilder::setMappingCache` instead.
+ * Added the `is_valid` function to the `Expression` constraint.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
@@ -62,6 +62,8 @@ class FakeMetadataFactory implements MetadataFactoryInterface
     public function addMetadata($metadata)
     {
         $this->metadatas[$metadata->getClassName()] = $metadata;
+
+        return $this;
     }
 
     public function addMetadataForValue($value, MetadataInterface $metadata)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/11940
| License       | MIT
| Doc PR        | TODO

The main benefit of this feature is to be able to support "or" constraints but it generally open the usage of this constraint to many cool cases.

`is_valid` accepts an unlimited number of arguments of 3 kinds:

1. Constraints (resolved in any way)
```php
/**
 * @Expression("is_valid(a) or is_valid(b)", values={"a": @Type('string'), "b": @Type('int')})
 */
```

```php
/**
 * @Expression("is_valid(this.method(), a)", values={"a": @Type('string')})
 */

// ...
public function method() { return new IdenticalToo('foo'); }
```

2. Array of constraints (resolved in any way)
```php
/**
 * @Expression("is_valid(a) or ...", values={"a": {@Type('int'), @GreaterThan(10)}})
 */
```

3. Strings that represents properties when validating an object
```php
/**
 * @Expression("not is_valid("foo") or not is_valid("bar")})
 */

// ...
public $foo;
public $bar;
```