### PR TITLE
[DependencyInjection] Bind with type is broken if no typehint used for constructor parameter

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -171,7 +171,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
                     continue;
                 }
 
-                if (count($this->searchBindingByPropertyName($bindings, $parameter->name)) !== 0) {
+                if (0 !== \count($this->searchBindingByPropertyName($bindings, $parameter->name))) {
                     $binding = $this->searchBindingByPropertyName($bindings, $parameter->name);
                     //if isset argument type
                     if (isset(explode(' ', array_key_first($binding), 2)[1])) {
@@ -232,15 +232,10 @@ class ResolveBindingsPass extends AbstractRecursivePass
         return $bindingValue;
     }
 
-    /**
-     * @param array $bindings
-     * @param string $propertyName
-     * @return array
-     */
     private function searchBindingByPropertyName(array $bindings, string $propertyName)
     {
         return array_filter($bindings, function ($key) use ($propertyName) {
-            return (strpos($key, $propertyName) !== false);
+            return false !== strpos($key, $propertyName);
         }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -150,4 +150,29 @@ class ResolveBindingsPassTest extends TestCase
 
         $this->assertSame([1 => 'bar'], $container->getDefinition(NamedArgumentsDummy::class)->getArguments());
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     */
+    public function testBindingTypeHint()
+    {
+        $container = new ContainerBuilder();
+
+        $bindings = [
+            'string $apiKey' => new BoundArgument('foo'),
+        ];
+
+        $definition = $container->register('def1', NamedArgumentsDummy::class);
+        $definition->setBindings($bindings);
+
+        $bindings = [
+            'string $c' => new BoundArgument('bar'),
+        ];
+
+        $definition = $container->register('def2', NamedArgumentsDummy::class);
+        $definition->setBindings($bindings);
+
+        $pass = new ResolveBindingsPass();
+        $pass->process($container);
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Compiler\AutowireRequiredMethodsPass;
-use Symfony\Component\DependencyInjection\Compiler\DefinitionErrorExceptionPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveBindingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -130,32 +129,10 @@ class ResolveBindingsPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testSyntheticServiceWithBind()
-    {
-        $container = new ContainerBuilder();
-        $argument = new BoundArgument('bar');
-
-        $container->register('foo', 'stdClass')
-            ->addArgument(new Reference('synthetic.service'));
-
-        $container->register('synthetic.service')
-            ->setSynthetic(true)
-            ->setBindings(['$apiKey' => $argument]);
-
-        $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class)
-            ->setBindings(['$apiKey' => $argument]);
-
-        (new ResolveBindingsPass())->process($container);
-        (new DefinitionErrorExceptionPass())->process($container);
-
-        $this->assertSame([1 => 'bar'], $container->getDefinition(NamedArgumentsDummy::class)->getArguments());
-    }
-
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     */
     public function testBindingTypeHint()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $container = new ContainerBuilder();
 
         $bindings = [


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       |  4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |  #33470 
| License       | MIT

I've added a condition that looks for arguments and if the typehint doesn’t match, throws an `InvalidArgumentException`
