### PR TITLE
[Messenger][Mailer] Send mails after the main message succeeded

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * Wired the `send_mail_after_current_bus` middleware by default in message buses, so mails are sent only after the main message succeeded
  * Added the `framework.router.context` configuration node to configure the `RequestContext`
  * Made `MicroKernelTrait::configureContainer()` compatible with `ContainerConfigurator`
  * Added a new `mailer.message_bus` option to configure or disable the message bus to use to send mails.

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -81,6 +81,7 @@ use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
 use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Messenger\Middleware\SendMailAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -1581,6 +1582,7 @@ class FrameworkExtension extends Extension
             'before' => [
                 ['id' => 'add_bus_name_stamp_middleware'],
                 ['id' => 'reject_redelivered_message_middleware'],
+                ['id' => 'send_mail_after_current_bus'],
                 ['id' => 'dispatch_after_current_bus'],
                 ['id' => 'failed_message_processing_middleware'],
             ],
@@ -1589,6 +1591,13 @@ class FrameworkExtension extends Extension
                 ['id' => 'handle_message'],
             ],
         ];
+
+        if (!class_exists(SendMailAfterCurrentBusMiddleware::class)) {
+            $container->removeDefinition('messenger.middleware.send_mail_after_current_bus');
+            $beforeMiddleware = &$defaultMiddleware['before'];
+            array_splice($beforeMiddleware, 2, 1);
+        }
+
         foreach ($config['buses'] as $busId => $bus) {
             $middleware = $bus['middleware'];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -44,6 +44,8 @@
 
         <service id="messenger.middleware.dispatch_after_current_bus" class="Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware" />
 
+        <service id="messenger.middleware.send_mail_after_current_bus" class="Symfony\Component\Mailer\Messenger\Middleware\SendMailAfterCurrentBusMiddleware" />
+
         <service id="messenger.middleware.validation" class="Symfony\Component\Messenger\Middleware\ValidationMiddleware">
             <argument type="service" id="validator" />
         </service>

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Added `SendMailAfterCurrentBusMiddleware` to send mails from message buses only after the main message succeeded
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/Mailer/Messenger/Middleware/SendMailAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Mailer/Messenger/Middleware/SendMailAfterCurrentBusMiddleware.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Messenger\Middleware;
+
+use Symfony\Component\Mailer\Messenger\SendEmailMessage;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+
+/**
+ * Automatically adds a stamp to mail messages, so these are only dispatched once the main message handler(s) succeeded.
+ * It prevents sending mails despite the main process failed.
+ * MUST be registered before the dispatch_after_current_bus middleware so the stamp is taken into account.
+ *
+ * @see \Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware
+ *
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class SendMailAfterCurrentBusMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var bool this property is used to signal if we are inside a the first/root call to
+     *           MessageBusInterface::dispatch() or if dispatch has been called inside a message handler
+     */
+    private $isRootDispatchCallRunning = false;
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        try {
+            if ($this->isRootDispatchCallRunning && $envelope->getMessage() instanceof SendEmailMessage) {
+                $envelope = $envelope->with(new DispatchAfterCurrentBusStamp());
+            }
+
+            // First time we get here, mark as inside a "root dispatch" call:
+            $this->isRootDispatchCallRunning = true;
+
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            $this->isRootDispatchCallRunning = false;
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/Messenger/Middleware/SendMailAfterCurrentBusMiddlewareTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Messenger/Middleware/SendMailAfterCurrentBusMiddlewareTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Symfony\Component\Mailer\Tests\Messenger\Middleware;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Messenger\Middleware\SendMailAfterCurrentBusMiddleware;
+use Symfony\Component\Mailer\Messenger\SendEmailMessage;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Mime\RawMessage;
+
+class SendMailAfterCurrentBusMiddlewareTest extends TestCase
+{
+    public function testMailSentAfterMainMessage()
+    {
+        $message = new DummyMessage();
+        $sendMail = new SendEmailMessage(new RawMessage('foo'));
+
+        $middleware = new SendMailAfterCurrentBusMiddleware();
+        $handlingMiddleware = $this->createMock(MiddlewareInterface::class);
+
+        $bus = new MessageBus([
+            $middleware,
+            new DispatchAfterCurrentBusMiddleware(),
+            $dispatchingMiddleware = new DispatchingMiddleware([
+                $sendMail,
+            ]),
+            $handlingMiddleware,
+        ]);
+
+        $dispatchingMiddleware->setBus($bus);
+
+        // Expect main dispatched message to be handled first:
+        $this->expectHandledMessage($handlingMiddleware, 0, $message);
+        // Then, expect mail to be sent:
+        $this->expectHandledMessage($handlingMiddleware, 1, $sendMail);
+
+        $bus->dispatch($message);
+    }
+
+    /**
+     * @param MiddlewareInterface|MockObject $handlingMiddleware
+     */
+    private function expectHandledMessage(MiddlewareInterface $handlingMiddleware, int $at, $message): void
+    {
+        $handlingMiddleware->expects($this->at($at))->method('handle')->with($this->callback(function (Envelope $envelope) use ($message) {
+            return $envelope->getMessage() === $message;
+        }))->willReturnCallback(function ($envelope, StackInterface $stack) {
+            return $stack->next()->handle($envelope, $stack);
+        });
+    }
+}
+
+class DummyMessage
+{
+}
+
+class DispatchingMiddleware implements MiddlewareInterface
+{
+    /** @var MessageBusInterface */
+    private $bus;
+    private $messages;
+
+    public function __construct(array $messages)
+    {
+        $this->messages = $messages;
+    }
+
+    public function setBus(MessageBusInterface $bus): void
+    {
+        $this->bus = $bus;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        while ($message = array_shift($this->messages)) {
+            $this->bus->dispatch($message);
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | TODO

**Description**  

When using the Mailer component with a message bus, given the following handler:

```php
class FooCommandHandler
{
    private $mailer;

    public function __construct(MailerInterface $mailer)
    {
        $this->mailer = $mailer;
    }

    public function __invoke(FooCommand $command): void
    {
        $this->mailer->send((new Email())
            ->to('foo@example.com')
            ->subject('foo')
            ->text('Hello')
        );

        throw new \RuntimeException('Foo');
    }
}
```

the mail is sent despite the handler failed (because of the exception). Same would go with an async email, as it'll still send the `SendEmailMessage` to the transport, independently from the main handler failure or success.

In a real app, this means a mail can be sent for a treatment that has actually failed (for instance, because the Doctrine middleware failed to flush the changes made in the handler).

**Possible solution**  

Rely on the `DispatchAfterCurrentBusMiddleware` and the `DispatchAfterCurrentBusStamp` stamp.
This stamps allows to only handle the stamped message if and only if the handler in which it was dispatched succeeded.

A new `SendMailAfterCurrentBusMiddleware` middleware can automatically add the stamp to `SendEmailMessage` when necessary. 
But this middleware must be registered before `DispatchAfterCurrentBusMiddleware` to work (which make it difficult to register in userland, as you need to disable default middleware to prepend it before).

1. Do we want this in core?
1. Should it be registered by default? 
    Right now, I don't see much drawbacks.
1. Should it be a new `default_middleware` value? (allowing an array, i.e: accept something like `['allow_no_handlers', 'send_mail_after_current_bus']`.
1. This middleware will add the stamp to all mails. Do we need a more fine grained control?