### PR TITLE
[VarDumper] Fix double method display for generators

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -145,6 +145,7 @@ class ExceptionCaster
                     'function' => isset($f['function']) ? $f['function'] : null,
                 ] + $frames[$i - 1],
                 false,
+                true,
                 true
             );
             $f = self::castFrameStub($frame, [], $frame, true);
@@ -225,13 +226,13 @@ class ExceptionCaster
                                 $templatePath = null;
                             }
                             if ($templateSrc) {
-                                $src = self::extractSource($templateSrc, $templateInfo[$f['line']], self::$srcContext, 'twig', $templatePath, $f);
+                                $src = self::extractSource($templateSrc, $templateInfo[$f['line']], self::$srcContext, 'twig', $templatePath, $frame->displayMethod ? $f : []);
                                 $srcKey = ($templatePath ?: $template->getTemplateName()).':'.$templateInfo[$f['line']];
                             }
                         }
                     }
                     if ($srcKey == $f['file']) {
-                        $src = self::extractSource(file_get_contents($f['file']), $f['line'], self::$srcContext, 'php', $f['file'], $f);
+                        $src = self::extractSource(file_get_contents($f['file']), $f['line'], self::$srcContext, 'php', $f['file'], $frame->displayMethod ? $f : []);
                         $srcKey .= ':'.$f['line'];
                         if ($ellipsis) {
                             $ellipsis += 1 + \strlen($f['line']);

--- a/src/Symfony/Component/VarDumper/Caster/FrameStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/FrameStub.php
@@ -20,11 +20,13 @@ class FrameStub extends EnumStub
 {
     public $keepArgs;
     public $inTraceStub;
+    public $displayMethod;
 
-    public function __construct(array $frame, bool $keepArgs = true, bool $inTraceStub = false)
+    public function __construct(array $frame, bool $keepArgs = true, bool $inTraceStub = false, bool $displayMethod = true)
     {
         $this->value = $frame;
         $this->keepArgs = $keepArgs;
         $this->inTraceStub = $inTraceStub;
+        $this->displayMethod = $displayMethod;
     }
 }

--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -134,7 +134,7 @@ class ReflectionCaster
             $trace[] = $frame;
             $a[$prefix.'trace'] = new TraceStub($trace, false, 0, -1, -1);
         } else {
-            $function = new FrameStub($frame, false, true);
+            $function = new FrameStub($frame, false, true, false);
             $function = ExceptionCaster::castFrameStub($function, [], $function, true);
             $a[$prefix.'executing'] = new EnumStub([
                 "\0~separator= \0".$frame['class'].$frame['type'].$frame['function'].'()' => $function[$prefix.'src'],

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -208,6 +208,7 @@ array:2 [
     this: Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo { …}
     trace: {
       %s%eTests%eFixtures%eGeneratorDemo.php:9 {
+        Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo()
         › {
         ›     yield 1;
         › }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes https://travis-ci.org/symfony/symfony/jobs/607923640#L12328 - the test is legitimate - we don't want to display 2 times the methods for generators.