### PR TITLE
[ErrorRenderer] Show generic message in non-debug mode

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
@@ -70,6 +70,6 @@ class JsonLoginTest extends AbstractWebTestCase
 
         $this->assertSame(400, $response->getStatusCode());
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
-        $this->assertSame(['title' => 'Bad Request', 'status' => 400], json_decode($response->getContent(), true));
+        $this->assertSame(['title' => 'Bad Request', 'status' => 400, 'detail' => 'Whoops, looks like something went wrong.'], json_decode($response->getContent(), true));
     }
 }

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/JsonErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/JsonErrorRenderer.php
@@ -40,12 +40,18 @@ class JsonErrorRenderer implements ErrorRendererInterface
     {
         $debug = $this->debug && ($exception->getHeaders()['X-Debug'] ?? true);
 
+        if ($debug) {
+            $message = $exception->getMessage();
+        } else {
+            $message = 404 === $exception->getStatusCode() ? 'Sorry, the page you are looking for could not be found.' : 'Whoops, looks like something went wrong.';
+        }
+
         $content = [
             'title' => $exception->getTitle(),
             'status' => $exception->getStatusCode(),
+            'detail' => $message,
         ];
         if ($debug) {
-            $content['detail'] = $exception->getMessage();
             $content['exceptions'] = $exception->toArray();
         }
 

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/TxtErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/TxtErrorRenderer.php
@@ -39,12 +39,18 @@ class TxtErrorRenderer implements ErrorRendererInterface
     public function render(FlattenException $exception): string
     {
         $debug = $this->debug && ($exception->getHeaders()['X-Debug'] ?? true);
-        $content = sprintf("[title] %s\n", $exception->getTitle());
-        $content .= sprintf("[status] %s\n", $exception->getStatusCode());
 
         if ($debug) {
-            $content .= sprintf("[detail] %s\n", $exception->getMessage());
+            $message = $exception->getMessage();
+        } else {
+            $message = 404 === $exception->getStatusCode() ? 'Sorry, the page you are looking for could not be found.' : 'Whoops, looks like something went wrong.';
+        }
 
+        $content = sprintf("[title] %s\n", $exception->getTitle());
+        $content .= sprintf("[status] %s\n", $exception->getStatusCode());
+        $content .= sprintf("[detail] %s\n", $message);
+
+        if ($debug) {
             foreach ($exception->toArray() as $i => $e) {
                 $content .= sprintf("[%d] %s: %s\n", $i + 1, $e['class'], $e['message']);
                 foreach ($e['trace'] as $trace) {

--- a/src/Symfony/Component/ErrorRenderer/ErrorRenderer/XmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorRenderer/ErrorRenderer/XmlErrorRenderer.php
@@ -42,14 +42,16 @@ class XmlErrorRenderer implements ErrorRendererInterface
     {
         $debug = $this->debug && ($exception->getHeaders()['X-Debug'] ?? true);
         $title = $this->escapeXml($exception->getTitle());
+        if ($debug) {
+            $message = $this->escapeXml($exception->getMessage());
+        } else {
+            $message = 404 === $exception->getStatusCode() ? 'Sorry, the page you are looking for could not be found.' : 'Whoops, looks like something went wrong.';
+        }
         $statusCode = $this->escapeXml($exception->getStatusCode());
         $charset = $this->escapeXml($this->charset);
 
         $exceptions = '';
-        $message = '';
         if ($debug) {
-            $message = '<detail>'.$this->escapeXml($exception->getMessage()).'</detail>';
-
             $exceptions .= '<exceptions>';
             foreach ($exception->toArray() as $e) {
                 $exceptions .= sprintf('<exception class="%s" message="%s"><traces>', $e['class'], $this->escapeXml($e['message']));
@@ -73,7 +75,7 @@ class XmlErrorRenderer implements ErrorRendererInterface
 <problem xmlns="urn:ietf:rfc:7807">
     <title>{$title}</title>
     <status>{$statusCode}</status>
-    {$message}
+    <detail>{$message}</detail>
     {$exceptions}
 </problem>
 EOF;

--- a/src/Symfony/Component/ErrorRenderer/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/Command/DebugCommandTest.php
@@ -56,7 +56,8 @@ TXT
         $this->assertSame(<<<TXT
 {
     "title": "Internal Server Error",
-    "status": 500
+    "status": 500,
+    "detail": "Whoops, looks like something went wrong."
 }
 
 TXT

--- a/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/JsonErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/JsonErrorRendererTest.php
@@ -44,7 +44,8 @@ JSON;
         $expectedNonDebug = <<<JSON
 {
     "title": "Internal Server Error",
-    "status": 500
+    "status": 500,
+    "detail": "Whoops, looks like something went wrong."
 }
 JSON;
 

--- a/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/TxtErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/TxtErrorRendererTest.php
@@ -39,6 +39,7 @@ TXT;
         $expectedNonDebug = <<<TXT
 [title] Internal Server Error
 [status] 500
+[detail] Whoops, looks like something went wrong.
 TXT;
 
         yield '->render() returns the TXT content WITH stack traces in debug mode' => [

--- a/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/XmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorRenderer/Tests/ErrorRenderer/XmlErrorRendererTest.php
@@ -43,7 +43,7 @@ XML;
 <problem xmlns="urn:ietf:rfc:7807">
     <title>Internal Server Error</title>
     <status>500</status>
-    
+    <detail>Whoops, looks like something went wrong.</detail>
     
 </problem>
 XML;

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ErrorControllerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ErrorControllerTest.php
@@ -61,7 +61,7 @@ class ErrorControllerTest extends TestCase
             $request,
             FlattenException::createFromThrowable(new \Exception('foo')),
             500,
-            '{"title": "Internal Server Error","status": 500}',
+            '{"title": "Internal Server Error","status": 500,"detail": "Whoops, looks like something went wrong."}',
         ];
 
         $request = new Request();
@@ -70,7 +70,7 @@ class ErrorControllerTest extends TestCase
             $request,
             FlattenException::createFromThrowable(new HttpException(405, 'Invalid request.')),
             405,
-            '{"title": "Method Not Allowed","status": 405}',
+            '{"title": "Method Not Allowed","status": 405,"detail": "Whoops, looks like something went wrong."}',
         ];
 
         $request = new Request();
@@ -79,7 +79,7 @@ class ErrorControllerTest extends TestCase
             $request,
             FlattenException::createFromThrowable(new HttpException(405, 'Invalid request.')),
             405,
-            '{"title": "Method Not Allowed","status": 405}',
+            '{"title": "Method Not Allowed","status": 405,"detail": "Whoops, looks like something went wrong."}',
         ];
 
         $request = new Request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I agree with @Tobion here https://github.com/symfony/symfony/pull/34158#issuecomment-548181099, so let's always show the detail message, but for 5xx errors we'll send a generic message instead.

/cc @dunglas wdyt?