### PR TITLE
[Validator] Fix wrong expression language value

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -37,6 +37,8 @@ class ExpressionValidator extends ConstraintValidator
             }
         } elseif (null !== $expressionLanguage && !$expressionLanguage instanceof ExpressionLanguage) {
             @trigger_error(sprintf('The "%s" first argument must be an instance of "%s" or null since 4.4. "%s" given', __METHOD__, ExpressionLanguage::class, \is_object($expressionLanguage) ? \get_class($expressionLanguage) : \gettype($expressionLanguage)), E_USER_DEPRECATED);
+
+            $expressionLanguage = null;
         }
 
         $this->expressionLanguage = $expressionLanguage;

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -302,11 +303,13 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The "Symfony\Component\Validator\Constraints\ExpressionValidator::__construct" first argument must be an instance of "Symfony\Component\ExpressionLanguage\ExpressionLanguage" or null since 4.4. "string" given
+     * @expectedDeprecation The "Symfony\Component\Validator\Constraints\ExpressionValidator::__construct" first argument must be an instance of "Symfony\Component\ExpressionLanguage\ExpressionLanguage" or null since 4.4. "Symfony\Component\PropertyAccess\PropertyAccessor" given
      */
-    public function testConstructorInvalidType()
+    public function testDeprecatedArgumentType()
     {
-        new ExpressionValidator('foo');
+        $validator = new ExpressionValidator(PropertyAccess::createPropertyAccessor());
+        $validator->initialize($this->createContext());
+        $validator->validate(null, new Expression(['expression' => 'false']));
     }
 
     public function testPassingCustomValues()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/blob/766162c4c790cc0b91185963b9c36b842bf2eb49/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php#L28

```php
(new ExpressionValidator($propertyAccessor))->validate($object, $constraint);
```
Based on the previous method signature (4.3 above), that code would result in an exception in 4.4:
```
Call to undefined method Symfony\Component\PropertyAccess\PropertyAccessor::evaluate()
```
Spotted by @fancyweb in https://github.com/symfony/symfony/pull/33829#discussion_r330995572

Fixed here and updated test case to avoid regression.