### PR TITLE
[Console] SymonfyStyle - Check value isset to avoid PHP notice

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -229,7 +229,7 @@ class SymfonyStyle extends OutputStyle
     {
         if (null !== $default) {
             $values = array_flip($choices);
-            $default = $values[$default];
+            $default = isset($values[$default]) ? $values[$default] : $default;
         }
 
         return $this->askQuestion(new ChoiceQuestion($question, $choices, $default));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34093 
| License       | MIT
| Doc PR        | n/a

This PR addresses the issue when a default value is not a valid choice. Currently this would throw a notice which outputs to the console.

This fix is a similar implementation to the `QuestionHelper`: https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Console/Helper/QuestionHelper.php#L63

Example console command and output can be found in the issue: #34093
