### PR TITLE
[Debug] remove return types that break FC badly

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -36,12 +36,18 @@ class FlattenException
     private $file;
     private $line;
 
+    /**
+     * @return static
+     */
     public static function create(\Exception $exception, $statusCode = null, array $headers = [])
     {
         return static::createFromThrowable($exception, $statusCode, $headers);
     }
 
-    public static function createFromThrowable(\Throwable $exception, int $statusCode = null, array $headers = []): self
+    /**
+     * @return static
+     */
+    public static function createFromThrowable(\Throwable $exception, int $statusCode = null, array $headers = [])
     {
         $e = new static();
         $e->setMessage($exception->getMessage());

--- a/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorRenderer/Exception/FlattenException.php
@@ -38,12 +38,12 @@ class FlattenException extends LegacyFlattenException
     private $file;
     private $line;
 
-    public static function create(\Exception $exception, $statusCode = null, array $headers = []): LegacyFlattenException
+    public static function create(\Exception $exception, $statusCode = null, array $headers = []): self
     {
         return static::createFromThrowable($exception, $statusCode, $headers);
     }
 
-    public static function createFromThrowable(\Throwable $exception, int $statusCode = null, array $headers = []): LegacyFlattenException
+    public static function createFromThrowable(\Throwable $exception, int $statusCode = null, array $headers = []): self
     {
         $e = new static();
         $e->setMessage($exception->getMessage());
@@ -228,7 +228,7 @@ class FlattenException extends LegacyFlattenException
     /**
      * @return $this
      */
-    public function setPrevious(LegacyFlattenException $previous): self
+    final public function setPrevious(LegacyFlattenException $previous): self
     {
         $this->previous = $previous;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The return type on Debug's FlattenException blocks creating a child class that is compatible with both v4.4 and v5.0.
Removing it fixes the issue with no BC break.
Adding `final` on `setPrevious` will allow updating its type hint in v5.0.