### PR TITLE
[Serializer] Added the ability to cast values to their corresponding property type

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * deprecated the `XmlEncoder::TYPE_CASE_ATTRIBUTES` constant, use `XmlEncoder::TYPE_CAST_ATTRIBUTES` instead
  * added option to output a UTF-8 BOM in CSV encoder via `CsvEncoder::OUTPUT_UTF8_BOM_KEY` context option
+ * added the ability when denormalizing to cast values to the primitive type of their corresponding 
+   property via the `AbstractObjectNormalizer::CAST_PRIMITIVE_TYPES` context option
 
 4.3.0
 -----

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -90,6 +90,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     public const PRESERVE_EMPTY_OBJECTS = 'preserve_empty_objects';
 
+    public const CAST_PRIMITIVE_TYPES = 'cast_primitive_types';
+
     private $propertyTypeExtractor;
     private $typesCache = [];
     private $attributesCache = [];
@@ -409,7 +411,6 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             if ('xml' === $format && null !== $collectionValueType && (!\is_array($data) || !\is_int(key($data)))) {
                 $data = [$data];
             }
-
             if (null !== $collectionValueType && Type::BUILTIN_TYPE_OBJECT === $collectionValueType->getBuiltinType()) {
                 $builtinType = Type::BUILTIN_TYPE_OBJECT;
                 $class = $collectionValueType->getClassName().'[]';
@@ -467,6 +468,21 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             if (('is_'.$builtinType)($data)) {
                 return $data;
+            }
+
+            // If the above condition found the data was of the incorrect type, try casting the data to a
+            //  primitive value.
+            if (isset($context[self::CAST_PRIMITIVE_TYPES]) && $context[self::CAST_PRIMITIVE_TYPES]) {
+                switch ($builtinType) {
+                    case Type::BUILTIN_TYPE_INT:
+                    case Type::BUILTIN_TYPE_FLOAT:
+                    case Type::BUILTIN_TYPE_STRING:
+                    case Type::BUILTIN_TYPE_BOOL:
+                    case Type::BUILTIN_TYPE_ARRAY:
+                    case Type::BUILTIN_TYPE_NULL:
+                        settype($data, $builtinType);
+                        return $data;
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #33811
| License       | MIT
| Doc PR        | symfony/symfony-docs#12471

I needed a way to cast data to the expected type for each corresponding property when denormalizing an array to an object.  For my specific use case, I was querying data from MySQL via PDO, which only returns arrays of `string` values.  I've provided a generic example of this functionality in my Doc PR linked above.
