### PR TITLE
[VarDumper] display the method we're in when dumping stack traces

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -206,7 +206,7 @@ class ExceptionCaster
                     $f['file'] = substr($f['file'], 0, -\strlen($match[0]));
                     $f['line'] = (int) $match[1];
                 }
-                $caller = isset($f['function']) ? sprintf('in %s() on line %d', (isset($f['class']) ? $f['class'].$f['type'] : '').$f['function'], $f['line']) : null;
+                $caller = isset($f['function']) ? sprintf('in %s()', (isset($f['class']) ? $f['class'].$f['type'] : '').$f['function']) : null;
                 $src = $f['line'];
                 $srcKey = $f['file'];
                 $ellipsis = new LinkStub($srcKey, 0);
@@ -317,7 +317,7 @@ class ExceptionCaster
             $src[] = (isset($srcLines[$i]) ? $srcLines[$i] : '')."\n";
         }
 
-        $srcLines = [];
+        $srcLines = $title ? ["\0~separator=\0" => new ConstStub('string', $title)] : [];
         $ltrim = 0;
         do {
             $pad = null;

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -47,6 +47,7 @@ Exception {
   #line: 28
   trace: {
     %s%eTests%eCaster%eExceptionCasterTest.php:28 {
+      "in Symfony\Component\VarDumper\Tests\Caster\ExceptionCasterTest->getTestException()"
       › {
       ›     return new \Exception(''.$msg);
       › }
@@ -66,11 +67,12 @@ EODUMP;
         $expectedDump = <<<'EODUMP'
 {
   %s%eTests%eCaster%eExceptionCasterTest.php:28 {
+    "in Symfony\Component\VarDumper\Tests\Caster\ExceptionCasterTest->getTestException()"
     › {
     ›     return new \Exception(''.$msg);
     › }
   }
-  %s%eTests%eCaster%eExceptionCasterTest.php:64 { …}
+  %s%eTests%eCaster%eExceptionCasterTest.php:65 { …}
 %A
 EODUMP;
 
@@ -90,11 +92,12 @@ Exception {
   #line: 28
   trace: {
     %sExceptionCasterTest.php:28 {
+      "in Symfony\Component\VarDumper\Tests\Caster\ExceptionCasterTest->getTestException()"
       › {
       ›     return new \Exception(''.$msg);
       › }
     }
-    %s%eTests%eCaster%eExceptionCasterTest.php:82 { …}
+    %s%eTests%eCaster%eExceptionCasterTest.php:84 { …}
 %A
 EODUMP;
 

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -143,6 +143,7 @@ RuntimeException {
   #line: %d
   trace: {
     %ACliDumperTest.php:%d {
+      "in Symfony\Component\VarDumper\Tests\Dumper\CliDumperTest->testDumpWithCommaFlagsAndExceptionCodeExcerpt()"
       › 
       › $ex = new \RuntimeException('foo');
       › 
@@ -382,6 +383,7 @@ stream resource {@{$ref}
     #message: "Unexpected Exception thrown from a caster: Foobar"
     trace: {
       %sTwig.php:2 {
+        "in __TwigTemplate_VarDumperFixture_u75a09->doDisplay()"
         › foo bar
         ›   twig source
         › 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR adds the line in green:
![image](https://user-images.githubusercontent.com/243674/67842741-0dfe0f80-fafb-11e9-9e46-28f388537278.png)

Without it, we're missing some context as the method is from a trait. This allows knowing which class is actually importing and using the method.