### PR TITLE
[Console] Detect dimensions using mode CON if vt100 is supported

### DIFF
--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -79,7 +79,9 @@ class Terminal
                 // or [w, h] from "wxh"
                 self::$width = (int) $matches[1];
                 self::$height = isset($matches[4]) ? (int) $matches[4] : (int) $matches[2];
-            } elseif (self::hasSttyAvailable()) {
+            } elseif (!self::hasVt100Support() && self::hasSttyAvailable()) {
+                // only use stty on Windows if the terminal does not support vt100 (e.g. Windows 7 + git-bash)
+                // testing for stty in a Windows 10 vt100-enabled console will implicitly disable vt100 support on STDOUT
                 self::initDimensionsUsingStty();
             } elseif (null !== $dimensions = self::getConsoleMode()) {
                 // extract [w, h] from "wxh"
@@ -91,6 +93,17 @@ class Terminal
         }
     }
 
+    /**
+     * Returns whether STDOUT has vt100 support (some Windows 10+ configurations).
+     */
+    private static function hasVt100Support(): bool
+    {
+        return \function_exists('sapi_windows_vt100_support') && sapi_windows_vt100_support(STDOUT);
+    }
+
+    /**
+     * Initializes dimensions using the output of an stty columns line.
+     */
     private static function initDimensionsUsingStty()
     {
         if ($sttyString = self::getSttyColumns()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33915 
| License       | MIT

This fixes color support detection for users of Win10 + git-bash.  If vt100 support is detected, the terminal will not try to use `stty` to test for dimensions. Calling such command implicitly disables vt100 support on STDOUT.