### PR TITLE
[Form][ButtonBuilder] Prevent buttons names from starting with a capital letter

### DIFF
--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -50,18 +50,14 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     private $options;
 
     /**
-     * @throws InvalidArgumentException if the name is empty
+     * @throws InvalidArgumentException if the name is empty or invalid
      */
     public function __construct(?string $name, array $options = [])
     {
-        if ('' === $name || null === $name) {
-            throw new InvalidArgumentException('Buttons cannot have empty names.');
-        }
+        self::validateName($name);
 
         $this->name = $name;
         $this->options = $options;
-
-        FormConfigBuilder::validateName($name);
     }
 
     /**
@@ -756,5 +752,32 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     public function getIterator()
     {
         return new \EmptyIterator();
+    }
+
+    /**
+     * Validates whether the given variable is a valid button name.
+     *
+     * @throws InvalidArgumentException if the name is empty or contains invalid characters
+     *
+     * @internal
+     */
+    final public static function validateName(?string $name): void
+    {
+        if ('' === $name || null === $name) {
+            throw new InvalidArgumentException('Buttons cannot have empty names.');
+        }
+
+        if (!self::isValidName($name)) {
+            throw new InvalidArgumentException(sprintf('The name "%s" contains illegal characters. Names should start with a lowercase letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").', $name));
+        }
+    }
+
+    /**
+     * A name is accepted if it starts with a lowercase letter, digit or underscore
+     * and contains only letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").
+     */
+    final public static function isValidName(string $name): bool
+    {
+        return (bool) preg_match('/^[a-z0-9_][a-zA-Z0-9_\-:]*$/D', $name);
     }
 }

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -42,16 +42,16 @@ class ButtonBuilderTest extends TestCase
     public function testNameContainingIllegalCharacters()
     {
         $this->expectException('Symfony\Component\Form\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('The name "button[]" contains illegal characters. Names should start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").');
+        $this->expectExceptionMessage('The name "button[]" contains illegal characters. Names should start with a lowercase letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").');
 
         $this->assertInstanceOf('\Symfony\Component\Form\ButtonBuilder', new ButtonBuilder('button[]'));
     }
 
-    /**
-     * @group legacy
-     */
     public function testNameStartingWithIllegalCharacters()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The name "Button" contains illegal characters. Names should start with a lowercase letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").');
+
         $this->assertInstanceOf('\Symfony\Component\Form\ButtonBuilder', new ButtonBuilder('Button'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Ping @xabbuh.
It was forbidden in https://github.com/symfony/symfony/pull/28969 but it does not throw in 5.0 as it should.
We cannot use `FormConfigBuilder::validateName()` in `ButtonBuilder` because this one allows first capital letters. We cannot change it because form names can start with capital letters (it is currently not deprecated in 4.4).
So we either also deprecate this (but why?) or we just validate button names in its own builder (proposed change in this PR).