### PR TITLE
[HttpCache] fixed if-modified-since header default to an empty string if the last-modified header was not set

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -352,7 +352,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         }
 
         // add our cached last-modified validator
-        $subRequest->headers->set('if_modified_since', $entry->headers->get('Last-Modified'));
+        $subRequest->headers->set('if_modified_since', $entry->headers->get('Last-Modified', ''));
 
         // Add our cached etag validator to the environment.
         // We keep the etags from the client to handle the case when the client


### PR DESCRIPTION
… if the last-modified header was not set

The problem I had with this was that the psr http factory would create the request, and would throw an exception because the null value isn't an allowed header value
https://github.com/symfony/psr-http-message-bridge/blob/8564bf76630423ced21bbbee189947b90677dcde/Factory/PsrHttpFactory.php#L72
https://github.com/Nyholm/psr7/blob/55ff6b76573f5b242554c9775792bd59fb52e11c/src/MessageTrait.php#L180

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

