### PR TITLE
[HttpClient] add HttpClient::createForBaseUri()

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -4,10 +4,11 @@ CHANGELOG
 4.4.0
 -----
 
- * added `StreamWrapper`
+ * added `HttpClient::createForBaseUri()`
  * added `HttplugClient` with support for sync and async requests
  * added `max_duration` option
  * added support for NTLM authentication
+ * added `StreamWrapper` to cast any `ResponseInterface` instances to PHP streams.
  * added `$response->toStream()` to cast responses to regular PHP streams
  * made `Psr18Client` implement relevant PSR-17 factories and have streaming responses
  * added `TraceableHttpClient`, `HttpClientDataCollector` and `HttpClientPass` to integrate with the web profiler

--- a/src/Symfony/Component/HttpClient/HttpClient.php
+++ b/src/Symfony/Component/HttpClient/HttpClient.php
@@ -39,4 +39,14 @@ final class HttpClient
 
         return new NativeHttpClient($defaultOptions, $maxHostConnections);
     }
+
+    /**
+     * Creates a client that adds options (e.g. authentication headers) only when the request URL matches the provided base URI.
+     */
+    public static function createForBaseUri(string $baseUri, array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 50): HttpClientInterface
+    {
+        $client = self::create([], $maxHostConnections, $maxPendingPushes);
+
+        return ScopingHttpClient::forBaseUri($client, $baseUri, $defaultOptions);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I've seen ppl use `HttpClient::create()` with default `base_uri` & `auth_bearer`. That's a security risk as the bearer would be sent to any hosts that the client requests.

Instead, ppl should use `ScopingHttpClient`.

The new method should help to discover and use it.