### PR TITLE
[ExpressionLanguage][Lexer] Exponential format for number

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -42,7 +42,7 @@ class Lexer
                 continue;
             }
 
-            if (preg_match('/[0-9]+(?:\.[0-9]+)?/A', $expression, $match, 0, $cursor)) {
+            if (preg_match('/[0-9]+(?:\.[0-9]+)?([Ee][\+\-][0-9]+)?/A', $expression, $match, 0, $cursor)) {
                 // numbers
                 $number = (float) $match[0];  // floats
                 if (preg_match('/^[0-9]+$/', $match[0]) && $number <= PHP_INT_MAX) {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -97,8 +97,10 @@ class LexerTest extends TestCase
                     new Token('punctuation', '[', 25),
                     new Token('number', '4', 26),
                     new Token('punctuation', ']', 27),
+                    new Token('operator', '-', 29),
+                    new Token('number', '1990', 31),
                 ],
-                '(3 + 5) ~ foo("bar").baz[4]',
+                '(3 + 5) ~ foo("bar").baz[4] - 1.99E+3',
             ],
             [
                 [new Token('operator', '..', 1)],


### PR DESCRIPTION
Exponential format has been added for numbers.
Ex: 1.99E+3 === 1990,
Ex: expression (1 + 1.99E+3) = 1991

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Exponential format has been added for numbers. 
Ex: 1.99E+3 === 1990, 
Expressions: 
0.1e+2 = 10
1e-2 = 0.01
(1 + 1.99E+3) = 1991
and etc...

