### PR TITLE
Allow exit status not to be 0 when symfony is out of maintenance

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -101,6 +101,13 @@ EOT
 
         $io->table([], $rows);
 
+        if (self::isExpired(Kernel::END_OF_LIFE)) {
+            return 2;
+        }
+        if (self::isExpired(Kernel::END_OF_MAINTENANCE)) {
+            return 1;
+        }
+
         return 0;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4<!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->

This is a suggestion to allow the `bin/console about` command to return a non-zero exit status when the Symfony version is no longer maintained (`1`) and no longer supported (`2`).

Doing this will allow integration tests to check for version in build pipelines to determine the current project status. This will aid in timely replacing and updating the framework.
