### PR TITLE
Add support for serializing stdClass objects 

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * deprecated the `XmlEncoder::TYPE_CASE_ATTRIBUTES` constant, use `XmlEncoder::TYPE_CAST_ATTRIBUTES` instead
  * added option to output a UTF-8 BOM in CSV encoder via `CsvEncoder::OUTPUT_UTF8_BOM_KEY` context option
  * added `ProblemNormalizer` to normalize errors according to the API Problem spec (RFC 7807)
+ * added support for serializing `stdClass` objects
 
 4.3.0
 -----

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -131,7 +131,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     public function supportsNormalization($data, $format = null)
     {
-        return \is_object($data) && !$data instanceof \Traversable;
+        return \is_object($data) && !$data instanceof \Traversable && !$data instanceof \stdClass;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -139,7 +139,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     public function normalize($object, $format = null, array $context = [])
     {
-        if (\stdClass::class === get_class($object)) {
+        if (\stdClass::class === \get_class($object)) {
             return $this->normalizeStdClassObject($object, $format, $context);
         }
 
@@ -636,11 +636,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     }
 
     /**
-     * @param \stdClass   $object
      * @param string|null $format
-     * @param array       $context
      *
-     * @return mixed
+     * @return array
      *
      * @throws LogicException
      */
@@ -649,7 +647,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $normalized = [];
         foreach ($object as $key => $val) {
             if (!$this->serializer instanceof NormalizerInterface) {
-                throw new LogicException(sprintf('Cannot normalize value for key "%s" because the injected serializer is not a normalizer', $key));
+                throw new LogicException(sprintf('Cannot normalize value for attribute "%s" because the injected serializer is not a normalizer', $key));
             }
 
             $normalized[$key] = $this->serializer->normalize($val, $format, $context);

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -156,7 +156,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             return $data;
         }
 
-        if (\is_array($data) || $data instanceof \Traversable) {
+        if (\is_array($data) || $data instanceof \Traversable || $data instanceof \stdClass) {
             $normalized = [];
             foreach ($data as $key => $val) {
                 $normalized[$key] = $this->normalize($val, $format, $context);

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -156,7 +156,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             return $data;
         }
 
-        if (\is_array($data) || $data instanceof \Traversable || $data instanceof \stdClass) {
+        if (\is_array($data) || $data instanceof \Traversable) {
             $normalized = [];
             foreach ($data as $key => $val) {
                 $normalized[$key] = $this->normalize($val, $format, $context);

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EmptyDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EmptyDummy.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class EmptyDummy
+{
+
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild;
 use Symfony\Component\Serializer\Tests\Fixtures\DummySecondChildQuux;
+use Symfony\Component\Serializer\Tests\Fixtures\EmptyDummy;
 
 class AbstractObjectNormalizerTest extends TestCase
 {
@@ -252,6 +253,18 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizedData = $normalizer->normalize(new EmptyDummy(), 'any', ['preserve_empty_objects' => true]);
         $this->assertEquals(new \ArrayObject(), $normalizedData);
     }
+
+    public function testNormalizeStdClassObjectLogicException()
+    {
+        $this->expectException('Symfony\Component\Serializer\Exception\LogicException');
+        $this->expectExceptionMessage('Cannot normalize value for attribute "foo" because the injected serializer is not a normalizer');
+
+        $std = new \stdClass();
+        $std->foo = 'bar';
+        $normalizer = new ObjectNormalizer();
+
+        $normalizer->normalize($std);
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
@@ -289,10 +302,6 @@ class Dummy
     public $foo;
     public $bar;
     public $baz;
-}
-
-class EmptyDummy
-{
 }
 
 class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -83,7 +83,7 @@ class SerializerTest extends TestCase
     {
         $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([$this->getMockBuilder('Symfony\Component\Serializer\Normalizer\CustomNormalizer')->getMock()]);
-        $serializer->normalize(new EmptyDummy(), 'xml');
+        $serializer->normalize(new \stdClass(), 'xml');
     }
 
     public function testNormalizeTraversable()
@@ -104,7 +104,7 @@ class SerializerTest extends TestCase
     {
         $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([new TestDenormalizer()], []);
-        $this->assertTrue($serializer->normalize(new EmptyDummy(), 'json'));
+        $this->assertTrue($serializer->normalize(new \stdClass(), 'json'));
     }
 
     public function testDenormalizeNoMatch()

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -42,6 +42,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo;
+use Symfony\Component\Serializer\Tests\Fixtures\EmptyDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\TraversableDummy;
 use Symfony\Component\Serializer\Tests\Normalizer\TestDenormalizer;
@@ -82,7 +83,7 @@ class SerializerTest extends TestCase
     {
         $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([$this->getMockBuilder('Symfony\Component\Serializer\Normalizer\CustomNormalizer')->getMock()]);
-        $serializer->normalize(new \stdClass(), 'xml');
+        $serializer->normalize(new EmptyDummy(), 'xml');
     }
 
     public function testNormalizeTraversable()
@@ -103,7 +104,7 @@ class SerializerTest extends TestCase
     {
         $this->expectException('Symfony\Component\Serializer\Exception\UnexpectedValueException');
         $serializer = new Serializer([new TestDenormalizer()], []);
-        $this->assertTrue($serializer->normalize(new \stdClass(), 'json'));
+        $this->assertTrue($serializer->normalize(new EmptyDummy(), 'json'));
     }
 
     public function testDenormalizeNoMatch()
@@ -189,6 +190,26 @@ class SerializerTest extends TestCase
         $this->assertEquals('"foo"', $result);
     }
 
+    public function testSerializeStdClass()
+    {
+        $std = new \stdClass();
+        $std->foo = ['bar', 'baz'];
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+        $result = $serializer->serialize($std, 'json');
+        $this->assertEquals('{"foo":["bar","baz"]}', $result);
+    }
+
+    public function testSerializeArrayStdClass()
+    {
+        $stdFoo = new \stdClass();
+        $stdFoo->foo = 'bar';
+        $stdBar = new \stdClass();
+        $stdBar->bar = 'baz';
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+        $result = $serializer->serialize([$stdFoo, $stdBar], 'json');
+        $this->assertEquals('[{"foo":"bar"},{"bar":"baz"}]', $result);
+    }
+
     public function testSerializeArrayOfScalars()
     {
         $serializer = new Serializer([], ['json' => new JsonEncoder()]);
@@ -200,7 +221,7 @@ class SerializerTest extends TestCase
     public function testSerializeEmpty()
     {
         $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
-        $data = ['foo' => new \stdClass()];
+        $data = ['foo' => new EmptyDummy()];
 
         //Old buggy behaviour
         $result = $serializer->serialize($data, 'json');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #33047
| License       | MIT
| Doc PR        | todo

Updated PR for issue #33047 :) Adding support for serializing stdClass objects, because it was missing. Thanks!
