### PR TITLE
[Messenger] Fix worker-only Doctrine middleware from running always

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineClearEntityManagerMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineClearEntityManagerMiddleware.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Messenger;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 
 /**
  * Clears entity manager after calling all handlers.
@@ -27,7 +28,9 @@ class DoctrineClearEntityManagerMiddleware extends AbstractDoctrineMiddleware
         try {
             return $stack->next()->handle($envelope, $stack);
         } finally {
-            $entityManager->clear();
+            if (null !== $envelope->last(ReceivedStamp::class)) {
+                $entityManager->clear();
+            }
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Messenger;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 
 /**
  * Closes connection and therefore saves number of connections.
@@ -29,7 +30,9 @@ class DoctrineCloseConnectionMiddleware extends AbstractDoctrineMiddleware
 
             return $stack->next()->handle($envelope, $stack);
         } finally {
-            $connection->close();
+            if (null !== $envelope->last(ReceivedStamp::class)) {
+                $connection->close();
+            }
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (or 4.3?, this is a bug fix)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #32436 Depends on #34069
| License       | MIT
| Doc PR        | not needed

Several Doctrine middleware are only meant to be run in a "worker" context: we want to "ping" the connection, "close" the connection and "clear" the entity manager ONLY when we are receiving messages. Before this PR, it was done always, which causes bad behavior for sync messages (imagine your Doctrine connection being closed in the middle of a controller or see https://github.com/symfony/symfony/pull/31334#issuecomment-544288437).

This fixes that in a pragmatic way: no new system for "worker-only" middleware or anything like that: just make the middleware smart enough to only do their work when a message is being received async.