### PR TITLE
[Form][DateTimeImmutableToDateTimeTransformer] Preserve microseconds and use \DateTime::createFromImmutable() when available

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
@@ -40,7 +40,11 @@ final class DateTimeImmutableToDateTimeTransformer implements DataTransformerInt
             throw new TransformationFailedException('Expected a \DateTimeImmutable.');
         }
 
-        return \DateTime::createFromFormat(\DateTime::RFC3339, $value->format(\DateTime::RFC3339));
+        if (\PHP_VERSION_ID >= 70300) {
+            return \DateTime::createFromImmutable($value);
+        }
+
+        return \DateTime::createFromFormat('U.u', $value->format('U.u'))->setTimezone($value->getTimezone());
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformerTest.php
@@ -16,16 +16,33 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeImmutableToDat
 
 class DateTimeImmutableToDateTimeTransformerTest extends TestCase
 {
-    public function testTransform()
+    /**
+     * @dataProvider provider
+     */
+    public function testTransform(\DateTime $expectedOutput, \DateTimeImmutable $input)
     {
         $transformer = new DateTimeImmutableToDateTimeTransformer();
 
-        $input = new \DateTimeImmutable('2010-02-03 04:05:06 UTC');
-        $expectedOutput = new \DateTime('2010-02-03 04:05:06 UTC');
         $actualOutput = $transformer->transform($input);
 
-        $this->assertInstanceOf(\DateTime::class, $actualOutput);
         $this->assertEquals($expectedOutput, $actualOutput);
+        $this->assertEquals($expectedOutput->getTimezone(), $actualOutput->getTimezone());
+    }
+
+    public function provider()
+    {
+        return [
+            [
+                new \DateTime('2010-02-03 04:05:06 UTC'),
+                new \DateTimeImmutable('2010-02-03 04:05:06 UTC'),
+            ],
+            [
+                (new \DateTime('2019-10-07 +11:00'))
+                    ->setTime(14, 27, 11, 10042),
+                (new \DateTimeImmutable('2019-10-07 +11:00'))
+                    ->setTime(14, 27, 11, 10042),
+            ],
+        ];
     }
 
     public function testTransformEmpty()
@@ -43,16 +60,17 @@ class DateTimeImmutableToDateTimeTransformerTest extends TestCase
         $transformer->transform(new \DateTime());
     }
 
-    public function testReverseTransform()
+    /**
+     * @dataProvider provider
+     */
+    public function testReverseTransform(\DateTime $input, \DateTimeImmutable $expectedOutput)
     {
         $transformer = new DateTimeImmutableToDateTimeTransformer();
 
-        $input = new \DateTime('2010-02-03 04:05:06 UTC');
-        $expectedOutput = new \DateTimeImmutable('2010-02-03 04:05:06 UTC');
         $actualOutput = $transformer->reverseTransform($input);
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $actualOutput);
         $this->assertEquals($expectedOutput, $actualOutput);
+        $this->assertEquals($expectedOutput->getTimezone(), $actualOutput->getTimezone());
     }
 
     public function testReverseTransformEmpty()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

For PHP >= 7.3, we should use [\DateTime::createFromImmutable()](https://www.php.net/manual/en/datetime.createfromimmutable.php) directly.

This patch also preserves the `\DateTime` microseconds when the conversion is done with `\DateTime::createFromFormat()`.