### PR TITLE
Prevent ProgressBar redraw when message is same

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -46,7 +46,7 @@ final class ProgressBar
     private $messages = [];
     private $overwrite = true;
     private $terminal;
-    private $firstRun = true;
+    private $previousMessage;
 
     private static $formatters;
     private static $formats;
@@ -432,8 +432,14 @@ final class ProgressBar
      */
     private function overwrite(string $message): void
     {
+        if ($this->previousMessage === $message) {
+            return;
+        }
+
+        $originalMessage = $message;
+
         if ($this->overwrite) {
-            if (!$this->firstRun) {
+            if (null !== $this->previousMessage) {
                 if ($this->output instanceof ConsoleSectionOutput) {
                     $lines = floor(Helper::strlen($message) / $this->terminal->getWidth()) + $this->formatLineCount + 1;
                     $this->output->clear($lines);
@@ -451,7 +457,7 @@ final class ProgressBar
             $message = PHP_EOL.$message;
         }
 
-        $this->firstRun = false;
+        $this->previousMessage = $originalMessage;
         $this->lastWriteTime = microtime(true);
 
         $this->output->write($message);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -187,7 +187,6 @@ class ProgressBarTest extends TestCase
     {
         $expected =
             '  0/10 [>---------------------------]   0%'.
-            $this->generateOutput(' 10/10 [============================] 100%').
             $this->generateOutput(' 10/10 [============================] 100%')
         ;
 
@@ -296,7 +295,6 @@ class ProgressBarTest extends TestCase
         rewind($output->getStream());
         $this->assertEquals(
             '  0/50 [>---------------------------]   0%'.
-            $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput('  1/50 [>---------------------------]   2%').
             $this->generateOutput('  2/50 [=>--------------------------]   4%'),
             stream_get_contents($output->getStream())
@@ -318,7 +316,6 @@ class ProgressBarTest extends TestCase
         rewind($output->getStream());
         $this->assertEquals(
             '  0/50 [>---------------------------]   0%'.
-            $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput('  1/50 [>---------------------------]   2%').
             $this->generateOutput('  2/50 [=>--------------------------]'),
             stream_get_contents($output->getStream())
@@ -340,7 +337,6 @@ class ProgressBarTest extends TestCase
         rewind($output->getStream());
         $this->assertEquals(
             '  0/50 [>---------------------------]   0%'.PHP_EOL.
-            "\x1b[1A\x1b[0J".'  0/50 [>---------------------------]   0%'.PHP_EOL.
             "\x1b[1A\x1b[0J".'  1/50 [>---------------------------]   2%'.PHP_EOL.
             "\x1b[1A\x1b[0J".'  2/50 [=>--------------------------]   4%'.PHP_EOL,
             stream_get_contents($output->getStream())
@@ -434,7 +430,6 @@ class ProgressBarTest extends TestCase
         rewind($output->getStream());
         $this->assertEquals(
             '  0/50 [>---------------------------]   0%'.
-            $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput('  1/50 [>---------------------------]   2%').
             $this->generateOutput(' 15/50 [========>-------------------]  30%').
             $this->generateOutput(' 25/50 [==============>-------------]  50%'),
@@ -541,7 +536,6 @@ class ProgressBarTest extends TestCase
         rewind($output->getStream());
         $this->assertEquals(
             '   0/200 [>---------------------------]   0%'.
-            $this->generateOutput('   0/200 [>---------------------------]   0%').
             $this->generateOutput(' 199/200 [===========================>]  99%').
             $this->generateOutput(' 200/200 [============================] 100%'),
             stream_get_contents($output->getStream())
@@ -888,7 +882,6 @@ class ProgressBarTest extends TestCase
         $this->assertEquals(
             ' 0/2 [>---------------------------]   0%'.
             $this->generateOutput(' 1/2 [==============>-------------]  50%').
-            $this->generateOutput(' 2/2 [============================] 100%').
             $this->generateOutput(' 2/2 [============================] 100%'),
             stream_get_contents($output->getStream())
         );
@@ -993,6 +986,20 @@ class ProgressBarTest extends TestCase
             '    0 [>---------------------------]'.
             $this->generateOutput('    2 [-->-------------------------]').
             $this->generateOutput('    4 [---->-----------------------]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testNoWriteWhenMessageIsSame(): void
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 2);
+        $bar->start();
+        $bar->advance();
+        $bar->display();
+        rewind($output->getStream());
+        $this->assertEquals(
+            ' 0/2 [>---------------------------]   0%'.
+            $this->generateOutput(' 1/2 [==============>-------------]  50%'),
             stream_get_contents($output->getStream())
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR prevents ProgressBar from performing unnecessary redrawes if new output is same as current one. This is mostly useful when working with multiple progress bars. Same behavior can enforced by carefully setting redraw frequency, but I don't see any downsides for smarter redrawing by default.

This can be moved to `if ($this->overwrite)` if necessary, so it's applied only in case overwriting is enabled. 