### PR TITLE
[TwigBridge] Add show-deprecations option to the lint:twig command

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
    `DebugCommand::__construct()` method, swap the variables position.
  * the `LintCommand` lints all the templates stored in all configured Twig paths if none argument is provided
  * deprecated accepting STDIN implicitly when using the `lint:twig` command, use `lint:twig -` (append a dash) instead to make it explicit.
+ * added `--show-deprecations` option to the `lint:twig` command
 
 4.3.0
 -----

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -50,6 +50,7 @@ class LintCommand extends Command
         $this
             ->setDescription('Lints a template and outputs encountered errors')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'txt')
+            ->addOption('show-deprecations', null, InputOption::VALUE_NONE, 'Show deprecations as errors')
             ->addArgument('filename', InputArgument::IS_ARRAY, 'A file, a directory or "-" for reading from STDIN')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command lints a template and outputs to STDOUT
@@ -77,6 +78,7 @@ EOF
     {
         $io = new SymfonyStyle($input, $output);
         $filenames = $input->getArgument('filename');
+        $showDeprecations = $input->getOption('show-deprecations');
 
         if (['-'] === $filenames) {
             return $this->display($input, $output, $io, [$this->validate($this->getStdin(), uniqid('sf_', true))]);
@@ -104,7 +106,28 @@ EOF
             }
         }
 
-        $filesInfo = $this->getFilesInfo($filenames);
+        if ($showDeprecations) {
+            $prevErrorHandler = set_error_handler(static function ($level, $message, $file, $line) use (&$prevErrorHandler) {
+                if (E_USER_DEPRECATED === $level) {
+                    $templateLine = 0;
+                    if (preg_match('/ at line (\d+) /', $message, $matches)) {
+                        $templateLine = $matches[1];
+                    }
+
+                    throw new Error($message, $templateLine);
+                }
+
+                return $prevErrorHandler ? $prevErrorHandler($level, $message, $file, $line) : false;
+            });
+        }
+
+        try {
+            $filesInfo = $this->getFilesInfo($filenames);
+        } finally {
+            if ($showDeprecations) {
+                restore_error_handler();
+            }
+        }
 
         return $this->display($input, $output, $io, $filesInfo);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #33957 (partially)
| License       | MIT
| Doc PR        | TODO

![lint-twig-deprecations](https://user-images.githubusercontent.com/2028198/66682028-fe994e00-ec41-11e9-91f3-43885c9ee48b.png)

