### PR TITLE
[HttpClient] resolve promise chains on HttplugClient::wait()

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
+++ b/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Http\Client\Exception\NetworkException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\HttpClient\Response\ResponseTrait;
+use Symfony\Component\HttpClient\Response\StreamWrapper;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+final class HttplugWaitLoop
+{
+    private $client;
+    private $promisePool;
+    private $responseFactory;
+    private $streamFactory;
+
+    public function __construct(HttpClientInterface $client, ?\SplObjectStorage $promisePool, ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory)
+    {
+        $this->client = $client;
+        $this->promisePool = $promisePool;
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory = $streamFactory;
+    }
+
+    public function wait(?ResponseInterface $pendingResponse, float $maxDuration = null, float $idleTimeout = null): int
+    {
+        if (!$this->promisePool) {
+            return 0;
+        }
+
+        $guzzleQueue = \GuzzleHttp\Promise\queue();
+
+        if (0.0 === $remainingDuration = $maxDuration) {
+            $idleTimeout = 0.0;
+        } elseif (null !== $maxDuration) {
+            $startTime = microtime(true);
+            $idleTimeout = max(0.0, min($maxDuration / 5, $idleTimeout ?? $maxDuration));
+        }
+
+        do {
+            foreach ($this->client->stream($this->promisePool, $idleTimeout) as $response => $chunk) {
+                try {
+                    if (null !== $maxDuration && $chunk->isTimeout()) {
+                        goto check_duration;
+                    }
+
+                    if ($chunk->isFirst()) {
+                        // Deactivate throwing on 3/4/5xx
+                        $response->getStatusCode();
+                    }
+
+                    if (!$chunk->isLast()) {
+                        goto check_duration;
+                    }
+
+                    if ([$request, $promise] = $this->promisePool[$response] ?? null) {
+                        unset($this->promisePool[$response]);
+                        $promise->resolve($this->createPsr7Response($response, true));
+                    }
+                } catch (\Exception $e) {
+                    if ([$request, $promise] = $this->promisePool[$response] ?? null) {
+                        unset($this->promisePool[$response]);
+
+                        if ($e instanceof TransportExceptionInterface) {
+                            $e = new NetworkException($e->getMessage(), $request, $e);
+                        }
+
+                        $promise->reject($e);
+                    }
+                }
+
+                $guzzleQueue->run();
+
+                if ($pendingResponse === $response) {
+                    return $this->promisePool->count();
+                }
+
+                check_duration:
+                if (null !== $maxDuration && $idleTimeout && $idleTimeout > $remainingDuration = max(0.0, $maxDuration - microtime(true) + $startTime)) {
+                    $idleTimeout = $remainingDuration / 5;
+                    break;
+                }
+            }
+
+            if (!$count = $this->promisePool->count()) {
+                return 0;
+            }
+        } while (null === $maxDuration || 0 < $remainingDuration);
+
+        return $count;
+    }
+
+    public function createPsr7Response(ResponseInterface $response, bool $buffer = false): Psr7ResponseInterface
+    {
+        $psrResponse = $this->responseFactory->createResponse($response->getStatusCode());
+
+        foreach ($response->getHeaders(false) as $name => $values) {
+            foreach ($values as $value) {
+                $psrResponse = $psrResponse->withAddedHeader($name, $value);
+            }
+        }
+
+        if (isset(class_uses($response)[ResponseTrait::class])) {
+            $body = $this->streamFactory->createStreamFromResource($response->toStream(false));
+        } elseif (!$buffer) {
+            $body = $this->streamFactory->createStreamFromResource(StreamWrapper::createResource($response, $this->client));
+        } else {
+            $body = $this->streamFactory->createStream($response->getContent(false));
+        }
+
+        if ($body->isSeekable()) {
+            $body->seek(0);
+        }
+
+        return $psrResponse->withBody($body);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Response/HttplugPromise.php
+++ b/src/Symfony/Component/HttpClient/Response/HttplugPromise.php
@@ -23,12 +23,10 @@ use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
 final class HttplugPromise implements HttplugPromiseInterface
 {
     private $promise;
-    private $cancel;
 
-    public function __construct(GuzzlePromiseInterface $promise, callable $cancel = null)
+    public function __construct(GuzzlePromiseInterface $promise)
     {
         $this->promise = $promise;
-        $this->cancel = $cancel;
     }
 
     public function then(callable $onFulfilled = null, callable $onRejected = null): self
@@ -57,17 +55,5 @@ final class HttplugPromise implements HttplugPromiseInterface
     public function wait($unwrap = true)
     {
         return $this->promise->wait($unwrap);
-    }
-
-    public function __destruct()
-    {
-        if ($this->cancel) {
-            ($this->cancel)();
-        }
-    }
-
-    public function __wakeup()
-    {
-        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #32142
| License       | MIT
| Doc PR        | -

Follow up of #33743

Right now, keeping a reference to promise objects returned by `HttplugClient::sendAsyncRequest()`, then calling their `wait()` method is the only way to actually resolve the promises. That's why when these promises are destructed, we cancel the corresponding HTTP request.

But thanks to the `HttplugClient::wait()` method, we have a hook to tick the event loop managed by the Symfony client.

I added a test case to run into this situation.

~It fails currently. I'd like asking @joelwurtz, @dbu and/or maybe @Nyholm if you could have a look and finish this PR? I'm not that familiar with promises and you might get faster and better to the goal. Anyone else is welcome also of course. Thank you for having a look :) PR welcome on my fork or as a separate one on this repos.~