### PR TITLE
[Filesystem] Improve exists() behaviour to be able to differentiate files/dirs

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -116,8 +116,8 @@ class Filesystem
     /**
      * Checks the existence of files or directories.
      *
-     * @param string|iterable $files A filename, an array of files, or a \Traversable instance to check
-     * @param string|null $isOfFileType A file type to check against, skipped if null (backward compatibility)
+     * @param string|iterable $files        A filename, an array of files, or a \Traversable instance to check
+     * @param string|null     $isOfFileType A file type to check against, skipped if null (backward compatibility)
      *
      * @return bool true if the file exists, false otherwise
      */
@@ -134,7 +134,7 @@ class Filesystem
                 return false;
             }
 
-            if (!is_null($isOfFileType)) {
+            if (null !== $isOfFileType) {
                 switch ($isOfFileType) {
                     case self::FILE_TYPE_REGULAR:
                         if (!is_file($file)) {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -116,12 +116,12 @@ class Filesystem
     /**
      * Checks the existence of files or directories.
      *
-     * @param string|iterable $files        A filename, an array of files, or a \Traversable instance to check
-     * @param string|null     $isOfFileType A file type to check against, skipped if null (backward compatibility)
+     * @param string|iterable $files  A filename, an array of files, or a \Traversable instance to check
+     * @param string|null     $ofType A file type to check against, skipped if null (backward compatibility)
      *
      * @return bool true if the file exists, false otherwise
      */
-    public function exists($files, $isOfFileType = null)
+    public function exists($files, $ofType = null)
     {
         $maxPathLength = PHP_MAXPATHLEN - 2;
 
@@ -134,8 +134,8 @@ class Filesystem
                 return false;
             }
 
-            if (null !== $isOfFileType) {
-                switch ($isOfFileType) {
+            if (null !== $ofType) {
+                switch ($ofType) {
                     case self::FILE_TYPE_REGULAR:
                         if (!is_file($file)) {
                             return false;

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -22,6 +22,9 @@ use Symfony\Component\Filesystem\Exception\IOException;
  */
 class Filesystem
 {
+    const FILE_TYPE_REGULAR = 'regular';
+    const FILE_TYPE_DIRECTORY = 'directory';
+
     private static $lastError;
 
     /**
@@ -114,10 +117,11 @@ class Filesystem
      * Checks the existence of files or directories.
      *
      * @param string|iterable $files A filename, an array of files, or a \Traversable instance to check
+     * @param string|null $isOfFileType A file type to check against, skipped if null (backward compatibility)
      *
      * @return bool true if the file exists, false otherwise
      */
-    public function exists($files)
+    public function exists($files, $isOfFileType = null)
     {
         $maxPathLength = PHP_MAXPATHLEN - 2;
 
@@ -128,6 +132,21 @@ class Filesystem
 
             if (!file_exists($file)) {
                 return false;
+            }
+
+            if (!is_null($isOfFileType)) {
+                switch ($isOfFileType) {
+                    case self::FILE_TYPE_REGULAR:
+                        if (!is_file($file)) {
+                            return false;
+                        }
+                        break;
+                    case self::FILE_TYPE_DIRECTORY:
+                        if (!is_dir($file)) {
+                            return false;
+                        }
+                        break;
+                }
             }
         }
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -117,7 +117,7 @@ class Filesystem
      * Checks the existence of files or directories.
      *
      * @param string|iterable $files  A filename, an array of files, or a \Traversable instance to check
-     * @param string|null     $ofType A file type to check against, skipped if null (backward compatibility)
+     * @param string|null     $ofType A file type to check against, skipped if null
      *
      * @return bool true if the file exists, false otherwise
      */

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -22,8 +22,8 @@ use Symfony\Component\Filesystem\Exception\IOException;
  */
 class Filesystem
 {
-    const FILE_TYPE_REGULAR = 'regular';
-    const FILE_TYPE_DIRECTORY = 'directory';
+    public const FILE_TYPE_REGULAR = 'regular';
+    public const FILE_TYPE_DIRECTORY = 'directory';
 
     private static $lastError;
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -394,6 +394,41 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertTrue($this->filesystem->exists($basePath.'folder', \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_DIRECTORY));
     }
 
+    public function testFilesExistsAndFullSetIsOfTheSameType()
+    {
+        $basePath = $this->workspace.\DIRECTORY_SEPARATOR.'directory'.\DIRECTORY_SEPARATOR;
+
+        mkdir($basePath);
+        touch($basePath.'file');
+        touch($basePath.'file2');
+        mkdir($basePath.'folder');
+        mkdir($basePath.'folder2');
+
+        $filesOnly = new \ArrayObject([
+            $basePath.'file', $basePath.'file2'
+        ]);
+
+        $dirsOnly = new \ArrayObject([
+            $basePath.'folder', $basePath.'folder2'
+        ]);
+
+        $mixedFilesDirs = new \ArrayObject([
+            $basePath.'file', $basePath.'folder', $basePath.'file2', $basePath.'folder2'
+        ]);
+
+        $mixedDirsFiles = new \ArrayObject([
+            $basePath.'folder', $basePath.'file', $basePath.'folder2', $basePath.'file2'
+        ]);
+
+        $this->assertTrue($this->filesystem->exists($filesOnly, \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_REGULAR));
+        $this->assertFalse($this->filesystem->exists($mixedFilesDirs, \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_REGULAR));
+        $this->assertFalse($this->filesystem->exists($mixedFilesDirs, \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_DIRECTORY));
+
+        $this->assertTrue($this->filesystem->exists($dirsOnly, \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_DIRECTORY));
+        $this->assertFalse($this->filesystem->exists($mixedDirsFiles, \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_DIRECTORY));
+        $this->assertFalse($this->filesystem->exists($mixedDirsFiles, \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_REGULAR));
+    }
+
     public function testFilesExistsFails()
     {
         $this->expectException('Symfony\Component\Filesystem\Exception\IOException');

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -370,6 +370,30 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertTrue($this->filesystem->exists($basePath.'folder'));
     }
 
+    public function testFilesExistsAndOfTypeRegular()
+    {
+        $basePath = $this->workspace.\DIRECTORY_SEPARATOR.'directory'.\DIRECTORY_SEPARATOR;
+
+        mkdir($basePath);
+        touch($basePath.'file1');
+
+        $this->assertTrue($this->filesystem->exists($basePath.'file1', null));
+        $this->assertTrue($this->filesystem->exists($basePath.'file1', \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_REGULAR));
+        $this->assertFalse($this->filesystem->exists($basePath.'file1', \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_DIRECTORY));
+    }
+
+    public function testFilesExistsAndOfTypeDirectory()
+    {
+        $basePath = $this->workspace.\DIRECTORY_SEPARATOR.'directory'.\DIRECTORY_SEPARATOR;
+
+        mkdir($basePath);
+        mkdir($basePath.'folder');
+
+        $this->assertTrue($this->filesystem->exists($basePath.'folder', null));
+        $this->assertFalse($this->filesystem->exists($basePath.'folder', \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_REGULAR));
+        $this->assertTrue($this->filesystem->exists($basePath.'folder', \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_DIRECTORY));
+    }
+
     public function testFilesExistsFails()
     {
         $this->expectException('Symfony\Component\Filesystem\Exception\IOException');

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -405,19 +405,19 @@ class FilesystemTest extends FilesystemTestCase
         mkdir($basePath.'folder2');
 
         $filesOnly = new \ArrayObject([
-            $basePath.'file', $basePath.'file2'
+            $basePath.'file', $basePath.'file2',
         ]);
 
         $dirsOnly = new \ArrayObject([
-            $basePath.'folder', $basePath.'folder2'
+            $basePath.'folder', $basePath.'folder2',
         ]);
 
         $mixedFilesDirs = new \ArrayObject([
-            $basePath.'file', $basePath.'folder', $basePath.'file2', $basePath.'folder2'
+            $basePath.'file', $basePath.'folder', $basePath.'file2', $basePath.'folder2',
         ]);
 
         $mixedDirsFiles = new \ArrayObject([
-            $basePath.'folder', $basePath.'file', $basePath.'folder2', $basePath.'file2'
+            $basePath.'folder', $basePath.'file', $basePath.'folder2', $basePath.'file2',
         ]);
 
         $this->assertTrue($this->filesystem->exists($filesOnly, \Symfony\Component\Filesystem\Filesystem::FILE_TYPE_REGULAR));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #33873
| License       | MIT
| Doc PR        | symfony/symfony-docs#12516

The current implementation of Filesystem::exists allowed to check whether a file is present on the filesystem, without any kind of distinction on the file type, so it is blind about the fact that it can be a file, directory, symlink, socket, ...

The new (optional) second argument allows to specify whether we want to check against a specific file type. I used the standard Unix/POSIX file types definition (see https://en.wikipedia.org/wiki/Unix_file_types), and implemented regular/directory. Class constants were added to list/use the available file types.

The change is BC and didn't alter the default/previous behaviour. I already pushed a usage example in the associated documentation.