### PR TITLE
[WIP][Yaml] add TagProcessor

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.0.1
+-----
+ * Add support for custom tag processors via `TagProcessorInterface`
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -12,6 +12,10 @@
 namespace Symfony\Component\Yaml;
 
 use Symfony\Component\Yaml\Tag\TaggedValue;
+use Symfony\Component\Yaml\TagProcessor\BinaryTagProcessor;
+use Symfony\Component\Yaml\TagProcessor\FloatTagProcessor;
+use Symfony\Component\Yaml\TagProcessor\StrTagProcessor;
+use Symfony\Component\Yaml\TagProcessor\TagProcessorInterface;
 
 /**
  * Dumper dumps PHP variables to YAML strings.
@@ -36,6 +40,21 @@ class Dumper
         }
 
         $this->indentation = $indentation;
+        $this->addTagProcessor(new BinaryTagProcessor());
+        $this->addTagProcessor(new StrTagProcessor());
+        $this->addTagProcessor(new FloatTagProcessor());
+    }
+
+    /**
+     * Add a tag processor to use while dumping yaml content.
+     *
+     * @return $this
+     */
+    public function addTagProcessor(TagProcessorInterface $processor): self
+    {
+        $this->processors[$processor->getTag()] = $processor;
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/Yaml/TagProcessor/BinaryTagProcessor.php
+++ b/src/Symfony/Component/Yaml/TagProcessor/BinaryTagProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\TagProcessor;
+
+use Symfony\Component\Yaml\Inline;
+use Symfony\Component\Yaml\Tag\TaggedValue;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ */
+class BinaryTagProcessor implements TagProcessorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag(): string
+    {
+        return '!!binary';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(TaggedValue $data): string
+    {
+        return Inline::evaluateBinaryScalar($data->getValue());
+    }
+}

--- a/src/Symfony/Component/Yaml/TagProcessor/FloatTagProcessor.php
+++ b/src/Symfony/Component/Yaml/TagProcessor/FloatTagProcessor.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\TagProcessor;
+
+use Symfony\Component\Yaml\Tag\TaggedValue;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ */
+class FloatTagProcessor implements TagProcessorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag(): string
+    {
+        return '!!float';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(TaggedValue $data): float
+    {
+        return (float) substr($data->getValue(), 8);
+    }
+}

--- a/src/Symfony/Component/Yaml/TagProcessor/StrTagProcessor.php
+++ b/src/Symfony/Component/Yaml/TagProcessor/StrTagProcessor.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\TagProcessor;
+
+use Symfony\Component\Yaml\Tag\TaggedValue;
+
+/**
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ */
+class StrTagProcessor implements TagProcessorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag(): string
+    {
+        return '!!str';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(TaggedValue $data): string
+    {
+        return (string) substr($data->getValue(), 6);
+    }
+}

--- a/src/Symfony/Component/Yaml/TagProcessor/TagProcessorInterface.php
+++ b/src/Symfony/Component/Yaml/TagProcessor/TagProcessorInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\TagProcessor;
+
+use Symfony\Component\Yaml\Tag\TaggedValue;
+
+/**
+ * Process TaggedValue and convert it a php value.
+ *
+ * @author Saif Eddin Gmati <azjezz@protonmail.com>
+ */
+interface TagProcessorInterface
+{
+    /**
+     * Returns the tag name.
+     */
+    public function getTag(): string;
+
+    /**
+     * Process The Tagged value and return the PHP value.
+     */
+    public function process(TaggedValue $data);
+}

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Inline;
 use Symfony\Component\Yaml\Tag\TaggedValue;
+use Symfony\Component\Yaml\TagProcessor\BinaryTagProcessor;
+use Symfony\Component\Yaml\TagProcessor\FloatTagProcessor;
 use Symfony\Component\Yaml\Yaml;
 
 class InlineTest extends TestCase
@@ -80,11 +82,11 @@ class InlineTest extends TestCase
     /**
      * @dataProvider getTestsForDump
      */
-    public function testDump($yaml, $value, $parseFlags = 0)
+    public function testDump($yaml, $value, $parseFlags = 0, array $processors = [])
     {
         $this->assertEquals($yaml, Inline::dump($value), sprintf('::dump() converts a PHP structure to an inline YAML (%s)', $yaml));
 
-        $this->assertSame($value, Inline::parse(Inline::dump($value), $parseFlags), 'check consistency');
+        $this->assertSame($value, Inline::parse(Inline::dump($value), $parseFlags, [], $processors), 'check consistency');
     }
 
     public function testDumpNumericValueWithLocale()
@@ -454,7 +456,7 @@ class InlineTest extends TestCase
             ['_12', '_12'],
             ["'12_'", '12_'],
             ["'quoted string'", 'quoted string'],
-            ['!!float 1230', 12.30e+02],
+            ['!!float 1230', 12.30e+02, 0, [new FloatTagProcessor()]],
             ['1234', 0x4D2],
             ['1243', 02333],
             ["'0x_4_D_2_'", '0x_4_D_2_'],
@@ -580,7 +582,7 @@ class InlineTest extends TestCase
      */
     public function testParseBinaryData($data)
     {
-        $this->assertSame('Hello world', Inline::parse($data));
+        $this->assertSame('Hello world', Inline::parse($data, 0, [], [new BinaryTagProcessor()]));
     }
 
     public function getBinaryData()
@@ -600,7 +602,7 @@ class InlineTest extends TestCase
         $this->expectException('Symfony\Component\Yaml\Exception\ParseException');
         $this->expectExceptionMessageRegExp($expectedMessage);
 
-        Inline::parse($data);
+        Inline::parse($data, 0, [], [new BinaryTagProcessor()]);
     }
 
     public function getInvalidBinaryData()

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -52,9 +52,9 @@ class Yaml
      */
     public static function parseFile(string $filename, int $flags = 0)
     {
-        $yaml = new Parser();
+        $parser = new Parser();
 
-        return $yaml->parseFile($filename, $flags);
+        return $parser->parseFile($filename, $flags);
     }
 
     /**
@@ -75,9 +75,9 @@ class Yaml
      */
     public static function parse(string $input, int $flags = 0)
     {
-        $yaml = new Parser();
+        $parser = new Parser();
 
-        return $yaml->parse($input, $flags);
+        return $parser->parse($input, $flags);
     }
 
     /**
@@ -95,8 +95,8 @@ class Yaml
      */
     public static function dump($input, int $inline = 2, int $indent = 4, int $flags = 0): string
     {
-        $yaml = new Dumper($indent);
+        $dumper = new Dumper();
 
-        return $yaml->dump($input, $inline, 0, $flags);
+        return $dumper->dump($input, $inline, 0, $flags);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This PR adds `Symfony\Component\Yaml\TagProcessor\TagProcessorInterface` interface, allowing developers to extend the yaml parser by adding new tag processors.

An example of using the new `TagProcessorInterface` to load file content :

```php
final class FileTagProcessor implements TagProcessorInterface {
  public function getTag(): string {
    return '!!file';
  }

  public function process(TaggedValue $data): string {
     // skip some checks
     return file_get_contents($data->getValue());
  }
}

$parser = new Yaml\Parser();
$parser->addTagProcessor(new FileTagProcessor());
$yaml = <<<YAML
certificate: !!file path/to/example.crt
YAML;

$parameters = $parser->parse($yaml);
$certificate = $parameters['certificate'];
dump($certificate); // file content
```
