### PR TITLE
[Validator] Validate timezone before passing to IntlDateFormatter

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -87,8 +87,14 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     {
         if (($format & self::PRETTY_DATE) && $value instanceof \DateTimeInterface) {
             if (class_exists('IntlDateFormatter')) {
+                $timezone = $value->getTimezone();
+                // Timezone 'Z' is a valid ISO8601 indicator for UTC
+                $timezone = 'Z' === strtoupper($timezone->getName()) ? new \DateTimeZone('UTC') : $timezone;
+                // Only use timezone if it's valid, otherwise fall back to system default
+                $timezone = \in_array($timezone->getName(), \DateTimeZone::listIdentifiers(), true) ? $timezone : null;
+
                 $locale = \Locale::getDefault();
-                $formatter = new \IntlDateFormatter($locale, \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT, $value->getTimezone());
+                $formatter = new \IntlDateFormatter($locale, \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT, $timezone);
 
                 // neither the native nor the stub IntlDateFormatter support
                 // DateTimeImmutable as of yet

--- a/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
@@ -25,6 +25,22 @@ final class ConstraintValidatorTest extends TestCase
         $this->assertSame($expected, (new TestFormatValueConstraintValidator())->formatValueProxy($value, $format));
     }
 
+    public function testInvalidTimezoneFallback()
+    {
+        if (!class_exists(\IntlDateFormatter::class)) {
+            $this->markTestSkipped('Test is only valid if IntlDateFormatter is present.');
+        }
+
+        $dateTime = new \DateTimeImmutable('1970-01-01T00:00:00X');
+
+        $locale = \Locale::getDefault();
+        $formatter = new \IntlDateFormatter($locale, \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT);
+        $expected = $formatter->format($dateTime);
+
+        $this->assertSame('X', $dateTime->getTimezone()->getName());
+        $this->assertSame($expected, (new TestFormatValueConstraintValidator())->formatValueProxy($dateTime, ConstraintValidator::PRETTY_DATE));
+    }
+
     public function formatValueProvider()
     {
         $data = [
@@ -38,6 +54,7 @@ final class ConstraintValidatorTest extends TestCase
             ['ccc', $toString, ConstraintValidator::OBJECT_TO_STRING],
             ['object', $dateTime = (new \DateTimeImmutable('@0'))->setTimezone(new \DateTimeZone('UTC'))],
             [class_exists(\IntlDateFormatter::class) ? 'Jan 1, 1970, 12:00 AM' : '1970-01-01 00:00:00', $dateTime, ConstraintValidator::PRETTY_DATE],
+            [class_exists(\IntlDateFormatter::class) ? 'Jan 1, 1970, 12:00 AM' : '1970-01-01 00:00:00', (new \DateTimeImmutable('@0'))->setTimezone(new \DateTimeZone('Z')), ConstraintValidator::PRETTY_DATE],
         ];
 
         return $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33901 
| License       | MIT
| Doc PR        | N/A

This change validates timezones before passing them to the IntlDateFormatter to prevent fatal errors where an invalid timezone is used. This wasn't previously passed in 4.3.4 and was added in 4.3.5 which causes a break when using valid ISO8601 zulu timestamps. If an invalid timezone is provided it will fall back to system default, which was used for all versions < 4.3.4.
