### PR TITLE
[OptionsResolver] Add new OptionConfigurator class to define options with fluent interface

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * added fluent configuration of options using `OptionResolver::define()`
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
+++ b/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\OptionsResolver;
+
+use Symfony\Component\OptionsResolver\Exception\AccessException;
+
+final class OptionConfigurator
+{
+    private $name;
+    private $resolver;
+
+    public function __construct(string $name, OptionsResolver $resolver)
+    {
+        $this->name = $name;
+        $this->resolver = $resolver;
+        $this->resolver->setDefined($name);
+    }
+
+    /**
+     * Adds allowed types for this option.
+     *
+     * @param string ...$types One or more accepted types
+     *
+     * @return $this
+     *
+     * @throws AccessException If called from a lazy option or normalizer
+     */
+    public function allowedTypes(string ...$types): self
+    {
+        $this->resolver->setAllowedTypes($this->name, $types);
+
+        return $this;
+    }
+
+    /**
+     * Sets allowed values for this option.
+     *
+     * @param mixed ...$values One or more acceptable values/closures
+     *
+     * @return $this
+     *
+     * @throws AccessException If called from a lazy option or normalizer
+     */
+    public function allowedValues(...$values): self
+    {
+        $this->resolver->setAllowedValues($this->name, $values);
+
+        return $this;
+    }
+
+    /**
+     * Sets the default value for this option.
+     *
+     * @param mixed $value The default value of the option
+     *
+     * @return $this
+     *
+     * @throws AccessException If called from a lazy option or normalizer
+     */
+    public function default($value): self
+    {
+        $this->resolver->setDefault($this->name, $value);
+
+        return $this;
+    }
+
+    /**
+     * Defines an option configurator with the given name.
+     */
+    public function define(string $option): self
+    {
+        return $this->resolver->define($option);
+    }
+
+    /**
+     * Marks this option as deprecated.
+     *
+     * @return $this
+     *
+     * @param string|\Closure $deprecationMessage
+     */
+    public function deprecated($deprecationMessage = 'The option "%name%" is deprecated.'): self
+    {
+        $this->resolver->setDeprecated($this->name, $deprecationMessage);
+
+        return $this;
+    }
+
+    /**
+     * Sets the normalizer for this option.
+     *
+     * @param \Closure $normalizer The normalizer
+     *
+     * @return $this
+     *
+     * @throws AccessException If called from a lazy option or normalizer
+     */
+    public function normalize(\Closure $normalizer): self
+    {
+        $this->resolver->setNormalizer($this->name, $normalizer);
+
+        return $this;
+    }
+
+    /**
+     * Marks this option as required.
+     *
+     * @return $this
+     *
+     * @throws AccessException If called from a lazy option or normalizer
+     */
+    public function required(): self
+    {
+        $this->resolver->setRequired($this->name);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -704,6 +704,18 @@ class OptionsResolver implements Options
     }
 
     /**
+     * Defines an option configurator with the given name.
+     */
+    public function define(string $option): OptionConfigurator
+    {
+        if (isset($this->defined[$option])) {
+            throw new OptionDefinitionException(sprintf('The options "%s" is already defined.', $option));
+        }
+
+        return new OptionConfigurator($option, $this);
+    }
+
+    /**
      * Removes the option with the given name.
      *
      * Undefined options are ignored.
@@ -830,7 +842,7 @@ class OptionsResolver implements Options
      * Returns the resolved value of an option.
      *
      * @param string $option             The option name
-     * @param bool   $triggerDeprecation Whether to trigger the deprecation or not
+     * @param bool   $triggerDeprecation Whether to trigger the deprecation or not (true by default)
      *
      * @return mixed The option value
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #33735
| License       | MIT
| Doc PR        |  https://github.com/symfony/symfony-docs/pull/12426

- [x] submit changes to the documentation

This PR adds OptionConfigurator to the OptionsResolver
