### PR TITLE
[Mailer] Fix typo

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
@@ -60,7 +60,7 @@ class SesApiTransport extends AbstractApiTransport
                 'Date' => $date,
                 'Content-Type' => 'application/x-www-form-urlencoded',
             ],
-            'body' => $this->getPayload($email, $envelope),
+            'body' => $payload = $this->getPayload($email, $envelope),
         ]);
 
         $result = new \SimpleXMLElement($response->getContent(false));
@@ -68,7 +68,9 @@ class SesApiTransport extends AbstractApiTransport
             throw new HttpTransportException(sprintf('Unable to send an email: %s (code %s).', $result->Error->Message, $result->Error->Code), $response);
         }
 
-        $sentMessage->setMessageId($result->SendEmailResult->MessageId);
+        $property = $payload['Action'].'Result';
+
+        $sentMessage->setMessageId($result->{$property}->MessageId);
 
         return $response;
     }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpTransport.php
@@ -68,7 +68,7 @@ class SesHttpTransport extends AbstractHttpTransport
             throw new HttpTransportException(sprintf('Unable to send an email: %s (code %s).', $result->Error->Message, $result->Error->Code), $response);
         }
 
-        $message->setMessageId($result->SendEmailResult->MessageId);
+        $message->setMessageId($result->SendRawEmailResult->MessageId);
 
         return $response;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features / 3.4 or 4.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34006
| License       | MIT
| Doc PR        | n/a

The XML is different depending on the way we are sending email. So, it's `SendEmailResult` when using the API and `SendRawEmailResult` when using the HTTP class (we are then sending the raw email).
