### PR TITLE
[TwigBridge] Fix switch-custom changelog entry

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
  * the `LintCommand` lints all the templates stored in all configured Twig paths if none argument is provided
  * deprecated accepting STDIN implicitly when using the `lint:twig` command, use `lint:twig -` (append a dash) instead to make it explicit.
  * added `--show-deprecations` option to the `lint:twig` command
- * added support for Bootstrap4 switches, use `switch-custom` as `label_attr` in a `CheckboxType`
+ * added support for Bootstrap4 switches: add the `switch-custom` class to the label attributes of a `CheckboxType`
  * Marked the `TwigDataCollector` class as `@final`.
 
 4.3.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Relates to #33954
| License       | MIT
| Doc PR        | N/A

As it doesn't really mention `switch-custom` is a css class.