### PR TITLE
[HttpKernel] Avoid nested exceptions if errors occur when generating file links

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpKernel\Debug;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -80,7 +79,7 @@ class FileLinkFormatter
     {
         try {
             return $router->generate($routeName).$queryString;
-        } catch (ExceptionInterface $e) {
+        } catch (\Throwable $e) {
             return null;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Multiple exceptions are fired until the fallback error page is rendered without the FileLinkFormatter:
https://github.com/symfony/symfony/blob/48282ce80f797b9c014f92985e7a293096703449/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php#L79-L86

**Before** (the reproducer is highlighted inside the picture or simply adds an undefined option to the `@Route()` annotation)
![error-page-before](https://user-images.githubusercontent.com/2028198/67356903-c8a17700-f529-11e9-9384-12a29e17b682.png)

**After** (I couldn't find a better solution to display this exception once)
![error-page-after](https://user-images.githubusercontent.com/2028198/67356941-db1bb080-f529-11e9-8808-d7f72dadc4d6.png)