### PR TITLE
[Form] Allow symfony/service-contracts v2

### DIFF
--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -23,7 +23,7 @@
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/property-access": "^3.4|^4.0|^5.0",
-        "symfony/service-contracts": "~1.1"
+        "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
         "doctrine/collections": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In Symfony 4.4 applications, the Form component currently prevents the installation of `symfony/service-contracts` 2.0.0. That should not be the case.