### PR TITLE
[Config] Disable default alphabet sorting in glob function due of unstable sort

### DIFF
--- a/link
+++ b/link
@@ -64,6 +64,6 @@ foreach (glob("$pathToProject/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as 
     echo "\"$package\" has been linked to \"$sfPackages[$package]\".".PHP_EOL;
 }
 
-foreach (glob("$pathToProject/var/cache/*") as $cacheDir) {
+foreach (glob("$pathToProject/var/cache/*", GLOB_NOSORT) as $cacheDir) {
     $filesystem->remove($cacheDir);
 }

--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -100,7 +100,9 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface,
         }
 
         if (0 !== strpos($this->prefix, 'phar://') && false === strpos($this->pattern, '/**/') && (\defined('GLOB_BRACE') || false === strpos($this->pattern, '{'))) {
-            foreach (glob($this->prefix.$this->pattern, \defined('GLOB_BRACE') ? GLOB_BRACE : 0) as $path) {
+            $paths = glob($this->prefix.$this->pattern, GLOB_NOSORT | (\defined('GLOB_BRACE') ? GLOB_BRACE : 0));
+            sort($paths);
+            foreach ($paths as $path) {
                 if ($this->recursive && is_dir($path)) {
                     $files = iterator_to_array(new \RecursiveIteratorIterator(
                         new \RecursiveCallbackFilterIterator(

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -541,7 +541,8 @@ class Finder implements \IteratorAggregate, \Countable
         foreach ((array) $dirs as $dir) {
             if (is_dir($dir)) {
                 $resolvedDirs[] = $this->normalizeDir($dir);
-            } elseif ($glob = glob($dir, (\defined('GLOB_BRACE') ? GLOB_BRACE : 0) | GLOB_ONLYDIR)) {
+            } elseif ($glob = glob($dir, (\defined('GLOB_BRACE') ? GLOB_BRACE : 0) | GLOB_ONLYDIR | GLOB_NOSORT)) {
+                sort($glob);
                 $resolvedDirs = array_merge($resolvedDirs, array_map([$this, 'normalizeDir'], $glob));
             } else {
                 throw new \InvalidArgumentException(sprintf('The "%s" directory does not exist.', $dir));

--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -89,7 +89,8 @@ function findTranslationFiles($originalFilePath, $localeToAnalyze)
     $originalFileName = basename($originalFilePath);
     $translationFileNamePattern = str_replace('.en.', '.*.', $originalFileName);
 
-    $translationFiles = glob($translationsDir.'/'.$translationFileNamePattern);
+    $translationFiles = glob($translationsDir.'/'.$translationFileNamePattern, GLOB_NOSORT);
+    sort($translationFiles);
     foreach ($translationFiles as $filePath) {
         $locale = extractLocaleFromFilePath($filePath);
 


### PR DESCRIPTION
…table sort

| Q             | A
| ------------- | ---
| Branch?       | 3.4  <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #33990  <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | no <!-- required for new features -->

`\Symfony\Component\Config\Resource\GlobResource::getIterator` loads files using `glob` not it the stable sorting, e.g several files: `doctrine.yml` and `doctrine_mongodb.yaml` in `config/packages` folder.
On requests these files come(randomly) in a different order, which leads to reinitialization of symfony kernel in `dev` environment. It's a little bit annoying and takes a lot of time in a common :(

<!--
Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
