### PR TITLE
[Lock][Cache] Allows URL DSN in PDO adapters

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -71,4 +71,33 @@ class PdoAdapterTest extends AdapterTestCase
         $this->assertFalse($newItem->isHit());
         $this->assertSame(0, $getCacheItemCount(), 'PDOAdapter must clean up expired items');
     }
+
+    /**
+     * @dataProvider provideDsn
+     */
+    public function testDsn(string $dsn, string $file = null)
+    {
+        try {
+            $pool = new PdoAdapter($dsn);
+            $pool->createTable();
+
+            $item = $pool->getItem('key');
+            $item->set('value');
+            $this->assertTrue($pool->save($item));
+        } finally {
+            if (null !== $file) {
+                @unlink($file);
+            }
+        }
+    }
+
+    public function provideDsn()
+    {
+        $dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');
+        yield ['sqlite://localhost/'.$dbFile, ''.$dbFile];
+        yield ['sqlite:'.$dbFile, ''.$dbFile];
+        yield ['sqlite3:///'.$dbFile, ''.$dbFile];
+        yield ['sqlite://localhost/:memory:'];
+        yield ['sqlite::memory:'];
+    }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -73,4 +73,34 @@ class PdoStoreTest extends AbstractStoreTest
 
         return new PdoStore('sqlite:'.self::$dbFile, [], 0.1, 0.1);
     }
+
+    /**
+     * @dataProvider provideDsn
+     */
+    public function testDsn(string $dsn, string $file = null)
+    {
+        $key = new Key(uniqid(__METHOD__, true));
+
+        try {
+            $store = new PdoStore($dsn);
+            $store->createTable();
+
+            $store->save($key);
+            $this->assertTrue($store->exists($key));
+        } finally {
+            if (null !== $file) {
+                @unlink($file);
+            }
+        }
+    }
+
+    public function provideDsn()
+    {
+        $dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');
+        yield ['sqlite://localhost/'.$dbFile, ''.$dbFile];
+        yield ['sqlite:'.$dbFile, ''.$dbFile];
+        yield ['sqlite3:///'.$dbFile, ''.$dbFile];
+        yield ['sqlite://localhost/:memory:'];
+        yield ['sqlite::memory:'];
+    }
 }

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -20,9 +20,12 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "doctrine/dbal": "~2.4",
+        "doctrine/dbal": "~2.5",
         "mongodb/mongodb": "~1.1",
         "predis/predis": "~1.0"
+    },
+    "conflict": {
+        "doctrine/dbal": "<2.5"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Lock\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

This PR duplicate a feature from PdoSessionHandler that convert URL DSN ( ie. mysql://localhost/test) into PDO DSN (ie. mysql:host=localhost;dbname=test)

that would ease configuration by using the same well-known variable
```
framework:
  lock: '%env(DATABASE_URL)%'
```

note: I applied the same change on Cache component for consistency.