### PR TITLE
[FrameworkBundle] Avoid using of kernel after shutdown in KernelTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -35,6 +35,7 @@ abstract class KernelTestCase extends TestCase
     private function doTearDown()
     {
         static::ensureKernelShutdown();
+        static::$kernel = null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I had sadly something like this in my codebase:

```php
if (!static::$kernel) {
    static::bootKernel();
}
```

As the $kernel is never set again to null a old $kernel was still there. I would not only set the $container also the $kernel variable to null. ~~As this could be a BC Break I'm targeting master~~.