### PR TITLE
[HttpClient] send `Accept: */*` by default, fix removing it when needed

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -220,7 +220,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
 
         // Prevent curl from sending its default Accept and Expect headers
         foreach (['accept', 'expect'] as $header) {
-            if (!isset($options['normalized_headers'][$header])) {
+            if (!isset($options['normalized_headers'][$header][0])) {
                 $curlopts[CURLOPT_HTTPHEADER][] = $header.':';
             }
         }
@@ -413,7 +413,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
                 return 0 !== stripos($h, 'Host:');
             });
 
-            if (isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie'])) {
+            if (isset($options['normalized_headers']['authorization'][0]) || isset($options['normalized_headers']['cookie'][0])) {
                 $redirectHeaders['no_auth'] = array_filter($options['headers'], static function ($h) {
                     return 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:');
                 });

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -57,7 +57,7 @@ trait HttpClientTrait
         }
 
         if (!isset($options['normalized_headers']['accept'])) {
-            $options['normalized_headers']['accept'] = [$options['headers'][] = 'Accept: *'];
+            $options['normalized_headers']['accept'] = [$options['headers'][] = 'Accept: */*'];
         }
 
         if (isset($options['body'])) {

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -19,4 +19,32 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
     {
         $this->markTestSkipped('Implemented as of version 4.4');
     }
+
+    public function testAcceptHeader()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $response = $client->request('GET', 'http://localhost:8057');
+        $requestHeaders = $response->toArray();
+
+        $this->assertSame('*/*', $requestHeaders['HTTP_ACCEPT']);
+
+        $response = $client->request('GET', 'http://localhost:8057', [
+            'headers' => [
+                'Accept' => 'foo/bar',
+            ],
+        ]);
+        $requestHeaders = $response->toArray();
+
+        $this->assertSame('foo/bar', $requestHeaders['HTTP_ACCEPT']);
+
+        $response = $client->request('GET', 'http://localhost:8057', [
+            'headers' => [
+                'Accept' => null,
+            ],
+        ]);
+        $requestHeaders = $response->toArray();
+
+        $this->assertArrayNotHasKey('HTTP_ACCEPT', $requestHeaders);
+    }
 }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -172,7 +172,7 @@ class HttpClientTraitTest extends TestCase
     public function testAuthBearerOption()
     {
         [, $options] = self::prepareRequest('POST', 'http://example.com', ['auth_bearer' => 'foobar'], HttpClientInterface::OPTIONS_DEFAULTS);
-        $this->assertSame(['Accept: *', 'Authorization: Bearer foobar'], $options['headers']);
+        $this->assertSame(['Accept: */*', 'Authorization: Bearer foobar'], $options['headers']);
         $this->assertSame(['Authorization: Bearer foobar'], $options['normalized_headers']['authorization']);
     }
 

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -36,6 +36,7 @@ class MockHttpClientTest extends HttpClientTestCase
             "SERVER_NAME": "127.0.0.1",
             "REQUEST_URI": "/",
             "REQUEST_METHOD": "GET",
+            "HTTP_ACCEPT": "*/*",
             "HTTP_FOO": "baR",
             "HTTP_HOST": "localhost:8057"
         }';
@@ -111,6 +112,12 @@ class MockHttpClientTest extends HttpClientTestCase
                     ->willThrowException(new TransportException('Timeout'));
 
                 $responses[] = $mock;
+                break;
+
+            case 'testAcceptHeader':
+                $responses[] = new MockResponse($body, ['response_headers' => $headers]);
+                $responses[] = new MockResponse(str_replace('*/*', 'foo/bar', $body), ['response_headers' => $headers]);
+                $responses[] = new MockResponse(str_replace('"HTTP_ACCEPT": "*/*",', '', $body), ['response_headers' => $headers]);
                 break;
 
             case 'testResolve':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Reported on Slack.