### PR TITLE
[Serializer] Use context to compute MetadataAwareNameConverter cache

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -26,11 +26,11 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
      */
     private $fallbackNameConverter;
 
-    private $normalizeCache = [];
+    private static $normalizeCache = [];
 
-    private $denormalizeCache = [];
+    private static $denormalizeCache = [];
 
-    private $attributesMetadataCache = [];
+    private static $attributesMetadataCache = [];
 
     public function __construct(ClassMetadataFactoryInterface $metadataFactory, NameConverterInterface $fallbackNameConverter = null)
     {
@@ -47,11 +47,11 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return $this->normalizeFallback($propertyName, $class, $format, $context);
         }
 
-        if (!isset($this->normalizeCache[$class][$propertyName])) {
-            $this->normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class);
+        if (!isset(self::$normalizeCache[$class][$propertyName])) {
+            self::$normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class);
         }
 
-        return $this->normalizeCache[$class][$propertyName] ?? $this->normalizeFallback($propertyName, $class, $format, $context);
+        return self::$normalizeCache[$class][$propertyName] ?? $this->normalizeFallback($propertyName, $class, $format, $context);
     }
 
     /**
@@ -63,11 +63,12 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return $this->denormalizeFallback($propertyName, $class, $format, $context);
         }
 
-        if (!isset($this->denormalizeCache[$class][$propertyName])) {
-            $this->denormalizeCache[$class][$propertyName] = $this->getCacheValueForDenormalization($propertyName, $class, $context);
+        $cacheKey = $this->getCacheKey($class, $context);
+        if (!isset(self::$denormalizeCache[$cacheKey][$propertyName])) {
+            self::$denormalizeCache[$cacheKey][$propertyName] = $this->getCacheValueForDenormalization($propertyName, $class, $context);
         }
 
-        return $this->denormalizeCache[$class][$propertyName] ?? $this->denormalizeFallback($propertyName, $class, $format, $context);
+        return self::$denormalizeCache[$cacheKey][$propertyName] ?? $this->denormalizeFallback($propertyName, $class, $format, $context);
     }
 
     private function getCacheValueForNormalization($propertyName, string $class)
@@ -89,13 +90,14 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         return $this->fallbackNameConverter ? $this->fallbackNameConverter->normalize($propertyName, $class, $format, $context) : $propertyName;
     }
 
-    private function getCacheValueForDenormalization($propertyName, string $class, $context)
+    private function getCacheValueForDenormalization($propertyName, string $class, array $context)
     {
-        if (!isset($this->attributesMetadataCache[$class])) {
-            $this->attributesMetadataCache[$class] = $this->getCacheValueForAttributesMetadata($class, $context);
+        $cacheKey = $this->getCacheKey($class, $context);
+        if (!isset(self::$attributesMetadataCache[$cacheKey])) {
+            self::$attributesMetadataCache[$cacheKey] = $this->getCacheValueForAttributesMetadata($class, $context);
         }
 
-        return $this->attributesMetadataCache[$class][$propertyName] ?? null;
+        return self::$attributesMetadataCache[$cacheKey][$propertyName] ?? null;
     }
 
     private function denormalizeFallback($propertyName, string $class = null, string $format = null, array $context = [])
@@ -103,7 +105,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         return $this->fallbackNameConverter ? $this->fallbackNameConverter->denormalize($propertyName, $class, $format, $context) : $propertyName;
     }
 
-    private function getCacheValueForAttributesMetadata(string $class, $context): array
+    private function getCacheValueForAttributesMetadata(string $class, array $context): array
     {
         if (!$this->metadataFactory->hasMetadataFor($class)) {
             return [];
@@ -129,5 +131,14 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         }
 
         return $cache;
+    }
+
+    private function getCacheKey(string $class, array $context): string
+    {
+        if (isset($context['cache_key'])) {
+            return $class.'-'.$context['cache_key'];
+        }
+
+        return $class.md5(serialize($context[AbstractNormalizer::GROUPS] ?? []));
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -120,6 +120,18 @@ final class MetadataAwareNameConverterTest extends TestCase
     /**
      * @dataProvider attributeAndContextProvider
      */
+    public function testNormalizeWithGroups($propertyName, $expected, $context = [])
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+
+        $this->assertEquals($expected, $nameConverter->normalize($propertyName, OtherSerializedNameDummy::class, null, $context));
+    }
+
+    /**
+     * @dataProvider attributeAndContextProvider
+     */
     public function testDenormalizeWithGroups($expected, $propertyName, $context = [])
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
@@ -137,5 +149,16 @@ final class MetadataAwareNameConverterTest extends TestCase
             ['buz', 'buz', ['groups' => ['c']]],
             ['buz', 'buz', []],
         ];
+    }
+
+    public function testDenormalizeWithCacheContext()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+
+        $this->assertEquals('buz', $nameConverter->denormalize('buz', OtherSerializedNameDummy::class, null, ['groups' => ['a']]));
+        $this->assertEquals('buzForExport', $nameConverter->denormalize('buz', OtherSerializedNameDummy::class, null, ['groups' => ['b']]));
+        $this->assertEquals('buz', $nameConverter->denormalize('buz', OtherSerializedNameDummy::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This is a follow up PR to #34035 to address @nicolas-grekas 's [comment](https://github.com/symfony/symfony/pull/34035#issuecomment-549867560)

The static cache has been re-introduced and the context is used to compute the cache key used for denormalization
