### PR TITLE
[HttpKernel] [WebProfilerBundle] List all installed packages in the Configuration's view

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -223,4 +223,24 @@
             </tbody>
         </table>
     {% endif %}
+
+    {% if collector.installedPackages %}
+        <h2>Installed Packages <small>({{ collector.installedPackages|length }})</small></h2>
+        <table>
+            <thead>
+            <tr>
+                <th class="key">Package</th>
+                <th>Version</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for name, version in collector.installedPackages %}
+                <tr>
+                    <th scope="row" class="font-normal">{{ name }}</th>
+                    <td class="font-normal">{{ version }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
 {% endblock %}

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -94,6 +94,13 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
             $this->data['php_version'] = $matches[1];
             $this->data['php_version_extra'] = $matches[2];
         }
+
+        if (class_exists(\PackageVersions\Versions::class)) {
+            foreach (\PackageVersions\Versions::VERSIONS as $package => $version) {
+                $this->data['installed_packages'][$package] = strtok($version, '@');
+            }
+            ksort($this->data['installed_packages']);
+        }
     }
 
     /**
@@ -329,6 +336,11 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
     public function getName()
     {
         return 'config';
+    }
+
+    public function getInstalledPackages()
+    {
+        return $this->data['installed_packages'];
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -41,6 +41,7 @@ class ConfigDataCollectorTest extends TestCase
         $this->assertSame(\extension_loaded('xdebug'), $c->hasXDebug());
         $this->assertSame(\extension_loaded('Zend OPcache') && filter_var(ini_get('opcache.enable'), FILTER_VALIDATE_BOOLEAN), $c->hasZendOpcache());
         $this->assertSame(\extension_loaded('apcu') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN), $c->hasApcu());
+        $this->assertIsArray($c->getInstalledPackages());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This small PR adds  the possibility to see all packages installed in the Profiler.
Actually it uses ocramius/package-versions (required by ocramius/proxy-manager, required-dev by symfony/symfony), split the package and the version n°.

I think it might be usefull to add a link to the repository/last commit hash, ... or improve the display, tell me your thoughts.

Actually the output looks like
![Capture d’écran de 2019-11-02 14-59-36](https://user-images.githubusercontent.com/7721219/68072058-c341f900-fd81-11e9-80b7-b0820af2e9a0.png)

PS: I wish you to have a great day
