### PR TITLE
[HttpKernel] [WebProfilerBundle] Added an icon in profile search results if something has been dumped

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -53,7 +53,7 @@
                             <span class="nowrap">{{ result.time|date('d-M-Y') }}</span>
                             <span class="nowrap newline">{{ result.time|date('H:i:s') }}</span>
                         </td>
-                        <td class="nowrap"><a href="{{ path('_profiler', { token: result.token }) }}">{{ result.token }}</a></td>
+                        <td class="nowrap"><a href="{{ path('_profiler', { token: result.token }) }}">{{ result.token }}</a>{% if result.has_dump %} <span class="sf-icon">{{ include('@Debug/Profiler/icon.svg') }}</span>{% endif %}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -85,7 +85,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 'time' => $csvTime,
                 'parent' => $csvParent,
                 'status_code' => $csvStatusCode,
-                'has_dump' => $hasDump
+                'has_dump' => $hasDump,
             ];
         }
 
@@ -200,7 +200,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 $profile->getTime(),
                 $profile->getParentToken(),
                 $profile->getStatusCode(),
-                $hasDump
+                $hasDump,
             ]);
             fclose($file);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | TODO

This is a proposal for a small feature : in the profiler search result, display a small icon next to the token link if something has been dump in this profiler token. This is particularly useful if browsing an app creates multiple profiles (via automatic AJAX calls for instance), and we want to quickly find which profile has debug info dumped in it : 

![image](https://user-images.githubusercontent.com/25033340/67968752-3d4e7280-fc08-11e9-84ed-0d03c3cf2fac.png)

As this is my first Symfony contribution, I'm not quite sure about the process, or even if this is an acceptable change. I also appreciate any feedback !

TODO
- [ ] update CHANGELOG file(s ?) I'm not sure about which files should be updated.
- [ ] doc PR. Here also, I'm not sure if a doc PR is needed, as this is a non-interactive feature (it juste displays an icon). Should I update some sreenshots somewhere to reflect this change ?