### PR TITLE
[Security/Core] make NativePasswordEncoder use sodium to validate passwords when possible

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -93,6 +93,6 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
             return \Sodium\crypto_pwhash_str_verify($encoded, $raw);
         }
 
-        throw new LogicException('Libsodium is not available. You should either install the sodium extension, upgrade to PHP 7.2+ or use a different encoder.');
+        return false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

sodium implementations are always faster, let's use them when possible. This also allows validating argon2 passwords when bcrypt is configured as the main one, making migrations possible.