### PR TITLE
[FrameworkBundle] Improve the sorting of tagged services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -286,6 +286,25 @@ abstract class Descriptor implements DescriptorInterface
         return array_keys($maxPriority);
     }
 
+    protected function sortTagsByPriority(array $tags): array
+    {
+        $sortedTags = [];
+        foreach ($tags as $tagName => $tag) {
+            $sortedTags[$tagName] = $this->sortByPriority($tag);
+        }
+
+        return $sortedTags;
+    }
+
+    protected function sortByPriority(array $tag): array
+    {
+        usort($tag, function ($a, $b) {
+            return ($b['priority'] ?? 0) <=> ($a['priority'] ?? 0);
+        });
+
+        return $tag;
+    }
+
     /**
      * Gets class description from a docblock.
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -270,7 +270,7 @@ class JsonDescriptor extends Descriptor
 
         if (!$omitTags) {
             $data['tags'] = [];
-            foreach ($definition->getTags() as $tagName => $tagData) {
+            foreach ($this->sortTagsByPriority($definition->getTags()) as $tagName => $tagData) {
                 foreach ($tagData as $parameters) {
                     $data['tags'][] = ['name' => $tagName, 'parameters' => $parameters];
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -233,7 +233,7 @@ class MarkdownDescriptor extends Descriptor
         }
 
         if (!(isset($options['omit_tags']) && $options['omit_tags'])) {
-            foreach ($definition->getTags() as $tagName => $tagData) {
+            foreach ($this->sortTagsByPriority($definition->getTags()) as $tagName => $tagData) {
                 foreach ($tagData as $parameters) {
                     $output .= "\n".'- Tag: `'.$tagName.'`';
                     foreach ($parameters as $name => $value) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -238,7 +238,7 @@ class TextDescriptor extends Descriptor
             $styledServiceId = $rawOutput ? $serviceId : sprintf('<fg=cyan>%s</fg=cyan>', OutputFormatter::escape($serviceId));
             if ($definition instanceof Definition) {
                 if ($showTag) {
-                    foreach ($definition->getTag($showTag) as $key => $tag) {
+                    foreach ($this->sortByPriority($definition->getTag($showTag)) as $key => $tag) {
                         $tagValues = [];
                         foreach ($tagsNames as $tagName) {
                             $tagValues[] = isset($tag[$tagName]) ? $tag[$tagName] : '';

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -371,7 +371,7 @@ class XmlDescriptor extends Descriptor
         }
 
         if (!$omitTags) {
-            if ($tags = $definition->getTags()) {
+            if ($tags = $this->sortTagsByPriority($definition->getTags())) {
                 $serviceXML->appendChild($tagsXML = $dom->createElement('tags'));
                 foreach ($tags as $tagName => $tagData) {
                     foreach ($tagData as $parameters) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.json
@@ -14,16 +14,16 @@
                 {
                     "name": "tag1",
                     "parameters": {
-                        "attr1": "val1",
-                        "attr2": "val2",
-                        "priority": 0
+                        "attr3": "val3",
+                        "priority": 40
                     }
                 },
                 {
                     "name": "tag1",
                     "parameters": {
-                        "attr3": "val3",
-                        "priority": 40
+                        "attr1": "val1",
+                        "attr2": "val2",
+                        "priority": 0
                     }
                 }
             ]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.md
@@ -16,12 +16,12 @@ Definitions
 - Autoconfigured: no
 - File: `/path/to/file`
 - Tag: `tag1`
+    - Attr3: val3
+    - Priority: 40
+- Tag: `tag1`
     - Attr1: val1
     - Attr2: val2
     - Priority: 0
-- Tag: `tag1`
-    - Attr3: val3
-    - Priority: 40
 
 ### definition_1
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.txt
@@ -5,8 +5,8 @@
  -------------- ------- ------- ---------- ------- ----------------------- 
  [32m Service ID   [39m [32m attr1 [39m [32m attr2 [39m [32m priority [39m [32m attr3 [39m [32m Class name            [39m 
  -------------- ------- ------- ---------- ------- ----------------------- 
-  definition_3   val1    val2    0                  Full\Qualified\Class3  
-    "                            40         val3                           
+  definition_3                   40         val3    Full\Qualified\Class3  
+    "            val1    val2    0                                         
   definition_1   val1            30                 Full\Qualified\Class1  
     "                    val2                                              
   definition_2   val1    val2    -20                Full\Qualified\Class2  

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_priority_tag.xml
@@ -3,13 +3,13 @@
   <definition id="definition_3" class="Full\Qualified\Class3" public="true" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file="/path/to/file">
     <tags>
       <tag name="tag1">
+        <parameter name="attr3">val3</parameter>
+        <parameter name="priority">40</parameter>
+      </tag>
+      <tag name="tag1">
         <parameter name="attr1">val1</parameter>
         <parameter name="attr2">val2</parameter>
         <parameter name="priority">0</parameter>
-      </tag>
-      <tag name="tag1">
-        <parameter name="attr3">val3</parameter>
-        <parameter name="priority">40</parameter>
       </tag>
     </tags>
   </definition>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/33716
| License       | MIT
| Doc PR        | -

Little DX improvement, to sort the tags inside each service tagged.
More details in linked issue.

