### PR TITLE
Notifier disable failed message listener by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1516,6 +1516,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                     ->end()
+                    ->booleanNode('notification_on_failed_messages')->defaultFalse()->end()
                     ->children()
                         ->arrayNode('channel_policy')
                             ->useAttributeAsKey('name')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1934,9 +1934,11 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('notifier.channel.email');
         }
 
-        if (!$this->messengerConfigEnabled) {
-            $container->removeDefinition('notifier.failed_message_listener');
-        } else {
+        if ($this->messengerConfigEnabled) {
+            if ($config['notification_on_failed_messages']) {
+                $container->getDefinition('notifier.failed_message_listener')->addTag('kernel.event_subscriber');
+            }
+
             // as we have a bus, the channels don't need the transports
             $container->getDefinition('notifier.channel.chat')->setArgument(0, null);
             $container->getDefinition('notifier.channel.email')->setArgument(0, null);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.xml
@@ -44,7 +44,6 @@
 
         <service id="notifier.failed_message_listener" class="Symfony\Component\Notifier\EventListener\SendFailedMessageToNotifierListener">
             <argument type="service" id="notifier" />
-            <tag name="kernel.event_subscriber" />
         </service>
 
         <!-- chatter -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | yes-ish <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | -

I forgot to disable by default the "notifications on failed messages" listener. It cannot be enabled by default as we need some configuration to make it work (an email address for the admin).

So, I made it disable by default, and added a config to enable it explicitly.
