### PR TITLE
[HttpFoundation] MockFileSessionStorageTest::sessionDir being used after it's unset

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -41,12 +41,12 @@ class MockFileSessionStorageTest extends TestCase
 
     protected function tearDown()
     {
-        $this->sessionDir = null;
-        $this->storage = null;
-        array_map('unlink', glob($this->sessionDir.'/*.session'));
+        array_map('unlink', glob($this->sessionDir.'/*'));
         if (is_dir($this->sessionDir)) {
             rmdir($this->sessionDir);
         }
+        $this->sessionDir = null;
+        $this->storage = null;
     }
 
     public function testStart()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `$sessionDir` property was used after being set to `null`.