### PR TITLE
[Messenger] Store message body as a blob object, not text

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -127,7 +127,7 @@ class Connection
             $now,
             $availableAt,
         ], [
-            null,
+            Type::BLOB,
             null,
             null,
             Type::DATETIME,

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -318,7 +318,7 @@ class Connection
         $table->addColumn('id', Type::BIGINT)
             ->setAutoincrement(true)
             ->setNotnull(true);
-        $table->addColumn('body', Type::TEXT)
+        $table->addColumn('body', Type::BLOB)
             ->setNotnull(true);
         $table->addColumn('headers', Type::TEXT)
             ->setNotnull(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33913 
| License       | MIT

This fixes #33913 for me. After changing the column type, I could send emails with attachments via messenger with no problems.