### PR TITLE
[PropertyAccessor] Add getValues method (like array_column)

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -19,6 +19,7 @@ use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Inflector\Inflector;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
+use Symfony\Component\PropertyAccess\Exception\ExceptionInterface;
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
@@ -179,6 +180,29 @@ class PropertyAccessor implements PropertyAccessorInterface
             // It wasn't thrown in this class so rethrow it
             throw $e;
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValues(array $array, $propertyPath): array
+    {
+        $values = [];
+        foreach ($array as $item) {
+            try {
+                $value = $this->getValue($item, $propertyPath);
+
+                if (null === $value) {
+                    continue;
+                }
+
+                $values[] = $value;
+            } catch (ExceptionInterface $e) {
+                // if was thrown continue
+            }
+        }
+
+        return $values;
     }
 
     private static function throwInvalidArgumentException(string $message, array $trace, int $i, string $propertyPath): void

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -111,4 +111,11 @@ interface PropertyAccessorInterface
      * @throws Exception\InvalidArgumentException If the property path is invalid
      */
     public function isReadable($objectOrArray, $propertyPath);
+
+    /**
+     * Returns the list of values from an array of data and/or objects.
+     *
+     * @param string|PropertyPathInterface $propertyPath
+     */
+    public function getValues(array $array, $propertyPath): array;
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
@@ -82,4 +82,28 @@ abstract class PropertyAccessorArrayAccessTest extends TestCase
     {
         $this->assertTrue($this->propertyAccessor->isWritable($collection, $path));
     }
+
+    public function getValidPropertyPathsForGetValues()
+    {
+        return [
+            [
+                [$this->getContainer(['firstName' => 'Bernhard']), $this->getContainer(['firstName' => 'Fabien'])],
+                '[firstName]',
+                ['Bernhard', 'Fabien'],
+            ],
+            [
+                [['person' => $this->getContainer(['firstName' => 'Bernhard'])], ['person' => $this->getContainer(['firstName' => 'Fabien'])]],
+                '[person][firstName]',
+                ['Bernhard', 'Fabien'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidPropertyPathsForGetValues
+     */
+    public function testGetValues($collection, $path, $value)
+    {
+        $this->assertSame($value, $this->propertyAccessor->getValues($collection, $path));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | #30647  <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

**getValues** method will return an array of valid values from an array of data/objects.
If an element of array return null will not be added to result or an element of array throw an exception the method will catch the exception and continue the loop.

**I think this method will be very useful to get a specific data from arrays with different data like this example:**

```
$persons = [
    'first_name' => 'Wouter',
    'company' => 'Company Name',
    'first_name' => 'Fabien',
];

var_dump($propertyAccessor->getValues($persons, '[first_name]'));

```
will get:
```
Array
(
    [0] => 'Wouter'
    [1] => 'Fabien'
)
```
