### PR TITLE
[FrameworkBundle] Remove suffix convention when using env vars to override secrets from the vault

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
@@ -45,7 +45,7 @@ final class SecretsDecryptToLocalCommand extends Command
             ->setDescription('Decrypts all secrets and stores them in the local vault.')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces overriding of secrets that already exist in the local vault')
             ->setHelp(<<<'EOF'
-The <info>%command.name%</info> command list decrypts all secrets and stores them in the local vault..
+The <info>%command.name%</info> command decrypts all secrets and copies them in the local vault.
 
     <info>%command.full_name%</info>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
@@ -89,10 +89,10 @@ EOF
         }
 
         foreach ($localSecrets ?? [] as $name => $value) {
-            $rows[$name] = [$name, $rows[$name][1] ?? '', $dump($value)];
+            if (isset($rows[$name])) {
+                $rows[$name][] = $dump($value);
+            }
         }
-
-        uksort($rows, 'strnatcmp');
 
         if (null !== $this->localVault && null !== $message = $this->localVault->getLastMessage()) {
             $io->comment($message);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
@@ -86,6 +86,12 @@ EOF
             return 1;
         }
 
+        if ($this->localVault === $vault && !\array_key_exists($name, $this->vault->list())) {
+            $io->error(sprintf('Secret "%s" does not exist in the vault, you cannot override it locally.', $name));
+
+            return 1;
+        }
+
         if (0 < $random = $input->getOption('random') ?? 16) {
             $value = strtr(substr(base64_encode(random_bytes($random)), 0, $random), '+/', '-_');
         } elseif (!$file = $input->getArgument('file')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
@@ -36,14 +36,13 @@ class DotenvVault extends AbstractVault
     {
         $this->lastMessage = null;
         $this->validateName($name);
-        $k = $name.'_SECRET';
         $v = str_replace("'", "'\\''", $value);
 
         $content = file_exists($this->dotenvFile) ? file_get_contents($this->dotenvFile) : '';
-        $content = preg_replace("/^$k=((\\\\'|'[^']++')++|.*)/m", "$k='$v'", $content, -1, $count);
+        $content = preg_replace("/^$name=((\\\\'|'[^']++')++|.*)/m", "$name='$v'", $content, -1, $count);
 
         if (!$count) {
-            $content .= "$k='$v'\n";
+            $content .= "$name='$v'\n";
         }
 
         file_put_contents($this->dotenvFile, $content);
@@ -55,8 +54,7 @@ class DotenvVault extends AbstractVault
     {
         $this->lastMessage = null;
         $this->validateName($name);
-        $k = $name.'_SECRET';
-        $v = \is_string($_SERVER[$k] ?? null) ? $_SERVER[$k] : ($_ENV[$k] ?? null);
+        $v = \is_string($_SERVER[$name] ?? null) ? $_SERVER[$name] : ($_ENV[$name] ?? null);
 
         if (null === $v) {
             $this->lastMessage = sprintf('Secret "%s" not found in "%s".', $name, $this->getPrettyPath($this->dotenvFile));
@@ -71,10 +69,9 @@ class DotenvVault extends AbstractVault
     {
         $this->lastMessage = null;
         $this->validateName($name);
-        $k = $name.'_SECRET';
 
         $content = file_exists($this->dotenvFile) ? file_get_contents($this->dotenvFile) : '';
-        $content = preg_replace("/^$k=((\\\\'|'[^']++')++|.*)\n?/m", '', $content, -1, $count);
+        $content = preg_replace("/^$name=((\\\\'|'[^']++')++|.*)\n?/m", '', $content, -1, $count);
 
         if ($count) {
             file_put_contents($this->dotenvFile, $content);
@@ -94,14 +91,14 @@ class DotenvVault extends AbstractVault
         $secrets = [];
 
         foreach ($_ENV as $k => $v) {
-            if (preg_match('/^(\w+)_SECRET$/D', $k, $m)) {
-                $secrets[$m[1]] = $reveal ? $v : null;
+            if (preg_match('/^\w+$/D', $k)) {
+                $secrets[$k] = $reveal ? $v : null;
             }
         }
 
         foreach ($_SERVER as $k => $v) {
-            if (\is_string($v) && preg_match('/^(\w+)_SECRET$/D', $k, $m)) {
-                $secrets[$m[1]] = $reveal ? $v : null;
+            if (\is_string($v) && preg_match('/^\w+$/D', $k)) {
+                $secrets[$k] = $reveal ? $v : null;
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SecretEnvVarProcessor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SecretEnvVarProcessor.php
@@ -44,9 +44,9 @@ class SecretEnvVarProcessor implements EnvVarProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function getEnv($prefix, $name, \Closure $getEnv)
+    public function getEnv($prefix, $name, \Closure $getEnv): string
     {
-        if (null !== $this->localVault && null !== $secret = $this->localVault->reveal($name)) {
+        if (null !== $this->localVault && null !== ($secret = $this->localVault->reveal($name)) && \array_key_exists($name, $this->vault->list())) {
             return $secret;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/DotenvVaultTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/DotenvVaultTest.php
@@ -37,21 +37,21 @@ class DotenvVaultTest extends TestCase
 
         $vault->seal('foo', $plain);
 
-        unset($_SERVER['foo_SECRET'], $_ENV['foo_SECRET']);
+        unset($_SERVER['foo'], $_ENV['foo']);
         (new Dotenv(false))->load($this->envFile);
 
         $decrypted = $vault->reveal('foo');
         $this->assertSame($plain, $decrypted);
 
-        $this->assertSame(['foo' => null], $vault->list());
-        $this->assertSame(['foo' => $plain], $vault->list(true));
+        $this->assertSame(['foo' => null], array_intersect_key($vault->list(), ['foo' => 123]));
+        $this->assertSame(['foo' => $plain], array_intersect_key($vault->list(true), ['foo' => 123]));
 
         $this->assertTrue($vault->remove('foo'));
         $this->assertFalse($vault->remove('foo'));
 
-        unset($_SERVER['foo_SECRET'], $_ENV['foo_SECRET']);
+        unset($_SERVER['foo'], $_ENV['foo']);
         (new Dotenv(false))->load($this->envFile);
 
-        $this->assertSame([], $vault->list());
+        $this->assertArrayNotHasKey('foo', $vault->list());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Right now, env vars that override encrypted secrets must en up with `_SECRET`.
This PR removes this convention. It also enforces that only vars defined in the vault can be overriden locally. This means one cannot set a local-only secret.