### PR TITLE
[HttpClient] always return the empty string when the response cannot have a body

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -112,11 +112,15 @@ trait ResponseTrait
                 }
             }
 
-            if (null === $content) {
-                throw new TransportException('Cannot get the content of the response twice: the request was issued with option "buffer" set to false.');
+            if (null !== $content) {
+                return $content;
             }
 
-            return $content;
+            if ('HEAD' === $this->info['http_method'] || \in_array($this->info['http_code'], [204, 304], true)) {
+                return '';
+            }
+
+            throw new TransportException('Cannot get the content of the response twice: the request was issued with option "buffer" set to false.');
         }
 
         foreach (self::stream([$this]) as $chunk) {

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -48,7 +48,7 @@ class MockHttpClientTest extends HttpClientTestCase
                 return new MockHttpClient(function (string $method, string $url, array $options) use ($client) {
                     try {
                         // force the request to be completed so that we don't test side effects of the transport
-                        $response = $client->request($method, $url, $options);
+                        $response = $client->request($method, $url, ['buffer' => false] + $options);
                         $content = $response->getContent(false);
 
                         return new MockResponse($content, $response->getInfo());

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -29,15 +29,20 @@ foreach ($_SERVER as $k => $v) {
     }
 }
 
+$json = json_encode($vars, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
 switch ($vars['REQUEST_URI']) {
     default:
         exit;
+
+    case '/head':
+        header('Content-Length: '.strlen($json), true);
+        break;
 
     case '/':
     case '/?a=a&b=b':
     case 'http://127.0.0.1:8057/':
     case 'http://localhost:8057/':
-        header('Content-Type: application/json');
         ob_start('ob_gzhandler');
         break;
 
@@ -85,6 +90,7 @@ switch ($vars['REQUEST_URI']) {
     case '/304':
         header('Content-Length: 10', true, 304);
         echo '12345';
+
         return;
 
     case '/307':
@@ -143,4 +149,4 @@ switch ($vars['REQUEST_URI']) {
 
 header('Content-Type: application/json', true);
 
-echo json_encode($vars, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+echo $json;

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -75,26 +75,24 @@ abstract class HttpClientTestCase extends TestCase
     public function testHeadRequest()
     {
         $client = $this->getHttpClient(__FUNCTION__);
-        $response = $client->request('HEAD', 'http://localhost:8057', [
+        $response = $client->request('HEAD', 'http://localhost:8057/head', [
             'headers' => ['Foo' => 'baR'],
             'user_data' => $data = new \stdClass(),
+            'buffer' => false,
         ]);
 
         $this->assertSame([], $response->getInfo('response_headers'));
-        $this->assertSame($data, $response->getInfo()['user_data']);
         $this->assertSame(200, $response->getStatusCode());
 
         $info = $response->getInfo();
-        $this->assertNull($info['error']);
-        $this->assertSame(0, $info['redirect_count']);
         $this->assertSame('HTTP/1.1 200 OK', $info['response_headers'][0]);
         $this->assertSame('Host: localhost:8057', $info['response_headers'][1]);
-        $this->assertSame('http://localhost:8057/', $info['url']);
 
         $headers = $response->getHeaders();
 
         $this->assertSame('localhost:8057', $headers['host'][0]);
         $this->assertSame(['application/json'], $headers['content-type']);
+        $this->assertTrue(0 < $headers['content-length'][0]);
 
         $this->assertSame('', $response->getContent());
     }
@@ -265,6 +263,7 @@ abstract class HttpClientTestCase extends TestCase
         $client = $this->getHttpClient(__FUNCTION__);
         $response = $client->request('GET', 'http://localhost:8057/304', [
             'headers' => ['If-Match' => '"abc"'],
+            'buffer' => false,
         ]);
 
         $this->assertSame(304, $response->getStatusCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This will fix tests on 4.4 also.