### PR TITLE
[TwigBundle] Cache Warmer node_modules bug fixed

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
+++ b/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
@@ -52,7 +52,7 @@ class TemplateIterator implements \IteratorAggregate
 
         $this->templates = array_merge(
             $this->findTemplatesInDirectory($this->rootDir.'/Resources/views'),
-            $this->findTemplatesInDirectory($this->defaultPath, null, ['bundles'])
+            $this->findTemplatesInDirectory($this->defaultPath, null, ['bundles', 'node_modules'])
         );
         foreach ($this->kernel->getBundles() as $bundle) {
             $name = $bundle->getName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

I created a theme structure in the "templates" directory. A different webpack structure is used for each theme.

I get an error while clearing the Symfony cache "bin/console cache:clear". While the cache is warming up, twig is trying to read files in node_modules directory.

There is no problem with "bin/console cache:clear --no-warmup".

Error: 
```
PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 815104 bytes) in /Users/apaydin/www/emlakpro/apps/vendor/twig/twig/src/Compiler.php on line 129
```