### PR TITLE
[Security] Fix defining multiple roles per access_control rule

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -68,7 +68,14 @@ class AccessListener implements ListenerInterface
             $this->tokenStorage->setToken($token);
         }
 
-        if (!$this->accessDecisionManager->decide($token, $attributes, $request)) {
+        $granted = false;
+        foreach ($attributes as $key => $value) {
+            if ($this->accessDecisionManager->decide($token, [$key => $value], $request)) {
+                $granted = true;
+            }
+        }
+
+        if (!$granted) {
             $exception = new AccessDeniedException();
             $exception->setAttributes($attributes);
             $exception->setSubject($request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        |  https://github.com/symfony/symfony-docs/pull/12371 needs to be reverted

#33584 deprecated passing multiple attributes to `AccessDecisionManager::decide()`, but this change must not impact `access_control` as you cannot define multiple rules with the same criteria for request matching (the first match wins).
