### PR TITLE
[Mailer] Fix attachments and embedded images for Mailchimp API

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/Api/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/Api/MandrillTransport.php
@@ -70,14 +70,15 @@ class MandrillTransport extends AbstractApiTransport
             $disposition = $headers->getHeaderBody('Content-Disposition');
 
             $att = [
+                'name' => $attachment->getName(),
                 'content' => $attachment->bodyToString(),
                 'type' => $headers->get('Content-Type')->getBody(),
             ];
 
             if ('inline' === $disposition) {
-                $payload['images'][] = $att;
+                $payload['message']['images'][] = $att;
             } else {
-                $payload['attachments'][] = $att;
+                $payload['message']['attachments'][] = $att;
             }
         }
 

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -69,6 +69,11 @@ class TextPart extends AbstractPart
         return $this->subtype;
     }
 
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
     /**
      * @param string $disposition one of attachment, inline, or form-data
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #33995 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT

Fix the Mandrill transport API payload for embedded images and attachments. Fixes #33995.

As mentioned in #33994, I will make another PR on Wednesday to add some tests on the payload for the 4.4 branch (tests on transports have been introduced for the 4.4 branch) once this gets merged. If you have any better idea, just let me know!