### PR TITLE
[DomCrawler] normalizeWhitespace should be true by default

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
@@ -29,7 +29,7 @@ class CsrfFormLoginTest extends AbstractWebTestCase
 
         $crawler = $client->followRedirect();
 
-        $text = $crawler->text();
+        $text = $crawler->text(null, true);
         $this->assertStringContainsString('Hello johannes!', $text);
         $this->assertStringContainsString('You\'re browsing to path "/profile".', $text);
 
@@ -56,7 +56,7 @@ class CsrfFormLoginTest extends AbstractWebTestCase
 
         $this->assertRedirect($client->getResponse(), '/login');
 
-        $text = $client->followRedirect()->text();
+        $text = $client->followRedirect()->text(null, true);
         $this->assertStringContainsString('Invalid CSRF token.', $text);
     }
 
@@ -75,7 +75,7 @@ class CsrfFormLoginTest extends AbstractWebTestCase
 
         $this->assertRedirect($client->getResponse(), '/foo');
 
-        $text = $client->followRedirect()->text();
+        $text = $client->followRedirect()->text(null, true);
         $this->assertStringContainsString('Hello johannes!', $text);
         $this->assertStringContainsString('You\'re browsing to path "/foo".', $text);
     }
@@ -96,7 +96,7 @@ class CsrfFormLoginTest extends AbstractWebTestCase
         $client->submit($form);
         $this->assertRedirect($client->getResponse(), '/protected-resource');
 
-        $text = $client->followRedirect()->text();
+        $text = $client->followRedirect()->text(null, true);
         $this->assertStringContainsString('Hello johannes!', $text);
         $this->assertStringContainsString('You\'re browsing to path "/protected-resource".', $text);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -27,7 +27,7 @@ class FormLoginTest extends AbstractWebTestCase
 
         $this->assertRedirect($client->getResponse(), '/profile');
 
-        $text = $client->followRedirect()->text();
+        $text = $client->followRedirect()->text(null, true);
         $this->assertStringContainsString('Hello johannes!', $text);
         $this->assertStringContainsString('You\'re browsing to path "/profile".', $text);
     }
@@ -47,7 +47,7 @@ class FormLoginTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/profile');
 
         $crawler = $client->followRedirect();
-        $text = $crawler->text();
+        $text = $crawler->text(null, true);
 
         $this->assertStringContainsString('Hello johannes!', $text);
         $this->assertStringContainsString('You\'re browsing to path "/profile".', $text);
@@ -80,7 +80,7 @@ class FormLoginTest extends AbstractWebTestCase
 
         $this->assertRedirect($client->getResponse(), '/foo');
 
-        $text = $client->followRedirect()->text();
+        $text = $client->followRedirect()->text(null, true);
         $this->assertStringContainsString('Hello johannes!', $text);
         $this->assertStringContainsString('You\'re browsing to path "/foo".', $text);
     }
@@ -101,7 +101,7 @@ class FormLoginTest extends AbstractWebTestCase
         $client->submit($form);
         $this->assertRedirect($client->getResponse(), '/protected_resource');
 
-        $text = $client->followRedirect()->text();
+        $text = $client->followRedirect()->text(null, true);
         $this->assertStringContainsString('Hello johannes!', $text);
         $this->assertStringContainsString('You\'re browsing to path "/protected_resource".', $text);
     }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -593,7 +593,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the text of the first node of the list.
      *
-     * Pass true as the 2nd argument to normalize whitespaces.
+     * Pass true as the second argument to normalize whitespaces.
      *
      * @param string|null $default             When not null: the value to return when the current node is empty
      * @param bool        $normalizeWhitespace Whether whitespaces should be trimmed and normalized to single spaces
@@ -602,7 +602,7 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function text(/* string $default = null, bool $normalizeWhitespace = false */)
+    public function text(/* string $default = null, bool $normalizeWhitespace = true */)
     {
         if (!$this->nodes) {
             if (0 < \func_num_args() && null !== func_get_arg(0)) {
@@ -613,6 +613,14 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         $text = $this->getNode(0)->nodeValue;
+
+        if (\func_num_args() <= 1) {
+            if (trim(preg_replace('/(?:\s{2,}+|[^\S ])/', ' ', $text)) !== $text) {
+                @trigger_error(sprintf('"%s()" will normalize whitespaces by default in Symfony 5.0, set the second "$normalizeWhitespace" argument to false to retrieve the non-normalized version of the text.', __METHOD__), E_USER_DEPRECATED);
+            }
+
+            return $text;
+        }
 
         if (\func_num_args() > 1 && func_get_arg(1)) {
             return trim(preg_replace('/(?:\s{2,}+|[^\S ])/', ' ', $text));

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -258,6 +258,14 @@ abstract class AbstractCrawlerTest extends TestCase
         $crawler = $this->createTestCrawler()->filterXPath('//p');
         $this->assertSame('Elsa <3', $crawler->text(null, true), '->text(null, true) returns the text with normalized whitespace');
         $this->assertNotSame('Elsa <3', $crawler->text(null, false));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyNormalizeWhiteSpace()
+    {
+        $crawler = $this->createTestCrawler()->filterXPath('//p');
         $this->assertNotSame('Elsa <3', $crawler->text());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

According to the [DOM](https://www.w3.org/TR/DOM-Level-3-Core/core.html#Text3-isElementContentWhitespace) and [WebDriver](https://www.w3.org/TR/webdriver/#get-element-text) specs, browsers always return the normalized text. In Panther, because of WebDriver, it's not even possible without dirty hacks to retrieve the "non normalized" text.

For compatibility with Panther it's mandatory to set this new parameter (introduced in 4.4) to `true` by default.

 I propose to change the default value to true in 5.0, it has the benefit of:

* being spec-compliant (in 5.0, text will be normalized by default)
* being cleaner when using Panther (`$node->text()` instead of `$node->text(null, true)`, passing true is mandatory because Panther doesn't support retrieving the non-normalized text)

For backward compatible with 4.x versions, if no argument is passed and the returned text isn't the same than the normalized one, a notice is triggered.