### PR TITLE
[FrameworkBundle] Don't reset the test container but the real one instead

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -93,7 +93,7 @@ Form
 FrameworkBundle
 ---------------
 
- * Deprecated booting the kernel before running `WebTestCase::createClient()`.
+ * Deprecated calling `WebTestCase::createClient()` while a kernel has been booted, ensure the kernel is shut down before calling the method
  * Deprecated support for `templating` engine in `TemplateController`, use Twig instead
  * The `$parser` argument of `ControllerResolver::__construct()` and `DelegatingLoader::__construct()`
    has been deprecated.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -222,8 +222,7 @@ Form
 FrameworkBundle
 ---------------
 
- * Dropped support for booting the kernel before running `WebTestCase::createClient()`. `createClient()` will throw an
-   exception if the kernel was already booted before.
+ * Calling `WebTestCase::createClient()` while a kernel has been booted now throws an exception, ensure the kernel is shut down before calling the method
  * Removed the `framework.templating` option, configure the Twig bundle instead.
  * The project dir argument of the constructor of `AssetsInstallCommand` is required.
  * Removed support for `bundle:controller:action` syntax to reference controllers. Use `serviceOrFqcn::method`

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
  * Deprecated the `controller_name_converter` and `resolve_controller_name_subscriber` services
  * The `ControllerResolver` and `DelegatingLoader` classes have been marked as `final`
  * Added support for configuring chained cache pools
- * Deprecated booting the kernel before running `WebTestCase::createClient()`
+ * Deprecated calling `WebTestCase::createClient()` while a kernel has been booted, ensure the kernel is shut down before calling the method
  * Deprecated `routing.loader.service`, use `routing.loader.container` instead.
  * Not tagging service route loaders with `routing.route_loader` has been deprecated.
  * Overriding the methods `KernelTestCase::tearDown()` and `WebTestCase::tearDown()` without the `void` return-type is deprecated.

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -37,7 +37,9 @@ abstract class KernelTestCase extends TestCase
      */
     protected static $container;
 
-    protected static $booted;
+    protected static $booted = false;
+
+    private static $kernelContainer;
 
     private function doTearDown()
     {
@@ -76,7 +78,7 @@ abstract class KernelTestCase extends TestCase
         static::$kernel->boot();
         static::$booted = true;
 
-        $container = static::$kernel->getContainer();
+        self::$kernelContainer = $container = static::$kernel->getContainer();
         static::$container = $container->has('test.service_container') ? $container->get('test.service_container') : $container;
 
         return static::$kernel;
@@ -127,17 +129,14 @@ abstract class KernelTestCase extends TestCase
     protected static function ensureKernelShutdown()
     {
         if (null !== static::$kernel) {
-            $isBooted = (new \ReflectionClass(static::$kernel))->getProperty('booted');
-            $isBooted->setAccessible(true);
-            if ($isBooted->getValue(static::$kernel)) {
-                $container = static::$kernel->getContainer();
-                static::$kernel->shutdown();
-                static::$booted = false;
-                if ($container instanceof ResetInterface) {
-                    $container->reset();
-                }
-            }
+            static::$kernel->shutdown();
+            static::$booted = false;
         }
-        static::$container = null;
+
+        if (self::$kernelContainer instanceof ResetInterface) {
+            self::$kernelContainer->reset();
+        }
+
+        static::$container = self::$kernelContainer = null;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
@@ -119,7 +119,7 @@ class TestContainer extends Container
      */
     public function reset()
     {
-        $this->getPublicContainer()->reset();
+        // ignore the call
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -41,8 +41,8 @@ abstract class WebTestCase extends KernelTestCase
      */
     protected static function createClient(array $options = [], array $server = [])
     {
-        if (true === static::$booted) {
-            @trigger_error(sprintf('Booting the kernel before calling %s() is deprecated and will throw in Symfony 5.0, the kernel should only be booted once.', __METHOD__), E_USER_DEPRECATED);
+        if (static::$booted) {
+            @trigger_error(sprintf('Calling "%s()" while a kernel has been booted is deprecated since Symfony 4.4 and will throw in 5.0, ensure the kernel is shut down before calling the method.', __METHOD__), E_USER_DEPRECATED);
         }
 
         $kernel = static::bootKernel($options);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -100,7 +100,7 @@ class AppKernel extends Kernel
 
     public function getContainer(): ContainerInterface
     {
-        if (!$this->booted) {
+        if (!$this->container) {
             throw new \LogicException('Cannot access the container on a non-booted kernel. Did you forget to boot it?');
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -102,7 +102,7 @@ class AppKernel extends Kernel
 
     public function getContainer(): ContainerInterface
     {
-        if (!$this->booted) {
+        if (!$this->container) {
             throw new \LogicException('Cannot access the container on a non-booted kernel. Did you forget to boot it?');
         }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -380,7 +380,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     public function getContainer()
     {
-        if (!$this->booted) {
+        if (!$this->container) {
             @trigger_error('Getting the container from a non-booted kernel is deprecated since Symfony 4.4.', E_USER_DEPRECATED);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

After #31202 and #32056, the tearDown method keeps throwing deprecation notices about "Getting the container from a non-booted kernel". The reason is that resetting the test-container calls `$kernel->getContainer()` while the kernel has been shut down.

This fixes it and a few other glitches found meanwhile.