### PR TITLE
[DependencyInjection] Throw better exception when missing use-statement

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -65,6 +65,14 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
             $class = $parameterBag->resolveValue($class);
 
             if (!$r = $container->getReflectionClass($class)) {
+                if ($id === $class) {
+                    /*
+                     * This happens when container has not been built before and if $class is missing some use-statements.
+                     * Make sure PHP loads the file to show any exceptions the user.
+                     */
+                    class_exists($class);
+                }
+
                 throw new InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
             }
             $isContainerAware = $r->implementsInterface(ContainerAwareInterface::class) || is_subclass_of($class, AbstractController::class);

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -68,7 +68,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                 if ($id === $class) {
                     /*
                      * This happens when container has not been built before and if $class is missing some use-statements.
-                     * Make sure PHP loads the file to show any exceptions the user.
+                     * Make sure PHP loads the file to show any exceptions to the user.
                      */
                     class_exists($class);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Im trying to address this issue: https://stackoverflow.com/questions/49958116/class-appbundle-controller-homecontroller-used-for-service-appbundle-controll

So here is the scenario: 

```php
namespace App\Foo;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

abstract class MyBaseController extends AbstractController{}
```
```php
namespace App\Bar;

// Note that "use App\Foo\MyBaseController" is missing
use App\MyService;

class StartpageController extends MyBaseController{
    public function action(MyService $service)
    {
        // ...
    }
}
```
Since `StartpageController` is autowired and tagged with `controller.service_arguments` we will run it in `RegisterControllerArgumentLocatorsPass`. 

If my cache folder is empty, I will get an error saying something like: 

> Class "App\Bar\StartpageController" used for service "App\Bar\StartpageController" cannot be found.

That does not make any sense. 


This PR is trying to load `App\Bar\StartpageController` to make PHP discover that we are missing something. Now I will get a much better error: 

> Attempted to load class "MyBaseController" from namespace "App\Bar". Did you forget a "use" statement for "App\Foo\MyBaseController"?

----------

If for some reason this is not the issue and PHP does not throw this error, we just continue with the normal exception. 
