### PR TITLE
Allow returning null from NormalizerInterface::normalize

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -30,9 +30,9 @@ interface NormalizerInterface
      * @param string $format  Format the normalization result will be encoded as
      * @param array  $context Context options for the normalizer
      *
-     * @return array|string|int|float|bool
+     * @return array|string|int|float|bool|null
      *
-     * @throws InvalidArgumentException   Occurs when the object given is not an attempted type for the normalizer
+     * @throws InvalidArgumentException   Occurs when the object given is not a supported type for the normalizer
      * @throws CircularReferenceException Occurs when the normalizer detects a circular reference when no circular
      *                                    reference handler can fix it
      * @throws LogicException             Occurs when the normalizer is not called in an expected context


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes?
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Looking at the code, it seems that a normalizer might be called with a `null` value for `$data`, and thus it's only sensible that it be allowed to return `null` too:

https://github.com/symfony/symfony/blob/7064ff35f2539e2c915257a50eb37839b485dbeb/src/Symfony/Component/Serializer/Serializer.php#L141-L148

Updating the phpdoc to match.