### PR TITLE
[Mime] Fixing multidimensional array structure with FormDataPart

### DIFF
--- a/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
+++ b/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
@@ -56,11 +56,20 @@ final class FormDataPart extends AbstractMultipartPart
     private function prepareFields(array $fields): array
     {
         $values = [];
-        array_walk_recursive($fields, function ($item, $key) use (&$values) {
-            if (!\is_array($item)) {
-                $values[] = $this->preparePart($key, $item);
+
+        $prepare = function ($item, $key, $root = null) use (&$values, &$prepare) {
+            $fieldName = $root ? sprintf('%s[%s]', $root, $key) : $key;
+
+            if (\is_array($item)) {
+                array_walk($item, $prepare, $fieldName);
+
+                return;
             }
-        });
+
+            $values[] = $this->preparePart($fieldName, $item);
+        };
+
+        array_walk($fields, $prepare);
 
         return $values;
     }

--- a/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
@@ -47,6 +47,34 @@ class FormDataPartTest extends TestCase
         $this->assertEquals([$t, $b, $c], $f->getParts());
     }
 
+    public function testNestedArrayParts()
+    {
+        $p1 = new TextPart('content', 'utf-8', 'plain', '8bit');
+        $f = new FormDataPart([
+            'foo' => clone $p1,
+            'bar' => [
+                'baz' => [
+                    clone $p1,
+                    'qux' => clone $p1,
+                ],
+            ],
+        ]);
+
+        $this->assertEquals('multipart', $f->getMediaType());
+        $this->assertEquals('form-data', $f->getMediaSubtype());
+
+        $p1->setName('foo');
+        $p1->setDisposition('form-data');
+
+        $p2 = clone $p1;
+        $p2->setName('bar[baz][0]');
+
+        $p3 = clone $p1;
+        $p3->setName('bar[baz][qux]');
+
+        $this->assertEquals([$p1, $p2, $p3], $f->getParts());
+    }
+
     public function testToString()
     {
         $p = DataPart::fromPath($file = __DIR__.'/../../Fixtures/mimetypes/test.gif');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33063 #34031
| License       | MIT
| Doc PR        | -

The issue is pretty much described on #34031 
The current structure of the raw body build on FormDataPart is not well recognized by the server. It considers all the fields as a root type, when actually it is possible to send arrays by html forms. 

Lets the following structure on the html
```html
<input type="text" name="names[]" value="John" />
<input type="text" name="names[]" value="Doe" />
```

It creates the following raw body:
```
----------------------------466490401959219490193856
Content-Disposition: form-data; name="names[]"

John
----------------------------466490401959219490193856
Content-Disposition: form-data; name="names[]"

Doe
----------------------------466490401959219490193856--
```

Meanwhile, the FormDataPart on Mime component generates the following body:
```
--_=_symfony_1571410799_b7846b3b4e86d821cdec4379e62b4068_=_
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: 8bit
Content-Disposition: form-data

John
--_=_symfony_1571410799_b7846b3b4e86d821cdec4379e62b4068_=_
Content-Type: text/plain; charset=utf-8; name=1
Content-Transfer-Encoding: 8bit
Content-Disposition: form-data; name=1

Doe
--_=_symfony_1571410799_b7846b3b4e86d821cdec4379e62b4068_=_--
```

For more complex structures, the $_POST doesn't even recognize properly the field names and values. 
