### PR TITLE
[Serializer] Fix property name usage for denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\NameConverter;
 
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
 /**
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
@@ -25,11 +26,11 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
      */
     private $fallbackNameConverter;
 
-    private static $normalizeCache = [];
+    private $normalizeCache = [];
 
-    private static $denormalizeCache = [];
+    private $denormalizeCache = [];
 
-    private static $attributesMetadataCache = [];
+    private $attributesMetadataCache = [];
 
     public function __construct(ClassMetadataFactoryInterface $metadataFactory, NameConverterInterface $fallbackNameConverter = null)
     {
@@ -46,11 +47,11 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return $this->normalizeFallback($propertyName, $class, $format, $context);
         }
 
-        if (!isset(self::$normalizeCache[$class][$propertyName])) {
-            self::$normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class);
+        if (!isset($this->normalizeCache[$class][$propertyName])) {
+            $this->normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class);
         }
 
-        return self::$normalizeCache[$class][$propertyName] ?? $this->normalizeFallback($propertyName, $class, $format, $context);
+        return $this->normalizeCache[$class][$propertyName] ?? $this->normalizeFallback($propertyName, $class, $format, $context);
     }
 
     /**
@@ -62,11 +63,11 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return $this->denormalizeFallback($propertyName, $class, $format, $context);
         }
 
-        if (!isset(self::$denormalizeCache[$class][$propertyName])) {
-            self::$denormalizeCache[$class][$propertyName] = $this->getCacheValueForDenormalization($propertyName, $class);
+        if (!isset($this->denormalizeCache[$class][$propertyName])) {
+            $this->denormalizeCache[$class][$propertyName] = $this->getCacheValueForDenormalization($propertyName, $class, $context);
         }
 
-        return self::$denormalizeCache[$class][$propertyName] ?? $this->denormalizeFallback($propertyName, $class, $format, $context);
+        return $this->denormalizeCache[$class][$propertyName] ?? $this->denormalizeFallback($propertyName, $class, $format, $context);
     }
 
     private function getCacheValueForNormalization($propertyName, string $class)
@@ -88,13 +89,13 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         return $this->fallbackNameConverter ? $this->fallbackNameConverter->normalize($propertyName, $class, $format, $context) : $propertyName;
     }
 
-    private function getCacheValueForDenormalization($propertyName, string $class)
+    private function getCacheValueForDenormalization($propertyName, string $class, $context)
     {
-        if (!isset(self::$attributesMetadataCache[$class])) {
-            self::$attributesMetadataCache[$class] = $this->getCacheValueForAttributesMetadata($class);
+        if (!isset($this->attributesMetadataCache[$class])) {
+            $this->attributesMetadataCache[$class] = $this->getCacheValueForAttributesMetadata($class, $context);
         }
 
-        return self::$attributesMetadataCache[$class][$propertyName] ?? null;
+        return $this->attributesMetadataCache[$class][$propertyName] ?? null;
     }
 
     private function denormalizeFallback($propertyName, string $class = null, string $format = null, array $context = [])
@@ -102,7 +103,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         return $this->fallbackNameConverter ? $this->fallbackNameConverter->denormalize($propertyName, $class, $format, $context) : $propertyName;
     }
 
-    private function getCacheValueForAttributesMetadata(string $class): array
+    private function getCacheValueForAttributesMetadata(string $class, $context): array
     {
         if (!$this->metadataFactory->hasMetadataFor($class)) {
             return [];
@@ -113,6 +114,14 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         $cache = [];
         foreach ($classMetadata->getAttributesMetadata() as $name => $metadata) {
             if (null === $metadata->getSerializedName()) {
+                continue;
+            }
+
+            $groups = $metadata->getGroups();
+            if (!$groups && ($context[AbstractNormalizer::GROUPS] ?? [])) {
+                continue;
+            }
+            if ($groups && !array_intersect($groups, $context[AbstractNormalizer::GROUPS] ?? [])) {
                 continue;
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -236,7 +236,6 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      *
      * @param object      $object
      * @param string|null $format
-     * @param array       $context
      *
      * @return string[]
      */

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+/**
+ * @author Anthony GRASSIOT <antograssiot@free.fr>
+ */
+class OtherSerializedNameDummy
+{
+    /**
+     * @Groups({"a"})
+     */
+    private $buz;
+
+    public function setBuz($buz)
+    {
+        $this->buz = $buz;
+    }
+
+    public function getBuz()
+    {
+        return $this->buz;
+    }
+
+    /**
+     * @Groups({"b"})
+     * @SerializedName("buz")
+     */
+    public function getBuzForExport()
+    {
+        return $this->buz.' Rocks';
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\OtherSerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SerializedNameDummy;
 
 /**
@@ -113,6 +114,28 @@ final class MetadataAwareNameConverterTest extends TestCase
             ['bar', 'qux'],
             ['quux', 'QUUX'],
             [0, 0],
+        ];
+    }
+
+    /**
+     * @dataProvider attributeAndContextProvider
+     */
+    public function testDenormalizeWithGroups($expected, $propertyName, $context = [])
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+
+        $this->assertEquals($expected, $nameConverter->denormalize($propertyName, OtherSerializedNameDummy::class, null, $context));
+    }
+
+    public function attributeAndContextProvider()
+    {
+        return [
+            ['buz', 'buz', ['groups' => ['a']]],
+            ['buzForExport', 'buz', ['groups' => ['b']]],
+            ['buz', 'buz', ['groups' => ['c']]],
+            ['buz', 'buz', []],
         ];
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\OtherSerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\AttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksObject;
@@ -478,6 +479,23 @@ class ObjectNormalizerTest extends TestCase
                 'symfony' => '@coopTilleuls',
                 'coop_tilleuls' => 'les-tilleuls.coop',
             ], 'Symfony\Component\Serializer\Tests\Fixtures\GroupDummy', null, [ObjectNormalizer::GROUPS => ['name_converter']])
+        );
+    }
+
+    public function testGroupsDenormalizeWithMetaDataNameConverter()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $this->normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        $this->normalizer->setSerializer($this->serializer);
+
+        $obj = new OtherSerializedNameDummy();
+        $obj->setBuz('Aldrin');
+
+        $this->assertEquals(
+            $obj,
+            $this->normalizer->denormalize([
+                'buz' => 'Aldrin',
+            ], 'Symfony\Component\Serializer\Tests\Fixtures\OtherSerializedNameDummy', null, [ObjectNormalizer::GROUPS => ['a']])
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 


Using the `@SerializedName()` and passing it an existing property name affects the deserialization even if `@Groups()` are not supposed to be involved.

## How to reproduce

Given the following class
```php

class Foo
{
    /**
     * @Group("list")
     */
    private $bar;

    public function setBar($bar)
    {
        $this->bar = $bar;
    }
    public function getBar()
    {
        return $this->bar;
    }
    /**
     * @Groups({"list:export"})
     * @SerializedName("bar")
     */
    public function getBarForExport()
    {
        return $this->bar.' Rocks';
    }
}
```

This allow us to change the content of the property based on the normalization context.

```php
$obj = new Foo();
$obj->setBar('Api Platform');

$data = $normalizer->normalize($obj, null, ['groups' => ["list"]]);
// $data => ['bar' => 'Api Platform'] as expected

$data = $normalizer->normalize($obj, null, ['groups' => ["list:export"]]);
// $data => ['bar' => 'Api Platform Rocks'] as expected

$obj = $normalizer->denormalize(['bar' => 'Api Platform'], Foo::class, null, ['groups' => ['list']]);
// $obj->getBar()  would return null instead of 'Api Platform' as expected.
```
