### PR TITLE
Re-allow to use "tagged" in service definitions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -502,8 +502,6 @@ class XmlFileLoader extends FileLoader
                     }
                     break;
                 case 'tagged':
-                    @trigger_error(sprintf('Type "%s" of tag <%s> in "%s" is deprecated since Symfony 4.4 and will be removed in 5.0, use "tagged_iterator" instead.', $arg->getAttribute('type'), $name, $file), E_USER_DEPRECATED);
-                    // no break
                 case 'tagged_iterator':
                 case 'tagged_locator':
                     $type = $arg->getAttribute('type');

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -742,10 +742,6 @@ class YamlFileLoader extends FileLoader
                 }
             }
             if (\in_array($value->getTag(), ['tagged', 'tagged_iterator', 'tagged_locator'], true)) {
-                if ('tagged' === $value->getTag()) {
-                    @trigger_error('"!tagged" is deprecated since Symfony 4.4 and will be removed in 5.0, use "!tagged_iterator" instead.', E_USER_DEPRECATED);
-                }
-
                 $forLocator = 'tagged_locator' === $value->getTag();
 
                 if (\is_array($argument) && isset($argument['tag']) && $argument['tag']) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -265,7 +265,7 @@
       <xsd:enumeration value="constant" />
       <xsd:enumeration value="iterator" />
       <xsd:enumeration value="service_locator" />
-      <!-- "tagged" is deprecated since Symfony 4.4 and will be removed in 5.0, use "tagged_iterator" instead. -->
+      <!-- "tagged" is an alias of "tagged_iterator", using "tagged_iterator" is preferred. -->
       <xsd:enumeration value="tagged" />
       <xsd:enumeration value="tagged_iterator" />
       <xsd:enumeration value="tagged_locator" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Re-allow to use `tagged` in 4.4 and 5.0. It makes it easier for bundles to support both Symfony 4.3- and Symfony 4.4+.

Needed to make API Platform compatible with Symfony 5 (api-platform/core#3009)