### PR TITLE
[HttpKernel] Fix ProfilerListener exception handling

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -63,6 +64,9 @@ class ProfilerListener implements EventSubscriberInterface
         }
 
         $this->exception = $event->getThrowable();
+        if (!$this->exception instanceof \Exception) {
+            $this->exception = new FatalThrowableError($this->exception);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`ProfilerListener` calls `Profiler::collect()` that calls data collectors with the exception. They are not compatible yet with `\Throwable`.