### PR TITLE
[Console] Fix commands description with numeric namespaces

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -129,23 +129,29 @@ class ApplicationDescription
     {
         $namespacedCommands = [];
         $globalCommands = [];
+        $sortedCommands = [];
         foreach ($commands as $name => $command) {
             $key = $this->application->extractNamespace($name, 1);
-            if (!$key) {
-                $globalCommands['_global'][$name] = $command;
+            if (\in_array($key, ['', self::GLOBAL_NAMESPACE], true)) {
+                $globalCommands[$name] = $command;
             } else {
                 $namespacedCommands[$key][$name] = $command;
             }
         }
-        ksort($namespacedCommands);
-        $namespacedCommands = array_merge($globalCommands, $namespacedCommands);
 
-        foreach ($namespacedCommands as &$commandsSet) {
-            ksort($commandsSet);
+        if ($globalCommands) {
+            ksort($globalCommands);
+            $sortedCommands[self::GLOBAL_NAMESPACE] = $globalCommands;
         }
-        // unset reference to keep scope clear
-        unset($commandsSet);
 
-        return $namespacedCommands;
+        if ($namespacedCommands) {
+            ksort($namespacedCommands);
+            foreach ($namespacedCommands as $key => $commandsSet) {
+                ksort($commandsSet);
+                $sortedCommands[$key] = $commandsSet;
+            }
+        }
+
+        return $sortedCommands;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Descriptor/ApplicationDescriptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/ApplicationDescriptionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Descriptor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Descriptor\ApplicationDescription;
+
+final class ApplicationDescriptionTest extends TestCase
+{
+    /**
+     * @dataProvider getNamespacesProvider
+     */
+    public function testGetNamespaces(array $expected, array $names)
+    {
+        $application = new TestApplication();
+        foreach ($names as $name) {
+            $application->add(new Command($name));
+        }
+
+        $this->assertSame($expected, array_keys((new ApplicationDescription($application))->getNamespaces()));
+    }
+
+    public function getNamespacesProvider()
+    {
+        return [
+            [['_global'], ['foobar']],
+            [['a', 'b'], ['b:foo', 'a:foo', 'b:bar']],
+            [['_global', 'b', 'z', 22, 33], ['z:foo', '1', '33:foo', 'b:foo', '22:foo:bar']],
+        ];
+    }
+}
+
+final class TestApplication extends Application
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultCommands()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/34111
| License       | MIT
| Doc PR        | -

This PR fixes the linked ticket case.

It also changes the keys sorting to display the numeric namespaces first.

It also fixes another bug if your command name starts with `_global:`. In this special case the command is considered global but its full name is still `_global:xxx`. We can't do better without more refactoring since the final array of namespaces and global commands is shared, `_global` just being a special key. Currently, if your command starts with `_global`, all global commands are not displayed at all so it's better like this anyway.

It also fixes another bug if your command starts with `0:` (cf `'' ===` comparison).