### PR TITLE
Unallow symfony/http-kernel ^5.0

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -28,7 +28,7 @@
         "symfony/config": "^4.2|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
         "symfony/form": "^4.4|^5.0",
-        "symfony/http-kernel": "^4.3.7|^5.0",
+        "symfony/http-kernel": "^4.3.7",
         "symfony/messenger": "^4.4|^5.0",
         "symfony/property-access": "^3.4|^4.0|^5.0",
         "symfony/property-info": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -27,7 +27,7 @@
         "symfony/finder": "^3.4|^4.0|^5.0",
         "symfony/form": "^4.4|^5.0",
         "symfony/http-foundation": "^4.3|^5.0",
-        "symfony/http-kernel": "^3.4|^4.0|^5.0",
+        "symfony/http-kernel": "^3.4|^4.0",
         "symfony/mime": "^4.3|^5.0",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/routing": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -32,7 +32,7 @@
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/console": "^4.3|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
-        "symfony/http-kernel": "^4.3|^5.0",
+        "symfony/http-kernel": "^4.3",
         "symfony/security-csrf": "^3.4|^4.0|^5.0",
         "symfony/translation": "^4.2|^5.0",
         "symfony/var-dumper": "^4.3|^5.0"

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -31,7 +31,7 @@
         "php-http/httplug": "^1.0|^2.0",
         "psr/http-client": "^1.0",
         "symfony/dependency-injection": "^4.3|^5.0",
-        "symfony/http-kernel": "^4.3|^5.0",
+        "symfony/http-kernel": "^4.3",
         "symfony/process": "^4.2|^5.0",
         "symfony/service-contracts": "^1.0|^2",
         "symfony/var-dumper": "^4.3|^5.0"

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -27,7 +27,7 @@
         "symfony/dependency-injection": "^3.4.19|^4.1.8|^5.0",
         "symfony/error-renderer": "^4.4|^5.0",
         "symfony/event-dispatcher": "^4.3|^5.0",
-        "symfony/http-kernel": "^4.4|^5.0",
+        "symfony/http-kernel": "^4.4",
         "symfony/process": "^3.4|^4.0|^5.0",
         "symfony/property-access": "^3.4|^4.0|^5.0",
         "symfony/serializer": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -24,7 +24,7 @@
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-        "symfony/http-kernel": "^3.4|^4.0|^5.0",
+        "symfony/http-kernel": "^3.4|^4.0",
         "symfony/intl": "^3.4|^4.0|^5.0",
         "symfony/service-contracts": "^1.1.2|^2",
         "symfony/var-dumper": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0",
         "symfony/http-foundation": "^4.1|^5.0",
-        "symfony/http-kernel": "^3.4|^4.0|^5.0",
+        "symfony/http-kernel": "^3.4|^4.0",
         "symfony/var-dumper": "^3.4|^4.0|^5.0",
         "symfony/intl": "^4.3|^5.0",
         "symfony/yaml": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/34265#discussion_r343739637
| License       | MIT
| Doc PR        | -

The components that have a data collector cannot be compatible with HttpKernel `DataCollectorInterface` 5.0.