### PR TITLE
Issue 34061: ContainerAwareTrait adds @required annotation for setContainer

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
@@ -23,6 +23,9 @@ trait ContainerAwareTrait
      */
     protected $container;
 
+    /**
+     * @required
+     */
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;


### PR DESCRIPTION
ContainerAwareTrait includes a @required annotation for `setContainer` as decribed in #34061 

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34061 
| License       | MIT
| Doc PR        | ---

This pull request drafts the recommended change in issue #34061.