### PR TITLE
[Validator] Set Length::$allowEmptyString to false when a NotBlank contraint is defined

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -57,13 +57,6 @@ class Length extends Constraint
 
         parent::__construct($options);
 
-        if (null === $this->allowEmptyString) {
-            $this->allowEmptyString = true;
-            if (null !== $this->min) {
-                @trigger_error(sprintf('Using the "%s" constraint with the "min" option without setting the "allowEmptyString" one is deprecated and defaults to true. In 5.0, it will become optional and default to false.', self::class), E_USER_DEPRECATED);
-            }
-        }
-
         if (null === $this->min && null === $this->max) {
             throw new MissingOptionsException(sprintf('Either option "min" or "max" must be given for constraint %s', __CLASS__), ['min', 'max']);
         }

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -30,7 +30,11 @@ class LengthValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Length');
         }
 
-        if (null === $value || ('' === $value && $constraint->allowEmptyString)) {
+        if (null !== $constraint->min && null === $constraint->allowEmptyString) {
+            @trigger_error(sprintf('Using the "%s" constraint with the "min" option without setting the "allowEmptyString" one is deprecated and defaults to true. In 5.0, it will become optional and default to false.', Length::class), E_USER_DEPRECATED);
+        }
+
+        if (null === $value || ('' === $value && ($constraint->allowEmptyString ?? true))) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Since #31528, we are told to do this kind of changes to our entities:
```diff
     /**
      * @Assert\NotBlank()
-     * @Assert\Length(min="10")
+     * @Assert\Length(min="10", allowEmptyString=false)
      */
     public $description;
```

But the `NotBlank` already says it - this is just boilerplate. More critically, this also means we cannot write annotations that are compatible with 3.4, 4.4 and 5.0 at the same time, making FC/BC hard.

By setting `Length::$allowEmptyString` to `false` when a `NotBlank` contraint is defined, we fix both issues.

/cc @ogizanagi 