### PR TITLE
[HttpClient] allow arbitrary JSON values in requests

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * added `TraceableHttpClient`, `HttpClientDataCollector` and `HttpClientPass` to integrate with the web profiler
  * allow enabling buffering conditionally with a Closure
  * allow option "buffer" to be a stream resource
+ * allow arbitrary values for the "json" option
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -332,17 +332,13 @@ trait HttpClientTrait
     }
 
     /**
-     * @param array|\JsonSerializable $value
+     * @param mixed $value
      *
      * @throws InvalidArgumentException When the value cannot be json-encoded
      */
     private static function jsonEncode($value, int $flags = null, int $maxDepth = 512): string
     {
         $flags = $flags ?? (JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_PRESERVE_ZERO_FRACTION);
-
-        if (!\is_array($value) && !$value instanceof \JsonSerializable) {
-            throw new InvalidArgumentException(sprintf('Option "json" must be array or JsonSerializable, %s given.', \is_object($value) ? \get_class($value) : \gettype($value)));
-        }
 
         try {
             $value = json_encode($value, $flags | (\PHP_VERSION_ID >= 70300 ? \JSON_THROW_ON_ERROR : 0), $maxDepth);

--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -86,7 +86,7 @@ class HttpOptions
     }
 
     /**
-     * @param array|\JsonSerializable $json
+     * @param mixed $json
      *
      * @return $this
      */

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -33,11 +33,11 @@ interface HttpClientInterface
         'query' => [],          // string[] - associative array of query string values to merge with the request's URL
         'headers' => [],        // iterable|string[]|string[][] - headers names provided as keys or as part of values
         'body' => '',           // array|string|resource|\Traversable|\Closure - the callback SHOULD yield a string
-                                //   smaller than the amount requested as argument; the empty string signals EOF; when
+                                //   smaller than the amount requested as argument; the empty string signals EOF; if
                                 //   an array is passed, it is meant as a form payload of field names and values
-        'json' => null,         // array|\JsonSerializable - when set, implementations MUST set the "body" option to
-                                //   the JSON-encoded value and set the "content-type" headers to a JSON-compatible
-                                //   value if they are not defined - typically "application/json"
+        'json' => null,         // mixed - if set, implementations MUST set the "body" option to the JSON-encoded
+                                //   value and set the "content-type" header to a JSON-compatible value if it is not
+                                //   explicitly defined in the headers option - typically "application/json"
         'user_data' => null,    // mixed - any extra data to attach to the request (scalar, callable, object...) that
                                 //   MUST be available via $response->getInfo('user_data') - not used internally
         'max_redirects' => 20,  // int - the maximum number of redirects to follow; a value lower than or equal to 0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Allow arbitrary values in the "json" request option. Previously values were
limitated to arrays and objects of type JsonSerializable. This doesn't account
for scalar values and classes with public properties (which don't need to
implement JsonSerializable), [all of which are perfectly acceptable arguments to
json_encode](https://www.php.net/manual/en/function.json-encode.php):

> value
> The value being encoded. Can be any type except a resource.

It seems silly to expect users to add classes implementing JsonSerializable to represent, say, scalar values or an empty object.

I'm not sure if you consider removed exceptional cases a BC break or not. I'm assuming "no" for now.