### PR TITLE
[FrameworkBundle] Remove project dir from Translator cache vary scanned directories

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1184,11 +1184,18 @@ class FrameworkExtension extends Extension
                 $files[$locale][] = (string) $file;
             }
 
+            $projectDir = $container->getParameter('kernel.project_dir');
+
             $options = array_merge(
                 $translator->getArgument(4),
                 [
                     'resource_files' => $files,
-                    'scanned_directories' => array_merge($dirs, $nonExistingDirs),
+                    'scanned_directories' => $scannedDirectories = array_merge($dirs, $nonExistingDirs),
+                    'cache_vary' => [
+                        'scanned_directories' => array_map(static function (string $dir) use ($projectDir): string {
+                            return 0 === strpos($dir, $projectDir.'/') ? substr($dir, 1 + \strlen($projectDir)) : $dir;
+                        }, $scannedDirectories),
+                    ],
                 ]
             );
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -824,6 +824,8 @@ abstract class FrameworkExtensionTest extends TestCase
         );
 
         $this->assertNotEmpty($nonExistingDirectories, 'FrameworkBundle should pass non existing directories to Translator');
+
+        $this->assertSame('Fixtures/translations', $options['cache_vary']['scanned_directories'][3]);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -255,8 +255,10 @@ class TranslatorTest extends TestCase
                     __DIR__.'/../Fixtures/Resources/translations/messages.fr.yml',
                 ],
             ],
-            'scanned_directories' => [
-                __DIR__.'/../Fixtures/Resources/translations/',
+            'cache_vary' => [
+                'scanned_directories' => [
+                    '/Fixtures/Resources/translations/',
+                ],
             ],
         ], 'yml');
 
@@ -271,9 +273,11 @@ class TranslatorTest extends TestCase
                     __DIR__.'/../Fixtures/Resources/translations2/ccc.fr.yml',
                 ],
             ],
-            'scanned_directories' => [
-                __DIR__.'/../Fixtures/Resources/translations/',
-                __DIR__.'/../Fixtures/Resources/translations2/',
+            'cache_vary' => [
+                'scanned_directories' => [
+                    '/Fixtures/Resources/translations/',
+                    '/Fixtures/Resources/translations2/',
+                ],
             ],
         ], 'yml');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -34,6 +34,7 @@ class Translator extends BaseTranslator implements WarmableInterface
         'debug' => false,
         'resource_files' => [],
         'scanned_directories' => [],
+        'cache_vary' => [],
     ];
 
     /**
@@ -61,9 +62,10 @@ class Translator extends BaseTranslator implements WarmableInterface
      *
      * Available options:
      *
-     *   * cache_dir: The cache directory (or null to disable caching)
-     *   * debug:     Whether to enable debugging or not (false by default)
+     *   * cache_dir:      The cache directory (or null to disable caching)
+     *   * debug:          Whether to enable debugging or not (false by default)
      *   * resource_files: List of translation resources available grouped by locale.
+     *   * cache_vary:     An array of data that is serialized to generate the cached catalogue name.
      *
      * @throws InvalidArgumentException
      */
@@ -82,9 +84,7 @@ class Translator extends BaseTranslator implements WarmableInterface
         $this->resourceFiles = $this->options['resource_files'];
         $this->scannedDirectories = $this->options['scanned_directories'];
 
-        parent::__construct($defaultLocale, $formatter, $this->options['cache_dir'], $this->options['debug'], [
-            'scanned_directories' => $this->scannedDirectories,
-        ]);
+        parent::__construct($defaultLocale, $formatter, $this->options['cache_dir'], $this->options['debug'], $this->options['cache_vary']);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Closes #34395
| License       | MIT
| Doc PR        | -

Weird cases such as having different paths for directories found through reflection (cf https://github.com/symfony/symfony/blob/8522a88185a7e283ad342b3539cd088d76968df9/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1105) or using different values on warmup and run for another parameter than `kernel.project_dir` are still unconvered. Unfortunately there is nothing we can do, do we care? If yes, then we might just wanna enable https://github.com/symfony/symfony/pull/34129 when the `debug` option is on.