### PR TITLE
[4.4] Disallow symfony/contracts v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "psr/container": "^1.0",
         "psr/link": "^1.0",
         "psr/log": "~1.0",
-        "symfony/contracts": "^1.1.7|^2",
+        "symfony/contracts": "^1.1.8",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-intl-idn": "^1.10",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Travis is red at the moment because unit tests on 4.4 are run against the incompatible event dispatcher contracts v2. https://travis-ci.org/symfony/symfony/jobs/609622341#L4719-L4725

~~This PR proposes to switch to individual packages, so we can specifically disallow those incompatible contracts.~~

This PR pins the `symfony/contracts` package to v1.1 on `symfony/symfony`.