### PR TITLE
Fixed invalid changelog 4.0.0 for VarDumper

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -25,9 +25,9 @@ CHANGELOG
  * support for passing `\ReflectionClass` instances to the `Caster::castObject()`
    method has been dropped, pass class names as strings instead
  * the `Data::getRawData()` method has been removed
- * the `VarDumperTestTrait::assertDumpEquals()` method expects a 3rd `$context = null`
+ * the `VarDumperTestTrait::assertDumpEquals()` method expects a 3rd `$filter = 0`
    argument and moves `$message = ''` argument at 4th position.
- * the `VarDumperTestTrait::assertDumpMatchesFormat()` method expects a 3rd `$context = null`
+ * the `VarDumperTestTrait::assertDumpMatchesFormat()` method expects a 3rd `$filter = 0`
    argument and moves `$message = ''` argument at 4th position.
 
 3.4.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

I changed CHANGELOG.md to reflect actual changes in the code. The third argument is called $filter, not $context. This mistake was propageted to UPGRADE-4.0.md. I fixed that in https://github.com/symfony/symfony/pull/33821