### PR TITLE
[Cache] fix 2RTT + race condition in AbstractTagAwareAdapter::deleteItems()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -133,12 +133,18 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
     /**
      * Removes multiple items from the pool and their corresponding tags.
      *
-     * @param array $ids     An array of identifiers that should be removed from the pool
-     * @param array $tagData Optional array of tag identifiers => key identifiers that should be removed from the pool
+     * @param array $ids An array of identifiers that should be removed from the pool
      *
      * @return bool True if the items were successfully removed, false otherwise
      */
-    abstract protected function doDelete(array $ids, array $tagData = []): bool;
+    abstract protected function doDelete(array $ids);
+
+    /**
+     * Removes relations between tags and deleted items.
+     *
+     * @param array $tagData Array of tag => key identifiers that should be removed from the pool
+     */
+    abstract protected function doDeleteTagRelations(array $tagData): bool;
 
     /**
      * Invalidates cached items using tags.
@@ -150,21 +156,21 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
     abstract protected function doInvalidate(array $tagIds): bool;
 
     /**
-     * Returns the tags bound to the provided ids.
+     * Delete items and yields the tags they were bound to.
      */
-    protected function doFetchTags(array $ids): iterable
+    protected function doDeleteYieldTags(array $ids): iterable
     {
         foreach ($this->doFetch($ids) as $id => $value) {
             yield $id => \is_array($value) && \is_array($value['tags'] ?? null) ? $value['tags'] : [];
         }
+
+        $this->doDelete($ids);
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
-    public function commit()
+    public function commit(): bool
     {
         $ok = true;
         $byLifetime = $this->mergeByLifetime;
@@ -223,17 +229,14 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
 
     /**
      * {@inheritdoc}
-     *
-     * Overloaded in order to deal with tags for adjusted doDelete() signature.
-     *
-     * @return bool
      */
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
         if (!$keys) {
             return true;
         }
 
+        $ok = true;
         $ids = [];
         $tagData = [];
 
@@ -243,23 +246,21 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
         }
 
         try {
-            foreach ($this->doFetchTags($ids) as $id => $tags) {
+            foreach ($this->doDeleteYieldTags(array_values($ids)) as $id => $tags) {
                 foreach ($tags as $tag) {
                     $tagData[$this->getId(self::TAGS_PREFIX.$tag)][] = $id;
                 }
             }
         } catch (\Exception $e) {
-            // ignore unserialization failures
+            $ok = false;
         }
 
         try {
-            if ($this->doDelete(array_values($ids), $tagData)) {
+            if ((!$tagData || $this->doDeleteTagRelations($tagData)) && $ok) {
                 return true;
             }
         } catch (\Exception $e) {
         }
-
-        $ok = true;
 
         // When bulk-delete failed, retry each item individually
         foreach ($ids as $key => $id) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

A final improvement to `AbstractTagAwareAdapter::deleteItems()`: this PR makes `deleteItems()` operate in 1RTT instead of 2.