### PR TITLE
[Cache] fixed TagAwareAdapter returning invalid cache

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -156,7 +156,12 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
         if (!$this->pool->hasItem($key)) {
             return false;
         }
-        if (!$itemTags = $this->pool->getItem(static::TAGS_PREFIX.$key)->get()) {
+
+        if (!($itemTags = $this->pool->getItem(static::TAGS_PREFIX.$key))->isHit()) {
+            return false;
+        }
+
+        if (!$itemTags = $itemTags->get()) {
             return true;
         }
 
@@ -296,7 +301,10 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
             }
 
             unset($tagKeys[$key]);
-            $itemTags[$key] = $item->get() ?: [];
+
+            if ($item->isHit()) {
+                $itemTags[$key] = $item->get() ?: [];
+            }
 
             if (!$tagKeys) {
                 $tagVersions = $this->getTagVersions($itemTags);

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -194,6 +194,84 @@ class TagAwareAdapterTest extends AdapterTestCase
         $this->assertTrue($pool->getItem('foo')->isHit());
     }
 
+    public function testTagEntryIsCreatedForItemWithoutTags()
+    {
+        $pool = $this->createCachePool();
+
+        $itemKey = 'foo';
+        $item = $pool->getItem($itemKey);
+        $pool->save($item);
+
+        $adapter = new FilesystemAdapter();
+        $this->assertTrue($adapter->hasItem(TagAwareAdapter::TAGS_PREFIX.$itemKey));
+    }
+
+    public function testHasItemReturnsFalseWhenPoolDoesNotHaveItemTags()
+    {
+        $pool = $this->createCachePool();
+
+        $itemKey = 'foo';
+        $item = $pool->getItem($itemKey);
+        $pool->save($item);
+
+        $anotherPool = $this->createCachePool();
+
+        $adapter = new FilesystemAdapter();
+        $adapter->deleteItem(TagAwareAdapter::TAGS_PREFIX.$itemKey); //simulate item losing tags pair
+
+        $this->assertFalse($anotherPool->hasItem($itemKey));
+    }
+
+    public function testGetItemReturnsCacheMissWhenPoolDoesNotHaveItemTags()
+    {
+        $pool = $this->createCachePool();
+
+        $itemKey = 'foo';
+        $item = $pool->getItem($itemKey);
+        $pool->save($item);
+
+        $anotherPool = $this->createCachePool();
+
+        $adapter = new FilesystemAdapter();
+        $adapter->deleteItem(TagAwareAdapter::TAGS_PREFIX.$itemKey); //simulate item losing tags pair
+
+        $item = $anotherPool->getItem($itemKey);
+        $this->assertFalse($item->isHit());
+    }
+
+    public function testHasItemReturnsFalseWhenPoolDoesNotHaveItemAndOnlyHasTags()
+    {
+        $pool = $this->createCachePool();
+
+        $itemKey = 'foo';
+        $item = $pool->getItem($itemKey);
+        $pool->save($item);
+
+        $anotherPool = $this->createCachePool();
+
+        $adapter = new FilesystemAdapter();
+        $adapter->deleteItem($itemKey); //simulate losing item but keeping tags
+
+        $this->assertFalse($anotherPool->hasItem($itemKey));
+    }
+
+    public function testGetItemReturnsCacheMissWhenPoolDoesNotHaveItemAndOnlyHasTags()
+    {
+        $pool = $this->createCachePool();
+
+        $itemKey = 'foo';
+        $item = $pool->getItem($itemKey);
+        $pool->save($item);
+
+        $anotherPool = $this->createCachePool();
+
+        $adapter = new FilesystemAdapter();
+        $adapter->deleteItem($itemKey); //simulate losing item but keeping tags
+
+        $item = $anotherPool->getItem($itemKey);
+        $this->assertFalse($item->isHit());
+    }
+
     /**
      * @return MockObject|PruneableCacheInterface
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #33953
| License       | MIT
| Doc PR        |  

This PR fixes `TagAwareAdapter` returning `CacheItem` when item-tags pair is missing tag key in pool. Currently `TagAwareAdapter` returns `CacheItem` with empty tags and `isHit` set to `true`. With this PR it returns `CacheItem` with `isHit` set to `false` as we can't know if item is valid or invalid when it's missing tag entry so we treat it as cache miss.