### PR TITLE
Connection parameter corrected (part 2 - StoreFactory)

### DIFF
--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -70,7 +70,7 @@ class StoreFactory
             case 0 === strpos($connection, 'rediss://'):
             case 0 === strpos($connection, 'memcached://'):
                 if (!class_exists(AbstractAdapter::class)) {
-                    throw new InvalidArgumentException(sprintf('Unsupported DSN "%s". Try running "composer require symfony/cache".', $this->dsn));
+                    throw new InvalidArgumentException(sprintf('Unsupported DSN "%s". Try running "composer require symfony/cache".', $connection));
                 }
                 $storeClass = 0 === strpos($connection, 'memcached://') ? MemcachedStore::class : RedisStore::class;
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Connection parameter incorrectly specified. This variable doesn't exist, the data is in $connection instead.
