### PR TITLE
[DI] Add extra type check to php dumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1889,7 +1889,7 @@ EOF;
             if (!$value = $edge->getSourceNode()->getValue()) {
                 continue;
             }
-            if ($edge->isLazy() || !$value->isShared()) {
+            if ($edge->isLazy() || !$value instanceof Definition || !$value->isShared()) {
                 return false;
             }
             $ids[$edge->getSourceNode()->getId()] = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33942 
| License       | MIT
| Doc PR        

This PR adds a missing type check in the PHP Dumper. The bug has been detected while working on the https://github.com/prooph/service-bus-symfony-bundle and I haven't been able to reproduce it within a minimalist testcase.

I would like to add a unit test to cover it once I have figured out the exact context in which the bug occurs.

Any help would be greatly appreciated to do so, especially from "senior" contributors of the DependencyInjection component, many thanks in advance!

You will find more information about this bug in the linked ticket above.