### PR TITLE
[HttpKernel] Fix to populate $dotenvVars in data collector when not using putenv()

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -80,9 +80,9 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         $dotenvVars = [];
-        foreach (explode(',', getenv('SYMFONY_DOTENV_VARS')) as $name) {
-            if ('' !== $name && false !== $value = getenv($name)) {
-                $dotenvVars[$name] = $value;
+        foreach (explode(',', $_SERVER['SYMFONY_DOTENV_VARS'] ?? $_ENV['SYMFONY_DOTENV_VARS'] ?? '') as $name) {
+            if ('' !== $name && isset($_ENV[$name])) {
+                $dotenvVars[$name] = $_ENV[$name];
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Fix to populate $dotenvVars in data collector when not using putenv()

Before:
<img width="618" alt="Screen Shot 2019-10-08 at 03 53 49" src="https://user-images.githubusercontent.com/707714/66360303-49397280-e983-11e9-98b9-5272b9762dda.png">
After:
<img width="614" alt="Screen Shot 2019-10-08 at 03 55 43" src="https://user-images.githubusercontent.com/707714/66360304-4b9bcc80-e983-11e9-82de-46d484daa585.png">

