### PR TITLE
Remove useless testCanCheckIfTerminalIsInteractive test case

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1587,23 +1587,6 @@ class ApplicationTest extends TestCase
         $this->assertStringContainsString('The foo:bar command', $tester->getDisplay());
     }
 
-    /**
-     * @requires function posix_isatty
-     */
-    public function testCanCheckIfTerminalIsInteractive()
-    {
-        $application = new CustomDefaultCommandApplication();
-        $application->setAutoExit(false);
-
-        $tester = new ApplicationTester($application);
-        $tester->run(['command' => 'help']);
-
-        $this->assertFalse($tester->getInput()->hasParameterOption(['--no-interaction', '-n']));
-
-        $inputStream = $tester->getInput()->getStream();
-        $this->assertEquals($tester->getInput()->isInteractive(), @posix_isatty($inputStream));
-    }
-
     public function testRunLazyCommandService()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This test case does not work for following reasons:
1. `$inputStream` is `NULL`. `posix_isatty` happily swallows null and returns `true`. Test would have to use [CommandTester::setInputs](https://github.com/symfony/symfony/blob/ac4e9b0b265add48604c58a17d3c7593c0587614/src/Symfony/Component/Console/Tester/CommandTester.php#L66) or call `$tester->getInput()->setStream()` to fix this
1. Even if 1. is fixed, there are no internal `posix_isatty` calls going on. [ApplicationTester calls setInteractive only when such option is passed](https://github.com/symfony/symfony/blob/b0a32085887d0025aa84b39d2b12a57dc71e59ae/src/Symfony/Component/Console/Tester/ApplicationTester.php#L66), otherwise it will never be marked as interactive