### PR TITLE
[Cache] Throw if Redis does not use supported eviction policies

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -59,7 +59,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
     private const DEFAULT_CACHE_TTL = 8640000;
 
     /**
-     * @var string|null Detected eviction policy used on Redis server.
+     * @var string|null detected eviction policy used on Redis server
      */
     private $redisEvictionPolicy;
 
@@ -85,7 +85,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
         }
 
         $eviction = $this->getRedisEvictionPolicy();
-        if ('noeviction' !== $eviction && strpos($eviction, 'volatile-') !== 0) {
+        if ('noeviction' !== $eviction && 0 !== strpos($eviction, 'volatile-')) {
             throw new InvalidArgumentException(sprintf('Redis maxmemory_policy setting "%s" is *not* supported by RedisTagAwareAdapter, use one "noeviction" or preferably one of "volatile-" eviction policies', $eviction));
         }
 

--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -96,6 +96,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
         $eviction = $this->getRedisEvictionPolicy();
         if ('noeviction' !== $eviction && 0 !== strpos($eviction, 'volatile-')) {
             CacheItem::log($this->logger, sprintf('Redis maxmemory-policy setting "%s" is *not* supported by RedisTagAwareAdapter, use "noeviction" or  "volatile-*" eviction policies', $eviction));
+
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| Deprecations? | no
| Tickets       | n.a.
| License       | MIT
| Doc PR        | n.a.

Adds validation to make sure Redis has been setup with the supported eviction policy to avoid surprises when cache suddenly is inconsistent. This is done in similar way to check for Redis version in 4.3, but in this case I opted to throw in constructor instead of doing it on demand and log warning only.

WDYT @nicolas-grekas ?

TODO:
- [ ] Test & adapt test setups for this