### PR TITLE
[Validator] Ensure numeric subpaths do not cause errors on PHP 7.4

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Util/PropertyPathTest.php
@@ -32,6 +32,7 @@ class PropertyPathTest extends TestCase
             ['foo', 'bar', 'foo.bar', 'It append the subPath to the basePath'],
             ['foo', '[bar]', 'foo[bar]', 'It does not include the dot separator if subPath uses the array notation'],
             ['0', 'bar', '0.bar', 'Leading zeros are kept.'],
+            ['0', 1, '0.1', 'Numeric subpaths do not cause PHP 7.4 errors.'],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Util/PropertyPath.php
+++ b/src/Symfony/Component/Validator/Util/PropertyPath.php
@@ -36,12 +36,13 @@ class PropertyPath
      */
     public static function append($basePath, $subPath)
     {
-        if ('' !== (string) $subPath) {
+        $subPath = (string) $subPath;
+        if ('' !== $subPath) {
             if ('[' === $subPath[0]) {
                 return $basePath.$subPath;
             }
 
-            return '' !== (string) $basePath ? $basePath.'.'.$subPath : $subPath;
+            return '' !== $basePath ? $basePath.'.'.$subPath : $subPath;
         }
 
         return $basePath;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Drupal is testing on PHP7.4 and hitting a problem with the line `if ('[' === $subPath[0]) {` because `$subPath` is not a string. We're already doing string casting in the method so we could do it once and be done. Note this is not a problem on the master branch / SF5 because of primitive typehinting.

Without this fix on PHP7.4 you see errors like...
```
1) Symfony\Component\Validator\Tests\Util\PropertyPathTest::testAppend with data set #5 ('0', 1, '0.1', 'Numeric subpaths do not cause...rrors.')
Trying to access array offset on value of type int
```