### PR TITLE
[HttpFoundation] Add an helper method to check if a request is a CORS preflight request

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,13 +4,14 @@ CHANGELOG
 4.4.0
 -----
 
+ * added `Request::isCorsPreflightRequest()`.
  * passing arguments to `Request::isMethodSafe()` is deprecated.
  * `ApacheRequest` is deprecated, use the `Request` class instead.
- * passing a third argument to `HeaderBag::get()` is deprecated, use method `all()` instead
+ * passing a third argument to `HeaderBag::get()` is deprecated, use method `all()` instead.
  * `PdoSessionHandler` now precalculates the expiry timestamp in the lifetime column,
     make sure to run `CREATE INDEX EXPIRY ON sessions (sess_lifetime)` to update your database
     to speed up garbage collection of expired sessions.
- * added `SessionHandlerFactory` to create session handlers with a DSN
+ * added `SessionHandlerFactory` to create session handlers with a DSN.
  * added `IpUtils::anonymize()` to help with GDPR compliance.
 
 4.3.0

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1734,6 +1734,16 @@ class Request
         return 'XMLHttpRequest' == $this->headers->get('X-Requested-With');
     }
 
+    /**
+     * Returns true if the request is a CORS-preflight request.
+     *
+     * @see https://fetch.spec.whatwg.org/#http-requests
+     */
+    public function isCorsPreflightRequest(): bool
+    {
+        return $this->isMethod('OPTIONS') && $this->headers->has('Access-Control-Request-Method');
+    }
+
     /*
      * The following methods are derived from code of the Zend Framework (1.10dev - 2010-01-24)
      *

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1493,6 +1493,18 @@ class RequestTest extends TestCase
         $this->assertFalse($request->isXmlHttpRequest());
     }
 
+    public function testIsCorsPreflightRequest()
+    {
+        $request = new Request();
+        $this->assertFalse($request->isCorsPreflightRequest());
+
+        $request->setMethod('OPTIONS');
+        $this->assertFalse($request->isCorsPreflightRequest());
+
+        $request->headers->set('Access-Control-Request-Method', 'POST');
+        $this->assertTrue($request->isCorsPreflightRequest());
+    }
+
     /**
      * @requires extension intl
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Add a new method to check if a request is a CORS preflight request according to the CORS spec.
It's useful in many cases (see https://github.com/api-platform/core/pull/3265), and will allow to remove code from API Platform and NelmioCorsBundle.