### PR TITLE
Release v4.3.8

### DIFF
--- a/CHANGELOG-4.3.md
+++ b/CHANGELOG-4.3.md
@@ -7,6 +7,16 @@ in 4.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.3.0...v4.3.1
 
+* 4.3.8 (2019-11-13)
+
+ * bug #34344 [Console] Constant STDOUT might be undefined (nicolas-grekas)
+ * security #cve-2019-18886 [Security\Core] throw AccessDeniedException when switch user fails (nicolas-grekas)
+ * security #cve-2019-18888 [Mime] fix guessing mime-types of files with leading dash (nicolas-grekas)
+ * security #cve-2019-11325 [VarExporter] fix exporting some strings (nicolas-grekas)
+ * security #cve-2019-18889 [Cache] forbid serializing AbstractAdapter and TagAwareAdapter instances (nicolas-grekas)
+ * security #cve-2019-18888 [HttpFoundation] fix guessing mime-types of files with leading dash (nicolas-grekas)
+ * security #cve-2019-18887 [HttpKernel] Use constant time comparison in UriSigner (stof)
+
 * 4.3.7 (2019-11-11)
 
  * bug #34294 [Workflow] Fix error when we use ValueObject for the marking property (FabienSalles)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.3.8-DEV';
+    const VERSION = '4.3.8';
     const VERSION_ID = 40308;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 3;
     const RELEASE_VERSION = 8;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2020';
     const END_OF_LIFE = '07/2020';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.3.7...v4.3.8)

 * bug #34344 [Console] Constant STDOUT might be undefined (@nicolas-grekas)
 * security #cve-2019-18886 [Security\Core] throw AccessDeniedException when switch user fails (@nicolas-grekas)
 * security #cve-2019-18888 [Mime] fix guessing mime-types of files with leading dash (@nicolas-grekas)
 * security #cve-2019-11325 [VarExporter] fix exporting some strings (@nicolas-grekas)
 * security #cve-2019-18889 [Cache] forbid serializing AbstractAdapter and TagAwareAdapter instances (@nicolas-grekas)
 * security #cve-2019-18888 [HttpFoundation] fix guessing mime-types of files with leading dash (@nicolas-grekas)
 * security #cve-2019-18887 [HttpKernel] Use constant time comparison in UriSigner (@stof)
