### PR TITLE
[WebProfilerBundle] Status code shows wrong color

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -33,7 +33,7 @@
             </thead>
             <tbody>
                 {% for result in tokens %}
-                    {% set css_class = result.status_code|default(0) > 399 ? 'status-error' : result.status_code|default(0) > 299 ? 'status-warning' : 'status-success' %}
+                    {% set css_class = (result.status_code|default(0) * 1) > 399 ? 'status-error' : (result.status_code|default(0) * 1) > 299 ? 'status-warning' : 'status-success' %}
 
                     <tr>
                         <td class="text-center">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

I recently tested php 7.3 (7.3.10) and wondered, why the status color in the results was inverted. So when i got a status code 400, the color was green, and everything with 200 was red. I'm currently unable to say, if it's actually this exact php version and if there were recent changes with comparisons. As i understood it until now, php casts strings to numbers, if compared with a number.

So i really don't know why it fails here, but in fact result.status_code is a string, and multiplying it with 1 casts it to a number, and then the right css style is applied.