### PR TITLE
[String] Add AbstractString::toString() method

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -589,6 +589,11 @@ abstract class AbstractString implements \JsonSerializable
         return new CodePointString($this->string);
     }
 
+    public function toString(): string
+    {
+        return $this->string;
+    }
+
     public function toUnicodeString(): UnicodeString
     {
         return new UnicodeString($this->string);

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1370,4 +1370,11 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['fo...', 'foobar', 5, '...'],
         ];
     }
+
+    public function testToString()
+    {
+        $instance = static::createFromString('foobar');
+
+        self::assertSame('foobar', $instance->toString());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Adds a way to use String in an objective way, without typecasting -> calling magical `__toString()`.

Before
```php
$value = (string) (new UnicodeString('foobar'))
    ->repeat(2)
    ->lower();
```

After also possible

```php
$value = (new UnicodeString('foobar'))
    ->repeat(2)
    ->lower()
    ->toString();
```
