### PR TITLE
Update bootstrap_4_layout.html.twig

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -123,7 +123,9 @@
         {%- set type = type|default('file') -%}
         {{- block('form_widget_simple') -}}
         {%- set label_attr = label_attr|merge({ class: (label_attr.class|default('') ~ ' custom-file-label')|trim }) -%}
-        <label for="{{ form.vars.id }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
+        {%- set input_lang = 'en' -%}
+        {% if app is defined and app.request is defined %}{%- set input_lang = app.request.locale -%}{%- endif -%}
+        <label for="{{ form.vars.id }}" lang="{{ input_lang }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
             {%- if attr.placeholder is defined and attr.placeholder is not none -%}
                 {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
             {%- endif -%}


### PR DESCRIPTION
Add lang attribute to enable translating the "Browse" after text using SCSS variables.
Example:
```
$custom-file-text: (
        en: "Browse",
        de: "Auswählen"
);
```

https://github.com/twbs/bootstrap/blob/v4.3.1/scss/_variables.scss#L640

| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 4.4.
 - Legacy code removals go to the master branch.
-->
