### PR TITLE
[Messenger] Fixed bad event dispatcher mocks

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -122,6 +122,8 @@ class WorkerTest extends TestCase
                 if ($event instanceof WorkerRunningEvent) {
                     $event->getWorker()->stop();
                 }
+
+                return $event;
             });
 
         $worker = new Worker([$receiver], $bus, $eventDispatcher);
@@ -151,6 +153,8 @@ class WorkerTest extends TestCase
                 if ($event instanceof WorkerRunningEvent) {
                     $event->getWorker()->stop();
                 }
+
+                return $event;
             });
 
         $worker = new Worker([$receiver], $bus, $eventDispatcher);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`EventDispatcherInterface::dispatch()` must return the passed event object. This PR fixes two mocks that violated this contract.