### PR TITLE
[Notifier][Telegram] Fixing Telegram token

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -38,7 +38,7 @@ final class TelegramTransport extends AbstractTransport
     private $token;
     private $chatChannel;
 
-    public function __construct(string $token, string $chatChannel, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $token, string $chatChannel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->chatChannel = $chatChannel;

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Telegram;
 
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -26,7 +27,7 @@ final class TelegramTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
-        $token = $this->getUser($dsn);
+        $token = $this->getToken($dsn);
         $channel = $dsn->getOption('channel');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
@@ -41,5 +42,18 @@ final class TelegramTransportFactory extends AbstractTransportFactory
     protected function getSupportedSchemes(): array
     {
         return ['telegram'];
+    }
+
+    private function getToken(Dsn $dsn): string
+    {
+        if (null === $dsn->getUser() && null === $dsn->getPassword()) {
+            throw new IncompleteDsnException('Missing token');
+        }
+
+        if (null === $dsn->getPassword()) {
+            throw new IncompleteDsnException('Malformed token');
+        }
+
+        return sprintf('%s:%s', $dsn->getUser(), $dsn->getPassword());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Thanks, i really love this integration! i needed to do two minor changes while playing around:

- token needs to contain user and password, see https://core.telegram.org/bots/api#making-requests
- channel should be optional for bot interaction, using `chat_id` as message option instead