### PR TITLE
[DoctrineBridge] Reopen DoctrineDataCollector to extensibility

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -68,7 +68,6 @@ DoctrineBridge
  * Deprecated `RegistryInterface`, use `Doctrine\Common\Persistence\ManagerRegistry`.
  * Added a new `getMetadataDriverClass` method to replace class parameters in `AbstractDoctrineExtension`. This method
    will be abstract in Symfony 5 and must be declared in extending classes.
- * Marked the `DoctrineDataCollector` class as `@final`.
 
 Filesystem
 ----------

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -8,7 +8,6 @@ CHANGELOG
  * deprecated `RegistryInterface`, use `Doctrine\Common\Persistence\ManagerRegistry`
  * added support for invokable event listeners
  * added `getMetadataDriverClass` method to deprecate class parameters in service configuration files
- * Marked the `DoctrineDataCollector` class as `@final`.
 
 4.3.0
 -----

--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -23,8 +23,6 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
  * DoctrineDataCollector.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @final since Symfony 4.4
  */
 class DoctrineDataCollector extends DataCollector
 {
@@ -56,8 +54,10 @@ class DoctrineDataCollector extends DataCollector
 
     /**
      * {@inheritdoc}
+     *
+     * @param \Throwable|null $exception
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response/*, \Throwable $exception = null*/)
     {
         $queries = [];
         foreach ($this->loggers as $name => $logger) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

DoctrineBundle is using it (https://github.com/doctrine/DoctrineBundle/blob/0d20a98fb80807e020e9371625dba4e81dad157a/DataCollector/DoctrineDataCollector.php#L41) and we don't want to prevent them from doing it.