### PR TITLE
[Security] Fix best encoder not wired using migrate_from

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
@@ -114,7 +114,9 @@ class EncoderFactory implements EncoderFactoryInterface
         }
 
         if ($fromEncoders = ($config['migrate_from'] ?? false)) {
-            $encoderChain = [];
+            unset($config['migrate_from']);
+            $encoderChain = [$this->createEncoder($config, true)];
+
             foreach ($fromEncoders as $name) {
                 if ($encoder = $this->encoders[$name] ?? false) {
                     $encoder = $encoder instanceof PasswordEncoderInterface ? $encoder : $this->createEncoder($encoder, true);

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
@@ -143,9 +143,7 @@ class EncoderFactoryTest extends TestCase
 
         $factory = new EncoderFactory([
             'digest_encoder' => $digest = new MessageDigestPasswordEncoder('sha256'),
-            'pbdkf2' => $digest = new MessageDigestPasswordEncoder('sha256'),
-            'bcrypt_encoder' => ['algorithm' => 'bcrypt'],
-            SomeUser::class => ['algorithm' => 'sodium', 'migrate_from' => ['bcrypt_encoder', 'digest_encoder']],
+            SomeUser::class => ['algorithm' => 'sodium', 'migrate_from' => ['bcrypt', 'digest_encoder']],
         ]);
 
         $encoder = $factory->getEncoder(SomeUser::class);
@@ -154,6 +152,7 @@ class EncoderFactoryTest extends TestCase
         $this->assertTrue($encoder->isPasswordValid((new SodiumPasswordEncoder())->encodePassword('foo', null), 'foo', null));
         $this->assertTrue($encoder->isPasswordValid((new NativePasswordEncoder(null, null, null, \PASSWORD_BCRYPT))->encodePassword('foo', null), 'foo', null));
         $this->assertTrue($encoder->isPasswordValid($digest->encodePassword('foo', null), 'foo', null));
+        $this->assertStringStartsWith(SODIUM_CRYPTO_PWHASH_STRPREFIX, $encoder->encodePassword('foo', null));
     }
 
     public function testDefaultMigratingEncoders()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Thanks @wouterj for spotting it.