### PR TITLE
[mailer] Easier multiple transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Added new `error_controller` configuration to handle system exceptions
  * Added sort option for `translation:update` command.
  * [BC Break] The `framework.messenger.routing.senders` config key is not deep merged anymore.
+ * Added services for each mailer transports.
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
@@ -16,6 +16,7 @@
         <service id="mailer.transports" class="Symfony\Component\Mailer\Transport\Transports">
             <factory service="mailer.transport_factory" method="fromStrings" />
             <argument type="collection" /> <!-- transports -->
+            <argument /> <!-- transport -->
         </service>
 
         <service id="mailer.transport_factory" class="Symfony\Component\Mailer\Transport">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -560,6 +560,9 @@
     <xsd:complexType name="mailer">
         <xsd:sequence>
             <xsd:element name="envelope" type="mailer_envelope" minOccurs="0" maxOccurs="1" />
+            <xsd:choice maxOccurs="unbounded">
+                <xsd:element name="transports" type="mailer_transports" minOccurs="0" maxOccurs="unbounded" />
+            </xsd:choice>
         </xsd:sequence>
         <xsd:attribute name="dsn" type="xsd:string" />
     </xsd:complexType>
@@ -569,5 +572,9 @@
             <xsd:element name="sender" type="xsd:string" />
             <xsd:element name="recipients" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="mailer_transports" mixed="true">
+        <xsd:attribute name="name" type="xsd:string" />
     </xsd:complexType>
 </xsd:schema>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_multiple_transport.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_multiple_transport.php
@@ -1,0 +1,11 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'mailer' => [
+        'transports' => [
+            'baz' => 'smtp://baz',
+            'foo' => 'smtp://foo',
+            'bar' => 'smtp://bar',
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_multiple_transport.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_multiple_transport.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:mailer>
+            <framework:transports name="baz">smtp://baz</framework:transports>
+            <framework:transports name="foo">smtp://foo</framework:transports>
+            <framework:transports name="bar">smtp://bar</framework:transports>
+        </framework:mailer>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_multiple_transport.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_multiple_transport.yml
@@ -1,0 +1,6 @@
+framework:
+    mailer:
+        transports:
+            baz: 'smtp://baz'
+            foo: 'smtp://foo'
+            bar: 'smtp://bar'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1580,6 +1580,24 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(['redirected@example.org', 'redirected1@example.org'], $l->getArgument(1));
     }
 
+    public function testMailerMultipleTransport(): void
+    {
+        $container = $this->createContainerFromFile('mailer_multiple_transport');
+
+        $this->assertTrue($container->hasDefinition('mailer.default_transport'));
+        $this->assertSame('smtp://baz', $container->getDefinition('mailer.default_transport')->getArgument(0));
+
+        $this->assertTrue($container->hasDefinition('mailer.transports'));
+        $this->assertSame('smtp://baz', $container->getDefinition('mailer.transports')->getArgument(1));
+
+        $this->assertTrue($container->hasDefinition('mailer.transports.baz'));
+        $this->assertSame('smtp://baz', $container->getDefinition('mailer.transports.baz')->getArgument(1));
+        $this->assertTrue($container->hasDefinition('mailer.transports.foo'));
+        $this->assertSame('smtp://foo', $container->getDefinition('mailer.transports.foo')->getArgument(1));
+        $this->assertTrue($container->hasDefinition('mailer.transports.bar'));
+        $this->assertSame('smtp://bar', $container->getDefinition('mailer.transports.bar')->getArgument(1));
+    }
+
     protected function createContainer(array $data = [])
     {
         return new ContainerBuilder(new ParameterBag(array_merge([

--- a/src/Symfony/Component/Mailer/Tests/Transport/TransportsTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/TransportsTest.php
@@ -35,6 +35,23 @@ class TransportsTest extends TestCase
         $transport->send($email);
     }
 
+    public function testSpecificTransport()
+    {
+        $transport = new Transports(
+            [
+                'foo' => $foo = $this->createMock(TransportInterface::class),
+                'bar' => $bar = $this->createMock(TransportInterface::class),
+            ],
+            $bar
+        );
+
+        $foo->expects($this->never())->method('send');
+        $bar->expects($this->once())->method('send');
+
+        $email = new Message(new Headers(), new TextPart('...'));
+        $transport->send($email);
+    }
+
     public function testOverrideTransport()
     {
         $transport = new Transports([

--- a/src/Symfony/Component/Mailer/Transport/Transports.php
+++ b/src/Symfony/Component/Mailer/Transport/Transports.php
@@ -29,13 +29,16 @@ final class Transports implements TransportInterface
     /**
      * @param TransportInterface[] $transports
      */
-    public function __construct(iterable $transports)
+    public function __construct(iterable $transports, TransportInterface $default = null)
     {
+        if (null === $default) {
+            $this->default = current($transports);
+        } else {
+            $this->default = $default;
+        }
+
         $this->transports = [];
         foreach ($transports as $name => $transport) {
-            if (null === $this->default) {
-                $this->default = $transport;
-            }
             $this->transports[$name] = $transport;
         }
 


### PR DESCRIPTION
See #33874

Add services based on the name of each mailer transport, to be injected more easier.
Add the XSD definition for mailer transport for the framework key.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #33874
| License       | MIT
| Doc PR        |