### PR TITLE
[SecurityBundle] correct types for default arguments for firewall configs

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -150,15 +150,15 @@
             <argument />                   <!-- name -->
             <argument />                   <!-- user_checker -->
             <argument />                   <!-- request_matcher -->
-            <argument />                   <!-- security enabled -->
-            <argument />                   <!-- stateless -->
+            <argument>false</argument>     <!-- security enabled -->
+            <argument>false</argument>     <!-- stateless -->
             <argument />                   <!-- provider -->
             <argument />                   <!-- context -->
             <argument />                   <!-- entry_point -->
             <argument />                   <!-- access_denied_handler -->
             <argument />                   <!-- access_denied_url -->
             <argument type="collection" /> <!-- listeners -->
-            <argument />                   <!-- switch_user -->
+            <argument>null</argument>      <!-- switch_user -->
         </service>
 
         <service id="security.logout_url_generator" class="Symfony\Component\Security\Http\Logout\LogoutUrlGenerator">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (and forward)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Up until now, the default template arguments in the `security.firewall.config` abstract service definition have been each defined (aside from the argument for `$listeners` which is given a `collection` type) in the XML as

```xml
<argument />
```

which resolves to an empty string, despite that some of the arguments are typed to being either `bool` or `array|null` on the `Symfony\Bundle\SecurityBundle\Security\FirewallConfig` class itself.

This wouldn't be so much of a problem if the child definitions that use this as a template overrode all the arguments every time, but in the case of firewall configs that mark security as _not_ being enabled, [only the first few arguments are overwritten](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php#L349-L352), so firewall config objects that do not have security enabled are instantiated by the DI container with parameters with some of the wrong types.

In general this wouldn't be an issue, as firewalls with security not enabled would not usually be consumed in a context where further security-related config were needed, but there is a case in `Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector` where the method `getSwitchUser()` on the firewall config object [can be called](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php#L181) without checking first whether the firewall has security enabled, which leads to an exception being thrown:

```
Symfony\Component\Debug\Exception\ContextErrorException
Warning: Illegal string offset 'parameter'
in vendor/symfony/symfony/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php (line 184) 
```

which is down to the firewall config being set with an empty string rather than `null` (in which case the logic here would function as expected).

It seemed most appropriate as a fix (especially given possible introduction of scalar type hints in the future) to apply types to the default arguments so that it was no longer possible to instantiate a firewall config object with parameters of unexpected types.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
