### PR TITLE
[Notifier] Set missing defaults

### DIFF
--- a/src/Symfony/Component/Notifier/Notification/Notification.php
+++ b/src/Symfony/Component/Notifier/Notification/Notification.php
@@ -38,8 +38,8 @@ class Notification
     public const IMPORTANCE_MEDIUM = 'medium';
     public const IMPORTANCE_LOW = 'low';
 
-    private $channels;
-    private $subject;
+    private $channels = [];
+    private $subject = '';
     private $content = '';
     private $emoji = '';
     private $exception;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->

When overriding the default Notification class, most of the time, we don't need to call the parent constructor. Having good defaults allows to skip it.
 