### PR TITLE
[Console] Revert wrong change

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -115,7 +115,7 @@ class QuestionHelper extends Helper
     {
         $this->writePrompt($output, $question);
 
-        $inputStream = $this->inputStream ?: fopen('php://stdin', 'r');
+        $inputStream = $this->inputStream ?: STDIN;
         $autocomplete = $question->getAutocompleterCallback();
 
         if (null === $autocomplete || !Terminal::hasSttyAvailable()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34012 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

This partially reverts #34012 as it breaks uses cases like this:

```
echo "foo\nbar\n" | SHELL_INTERACTIVE=1 symfony console something
```
