### PR TITLE
Add ability to deactivate Web Debug Toolbar in header

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+*  added ability to prevent toolbar being displayed by setting
+   `Symfony-Debug-Toolbar header` to `disable`
+
 5.0.0
 -----
 

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -104,6 +104,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
             || ($response->headers->has('Content-Type') && false === strpos($response->headers->get('Content-Type'), 'html'))
             || 'html' !== $request->getRequestFormat()
             || false !== stripos($response->headers->get('Content-Disposition'), 'attachment;')
+            || ($response->headers->has('Symfony-Debug-Toolbar') && 'disable' === $response->headers->get('Symfony-Debug-Toolbar'))
         ) {
             return;
         }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -234,6 +234,22 @@ class WebDebugToolbarListenerTest extends TestCase
         $this->assertEquals('<html><head></head><body></body></html>', $response->getContent());
     }
 
+    /***
+     * @depends testToolbarIsInjected
+     */
+    public function testToolbarIsNotInjectedWhenDisablingHeaderIsPresent()
+    {
+        $response = new Response('<html><head></head><body></body></html>');
+        $response->headers->set('Symfony-Debug-Toolbar', 'disable');
+
+        $event = new ResponseEvent($this->getKernelMock(), $this->getRequestMock(), HttpKernelInterface::MASTER_REQUEST, $response);
+
+        $listener = new WebDebugToolbarListener($this->getTwigMock());
+        $listener->onKernelResponse($event);
+
+        $this->assertEquals('<html><head></head><body></body></html>', $response->getContent());
+    }
+
     public function testXDebugUrlHeader()
     {
         $response = new Response();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #34253
| License       | MIT
| Doc PR        |  TODO

Added ability to set a 'Symfony-Debug-Toolbar' header to 'disable' in response to prevent web debug toolbar from displaying on the page. Profiler still functions. Tests included and works fine in a trial app.

