### PR TITLE
Remove wrong @group legacy annotations

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -60,8 +60,6 @@ class ConfigurationTest extends TestCase
     }
 
     /**
-     * @group legacy
-     *
      * @dataProvider getInterceptRedirectsConfiguration
      */
     public function testConfigTreeUsingInterceptRedirects(bool $interceptRedirects, array $expectedResult)

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -142,8 +142,6 @@ class WebProfilerExtensionTest extends TestCase
     }
 
     /**
-     * @group legacy
-     *
      * @dataProvider getInterceptRedirectsToolbarConfig
      */
     public function testToolbarConfigUsingInterceptRedirects(

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -28,9 +28,6 @@ class BundleTest extends TestCase
         );
     }
 
-    /**
-     * @group legacy
-     */
     public function testGetContainerExtensionWithInvalidClass()
     {
         $this->expectException('LogicException');

--- a/src/Symfony/Component/Routing/Loader/ObjectLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectLoader.php
@@ -52,7 +52,7 @@ abstract class ObjectLoader extends Loader
         $loaderObject = $this->getObject($parts[0]);
 
         if (!\is_object($loaderObject)) {
-            throw new \LogicException(sprintf('%s:getObject() must return an object: %s returned', \get_class($this), \gettype($loaderObject)));
+            throw new \TypeError(sprintf('%s:getObject() must return an object: %s returned', \get_class($this), \gettype($loaderObject)));
         }
 
         if (!\is_callable([$loaderObject, $method])) {

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
@@ -62,12 +62,9 @@ class ObjectLoaderTest extends TestCase
         ];
     }
 
-    /**
-     * @group legacy
-     */
     public function testExceptionOnNoObjectReturned()
     {
-        $this->expectException('LogicException');
+        $this->expectException(\TypeError::class);
         $loader = new TestObjectLoader();
         $loader->loaderMap = ['my_service' => 'NOT_AN_OBJECT'];
         $loader->load('my_service::method');

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -22,9 +22,6 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class DaoAuthenticationProviderTest extends TestCase
 {
-    /**
-     * @group legacy
-     */
     public function testRetrieveUserWhenProviderDoesNotReturnAnUserInterface()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationServiceException');

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -62,9 +62,6 @@ class UserAuthenticationProviderTest extends TestCase
         $provider->authenticate($this->getSupportedToken());
     }
 
-    /**
-     * @group legacy
-     */
     public function testAuthenticateWhenProviderDoesNotReturnAnUserInterface()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationServiceException');

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -72,9 +72,6 @@ class ExceptionListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @group legacy
-     */
     public function testExceptionWhenEntryPointReturnsBadValue()
     {
         $event = $this->createEvent(new AuthenticationException());

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -123,9 +123,6 @@ class LogoutListenerTest extends TestCase
         $listener($event);
     }
 
-    /**
-     * @group legacy
-     */
     public function testSuccessHandlerReturnsNonResponse()
     {
         $this->expectException('RuntimeException');

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -39,9 +39,6 @@ class AbstractRememberMeServicesTest extends TestCase
         $this->assertNull($service->autoLogin(new Request()));
     }
 
-    /**
-     * @group legacy
-     */
     public function testAutoLoginThrowsExceptionWhenImplementationDoesNotReturnUserInterface()
     {
         $this->expectException('RuntimeException');

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -20,9 +20,6 @@ class WorkflowTest extends TestCase
 {
     use WorkflowBuilderTrait;
 
-    /**
-     * @group legacy
-     */
     public function testGetMarkingWithInvalidStoreReturn()
     {
         $this->expectException('Symfony\Component\Workflow\Exception\LogicException');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

These annotations are still found on branch 5.0.
Does this mean they are wrong? Why don't they make 5.0 fail if not?