### PR TITLE
Keeping backward compatibility with legacy FlattenException usage

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -155,6 +155,33 @@ HttpKernel
    current directory or with a glob pattern. The fallback directories have never been advocated
    so you likely do not use those in any app based on the SF Standard or Flex edition.
  * Getting the container from a non-booted kernel is deprecated
+ * Deprecated passing the `exception` attribute (instance of `Symfony\Component\Debug\Exception\FlattenException`) 
+   to the configured controller of the `ExceptionListener`, use the `e` attribute 
+   (instance of `Symfony\Component\ErrorRenderer\Exception\FlattenException`) instead
+   
+   before:
+   ```php
+   use Symfony\Component\Debug\Exception\FlattenException;   
+
+   class ExceptionController
+   {
+       public function __invoke(FlattenException $exception)
+       {
+       }
+   }
+   ```  
+ 
+   after:
+   ```php
+   use Symfony\Component\ErrorRenderer\Exception\FlattenException;   
+
+   class ExceptionController
+   {
+       public function __invoke(FlattenException $e)
+       {
+       }
+   }
+   ```
 
 Lock
 ----

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -341,6 +341,33 @@ HttpKernel
  * Removed the second and third argument of `FileLocator::__construct`
  * Removed loading resources from `%kernel.root_dir%/Resources` and `%kernel.root_dir%` as
    fallback directories.
+ * Removed passing the `exception` attribute (instance of `Symfony\Component\Debug\Exception\FlattenException`) 
+   to the configured controller of the `ExceptionListener`, use the `e` attribute 
+   (instance of `Symfony\Component\ErrorRenderer\Exception\FlattenException`) instead
+   
+   before:
+   ```php
+   use Symfony\Component\Debug\Exception\FlattenException;   
+
+   class ExceptionController
+   {
+       public function __invoke(FlattenException $exception)
+       {
+       }
+   }
+   ```  
+ 
+   after:
+   ```php
+   use Symfony\Component\ErrorRenderer\Exception\FlattenException;   
+
+   class ExceptionController
+   {
+       public function __invoke(FlattenException $e)
+       {
+       }
+   }
+   ```
 
 Intl
 ----

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\Controller;
 
-use Symfony\Component\ErrorRenderer\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;

--- a/src/Symfony/Bundle/TwigBundle/Controller/PreviewErrorController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/PreviewErrorController.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\Controller;
 
-use Symfony\Component\ErrorRenderer\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\TwigBundle\Tests\Controller;
 
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
-use Symfony\Component\ErrorRenderer\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/PreviewErrorControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/PreviewErrorControllerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\TwigBundle\Tests\Controller;
 
 use Symfony\Bundle\TwigBundle\Controller\PreviewErrorController;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
-use Symfony\Component\ErrorRenderer\Exception\FlattenException;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;

--- a/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
  * Basically, this class removes all objects from the trace.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
  */
 class FlattenException
 {
@@ -36,6 +38,11 @@ class FlattenException
     private $headers;
     private $file;
     private $line;
+
+    public static function create(\Exception $exception, int $statusCode = null, array $headers = []): self
+    {
+        return static::createFromThrowable($exception, $statusCode, $headers);
+    }
 
     public static function createFromThrowable(\Throwable $exception, int $statusCode = null, array $headers = []): self
     {
@@ -372,20 +379,5 @@ class FlattenException
         }
 
         return rtrim($message);
-    }
-}
-
-namespace Symfony\Component\Debug\Exception;
-
-if (!class_exists(FlattenException::class, false)) {
-    class_alias(\Symfony\Component\ErrorRenderer\Exception\FlattenException::class, FlattenException::class);
-}
-
-if (false) {
-    /**
-     * @deprecated since Symfony 4.4, use Symfony\Component\ErrorRenderer\Exception\FlattenException instead.
-     */
-    class FlattenException extends \Symfony\Component\ErrorRenderer\Exception\FlattenException
-    {
     }
 }

