### PR TITLE
[HttpClient] Fix perf issue when doing thousands of requests with curl

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -142,7 +142,6 @@ final class CurlResponse implements ResponseInterface
         // Schedule the request in a non-blocking way
         $multi->openHandles[$id] = [$ch, $options];
         curl_multi_add_handle($multi->handle, $ch);
-        self::perform($multi);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Performing while scheduling requests was a terrible idea: it makes buffers fill in memory and requires CPU do deal with the pending list, while all this in dealt with much more efficiently by any response-reading code that comes after.