### PR TITLE
[TwigBundle] allow option "twig.exception_controller" to be null on Symfony 5

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\TwigBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * TwigExtension configuration structure.
@@ -31,6 +32,19 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('twig');
         $rootNode = $treeBuilder->getRootNode();
+
+        $rootNode->beforeNormalization()
+            ->ifTrue(function ($v) { return \is_array($v) && \array_key_exists('exception_controller', $v); })
+            ->then(function ($v) {
+                if (isset($v['exception_controller'])) {
+                    throw new InvalidConfigurationException('Option "exception_controller" under "twig" must be null or unset, use "error_controller" under "framework" instead.');
+                }
+
+                unset($v['exception_controller']);
+
+                return $v;
+            })
+        ->end();
 
         $this->addFormThemesSection($rootNode);
         $this->addGlobalsSection($rootNode);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Otherwise, it's really hard for bundles to allow v5 while still supporting v4/v3.