### PR TITLE
States that the HttpClient provides a Http Async implementation

### DIFF
--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "provide": {
+        "php-http/async-client-implementation": "*",
         "php-http/client-implementation": "*",
         "psr/http-client-implementation": "1.0",
         "symfony/http-client-implementation": "1.1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no (not really)
| New feature?  | no (not really)
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

Add in the composer.json of the HttpClient that it now provides an implementation for the `php-http/async-client-implementation` virtual package, as @Nyholm did the implementation on the HttpPlug bridge in #33743.