### PR TITLE
[Serializer] CsvEncoder::NO_HEADERS_KEY ignored when used in constructor

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -40,6 +40,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         self::HEADERS_KEY => [],
         self::KEY_SEPARATOR_KEY => '.',
         self::NO_HEADERS_KEY => false,
+        self::AS_COLLECTION_KEY => false,
     ];
 
     /**
@@ -101,7 +102,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
         $headers = array_merge(array_values($headers), array_diff($this->extractHeaders($data), $headers));
 
-        if (!($context[self::NO_HEADERS_KEY] ?? false)) {
+        if (!($context[self::NO_HEADERS_KEY] ?? $this->defaultContext[self::NO_HEADERS_KEY])) {
             fputcsv($handle, $headers, $delimiter, $enclosure, $escapeChar);
         }
 
@@ -147,7 +148,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
             if (null === $headers) {
                 $nbHeaders = $nbCols;
 
-                if ($context[self::NO_HEADERS_KEY] ?? false) {
+                if ($context[self::NO_HEADERS_KEY] ?? $this->defaultContext[self::NO_HEADERS_KEY]) {
                     for ($i = 0; $i < $nbCols; ++$i) {
                         $headers[] = [$i];
                     }
@@ -187,7 +188,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         }
         fclose($handle);
 
-        if ($context[self::AS_COLLECTION_KEY] ?? false) {
+        if ($context[self::AS_COLLECTION_KEY] ?? $this->defaultContext[self::AS_COLLECTION_KEY]) {
             return $result;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -202,6 +202,24 @@ CSV
         ]));
     }
 
+    public function testEncodeCustomSettingsPassedInConstructor()
+    {
+        $encoder = new CsvEncoder([
+            CsvEncoder::DELIMITER_KEY => ';',
+            CsvEncoder::ENCLOSURE_KEY => "'",
+            CsvEncoder::ESCAPE_CHAR_KEY => '|',
+            CsvEncoder::KEY_SEPARATOR_KEY => '-',
+        ]);
+        $value = ['a' => 'he\'llo', 'c' => ['d' => 'foo']];
+
+        $this->assertSame(<<<'CSV'
+a;c-d
+'he''llo';foo
+
+CSV
+        , $encoder->encode($value, 'csv'));
+    }
+
     public function testEncodeEmptyArray()
     {
         $this->assertEquals("\n\n", $this->encoder->encode([], 'csv'));
@@ -373,6 +391,15 @@ CSV
             , $this->encoder->encode([['a', 'b'], ['c', 'd']], 'csv', [
                 CsvEncoder::NO_HEADERS_KEY => true,
             ]));
+        $encoder = new CsvEncoder([CsvEncoder::NO_HEADERS_KEY => true]);
+        $this->assertSame(<<<'CSV'
+a,b
+c,d
+
+CSV
+            , $encoder->encode([['a', 'b'], ['c', 'd']], 'csv', [
+                CsvEncoder::NO_HEADERS_KEY => true,
+            ]));
     }
 
     public function testSupportsDecoding()
@@ -524,6 +551,23 @@ CSV
         ]));
     }
 
+    public function testDecodeCustomSettingsPassedInConstructor()
+    {
+        $encoder = new CsvEncoder([
+            CsvEncoder::DELIMITER_KEY => ';',
+            CsvEncoder::ENCLOSURE_KEY => "'",
+            CsvEncoder::ESCAPE_CHAR_KEY => '|',
+            CsvEncoder::KEY_SEPARATOR_KEY => '-',
+            CsvEncoder::AS_COLLECTION_KEY => true, // Can be removed in 5.0
+        ]);
+        $expected = [['a' => 'hell\'o', 'bar' => ['baz' => 'b']]];
+        $this->assertEquals($expected, $encoder->decode(<<<'CSV'
+a;bar-baz
+'hell''o';b;c
+CSV
+        , 'csv'));
+    }
+
     public function testDecodeMalformedCollection()
     {
         $expected = [
@@ -550,6 +594,15 @@ CSV
     public function testDecodeWithoutHeader()
     {
         $this->assertEquals([['a', 'b'], ['c', 'd']], $this->encoder->decode(<<<'CSV'
+a,b
+c,d
+
+CSV
+        , 'csv', [
+            CsvEncoder::NO_HEADERS_KEY => true,
+        ]));
+        $encoder = new CsvEncoder([CsvEncoder::NO_HEADERS_KEY => true]);
+        $this->assertEquals([['a', 'b'], ['c', 'd']], $encoder->decode(<<<'CSV'
 a,b
 c,d
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

My first pull request...
The following code:
```
$data = <<<EOD
a,b
c,d
EOD;
$encoder = new CsvEncoder([CsvEncoder::NO_HEADERS_KEY=>true]);
var_dump($encoder->decode($data,'csv'));
```
produces:
```
array(2) {
  'a' =>
  string(1) "c"
  'b' =>
  string(1) "d"
}
```
instead of the expected:
```
array(2) {
  [0] =>
  array(2) {
    [0] =>
    string(1) "a"
    [1] =>
    string(1) "b"
  }
  [1] =>
  array(2) {
    [0] =>
    string(1) "c"
    [1] =>
    string(1) "d"
  }
}
```
