### PR TITLE
[5.0][Security] Minor clarification of the new isGranted signature

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Core\Authorization;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 
 /**
  * AuthorizationChecker is the main authorization point of the Security component.
@@ -44,7 +43,7 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
      *
      * @throws AuthenticationCredentialsNotFoundException when the token storage has no authentication token
      */
-    final public function isGranted($attributes, $subject = null): bool
+    final public function isGranted($attribute, $subject = null): bool
     {
         if (null === ($token = $this->tokenStorage->getToken())) {
             throw new AuthenticationCredentialsNotFoundException('The token storage contains no authentication token. One possible reason may be that there is no firewall configured for this URL.');
@@ -54,10 +53,6 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
             $this->tokenStorage->setToken($token = $this->authenticationManager->authenticate($token));
         }
 
-        if (\is_array($attributes)) {
-            throw new InvalidArgumentException(sprintf('Passing an array of Security attributes to %s() is not supported.', __METHOD__));
-        }
-
-        return $this->accessDecisionManager->decide($token, [$attributes], $subject);
+        return $this->accessDecisionManager->decide($token, [$attribute], $subject);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
@@ -21,10 +21,10 @@ interface AuthorizationCheckerInterface
     /**
      * Checks if the attributes are granted against the current authentication token and optionally supplied subject.
      *
-     * @param mixed $attributes
+     * @param mixed $attribute A single attribute to vote on (can be of any type, string and instance of Expression are supported by the core)
      * @param mixed $subject
      *
      * @return bool
      */
-    public function isGranted($attributes, $subject = null);
+    public function isGranted($attribute, $subject = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

As we now only allow a single attribute for `isGranted()` in Symfony 5, let's adapt the PHPdoc and parameter name as well.