### PR TITLE
[PropertyInfo] Respect property name case when guessing from public method name

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -103,8 +103,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             if (!$propertyName || isset($properties[$propertyName])) {
                 continue;
             }
-            if (!$reflectionClass->hasProperty($propertyName) && !preg_match('/^[A-Z]{2,}/', $propertyName)) {
-                $propertyName = lcfirst($propertyName);
+            if ($reflectionClass->hasProperty($lowerCasedPropertyName = lcfirst($propertyName)) || (!$reflectionClass->hasProperty($propertyName) && !preg_match('/^[A-Z]{2,}/', $propertyName))) {
+                $propertyName = $lowerCasedPropertyName;
             }
             $properties[$propertyName] = $propertyName;
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -59,6 +59,8 @@ class ReflectionExtractorTest extends TestCase
                 '123',
                 'self',
                 'realParent',
+                'xTotals',
+                'YT',
                 'c',
                 'd',
                 'e',

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -94,6 +94,16 @@ class Dummy extends ParentDummy
     public $j;
 
     /**
+     * @var array
+     */
+    private $xTotals;
+
+    /**
+     * @var string
+     */
+    private $YT;
+
+    /**
      * This should not be removed.
      *
      * @var
@@ -164,6 +174,20 @@ class Dummy extends ParentDummy
      * @param parent $realParent
      */
     public function setRealParent(parent $realParent)
+    {
+    }
+
+    /**
+     * @return array
+     */
+    public function getXTotals()
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getYT()
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #32656
| License       | MIT
| Doc PR        | 

Using camelCase, with an attribute `$aFooBar`, naming the getter/setter `getAFooBar()`/`setAFooBar()`,  returns the property name as AFooBar instead of aFooBar.

# Before 
Property name `'AFooBar'`

# After
Property name `'aFooBar'` as expected
