### PR TITLE
[Workflow] Simplified EventDispatcherMock

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -572,40 +572,12 @@ class WorkflowTest extends TestCase
     }
 }
 
-class EventDispatcherMock implements \Symfony\Component\EventDispatcher\EventDispatcherInterface
+class EventDispatcherMock implements \Symfony\Contracts\EventDispatcher\EventDispatcherInterface
 {
     public $dispatchedEvents = [];
 
     public function dispatch($event, string $eventName = null)
     {
         $this->dispatchedEvents[] = $eventName;
-    }
-
-    public function addListener($eventName, $listener, $priority = 0)
-    {
-    }
-
-    public function addSubscriber(\Symfony\Component\EventDispatcher\EventSubscriberInterface $subscriber)
-    {
-    }
-
-    public function removeListener($eventName, $listener)
-    {
-    }
-
-    public function removeSubscriber(\Symfony\Component\EventDispatcher\EventSubscriberInterface $subscriber)
-    {
-    }
-
-    public function getListeners($eventName = null)
-    {
-    }
-
-    public function getListenerPriority($eventName, $listener)
-    {
-    }
-
-    public function hasListeners($eventName = null)
-    {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR simplifies the Workflow component's mock implementation of the event dispatcher by implementing the much simpler contracts interface instead of the full-blown component interface.