### PR TITLE
[Cache] ignore unserialization failures in AbstractTagAwareAdapter::doDelete()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -229,10 +229,14 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
             unset($this->deferred[$key]);
         }
 
-        foreach ($this->doFetch($ids) as $id => $value) {
-            foreach ($value['tags'] ?? [] as $tag) {
-                $tagData[$this->getId(self::TAGS_PREFIX.$tag)][] = $id;
+        try {
+            foreach ($this->doFetch($ids) as $id => $value) {
+                foreach ($value['tags'] ?? [] as $tag) {
+                    $tagData[$this->getId(self::TAGS_PREFIX.$tag)][] = $id;
+                }
             }
+        } catch (\Exception $e) {
+            // ignore unserialization failures
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Making things more robust, part of #33924