### PR TITLE
[Stopwatch] Fixed a bug in StopwatchEvent::getStartTime

### DIFF
--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -154,7 +154,15 @@ class StopwatchEvent
      */
     public function getStartTime()
     {
-        return isset($this->periods[0]) ? $this->periods[0]->getStartTime() : 0;
+        if (isset($this->periods[0])) {
+            return $this->periods[0]->getStartTime();
+        }
+
+        if ($this->started) {
+            return $this->started[0];
+        }
+
+        return 0;
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -152,6 +152,27 @@ class StopwatchEventTest extends TestCase
         $this->assertEqualsWithDelta(0, $event->getStartTime(), self::DELTA);
     }
 
+    public function testStartTimeWhenStartedLater()
+    {
+        $event = new StopwatchEvent(microtime(true) * 1000);
+        usleep(100000);
+        $this->assertLessThanOrEqual(0.5, $event->getStartTime());
+
+        $event = new StopwatchEvent(microtime(true) * 1000);
+        usleep(100000);
+        $event->start();
+        $event->stop();
+        $this->assertLessThanOrEqual(101, $event->getStartTime());
+
+        $event = new StopwatchEvent(microtime(true) * 1000);
+        usleep(100000);
+        $event->start();
+        usleep(100000);
+        $this->assertEqualsWithDelta(100, $event->getStartTime(), self::DELTA);
+        $event->stop();
+        $this->assertEqualsWithDelta(100, $event->getStartTime(), self::DELTA);
+    }
+
     public function testInvalidOriginThrowsAnException()
     {
         $this->expectException('InvalidArgumentException');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34088
| License       | MIT
| Doc PR        | N/A

When using a `StopwatchEvent` with an `$origin` that's smaller than the first start time, calling `getStartTime()` before ending the event will give `0` instead of the correct number.

The proposed fix in #34088 fixes this.