### PR TITLE
[Validator] ConstraintValidatorTestCase: add missing return value to mocked validate method calls

### DIFF
--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -177,7 +177,8 @@ abstract class ConstraintValidatorTestCase extends TestCase
             ->willReturn($validator);
         $validator->expects($this->at(2 * $i + 1))
             ->method('validate')
-            ->with($value, $this->logicalOr(null, [], $this->isInstanceOf('\Symfony\Component\Validator\Constraints\Valid')), $group);
+            ->with($value, $this->logicalOr(null, [], $this->isInstanceOf('\Symfony\Component\Validator\Constraints\Valid')), $group)
+            ->willReturn($validator);
     }
 
     protected function expectValidateValueAt($i, $propertyPath, $value, $constraints, $group = null)
@@ -189,7 +190,8 @@ abstract class ConstraintValidatorTestCase extends TestCase
             ->willReturn($contextualValidator);
         $contextualValidator->expects($this->at(2 * $i + 1))
             ->method('validate')
-            ->with($value, $constraints, $group);
+            ->with($value, $constraints, $group)
+            ->willReturn($contextualValidator);
     }
 
     protected function assertNoViolation()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | N/A

Spotted while working on https://github.com/symfony/symfony/pull/34456.
Not sure it should really qualify as a bugfix, but the `ContextualValidatorInterface::validate` method is expected to return the instance. If [chaining in a validator](https://github.com/symfony/symfony/pull/34456/files#diff-0e6e3106aa637d750d47e86a14cef8d4R43), trying to use this test methods would throw an error, trying to call a method on `null`.