### PR TITLE
[CssSelector] Support *:only-of-type

### DIFF
--- a/src/Symfony/Component/CssSelector/CHANGELOG.md
+++ b/src/Symfony/Component/CssSelector/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.0
+-----
+
+ * Added support for `*:only-of-type`
+
 2.8.0
 -----
 

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -308,6 +308,8 @@ HTML
             ['li div:only-child', ['li-div']],
             ['div *:only-child', ['li-div', 'foobar-span']],
             ['p:only-of-type', ['paragraph']],
+            [':only-of-type', ['html', 'li-div', 'foobar-span', 'paragraph']],
+            ['div#foobar-div :only-of-type', ['foobar-span']],
             ['a:empty', ['name-anchor']],
             ['a:EMpty', ['name-anchor']],
             ['li:empty', ['third-li', 'fourth-li', 'fifth-li', 'sixth-li']],

--- a/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
@@ -100,16 +100,9 @@ class PseudoClassExtension extends AbstractExtension
             ->addCondition('last() = 1');
     }
 
-    /**
-     * @throws ExpressionErrorException
-     */
     public function translateOnlyOfType(XPathExpr $xpath): XPathExpr
     {
         $element = $xpath->getElement();
-
-        if ('*' === $element) {
-            throw new ExpressionErrorException('"*:only-of-type" is not implemented.');
-        }
 
         return $xpath->addCondition(sprintf('count(preceding-sibling::%s)=0 and count(following-sibling::%s)=0', $element, $element));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Before, this pseudo class selector only worked when the element was specified, i.e. `p:only-of-type` would select all paragraphs which are the only child of its parent.

Now, `*:only-of-type` is also supported to select any single child.