### PR TITLE
[ErrorRenderer] FlattenException cannot be final

### DIFF
--- a/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class FlattenException extends LegacyFlattenException
+class FlattenException extends LegacyFlattenException
 {
     private $title;
     private $message;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Making it final forces tight coupling with the implementation as soon as one type-hints for the class.

That's a blocker on making e.g. `EasyAdminBundle` compatible with Symfony 5.