### PR TITLE
Release v4.2.12

### DIFF
--- a/CHANGELOG-4.2.md
+++ b/CHANGELOG-4.2.md
@@ -7,6 +7,14 @@ in 4.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.2.0...v4.2.1
 
+* 4.2.12 (2019-11-13)
+
+ * security #cve-2019-18886 [Security\Core] throw AccessDeniedException when switch user fails (nicolas-grekas)
+ * security #cve-2019-18889 [Cache] forbid serializing AbstractAdapter and TagAwareAdapter instances (nicolas-grekas)
+ * security #cve-2019-11325 [VarExporter] fix exporting some strings (nicolas-grekas)
+ * security #cve-2019-18888 [HttpFoundation] fix guessing mime-types of files with leading dash (nicolas-grekas)
+ * security #cve-2019-18887 [HttpKernel] Use constant time comparison in UriSigner (stof)
+
 * 4.2.11 (2019-07-28)
 
  * bug #32760 [HttpKernel] clarify error handler restoring process (xabbuh)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.2.12-DEV';
+    const VERSION = '4.2.12';
     const VERSION_ID = 40212;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 2;
     const RELEASE_VERSION = 12;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2019';
     const END_OF_LIFE = '01/2020';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.2.11...v4.2.12)

 * security #cve-2019-18886 [Security\Core] throw AccessDeniedException when switch user fails (@nicolas-grekas)
 * security #cve-2019-18889 [Cache] forbid serializing AbstractAdapter and TagAwareAdapter instances (@nicolas-grekas)
 * security #cve-2019-11325 [VarExporter] fix exporting some strings (@nicolas-grekas)
 * security #cve-2019-18888 [HttpFoundation] fix guessing mime-types of files with leading dash (@nicolas-grekas)
 * security #cve-2019-18887 [HttpKernel] Use constant time comparison in UriSigner (@stof)
