### PR TITLE
[Routing] fix route loading with wildcard, but dir or file is empty

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
@@ -39,7 +39,8 @@ class RoutingConfigurator
     final public function import($resource, $type = null, $ignoreErrors = false)
     {
         $this->loader->setCurrentDir(\dirname($this->path));
-        $imported = $this->loader->import($resource, $type, $ignoreErrors, $this->file);
+        $imported = $this->loader->import($resource, $type, $ignoreErrors, $this->file) ?? [];
+
         if (!\is_array($imported)) {
             return new ImportConfigurator($this->collection, $imported);
         }

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -169,7 +169,7 @@ class XmlFileLoader extends FileLoader
         $this->setCurrentDir(\dirname($path));
 
         /** @var RouteCollection[] $imported */
-        $imported = $this->import($resource, ('' !== $type ? $type : null), false, $file);
+        $imported = $this->import($resource, ('' !== $type ? $type : null), false, $file) ?? [];
 
         if (!\is_array($imported)) {
             $imported = [$imported];

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -187,7 +187,7 @@ class YamlFileLoader extends FileLoader
 
         $this->setCurrentDir(\dirname($path));
 
-        $imported = $this->import($config['resource'], $type, false, $file);
+        $imported = $this->import($config['resource'], $type, false, $file) ?? [];
 
         if (!\is_array($imported)) {
             $imported = [$imported];

--- a/src/Symfony/Component/Routing/Tests/Fixtures/import_with_name_prefix/routing.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/import_with_name_prefix/routing.yml
@@ -5,3 +5,7 @@ api:
     resource: ../controller/routing.yml
     name_prefix: api_
     prefix: /api
+
+empty_wildcard:
+    resource: ../controller/empty_wildcard/*
+    prefix: /empty_wildcard


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no ticket i see so far
| License       | MIT

In my route config i have something like:

```yaml
empty_wildcard:
    resource: ../controller/empty_wildcard/*
    prefix: /empty_wildcard
```

But ``empty_wildcard`` is empty or has no route configured.

So i had this error:

``Call to a member function addPrefix() on null``

This PR take care if no route is configured, there will be no error.