### PR TITLE
[HttpClient] bugfix exploding values of headers

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -77,17 +77,20 @@ class CachingHttpClient implements HttpClientInterface
         $request = Request::create($url, $method);
         $request->attributes->set('http_client_options', $options);
 
-        foreach ($options['headers'] as $name => $values) {
+        foreach ($options['normalized_headers'] as $name => $values) {
             if ('cookie' !== $name) {
-                $request->headers->set($name, $values);
+                foreach ($values as $value) {
+                    $request->headers->set($name, substr($value, 2 + \strlen($name)), false);
+                }
+
                 continue;
             }
 
             foreach ($values as $cookies) {
-                foreach (explode('; ', $cookies) as $cookie) {
+                foreach (explode('; ', substr($cookies, \strlen('Cookie: '))) as $cookie) {
                     if ('' !== $cookie) {
                         $cookie = explode('=', $cookie, 2);
-                        $request->cookies->set($cookie[0], $cookie[1] ?? null);
+                        $request->cookies->set($cookie[0], $cookie[1] ?? '');
                     }
                 }
             }

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -196,10 +196,21 @@ trait HttpClientTrait
         $normalizedHeaders = [];
 
         foreach ($headers as $name => $values) {
+            if (\is_object($values) && method_exists('__toString')) {
+                $values = (string) $values;
+            }
+
             if (\is_int($name)) {
+                if (!\is_string($values)) {
+                    throw new InvalidArgumentException(sprintf('Invalid value for header "%s": expected string, %s given.', $name, \gettype($values)));
+                }
                 [$name, $values] = explode(':', $values, 2);
                 $values = [ltrim($values)];
             } elseif (!is_iterable($values)) {
+                if (\is_object($values)) {
+                    throw new InvalidArgumentException(sprintf('Invalid value for header "%s": expected string, %s given.', $name, \get_class($values)));
+                }
+
                 $values = (array) $values;
             }
 

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CachingHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpKernel\HttpCache\Store;
+
+class CachingHttpClientTest extends TestCase
+{
+    public function testRequestHeaders()
+    {
+        $options = [
+            'headers' => [
+                'Application-Name' => 'test1234',
+                'Test-Name-Header' => 'test12345',
+            ],
+        ];
+
+        $mockClient = new MockHttpClient();
+        $store = new Store(sys_get_temp_dir().'/sf_http_cache');
+        $client = new CachingHttpClient($mockClient, $store, $options);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+
+        rmdir(sys_get_temp_dir().'/sf_http_cache');
+        self::assertInstanceOf(MockResponse::class, $response);
+        self::assertSame($response->getRequestOptions()['normalized_headers']['application-name'][0], 'Application-Name: test1234');
+        self::assertSame($response->getRequestOptions()['normalized_headers']['test-name-header'][0], 'Test-Name-Header: test12345');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I tried to use CachingHttpClient yesterday and I received an error.

```
explode() expects parameter 2 to be string, array given
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpClient\HttpClientTrait.php:200
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpClient\HttpClientTrait.php:131
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpClient\HttpClientTrait.php:45
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpClient\CurlHttpClient.php:105
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpKernel\HttpClientKernel.php:54
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpKernel\HttpCache\SubRequestHandler.php:85
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpKernel\HttpCache\HttpCache.php:477
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpKernel\HttpCache\HttpCache.php:450
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpKernel\HttpCache\HttpCache.php:347
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpKernel\HttpCache\HttpCache.php:222
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpClient\CachingHttpClient.php:96
 C:\PROJEKTY\PHPStorm\symfony\src\Symfony\Component\HttpClient\Tests\CachingHttpClientTest.php:34

```
This PR fix this.
