### PR TITLE
[HttpKernel] Fix missing import in GetResponseForExceptionEvent

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Event;
 
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 

--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -106,7 +106,7 @@ class ErrorListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER_ARGUMENTS => 'onControllerArguments',
@@ -119,11 +119,8 @@ class ErrorListener implements EventSubscriberInterface
 
     /**
      * Logs an exception.
-     *
-     * @param \Exception $exception The \Exception instance
-     * @param string     $message   The error message to log
      */
-    protected function logException(\Exception $exception, $message)
+    protected function logException(\Throwable $exception, string $message): void
     {
         if (null !== $this->logger) {
             if (!$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= 500) {
@@ -136,10 +133,8 @@ class ErrorListener implements EventSubscriberInterface
 
     /**
      * Clones the request for the exception.
-     *
-     * @return Request The cloned request
      */
-    protected function duplicateRequest(\Exception $exception, Request $request)
+    protected function duplicateRequest(\Throwable $exception, Request $request): Request
     {
         $attributes = [
             '_controller' => $this->controller,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

