### PR TITLE
[HttpClient] workaround curl_multi_select() issue

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,7 +48,6 @@ install:
     - php composer.phar global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
     - git config --global user.email ""
     - git config --global user.name "Symfony"
-    - php .github/build-packages.php "HEAD^" src\Symfony\Bridge\PhpUnit
     - php .github/build-packages.php "HEAD^" src\Symfony\Bridge\PhpUnit src\Symfony\Contracts
     - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
     - php composer.phar update --no-progress --no-suggest --ansi

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -274,6 +274,11 @@ final class CurlResponse implements ResponseInterface
      */
     private static function select(CurlClientState $multi, float $timeout): int
     {
+        if (\PHP_VERSION_ID < 70123 || (70200 <= \PHP_VERSION_ID && \PHP_VERSION_ID < 70211)) {
+            // workaround https://bugs.php.net/76480
+            $timeout = min($timeout, 0.01);
+        }
+
         return curl_multi_select($multi->handle, $timeout);
     }
 

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -597,9 +597,9 @@ abstract class HttpClientTestCase extends TestCase
     {
         $client = $this->getHttpClient(__FUNCTION__);
         $response = $client->request('GET', 'http://localhost:8057/timeout-header', [
-            'timeout' => 0.5,
+            'timeout' => 0.9,
         ]);
-        usleep(510000);
+        sleep(1);
         $this->assertSame(200, $response->getStatusCode());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

1) Symfony\Component\HttpClient\Tests\CurlHttpClientTest::testNotATimeout
Symfony\Component\HttpClient\Exception\TransportException: Reading from the response stream reached the idle timeout.