### PR TITLE
[Monolog] Use a standalone http client for ElasticsearchLogstashHandler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -19,6 +19,7 @@ use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerAwareInterface;
+use Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -43,6 +44,7 @@ use Symfony\Component\Config\ResourceCheckerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
@@ -445,6 +447,11 @@ class FrameworkExtension extends Extension
             ->addTag('mime.mime_type_guesser');
         $container->registerForAutoconfiguration(LoggerAwareInterface::class)
             ->addMethodCall('setLogger', [new Reference('logger')]);
+
+        $handlerAutoconfiguration = $container->registerForAutoconfiguration(ElasticsearchLogstashHandler::class);
+        $handlerAutoconfiguration->setBindings($handlerAutoconfiguration->getBindings() + [
+            HttpClientInterface::class => new BoundArgument(new Reference('monolog.http_client'), false),
+        ]);
 
         if (!$container->getParameter('kernel.debug')) {
             // remove tagged iterator argument for resource checkers

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -127,5 +127,9 @@
             <argument type="service" id="service_container" />
             <argument type="tagged_iterator" tag="container.env_var_loader" />
         </service>
+
+        <service id="monolog.http_client" class="Symfony\Contracts\HttpClient\HttpClientInterface">
+            <factory class="Symfony\Component\HttpClient\HttpClient" method="create" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/32360#issuecomment-554511075 https://github.com/symfony/symfony-docs/pull/12642
| License       | MIT
| Doc PR        |

This mean the logger will not be injected in this Handler, and it will
prevent an infinite loop :

a log > ElasticsearchLogstashHandler > fire an HTTP request > the http
request emits another log > ...

I did not submit this patch on monolog-bundle because:

* The handler is defined in Symfony, not monolog
* We need advanced DIC features, the bundle still work with SF 3.4
* The only way to fix this issue for sure, it's in symfony