### PR TITLE
[Notifier] Fix default value for phone number of admins

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1531,7 +1531,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('array')
                                 ->children()
                                     ->scalarNode('email')->cannotBeEmpty()->end()
-                                    ->scalarNode('phone')->defaultNull()->end()
+                                    ->scalarNode('phone')->defaultValue('')->end()
                                 ->end()
                             ->end()
                         ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

`AdminRecipient` does not support `null` for phone.
