### PR TITLE
[HttpFoundation] Allow to not pass a parameter to Request::isMethodSafe()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1447,14 +1447,11 @@ class Request
      *
      * @see https://tools.ietf.org/html/rfc7231#section-4.2.1
      *
-     * @param bool $andCacheable Adds the additional condition that the method should be cacheable. True by default.
-     *
      * @return bool
      */
-    public function isMethodSafe(/* $andCacheable = true */)
+    public function isMethodSafe()
     {
-        if (!\func_num_args() || func_get_arg(0)) {
-            // setting $andCacheable to false should be deprecated in 4.1
+        if (\func_num_args() > 0 && func_get_arg(0)) {
             throw new \BadMethodCallException('Checking only for cacheable HTTP methods with Symfony\Component\HttpFoundation\Request::isMethodSafe() is not supported.');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2132,7 +2132,7 @@ class RequestTest extends TestCase
         $this->expectException('BadMethodCallException');
         $request = new Request();
         $request->setMethod('OPTIONS');
-        $request->isMethodSafe();
+        $request->isMethodSafe(true);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This parameter was already deprecated in Symfony 4. Allowing to not pass it in Symfony 4.3 without triggering a deprecation allows to support both HttpFoundation 4.3 and 4.4, otherwise it's not possible.

Needed to make API Platform compatible with Symfony 5 (https://github.com/api-platform/core/pull/3009)