### PR TITLE
[Mailer] Fix TLS capabilities detection

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -106,7 +106,7 @@ class EsmtpTransport extends SmtpTransport
 
         /** @var SocketStream $stream */
         $stream = $this->getStream();
-        if (!$stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && \array_key_exists('STARTTLS', $capabilities)) {
+        if (!$stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && ($capabilities['STARTTLS'] ?? false)) {
             $this->executeCommand("STARTTLS\r\n", [220]);
 
             if (!$stream->startTLS()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

Before this patch, the key `STARTTLS` was in $capabilities, but the
value was an empty array when the server does not support TLS.

I also tested it with gmail => OK

---

Reproducer

```php
use Symfony\Component\Mailer\Bridge\Google\Transport\GmailSmtpTransport;
use Symfony\Component\Mailer\Mailer;
use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
use Symfony\Component\Mime\Email;

// For this transport, use the following command line
// docker run -p 1080:80 -p 1025:25 djfarrelly/maildev
$transport = new EsmtpTransport('localhost', 1025);

$transport = new GmailSmtpTransport('lyrixx@lyrixx.info', 'FIXME');

$mailer = new Mailer($transport);

$email = (new Email())
    ->from('lyrixx@lyrixx.info')
    ->to('lyrixx@lyrixx.info')
    ->subject('test - ' . microtime(true))
    ->text('test - ' . microtime(true))
;

$mailer->send($email);
```