### PR TITLE
[Stopwatch] Fixed bug in getDuration when counting multiple ongoing periods

### DIFF
--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -177,12 +177,10 @@ class StopwatchEvent
     public function getDuration()
     {
         $periods = $this->periods;
-        $stopped = \count($periods);
-        $left = \count($this->started) - $stopped;
+        $left = \count($this->started);
 
-        for ($i = 0; $i < $left; ++$i) {
-            $index = $stopped + $i;
-            $periods[] = new StopwatchPeriod($this->started[$index], $this->getNow(), $this->morePrecision);
+        for ($i = $left - 1; $i >= 0; --$i) {
+            $periods[] = new StopwatchPeriod($this->started[$i], $this->getNow(), $this->morePrecision);
         }
 
         $total = 0;

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -99,8 +99,25 @@ class StopwatchEventTest extends TestCase
         $event->stop();
         usleep(50000);
         $event->start();
-        usleep(100000);
         $this->assertEqualsWithDelta(100, $event->getDuration(), self::DELTA);
+        usleep(100000);
+        $this->assertEqualsWithDelta(200, $event->getDuration(), self::DELTA);
+    }
+
+    public function testDurationWithMultipleStarts()
+    {
+        $event = new StopwatchEvent(microtime(true) * 1000);
+        $event->start();
+        usleep(100000);
+        $event->start();
+        usleep(100000);
+        $this->assertEqualsWithDelta(300, $event->getDuration(), self::DELTA);
+        $event->stop();
+        $this->assertEqualsWithDelta(300, $event->getDuration(), self::DELTA);
+        usleep(100000);
+        $this->assertEqualsWithDelta(400, $event->getDuration(), self::DELTA);
+        $event->stop();
+        $this->assertEqualsWithDelta(400, $event->getDuration(), self::DELTA);
     }
 
     public function testStopWithoutStart()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34087
| License       | MIT
| Doc PR        | N/A

When running multiple periods in StopwatchEvent (start multiple times and not stop them all), the getDuration() method would return unexpected values.

This was because at every stop, the last entry in the `started` array was removed, while the `getDuration` method was still expecting all the started events to still be there.

Now, when calling `getDuration`, the duration of all the finished periods are added together with the unfinished counts.