### PR TITLE
[DI] Unknown env prefix not recognized as such

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -126,9 +126,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if (false !== $i || 'string' !== $prefix) {
-            if (null === $env = $getEnv($name)) {
-                return null;
-            }
+            $env = $getEnv($name);
         } elseif (isset($_ENV[$name])) {
             $env = $_ENV[$name];
         } elseif (isset($_SERVER[$name]) && 0 !== strpos($name, 'HTTP_')) {
@@ -173,10 +171,16 @@ class EnvVarProcessor implements EnvVarProcessorInterface
                     throw new EnvNotFoundException(sprintf('Environment variable not found: "%s".', $name));
                 }
 
-                if (null === $env = $this->container->getParameter("env($name)")) {
-                    return null;
-                }
+                $env = $this->container->getParameter("env($name)");
             }
+        }
+
+        if (null === $env) {
+            if (!isset($this->getProvidedTypes()[$prefix])) {
+                throw new RuntimeException(sprintf('Unsupported env var prefix "%s".', $prefix));
+            }
+
+            return null;
         }
 
         if (!is_scalar($env)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\EnvVarLoaderInterface;
 use Symfony\Component\DependencyInjection\EnvVarProcessor;
 use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 class EnvVarProcessorTest extends TestCase
 {
@@ -594,5 +595,18 @@ CSV;
         $this->assertNull($result);
 
         $this->assertSame(2, $index);
+    }
+
+    public function testGetEnvInvalidPrefixWithDefault()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported env var prefix');
+        $processor = new EnvVarProcessor(new Container());
+
+        $processor->getEnv('unknown', 'default::FAKE', function ($name) {
+            $this->assertSame('default::FAKE', $name);
+
+            return null;
+        });
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is a failing test to illustrate the difference between real and fake env vars when using an unknown prefix, followed by the `default` prefix.

```
%env(unknown:default::REAL)%
// Unsupported env var prefix "unknown".

%env(unknown:default::FAKE)%
// null
```

For `default::FAKE` we get `null` at

https://github.com/symfony/symfony/blob/38b9a27976d36c4ffbfeb9e666319d77ffc8b3c0/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php#L103

which is then preserved at

https://github.com/symfony/symfony/blob/38b9a27976d36c4ffbfeb9e666319d77ffc8b3c0/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php#L123

need inspiration for a patch still :)