### PR TITLE
[Validator] Fix ValidValidator group cascading usage

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ValidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ValidValidator.php
@@ -33,6 +33,6 @@ class ValidValidator extends ConstraintValidator
         $this->context
             ->getValidator()
             ->inContext($this->context)
-            ->validate($value, null, [$this->context->getGroup()]);
+            ->validate($value, null, $this->context->getGroup());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`$this->context->getGroup()` returns `string` or `null`.

`ContextualValidatorInterface::validate()` 3rd argument accepts an array but it must not contain `null` (its contract doesn't allow it). If it does, it will fail in `RecursiveContextualValidator::validateInGroup()` for example because of the `string` scalar type on the `$group` argument. (on 4.4)

Note that in our "common" usage of the `Valid` constraint, the group in its validator will never be `null` because this constraint has a special treatment. However, if this validator is reused in a custom way, it can fail.