### PR TITLE
[Routing] revert the return type for UrlGeneratorInterface::generate to remove null

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -75,7 +75,7 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      * @param mixed[] $parameters    An array of parameters
      * @param int     $referenceType The type of reference to be generated (one of the constants)
      *
-     * @return string|null The generated URL
+     * @return string The generated URL
      *
      * @throws RouteNotFoundException              If the named route doesn't exist
      * @throws MissingMandatoryParametersException When some parameters are missing that are mandatory for the route


### PR DESCRIPTION
…to remove null

| Q             | A
| ------------- | ---
| Branch?       | 3.4 (only)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Bit of a casualty of commit tennis this:

A change to add `null` here as an option for how `UrlGeneratorInterface::generate()` (rather than the concrete `UrlGenerator`) was merged in https://github.com/symfony/symfony/pull/28321, but then [reverted](https://github.com/symfony/symfony/commit/90494c20cc1f029293d12b480c280cb056751a2b) for the reason [that this could be seen as a BC break](https://github.com/symfony/symfony/pull/28321#issuecomment-418540080), as the `null` return had not previously been documented (and is still not as part of the interface method docs).

However, in a subsequent change (https://github.com/symfony/symfony/pull/33252) with a wider scope, this doc change was added _back_ in order to reflect the underlying implementation as a result of a PHPStorm plugin complaining. There's no indication though of what a `null` return here though would mean, and for the same reason as the first revert (that this should be seen as a BC break), I'd like to submit this to be reverted for the 3.4 branch. (In 4.4 the `null` has already been removed.)

Having the interface indicating that this method can return `null` necessitates introducing a lot of actually redundant null checks in code that is covered by static analysis tools such as PHPStan. 
