### PR TITLE
[HttpClient] fix "no_proxy" option ignored in NativeHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -203,7 +203,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
         ];
 
         $proxy = self::getProxy($options['proxy'], $url);
-        $noProxy = $_SERVER['no_proxy'] ?? $_SERVER['NO_PROXY'] ?? '';
+        $noProxy = $options['no_proxy'] ?? $_SERVER['no_proxy'] ?? $_SERVER['NO_PROXY'] ?? '';
         $noProxy = $noProxy ? preg_split('/[\s,]+/', $noProxy) : [];
 
         $resolveRedirect = self::createRedirectResolver($options, $host, $proxy, $noProxy, $info, $onProgress);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33832 
| License       | MIT
| Doc PR        | 

Allow overriding of no_proxy environment variable by passing no_proxy option in NativeHttpClient::request() method. 