### PR TITLE
[Yaml][Parser] Remove the getLastLineNumberBeforeDeprecation() internal unused method

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -108,14 +108,6 @@ class Parser
         return $data;
     }
 
-    /**
-     * @internal
-     */
-    public function getLastLineNumberBeforeDeprecation(): int
-    {
-        return $this->getRealCurrentLineNb();
-    }
-
     private function doParse(string $value, int $flags)
     {
         $this->currentLineNb = -1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This method is internal and unused. It was removed by https://github.com/symfony/symfony/pull/23332/commits/a2ae6bf745f18936ed876cfd34967ffe6e507edd but was added back mistakenly by https://github.com/symfony/symfony/pull/23332/commits/1baac5a74ff313342f3ca1b3b616b8592eeaa953.
