### PR TITLE
[HttpKernel] Fix wrapping the end of handleException() on PHP 7

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -258,8 +258,10 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         try {
             return $this->filterResponse($response, $request, $type);
         } catch (\Exception $e) {
-            return $response;
+        } catch (\Throwable $e) {
         }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I discovered this while working on https://github.com/symfony/symfony/pull/33065.

https://github.com/symfony/symfony/pull/458 is not working with PHP 7 if the listener throws an `\Error`. That means we should catch `\Throwable` here.