### PR TITLE
[HttpClient] ignore the body of responses to HEAD requests

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -197,6 +197,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface
         if ('POST' === $method) {
             // Use CURLOPT_POST to have browser-like POST-to-GET redirects for 301, 302 and 303
             $curlopts[CURLOPT_POST] = true;
+        } elseif ('HEAD' === $method) {
+            $curlopts[CURLOPT_NOBODY] = true;
         } else {
             $curlopts[CURLOPT_CUSTOMREQUEST] = $method;
         }

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -176,7 +176,7 @@ class MockResponse implements ResponseInterface
                 try {
                     $offset = 0;
                     $chunk[1]->getStatusCode();
-                    $response->headers = $chunk[1]->getHeaders(false);
+                    $chunk[1]->getHeaders(false);
                     self::readResponse($response, $chunk[0], $chunk[1], $offset);
                     $multi->handlesActivity[$id][] = new FirstChunk();
                 } catch (\Throwable $e) {

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -174,8 +174,16 @@ final class NativeResponse implements ResponseInterface
             $this->inflate = null;
         }
 
-        $this->multi->openHandles[$this->id] = [$h, $this->buffer, $this->inflate, $this->content, $this->onProgress, &$this->remaining, &$this->info];
         $this->multi->handlesActivity[$this->id] = [new FirstChunk()];
+
+        if ('HEAD' === $context['http']['method']) {
+            $this->multi->handlesActivity[$this->id][] = null;
+            $this->multi->handlesActivity[$this->id][] = null;
+
+            return;
+        }
+
+        $this->multi->openHandles[$this->id] = [$h, $this->buffer, $this->inflate, $this->content, $this->onProgress, &$this->remaining, &$this->info];
     }
 
     /**

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -72,6 +72,33 @@ abstract class HttpClientTestCase extends TestCase
         $response->getContent();
     }
 
+    public function testHeadRequest()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('HEAD', 'http://localhost:8057', [
+            'headers' => ['Foo' => 'baR'],
+            'user_data' => $data = new \stdClass(),
+        ]);
+
+        $this->assertSame([], $response->getInfo('response_headers'));
+        $this->assertSame($data, $response->getInfo()['user_data']);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $info = $response->getInfo();
+        $this->assertNull($info['error']);
+        $this->assertSame(0, $info['redirect_count']);
+        $this->assertSame('HTTP/1.1 200 OK', $info['response_headers'][0]);
+        $this->assertSame('Host: localhost:8057', $info['response_headers'][1]);
+        $this->assertSame('http://localhost:8057/', $info['url']);
+
+        $headers = $response->getHeaders();
+
+        $this->assertSame('localhost:8057', $headers['host'][0]);
+        $this->assertSame(['application/json'], $headers['content-type']);
+
+        $this->assertSame('', $response->getContent());
+    }
+
     public function testNonBufferedGetRequest()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34102
| License       | MIT
| Doc PR        | -