### PR TITLE
[TwigBundle][exception] Added missing css variable to highlight line in trace

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
@@ -28,6 +28,7 @@
     --shadow: 0px 0px 1px rgba(128, 128, 128, .2);
     --border: 1px solid #e0e0e0;
     --background-error: var(--color-error);
+    --trace-selected-background: #F7E5A1;
     --highlight-comment: #969896;
     --highlight-default: #222222;
     --highlight-keyword: #a71d5d;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

To get the yellow background
![image](https://user-images.githubusercontent.com/408368/67779323-c331b880-fa64-11e9-9a2f-97730a89a6d6.png)
