### PR TITLE
[Security] Add back ROLE_PREVIOUS_ADMIN to impersonated user

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -149,7 +149,7 @@ class SwitchUserListener
         $this->userChecker->checkPostAuth($user);
 
         $roles = $user->getRoles();
-
+        $roles[] = 'ROLE_PREVIOUS_ADMIN';
         $token = new SwitchUserToken($user, $user->getPassword(), $this->providerKey, $roles, $token);
 
         if (null !== $this->dispatcher) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Still useful as per https://symfony.com/doc/master/security/impersonating_user.html#knowing-when-impersonation-is-active