### PR TITLE
Error with empty array and status code 204 (no content)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -75,8 +75,18 @@ class JsonResponseTest extends TestCase
     {
         $response = new JsonResponse([], 200, ['ETag' => 'foo']);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{}', $response->getContent());
         $this->assertSame('foo', $response->headers->get('ETag'));
     }
+    
+    public function testStatusCodeNoContentDeliversEmptyArray()
+    {
+        $response = new JsonResponse([], 204);
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
+        $this->assertEquals('{}', $response->getContent());
+        $this->assertEquals(204, $response->getStatusCode());        
+    }    
 
     public function testConstructorWithCustomContentType()
     {
@@ -106,6 +116,15 @@ class JsonResponseTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
         $this->assertEquals('{"foo":"bar"}', $response->getContent());
         $this->assertEquals(204, $response->getStatusCode());
+    }
+    
+    public function testStatusCodeNoContentDeliversEmptyArray()
+    {
+        $response = JsonResponse::create([], 204);
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
+        $this->assertEquals('{}', $response->getContent());
+        $this->assertEquals(204, $response->getStatusCode());        
     }
 
     public function testStaticCreateEmptyJsonObject()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | no

It delivers `null` instead of the provided `[]`:
```php
return new JsonResponse([], Response::HTTP_NO_CONTENT);
```

I expect to get `[]`!