### PR TITLE
[PhpUnitBridge] Also search for composer.phar in git root folder

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -99,6 +99,7 @@ foreach ($defaultEnvs as $envName => $envValue) {
 $COMPOSER = file_exists($COMPOSER = $oldPwd.'/composer.phar')
     || ($COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer.phar`) : `which composer.phar 2> /dev/null`))
     || ($COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer`) : `which composer 2> /dev/null`))
+    || file_exists($COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? `git rev-parse --show-toplevel 2> NUL` : `git rev-parse --show-toplevel 2> /dev/null`).DIRECTORY_SEPARATOR.'composer.phar')
     ? $PHP.' '.escapeshellarg($COMPOSER)
     : 'composer';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features 
| Bug fix?      | kindof
| New feature?  | addition to existing feature
| Deprecations? | no
| Tickets       | Related: https://github.com/symfony/symfony/issues/26637#issuecomment-390749681
| License       | MIT

When you don't have a system `composer` installation, but a `composer.phar` in the project folder, you cannot use the `simple-phpunit` script from a subfolder of the project with e.g. `../vendor/bin/simple-phpunit`.

This change also searches for the `composer.phar` in the current git root folder if it was not found at any other places to increase the likelihood of it being found.