### PR TITLE
Fix bc compatiblity between ErrorRenderer FlattenException and Debug FlattenException

### DIFF
--- a/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
@@ -43,7 +43,7 @@ class FlattenException
     public static function create(\Exception $exception, $statusCode = null, array $headers = [])
     {
         @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.4, use "createFromThrowable()" instead.', __METHOD__), E_USER_DEPRECATED);
-        
+
         return static::createFromThrowable($exception, $statusCode, $headers);
     }
 

--- a/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
@@ -37,6 +37,14 @@ class FlattenException
     private $file;
     private $line;
 
+    /**
+     * @deprecated since Symfony 4.4, use createFromThrowable instead.
+     */
+    public static function create(\Exception $exception, $statusCode = null, array $headers = [])
+    {
+        return static::createFromThrowable($exception, $statusCode, $headers);
+    }
+
     public static function createFromThrowable(\Throwable $exception, int $statusCode = null, array $headers = []): self
     {
         $e = new static();

--- a/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
@@ -38,10 +38,12 @@ class FlattenException
     private $line;
 
     /**
-     * @deprecated since Symfony 4.4, use createFromThrowable instead.
+     * @deprecated since Symfony 4.4, use createFromThrowable() instead.
      */
     public static function create(\Exception $exception, $statusCode = null, array $headers = [])
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 4.4, use "createFromThrowable()" instead.', __METHOD__), E_USER_DEPRECATED);
+        
         return static::createFromThrowable($exception, $statusCode, $headers);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I'm currently trying to test 4.4-dev and did get over this issue when using FosRestBundle.
I also created a fix [there](https://github.com/FriendsOfSymfony/FOSRestBundle/pull/2023) but think this should not break in 4.4.
The old FlattenException did implement a `create` function.