### PR TITLE
[Messenger] Add reply functionality

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1711,6 +1711,7 @@ class FrameworkExtension extends Extension
             'after' => [
                 ['id' => 'send_message'],
                 ['id' => 'handle_message'],
+                ['id' => 'reply_middleware'],
             ],
         ];
         foreach ($config['buses'] as $busId => $bus) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -56,6 +56,8 @@
             <argument type="service" id="debug.stopwatch" />
         </service>
 
+        <service id="messenger.middleware.reply_middleware" class="Symfony\Component\Messenger\Middleware\ReplyMiddleware" />
+
         <!-- Discovery -->
         <service id="messenger.receiver_locator">
             <tag name="container.service_locator" />

--- a/src/Symfony/Component/Messenger/Middleware/ReplyMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ReplyMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\ReplyStamp;
+use Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceivedStamp;
+
+/**
+ * Middleware responsible for replying results returned by handler.
+ */
+class ReplyMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param Envelope $envelope
+     * @param StackInterface $stack
+     * @return Envelope
+     */
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if (($handledStamp = $envelope->last(HandledStamp::class))
+            && ($replyStamp = $envelope->last(ReplyStamp::class))
+        ) {
+            $response = $handledStamp->getResult();
+
+            // Make the result available to sender if sync transport is used
+            $replyStamp->setResponse($response);
+
+            if ($amqpRecievedStamp = $envelope->last(AmqpReceivedStamp::class)) {
+                $replyTo = $amqpRecievedStamp->getAmqpEnvelope()->getReplyTo();
+                $amqpRecievedStamp->getConnection()->reply($response, $replyTo);
+            }
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/ReplyStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ReplyStamp.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Stamp used to identify that client wants a response.
+ * Client gets a response from a handler via this stamp.
+ */
+class ReplyStamp implements StampInterface
+{
+    /**
+     * @var string
+     */
+    private $response;
+
+    /**
+     * @param string $response
+     */
+    public function setResponse(string $response): void
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponse(): string
+    {
+        return $this->response;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceivedStamp.php
@@ -18,13 +18,20 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
  */
 class AmqpReceivedStamp implements NonSendableStampInterface
 {
+    private $connection;
     private $amqpEnvelope;
     private $queueName;
 
-    public function __construct(\AMQPEnvelope $amqpEnvelope, string $queueName)
+    public function __construct(Connection $connection, \AMQPEnvelope $amqpEnvelope, string $queueName)
     {
+        $this->connection = $connection;
         $this->amqpEnvelope = $amqpEnvelope;
         $this->queueName = $queueName;
+    }
+
+    public function getConnection(): Connection
+    {
+        return $this->connection;
     }
 
     public function getAmqpEnvelope(): \AMQPEnvelope

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -72,7 +72,7 @@ class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
             throw $exception;
         }
 
-        yield $envelope->with(new AmqpReceivedStamp($amqpEnvelope, $queueName));
+        yield $envelope->with(new AmqpReceivedStamp($this->connection, $amqpEnvelope, $queueName));
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReplyStamp.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReplyStamp.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\AmqpExt;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+/**
+ * Stamp added by @see AmqpSender when a client wants a response from handler.
+ * Client gets a response from a dedicated exclusive queue.
+ */
+class AmqpReplyStamp implements NonSendableStampInterface
+{
+    /**
+     * @var \AMQPQueue
+     */
+    private $replyQueue;
+
+    /**
+     * AmqpReplyStamp constructor.
+     * @param \AMQPQueue $replyQueue
+     */
+    public function __construct(\AMQPQueue $replyQueue)
+    {
+        $this->replyQueue = $replyQueue;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponse(): string
+    {
+        $response = null;
+        $this->replyQueue->consume(function(\AMQPEnvelope $envelope) use (&$response) {
+            $response = $envelope->getBody();
+
+            return false;
+        });
+
+        return $response;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -289,6 +289,30 @@ class Connection
         return $queue;
     }
 
+    /**
+     * Create an exclusive queue to put a response to.
+     */
+    public function createReplyQueue()
+    {
+        $queue = $this->amqpFactory->createQueue($this->channel());
+        $queue->setFlags(\AMQP_EXCLUSIVE);
+        $queue->declareQueue();
+
+        return $queue;
+    }
+
+    /**
+     * Put a response to an exclusive queue
+     *
+     * @param string $response
+     * @param string $replyTo Queue name to reply to
+     */
+    public function reply(string $response, string $replyTo)
+    {
+        $defaultExchange = new \AMQPExchange($this->channel());
+        $defaultExchange->publish($response, $replyTo);
+    }
+
     private function getRoutingKeyForDelay(int $delay, ?string $finalRoutingKey): string
     {
         return str_replace(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | coming

It would be nice to provide developers with possibility to retrieve the result from a handler (with some sort of RPC):

```php
// Get the result from sync transport
$envelope = $messageBus->dispatch($message, [new ReplyStamp()]);
$replyStamp = $envelope->last(ReplyStamp::class);
$result = $replyStamp->getResponse();
```

```php
// Get the result from amqp transport
$envelope = $messageBus->dispatch($message, [new ReplyStamp()]);
// do something while messange is being treated
$replyStamp = $envelope->last(AmqpReplyStamp::class);
$result = $replyStamp->getResponse(); // wait for reponse, blocking call
```

Let's consider this PR as a discussion to find out:
- whether we need this functionality at all,
- whether this solution is on the right way.

I will add necssary tests/documentation if community is interested in this implementation.

Thanks for giving your opinion.

