### PR TITLE
[HttpFoundation] Add method to ParameterBag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
     to speed up garbage collection of expired sessions.
  * added `SessionHandlerFactory` to create session handlers with a DSN
  * added `IpUtils::anonymize()` to help with GDPR compliance.
+ * added a new method `getJsonArray` to `ParameterBag` for getting the `json` value and converting into `array`.
 
 4.3.0
 -----

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -202,4 +202,22 @@ class ParameterBag implements \IteratorAggregate, \Countable
     {
         return \count($this->parameters);
     }
+
+    /**
+     * Returns the parameter value converted to array.
+     *
+     * @param string $key
+     * @param array $default
+     * @return array
+     */
+    public function getJsonArray($key, $default = [])
+    {
+        $value = $this->get($key, $default);
+
+        if (is_string($value)) {
+            $value = json_decode ($value);
+        }
+
+        return (array) $value;
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -218,6 +218,6 @@ class ParameterBag implements \IteratorAggregate, \Countable
             $value = (array) $value;
         }
 
-        return $value;
+        return is_array($value) ? $value : $default;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -207,18 +207,22 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * Returns the parameter value converted to array.
      *
      * @param string $key
-     * @param array  $default
+     * @param array|null  $default
      *
      * @return array
      */
-    public function getJsonArray($key, $default = [])
+    public function getJsonArray(string $key, ?array $default = []): array
     {
         $value = $this->get($key, $default);
 
         if (\is_string($value)) {
-            $value = json_decode($value);
+            $value = json_decode($value, true);
         }
 
-        return (array) $value;
+        if (\is_object($value)) {
+            $value = (array) $value;
+        }
+
+        return $value;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -207,15 +207,16 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * Returns the parameter value converted to array.
      *
      * @param string $key
-     * @param array $default
+     * @param array  $default
+     *
      * @return array
      */
     public function getJsonArray($key, $default = [])
     {
         $value = $this->get($key, $default);
 
-        if (is_string($value)) {
-            $value = json_decode ($value);
+        if (\is_string($value)) {
+            $value = json_decode($value);
         }
 
         return (array) $value;

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -205,11 +205,6 @@ class ParameterBag implements \IteratorAggregate, \Countable
 
     /**
      * Returns the parameter value converted to array.
-     *
-     * @param string $key
-     * @param array|null  $default
-     *
-     * @return array
      */
     public function getJsonArray(string $key, ?array $default = []): array
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -191,4 +191,21 @@ class ParameterBagTest extends TestCase
         $this->assertFalse($bag->getBoolean('string_false'), '->getBoolean() gets the string false as boolean false');
         $this->assertFalse($bag->getBoolean('unknown'), '->getBoolean() returns false if a parameter is not defined');
     }
+
+    public function testJsonArray()
+    {
+        $obj = new \stdClass ();
+        $obj->foo = 'bar';
+        $obj->hello = 'world';
+
+        $array = (array) $obj;
+        $bag = new ParameterBag([
+            'json' => json_encode($array),
+            'object' => $obj,
+        ]);
+
+        $this->assertEquals($array, $bag->getJsonArray('object'), '->getJsonArray() gets a value of parameter as array');
+        $this->assertEquals($array, $bag->getJsonArray('json'), '->getJsonArray() gets a value of parameter as array');
+        $this->assertEquals([], $bag->getJsonArray('unknown'), '->getJsonArray() returns empty array if a parameter is not defined');
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -194,7 +194,7 @@ class ParameterBagTest extends TestCase
 
     public function testJsonArray()
     {
-        $obj = new \stdClass ();
+        $obj = new \stdClass();
         $obj->foo = 'bar';
         $obj->hello = 'world';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Added a new method `getJsonArray` to `ParameterBag` for getting the `json` value and converting it into `array`.