### PR TITLE
[VarDumper] improve displaying cut closures

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/CutStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/CutStub.php
@@ -28,6 +28,11 @@ class CutStub extends Stub
             case 'object':
                 $this->type = self::TYPE_OBJECT;
                 $this->class = \get_class($value);
+
+                if ($value instanceof \Closure) {
+                    ReflectionCaster::castClosure($value, [], $this, true, Caster::EXCLUDE_VERBOSE);
+                }
+
                 $this->cut = -1;
                 break;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Minor but still an improvement so 4.4: this change makes closures replaced by `CutStub` be displayed with their signature instead of just the `Closure` label.