### PR TITLE
[VarDumper] Added a support for casting Ramsey/Uuid

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
    to configure casters & flags to use in tests
  * added `ImagineCaster` and infrastructure to dump images
  * added the stamps of a message after it is dispatched in `TraceableMessageBus` and `MessengerDataCollector` collected data
+ * added `UuidCaster`
 
 4.3.0
 -----

--- a/src/Symfony/Component/VarDumper/Caster/ImagineCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ImagineCaster.php
@@ -19,7 +19,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class ImagineCaster
 {
-    public static function castImage(ImageInterface $c, array $a, Stub $stub, $isNested)
+    public static function castImage(ImageInterface $c, array $a, Stub $stub, bool $isNested): array
     {
         $imgData = $c->get('png');
         if (\strlen($imgData) > 1 * 1000 * 1000) {

--- a/src/Symfony/Component/VarDumper/Caster/UuidCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/UuidCaster.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class UuidCaster
+{
+    public static function castRamseyUuid(UuidInterface $c, array $a, Stub $stub, bool $isNested): array
+    {
+        $a += [
+            Caster::PREFIX_VIRTUAL.'uuid' => (string) $c,
+        ];
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -89,6 +89,8 @@ abstract class AbstractCloner implements ClonerInterface
 
         'Imagine\Image\ImageInterface' => ['Symfony\Component\VarDumper\Caster\ImagineCaster', 'castImage'],
 
+        'Ramsey\Uuid\UuidInterface' => ['Symfony\Component\VarDumper\Caster\UuidCaster', 'castRamseyUuid'],
+
         'ProxyManager\Proxy\ProxyInterface' => ['Symfony\Component\VarDumper\Caster\ProxyManagerCaster', 'castProxy'],
         'PHPUnit_Framework_MockObject_MockObject' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'cutInternals'],
         'PHPUnit\Framework\MockObject\MockObject' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'cutInternals'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

I worked on a project using ramsey/uuid and I noticed a dumped uuid does
not contain the uuid. So here we go :)

(Note: don't get me wrong, I still do not recommend this lib)

---

Before / After:
![Before / After](https://user-images.githubusercontent.com/408368/66298080-49892d80-e8f1-11e9-969f-95ae5169adb1.png)
