### PR TITLE
[Messenger] remove infinite (nullable) max retries

### DIFF
--- a/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/MultiplierRetryStrategy.php
@@ -38,12 +38,12 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
     private $maxDelayMilliseconds;
 
     /**
-     * @param int   $maxRetries           The maximum number of time to retry (null means indefinitely)
+     * @param int   $maxRetries           The maximum number of times to retry
      * @param int   $delayMilliseconds    Amount of time to delay (or the initial value when multiplier is used)
      * @param float $multiplier           Multiplier to apply to the delay each time a retry occurs
      * @param int   $maxDelayMilliseconds Maximum delay to allow (0 means no maximum)
      */
-    public function __construct(?int $maxRetries = 3, int $delayMilliseconds = 1000, float $multiplier = 1, int $maxDelayMilliseconds = 0)
+    public function __construct(int $maxRetries = 3, int $delayMilliseconds = 1000, float $multiplier = 1, int $maxDelayMilliseconds = 0)
     {
         $this->maxRetries = $maxRetries;
 
@@ -65,10 +65,6 @@ class MultiplierRetryStrategy implements RetryStrategyInterface
 
     public function isRetryable(Envelope $message): bool
     {
-        if (null === $this->maxRetries) {
-            return true;
-        }
-
         $retries = RedeliveryStamp::getRetryCountFromEnvelope($message);
 
         return $retries < $this->maxRetries;

--- a/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Retry/MultiplierRetryStrategyTest.php
@@ -26,16 +26,6 @@ class MultiplierRetryStrategyTest extends TestCase
         $this->assertTrue($strategy->isRetryable($envelope));
     }
 
-    public function testIsRetryableWithNullMax()
-    {
-        $strategy = new MultiplierRetryStrategy(null);
-        $envelope = new Envelope(new \stdClass(), [new RedeliveryStamp(0, 'sender_alias')]);
-        $this->assertTrue($strategy->isRetryable($envelope));
-
-        $envelope = new Envelope(new \stdClass(), [new RedeliveryStamp(1, 'sender_alias')]);
-        $this->assertTrue($strategy->isRetryable($envelope));
-    }
-
     public function testIsNotRetryable()
     {
         $strategy = new MultiplierRetryStrategy(3);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #33284
| License       | MIT
| Doc PR        | 

Infinite retries are useless and putting a high enough number is more self-explaining. Infinite retries could not be configured using the framework anyway, see issue.