### PR TITLE
[WebProfilerBundle] Require symfony/twig-bundle

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/http-kernel": "~3.4.25|^4.2.6",
         "symfony/polyfill-php70": "~1.0",
         "symfony/routing": "~2.8|~3.0|~4.0",
-        "symfony/twig-bridge": "~2.8|~3.0|~4.0",
+        "symfony/twig-bundle": "~2.8|~3.0|~4.0",
         "symfony/var-dumper": "~3.3|~4.0",
         "twig/twig": "~1.34|~2.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Starting from a fresh 3.4 I did `composer require symfony/web-profiler-bundle --dev` but it fails on post install cache clear because https://github.com/symfony/symfony/blob/8a68d2d358ae7db406f72711c24d5c8f687cf7b6/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml#L13 needs the `twig` service that is declared in the `TwigBundle`.

`symfony/twig-bundle` is already a hard depency of the `WebProfilerBundle` on 4.3+ (cf https://github.com/symfony/symfony/commit/cac37caa7de85cdd4f16072e4f1f86e2c0afed7c).
