### PR TITLE
[HttpKernel] dont check cache freshness more than once per process

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -74,6 +74,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
+    private static $freshCache = [];
+
     const VERSION = '4.4.0-DEV';
     const VERSION_ID = 40400;
     const MAJOR_VERSION = 4;
@@ -511,7 +513,9 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $errorLevel = error_reporting(\E_ALL ^ \E_WARNING);
 
         try {
-            if (file_exists($cachePath) && \is_object($this->container = include $cachePath) && (!$this->debug || $cache->isFresh())) {
+            if (file_exists($cachePath) && \is_object($this->container = include $cachePath)
+                && (!$this->debug || (self::$freshCache[$k = $cachePath.'.'.$this->environment] ?? self::$freshCache[$k] = $cache->isFresh()))
+            ) {
                 $this->container->set('kernel', $this);
                 error_reporting($errorLevel);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While running some functional tests in a loop, I noticed that half the time is spent computing cache freshness. This makes no sense - this mechanism is supposed to run once per process.

Here is the Blackfire comparison:
https://blackfire.io/profiles/compare/a4f2eb44-ae85-440b-ae87-edf43c2b2ef7/graph

![image](https://user-images.githubusercontent.com/243674/68955196-c5667780-07c5-11ea-9a19-f8e765664a8e.png)
