### PR TITLE
[Lock] Set ReturnType of LockFactory to LockInterface

### DIFF
--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -26,7 +26,7 @@ class LockFactory extends Factory
      * @param float|null $ttl         Maximum expected lock duration in seconds
      * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
      */
-    public function createLock($resource, $ttl = 300.0, $autoRelease = true): Lock
+    public function createLock($resource, $ttl = 300.0, $autoRelease = true): LockInterface
     {
         return parent::createLock($resource, $ttl, $autoRelease);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #...
| License       | MIT
| Doc PR        |

LockFactory I think should return a LockInterface and not the Lock class.

/cc @chalasr 