### PR TITLE
[Messenger] Perform no deep merging of bus middleware

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,10 +17,11 @@ CHANGELOG
  * Overriding the methods `KernelTestCase::tearDown()` and `WebTestCase::tearDown()` without the `void` return-type is deprecated.
  * Added new `error_controller` configuration to handle system exceptions
  * Added sort option for `translation:update` command.
- * [BC Break] The `framework.messenger.routing.senders` config key is not deep merged anymore.
+ * [BC Break] The `framework.messenger.routing.senders` config key is not deeply merged anymore.
  * Added `secrets:*` commands and `%env(secret:...)%` processor to deal with secrets seamlessly.
  * Made `framework.session.handler_id` accept a DSN
  * Marked the `RouterDataCollector` class as `@final`.
+ * [BC Break] The `framework.messenger.buses.<name>.middleware` config key is not deeply merged anymore.
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1293,6 +1293,7 @@ class Configuration implements ConfigurationInterface
                                         ->defaultTrue()
                                     ->end()
                                     ->arrayNode('middleware')
+                                        ->performNoDeepMerging()
                                         ->beforeNormalization()
                                             ->ifTrue(function ($v) { return \is_string($v) || (\is_array($v) && !\is_int(key($v))); })
                                             ->then(function ($v) { return [$v]; })

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -271,6 +271,64 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
+    public function testBusMiddlewareDontMerge()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $config = $processor->processConfiguration($configuration, [
+            [
+                'messenger' => [
+                    'default_bus' => 'existing_bus',
+                    'buses' => [
+                        'existing_bus' => [
+                            'middleware' => 'existing_bus.middleware',
+                        ],
+                        'common_bus' => [
+                            'default_middleware' => false,
+                            'middleware' => 'common_bus.old_middleware',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'messenger' => [
+                    'buses' => [
+                        'common_bus' => [
+                            'middleware' => 'common_bus.new_middleware',
+                        ],
+                        'new_bus' => [
+                            'middleware' => 'new_bus.middleware',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(
+            [
+                'existing_bus' => [
+                    'default_middleware' => true,
+                    'middleware' => [
+                        ['id' => 'existing_bus.middleware', 'arguments' => []],
+                    ],
+                ],
+                'common_bus' => [
+                    'default_middleware' => false,
+                    'middleware' => [
+                        ['id' => 'common_bus.new_middleware', 'arguments' => []],
+                    ],
+                ],
+                'new_bus' => [
+                    'default_middleware' => true,
+                    'middleware' => [
+                        ['id' => 'new_bus.middleware', 'arguments' => []],
+                    ],
+                ],
+            ],
+            $config['messenger']['buses']
+        );
+    }
+
     protected static function getBundleDefaultConfig()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This change helps in case one needs to configure a bus differently for a custom environment while keeping existing handlers attached by name.