### PR TITLE
[DoctrineBridge] conflict with validator < 4.4

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -35,7 +35,7 @@
         "symfony/proxy-manager-bridge": "^3.4|^4.0|^5.0",
         "symfony/security-core": "^4.4|^5.0",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
-        "symfony/validator": "^3.4.31|^4.3.4|^5.0",
+        "symfony/validator": "^4.4|^5.0",
         "symfony/var-dumper": "^3.4|^4.0|^5.0",
         "symfony/translation": "^3.4|^4.0|^5.0",
         "doctrine/annotations": "~1.7",
@@ -52,7 +52,8 @@
         "symfony/form": "<4.4",
         "symfony/http-kernel": "<4.3.7",
         "symfony/messenger": "<4.3",
-        "symfony/security-core": "<4.4"
+        "symfony/security-core": "<4.4",
+        "symfony/validator": "<4.4"
     },
     "suggest": {
         "symfony/form": "",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Or you'll get `PHP Fatal error:  Trait 'Symfony\Component\Validator\Mapping\Loader\AutoMappingTrait' not found`.

/cc @dunglas FYI