### PR TITLE
[HttpKernel] Add kernel.error event to handle uncaught \Error

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Marked the `RouterDataCollector::collect()` method as `@final`.
  * The `DataCollectorInterface::collect()` and `Profiler::collect()` methods third parameter signature
    will be `\Throwable $exception = null` instead of `\Exception $exception = null` in Symfony 5.0.
+ * Added the `kernel.error` event to handle uncaught `\Error`.
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpKernel/Event/ErrorEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ErrorEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class ErrorEvent extends RequestEvent
+{
+    private $error;
+    private $allowCustomResponseCode = false;
+
+    public function __construct(HttpKernelInterface $kernel, Request $request, int $requestType, \Error $error)
+    {
+        parent::__construct($kernel, $request, $requestType);
+
+        $this->error = $error;
+    }
+
+    public function getError(): \Error
+    {
+        return $this->error;
+    }
+
+    public function allowCustomResponseCode(): void
+    {
+        $this->allowCustomResponseCode = true;
+    }
+
+    public function isAllowingCustomResponseCode(): bool
+    {
+        return $this->allowCustomResponseCode;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -112,10 +112,6 @@ class DebugHandlersListener implements EventSubscriberInterface
                             throw $e;
                         }
 
-                        if (!$e instanceof \Exception) {
-                            $e = new ErrorException($e);
-                        }
-
                         $hasRun = true;
                         $kernel->terminateWithException($e, $request);
                     };

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -35,8 +35,6 @@ interface HttpKernelInterface
      * @param bool $catch Whether to catch exceptions or not
      *
      * @return Response A Response instance
-     *
-     * @throws \Exception When an Exception occurs during processing
      */
     public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true);
 }

--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -30,6 +30,18 @@ final class KernelEvents
     const REQUEST = 'kernel.request';
 
     /**
+     * The ERROR event occurs when an uncaught error appears.
+     *
+     * This event allows you to create a response for a thrown error.
+     *
+     * If no response is created, the error is converted into an uncaught
+     * exception (@see KernelEvents::EXCEPTION).
+     *
+     * @Event("Symfony\Component\HttpKernel\Event\ErrorEvent")
+     */
+    const ERROR = 'kernel.error';
+
+    /**
      * The EXCEPTION event occurs when an uncaught exception appears.
      *
      * This event allows you to create a response for a thrown exception or


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/33065#issuecomment-549431051
| License       | MIT
| Doc PR        | TODO

This PR adds the `kernel.error` event as suggested in https://github.com/symfony/symfony/pull/33065#issuecomment-549431051.

~Only the second commit should be reviewed here.~
