### PR TITLE
[Notifier] Defaults to NoNotifier when sending a notification without recipients

### DIFF
--- a/src/Symfony/Component/Notifier/Notifier.php
+++ b/src/Symfony/Component/Notifier/Notifier.php
@@ -18,6 +18,7 @@ use Symfony\Component\Notifier\Channel\ChannelPolicyInterface;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Recipient\AdminRecipient;
+use Symfony\Component\Notifier\Recipient\NoRecipient;
 use Symfony\Component\Notifier\Recipient\Recipient;
 
 /**
@@ -42,6 +43,10 @@ final class Notifier implements NotifierInterface
 
     public function send(Notification $notification, Recipient ...$recipients): void
     {
+        if (!$recipients) {
+            $recipients = [new NoRecipient()];
+        }
+
         foreach ($recipients as $recipient) {
             foreach ($this->getChannels($notification, $recipient) as $channel => $transportName) {
                 $channel->notify($notification, $recipient, $transportName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0 <!-- see below -->
| Bug fix?      | no-ish
| New feature?  | yes-ish <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

Having no recipients is possible for some channels like the browser channel. Right now, we need to explicitely use the NoRecipient class, which looks weird, let's do it on our side instead.
