### PR TITLE
[Finder] Allow ssh2 stream wrapper for sftp

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -746,7 +746,7 @@ class Finder implements \IteratorAggregate, \Countable
     {
         $dir = rtrim($dir, '/'.\DIRECTORY_SEPARATOR);
 
-        if (preg_match('#^s?ftp://#', $dir)) {
+        if (preg_match('#^(ssh2\.)?s?ftp://#', $dir)) {
             $dir .= '/';
         }
 


### PR DESCRIPTION
Same fix as #28604 but for the ssh2.sftp wrapper.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #28604 maybe
| License       | MIT
| Doc PR        | 


Without this patch, we can't use the finder with ssh2.sftp connections.

```php
$connection = \ssh2_connect('host', 22);
\ssh2_auth_password($connection, 'user', 'pass');

$sftp = \ssh2_sftp($connection);
$path = "ssh2.sftp://".intval($sftp)."/";

$finder = new Finder();

foreach ($finder->in($path)->files() as $directory) {
    dump(file_get_contents($directory));
}
```

Without the patch:

>   RecursiveDirectoryIterator::__construct(ssh2.sftp://838): failed to open dir: operation failed  

