### PR TITLE
[HttpKernel] Flatten "exception" controller argument if not typed

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -99,7 +99,7 @@ class ErrorListener implements EventSubscriberInterface
         $r = new \ReflectionFunction(\Closure::fromCallable($event->getController()));
         $r = $r->getParameters()[$k] ?? null;
 
-        if ($r && $r->hasType() && FlattenException::class === $r->getType()->getName()) {
+        if ($r && (!$r->hasType() || FlattenException::class === $r->getType()->getName())) {
             $arguments = $event->getArguments();
             $arguments[$k] = FlattenException::createFromThrowable($e);
             $event->setArguments($arguments);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes a BC break and makes it easier for libs to support both debug & error-handler e.g. https://github.com/api-platform/core/pull/3246#discussion_r346912822