### PR TITLE
[Serializer] fix denormalization of basic property-types in XML and CSV

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -273,6 +273,79 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertInstanceOf(AbstractDummySecondChild::class, $denormalizedData);
     }
 
+    public function testDenormalizeBasicTypePropertiesFromXml()
+    {
+        $denormalizer = $this->getDenormalizerForObjectWithBasicProperties();
+
+        // bool
+        $objectWithBooleanProperties = $denormalizer->denormalize(
+            [
+                'boolTrue1' => 'true',
+                'boolFalse1' => 'false',
+                'boolTrue2' => '1',
+                'boolFalse2' => '0',
+                'int1' => '4711',
+                'int2' => '-4711',
+                'float1' => '123.456',
+                'float2' => '-1.2344e56',
+                'float3' => '45E-6',
+                'floatNaN' => 'NaN',
+                'floatInf' => 'INF',
+                'floatNegInf' => '-INF',
+            ],
+            ObjectWithBasicProperties::class,
+            'xml'
+        );
+
+        $this->assertInstanceOf(ObjectWithBasicProperties::class, $objectWithBooleanProperties);
+
+        // Bool Properties
+        $this->assertTrue($objectWithBooleanProperties->boolTrue1);
+        $this->assertFalse($objectWithBooleanProperties->boolFalse1);
+        $this->assertTrue($objectWithBooleanProperties->boolTrue2);
+        $this->assertFalse($objectWithBooleanProperties->boolFalse2);
+
+        // Integer Properties
+        $this->assertEquals(4711, $objectWithBooleanProperties->int1);
+        $this->assertEquals(-4711, $objectWithBooleanProperties->int2);
+
+        // Float Properties
+        $this->assertEqualsWithDelta(123.456, $objectWithBooleanProperties->float1, 0.01);
+        $this->assertEqualsWithDelta(-1.2344e56, $objectWithBooleanProperties->float2, 1);
+        $this->assertEqualsWithDelta(45E-6, $objectWithBooleanProperties->float3, 1);
+        $this->assertNan($objectWithBooleanProperties->floatNaN);
+        $this->assertInfinite($objectWithBooleanProperties->floatInf);
+        $this->assertEquals(-INF, $objectWithBooleanProperties->floatNegInf);
+    }
+
+    private function getDenormalizerForObjectWithBasicProperties()
+    {
+        $extractor = $this->getMockBuilder(PhpDocExtractor::class)->getMock();
+        $extractor->method('getTypes')
+            ->will($this->onConsecutiveCalls(
+                [new Type('bool')],
+                [new Type('bool')],
+                [new Type('bool')],
+                [new Type('bool')],
+                [new Type('int')],
+                [new Type('int')],
+                [new Type('float')],
+                [new Type('float')],
+                [new Type('float')],
+                [new Type('float')],
+                [new Type('float')],
+                [new Type('float')]
+            ));
+
+        $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
+        $arrayDenormalizer = new ArrayDenormalizerDummy();
+        $serializer = new SerializerCollectionDummy([$arrayDenormalizer, $denormalizer]);
+        $arrayDenormalizer->setSerializer($serializer);
+        $denormalizer->setSerializer($serializer);
+
+        return $denormalizer;
+    }
+
     /**
      * Test that additional attributes throw an exception if no metadata factory is specified.
      */
@@ -357,6 +430,45 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
     {
         $object->$attribute = $value;
     }
+}
+
+class ObjectWithBasicProperties
+{
+    /** @var bool */
+    public $boolTrue1;
+
+    /** @var bool */
+    public $boolFalse1;
+
+    /** @var bool */
+    public $boolTrue2;
+
+    /** @var bool */
+    public $boolFalse2;
+
+    /** @var int */
+    public $int1;
+
+    /** @var int */
+    public $int2;
+
+    /** @var float */
+    public $float1;
+
+    /** @var float */
+    public $float2;
+
+    /** @var float */
+    public $float3;
+
+    /** @var float */
+    public $floatNaN;
+
+    /** @var float */
+    public $floatInf;
+
+    /** @var float */
+    public $floatNegInf;
 }
 
 class StringCollection


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33849
| License       | MIT
| Doc PR        | 

Like I explained in the Issue, the serializer cannot de-serialize non-string basic properties (int, float, bool). This PR add's some logic to cast to the expected types.

Similar logic is already present in the [XmlUtils](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Config/Util/XmlUtils.php#L215)-Class of the Config-Component