### PR TITLE
[Notifier] add RocketChat bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -92,6 +92,7 @@ use Symfony\Component\Mime\MimeTypeGuesserInterface;
 use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
+use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
@@ -2000,6 +2001,7 @@ class FrameworkExtension extends Extension
             TelegramTransportFactory::class => 'notifier.transport_factory.telegram',
             MattermostTransportFactory::class => 'notifier.transport_factory.mattermost',
             NexmoTransportFactory::class => 'notifier.transport_factory.nexmo',
+            RocketChatTransportFactory::class => 'notifier.transport_factory.rocketchat',
             TwilioTransportFactory::class => 'notifier.transport_factory.twilio',
         ];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.xml
@@ -26,6 +26,10 @@
             <tag name="texter.transport_factory" />
         </service>
 
+        <service id="notifier.transport_factory.rocketchat" class="Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory" parent="notifier.transport_factory.abstract">
+            <tag name="chatter.transport_factory" />
+        </service>
+
         <service id="notifier.transport_factory.twilio" class="Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory" parent="notifier.transport_factory.abstract">
             <tag name="texter.transport_factory" />
         </service>

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.1.0
+-----
+
+ * Added the bridge

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/README.md
@@ -1,0 +1,12 @@
+RocketChat Notifier
+===================
+
+Provides RocketChat integration for Symfony Notifier.
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatOptions.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\RocketChat;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Jeroen Spee <https://github.com/Jeroeny>
+ *
+ * @experimental in 5.1
+ *
+ * @see https://rocket.chat/docs/administrator-guides/integrations/
+ */
+final class RocketChatOptions implements MessageOptionsInterface
+{
+    /** @var string|null prefix with '@' for personal messages */
+    private $channel;
+
+    /** @var mixed[] */
+    private $attachments;
+
+    /**
+     * @param string[] $attachments
+     */
+    public function __construct(array $attachments = [])
+    {
+        $this->attachments = $attachments;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'attachments' => [$this->attachments],
+        ];
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return $this->channel;
+    }
+
+    /**
+     * @return $this
+     */
+    public function channel(string $channel): self
+    {
+        $this->channel = $channel;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\RocketChat;
+
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Jeroen Spee <https://github.com/Jeroeny>
+ *
+ * @internal
+ *
+ * @experimental in 5.1
+ */
+final class RocketChatTransport extends AbstractTransport
+{
+    protected const HOST = 'rocketchat.com';
+
+    private $accessToken;
+    private $chatChannel;
+
+    public function __construct(string $accessToken, string $chatChannel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->accessToken = $accessToken;
+        $this->chatChannel = $chatChannel;
+        $this->client = $client;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('rocketchat://%s?channel=%s', $this->getEndpoint(), $this->chatChannel);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof ChatMessage && (null === $message->getOptions() || $message->getOptions() instanceof RocketChatOptions);
+    }
+
+    /**
+     * @see https://rocket.chat/docs/administrator-guides/integrations/
+     */
+    protected function doSend(MessageInterface $message): void
+    {
+        if (!$message instanceof ChatMessage) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, \get_class($message)));
+        }
+        if ($message->getOptions() && !$message->getOptions() instanceof RocketChatOptions) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, RocketChatOptions::class));
+        }
+
+        $options = ($opts = $message->getOptions()) ? $opts->toArray() : [];
+        if (!isset($options['channel'])) {
+            $options['channel'] = $message->getRecipientId() ?: $this->chatChannel;
+        }
+        $options['text'] = $message->getSubject();
+
+        $response = $this->client->request(
+            'POST',
+            sprintf('https://%s/hooks/%s', $this->getEndpoint(), $this->accessToken),
+            [
+                'json' => array_filter($options),
+            ]
+        );
+
+        if (200 !== $response->getStatusCode()) {
+            throw new TransportException(sprintf('Unable to post the RocketChat message: %s.', $response->getContent(false)), $response);
+        }
+
+        $result = $response->toArray(false);
+        if (!$result['success']) {
+            throw new TransportException(sprintf('Unable to post the RocketChat message: %s.', $result['error']), $response);
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransportFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\RocketChat;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author Jeroen Spee <https://github.com/Jeroeny>
+ *
+ * @experimental in 5.1
+ */
+final class RocketChatTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+        $accessToken = $this->getUser($dsn);
+        $channel = $dsn->getOption('channel');
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        if ('rocketchat' === $scheme) {
+            return (new RocketChatTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        }
+
+        throw new UnsupportedSchemeException($dsn, 'rocketchat', $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['rocketchat'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "symfony/rocketchat-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony RocketChat Notifier Bridge",
+    "keywords": ["rocketchat", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jeroen Spee",
+            "homepage": "https://github.com/Jeroeny"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": "^7.2.5",
+        "symfony/http-client": "^4.3|^5.0",
+        "symfony/notifier": "^5.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\RocketChat\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.1-dev"
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony RocketChat Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -38,6 +38,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Nexmo\NexmoTransportFactory::class,
             'package' => 'symfony/nexmo-notifier',
         ],
+        'rocketchat' => [
+            'class' => Bridge\RocketChat\RocketChatTransportFactory::class,
+            'package' => 'rocketchat-notifier',
+        ],
         'twilio' => [
             'class' => Bridge\Twilio\TwilioTransportFactory::class,
             'package' => 'symfony/twilio-notifier',

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier;
 
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
+use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
@@ -39,6 +40,7 @@ class Transport
         TelegramTransportFactory::class,
         MattermostTransportFactory::class,
         NexmoTransportFactory::class,
+        RocketChatTransportFactory::class,
         TwilioTransportFactory::class,
     ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | See #33687
| License       | MIT

This would add [RocketChat](https://rocket.chat/) integration for the Notifier component. RocketChat is a self hosted chat service. 

Fully tested with a trial version of RocketChat.

@wirone I noticed you suggested this.
