### PR TITLE
[Messenger] Removed strict types in DispatchAfterCurrentBusStamp

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/DispatchAfterCurrentBusStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DispatchAfterCurrentBusStamp.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 namespace Symfony\Component\Messenger\Stamp;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a