### PR TITLE
[Mailer] Improve type checks when trying to send raw message without envelope

### DIFF
--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -12,9 +12,8 @@
 namespace Symfony\Component\Mailer;
 
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
-use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mime\Address;
-use Symfony\Component\Mime\RawMessage;
+use Symfony\Component\Mime\Message;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -33,12 +32,8 @@ class Envelope
         $this->setRecipients($recipients);
     }
 
-    public static function create(RawMessage $message): self
+    public static function create(Message $message): self
     {
-        if (RawMessage::class === \get_class($message)) {
-            throw new LogicException('Cannot send a RawMessage instance without an explicit Envelope.');
-        }
-
         return new DelayedEnvelope($message);
     }
 

--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -13,9 +13,11 @@ namespace Symfony\Component\Mailer;
 
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Messenger\SendEmailMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -45,6 +47,11 @@ final class Mailer implements MailerInterface
 
         if (null !== $this->dispatcher) {
             $message = clone $message;
+
+            if (null === $envelope && !$message instanceof Message) {
+                throw new LogicException(sprintf('Cannot send a "%s" instance without an explicit Envelope.', \get_class($message)));
+            }
+
             $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
             $event = new MessageEvent($message, $envelope, (string) $this->transport, true);
             $this->dispatcher->dispatch($event);

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -13,11 +13,9 @@ namespace Symfony\Component\Mailer\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Envelope;
-use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Message;
-use Symfony\Component\Mime\RawMessage;
 
 class EnvelopeTest extends TestCase
 {
@@ -101,12 +99,5 @@ class EnvelopeTest extends TestCase
         $headers->addMailboxListHeader('Bcc', [new Address('bcc@symfony.com', 'bcc')]);
         $e = Envelope::create(new Message($headers));
         $this->assertEquals([new Address('to@symfony.com', 'to'), new Address('cc@symfony.com', 'cc'), new Address('bcc@symfony.com', 'bcc')], $e->getRecipients());
-    }
-
-    public function testFromRawMessages()
-    {
-        $this->expectException(LogicException::class);
-
-        Envelope::create(new RawMessage('Some raw email message'));
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -24,6 +24,7 @@ class MailerTest extends TestCase
     public function testSendingRawMessages()
     {
         $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot send a "Symfony\Component\Mime\RawMessage" instance without an explicit Envelope.');
 
         $transport = new Mailer($this->createMock(TransportInterface::class), $this->createMock(MessageBusInterface::class), $this->createMock(EventDispatcherInterface::class));
         $transport->send(new RawMessage('Some raw email message'));

--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
@@ -51,6 +51,7 @@ class AbstractTransportTest extends TestCase
     public function testSendingRawMessages()
     {
         $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot send a "Symfony\Component\Mime\RawMessage" instance without an explicit Envelope.');
 
         $transport = new NullTransport();
         $transport->send(new RawMessage('Some raw email message'));

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -13,11 +13,13 @@ namespace Symfony\Component\Mailer\Transport;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -55,6 +57,11 @@ abstract class AbstractTransport implements TransportInterface
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         $message = clone $message;
+
+        if (null === $envelope && !$message instanceof Message) {
+            throw new LogicException(sprintf('Cannot send a "%s" instance without an explicit Envelope.', \get_class($message)));
+        }
+
         $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
 
         if (null !== $this->dispatcher) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes?
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | N/A

This attempts to solve #33454 a bit differently. 
The main motivation here being the fact not only a `RawMessage` instance would fail without an envelope with these implementations, but anything else than a `Message`, which is required by `DelayedEnvelope::__construct` (to rely on `Message::getHeaders`).