### PR TITLE
[Workflow] Fix error when we use ValueObject for the marking property

### DIFF
--- a/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
@@ -61,7 +61,7 @@ final class MethodMarkingStore implements MarkingStoreInterface
         }
 
         if ($this->singleState) {
-            $marking = [$marking => 1];
+            $marking = [(string) $marking => 1];
         }
 
         return new Marking($marking);

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
@@ -52,4 +52,35 @@ class MethodMarkingStoreTest extends TestCase
 
         $this->assertEquals($marking, $marking2);
     }
+
+    public function testGetMarkingWithValueObject()
+    {
+        $subject = new Subject($this->createValueObject('first_place'));
+
+        $markingStore = new MethodMarkingStore(true);
+
+        $marking = $markingStore->getMarking($subject);
+
+        $this->assertInstanceOf(Marking::class, $marking);
+        $this->assertCount(1, $marking->getPlaces());
+        $this->assertSame('first_place', (string) $subject->getMarking());
+    }
+
+    private function createValueObject(string $markingValue)
+    {
+        return new class($markingValue) {
+            /** @var string */
+            private $markingValue;
+
+            public function __construct(string $markingValue)
+            {
+                $this->markingValue = $markingValue;
+            }
+
+            public function __toString()
+            {
+                return $this->markingValue;
+            }
+        };
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #28203 #22031
| License       | MIT

Fix Illegal offset type in `MethodMarkingStore` class when we use Value Object for
the marking property.

Now, we can avoid to use only a string an we can have a Subject class with a Value Object like this : 
```php
final class State
{
    public const DRAFT = 'draft';
    public const REVIEWED = 'reviewed';
    public const REJECTED = 'rejected';
    public const PUBLISHED = 'published';
            
     /** @var string */
    private $state;

    public function __construct(string $state)
    {
        // some validation
        $this->state = $state;
    }

    public function __toString()
     {
         return $this->state;
    }

    public static function Draft()
     {
         return new self(self::DRAFT);      
     }
    ...
}

final class Subject
{
    private $marking;

    public function __construct(State $marking = null)
    {
        $this->marking = $marking;
    }

    public function getMarking()
    {
        return $this->marking;
    }

    public function setMarking($marking)
    {
        $this->marking = $marking instanceof State ? $marking : new State($marking);
    }

```