--- a/src/Symfony/Component/ErrorRenderer/Resources/stubs/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorRenderer/Resources/stubs/Exception/FlattenException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Exception;
+
+if (!class_exists(FlattenException::class, false)) {
+    class_alias(\Symfony\Component\ErrorRenderer\Exception\FlattenException::class, FlattenException::class);
+}
+
+if (false) {
+    /**
+     * @deprecated since Symfony 4.4, use Symfony\Component\ErrorRenderer\Exception\FlattenException instead.
+     */
+    class FlattenException extends \Symfony\Component\ErrorRenderer\Exception\FlattenException
+    {
+    }
+}

--- a/src/Symfony/Component/ErrorRenderer/composer.json
+++ b/src/Symfony/Component/ErrorRenderer/composer.json
@@ -33,6 +33,7 @@
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\ErrorRenderer\\": "" },
+        "classmap": [ "Resources/stubs/Exception/FlattenException.php" ],
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -15,6 +15,8 @@ CHANGELOG
  * Marked all dispatched event classes as `@final`
  * Added `ErrorController` to enable the preview and error rendering mechanism
  * Getting the container from a non-booted kernel is deprecated.
+ * Deprecated passing the `exception` attribute (instance of `Symfony\Component\Debug\Exception\FlattenException`) 
+   to the configured controller of the `ExceptionListener` 
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
@@ -37,12 +37,12 @@ class ErrorController
         $this->errorRenderer = $errorRenderer;
     }
 
-    public function __invoke(Request $request, FlattenException $exception): Response
+    public function __invoke(Request $request, FlattenException $e): Response
     {
         try {
-            return new Response($this->errorRenderer->render($exception, $request->getPreferredFormat()), $exception->getStatusCode(), $exception->getHeaders());
-        } catch (ErrorRendererNotFoundException $e) {
-            return new Response($this->errorRenderer->render($exception), $exception->getStatusCode(), $exception->getHeaders());
+            return new Response($this->errorRenderer->render($e, $request->getPreferredFormat()), $e->getStatusCode(), $e->getHeaders());
+        } catch (ErrorRendererNotFoundException $_) {
+            return new Response($this->errorRenderer->render($e), $e->getStatusCode(), $e->getHeaders());
         }
     }
 
@@ -57,7 +57,7 @@ class ErrorController
          */
         $subRequest = $request->duplicate(null, null, [
             '_controller' => $this->controller,
-            'exception' => $exception,
+            'e' => $exception,
             'logger' => null,
             'showException' => false,
         ]);

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
 use Symfony\Component\ErrorRenderer\Exception\FlattenException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -123,9 +124,21 @@ class ExceptionListener implements EventSubscriberInterface
      */
     protected function duplicateRequest(\Exception $exception, Request $request)
     {
+        @trigger_error(sprintf('Passing the "exception" attribute (instance of "%s") to the configured controller of the "%s" class is deprecated since Symfony 4.4, use the passed "e" attribute (instance of "%s") instead.', LegacyFlattenException::class, self::class, FlattenException::class));
+
+        $flattenException = FlattenException::createFromThrowable($exception);
+
+        // BC layer to be removed in 5.0
+        if (class_exists(\Symfony\Component\Debug\Debug::class, false)) {
+            $legacyFlattenException = LegacyFlattenException::createFromThrowable($exception);
+        } else {
+            $legacyFlattenException = $flattenException;
+        }
+
         $attributes = [
             '_controller' => $this->controller,
-            'exception' => FlattenException::createFromThrowable($exception),
+            'exception' => $legacyFlattenException, // to be removed in 5.0
+            'e' => $flattenException,
             'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
         ];
         $request = $request->duplicate(null, null, $attributes);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ErrorControllerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ErrorControllerTest.php
@@ -103,7 +103,7 @@ class ErrorControllerTest extends TestCase
             ->method('handle')
             ->with(
                 $this->callback(function (Request $request) use ($_controller, $code) {
-                    $exception = $request->attributes->get('exception');
+                    $exception = $request->attributes->get('e');
 
                     $this->assertSame($_controller, $request->attributes->get('_controller'));
                     $this->assertInstanceOf(FlattenException::class, $exception);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #33929
| License       | MIT
| Doc PR        | -
