### PR TITLE
[Form] group constraints when calling the validator

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -76,6 +76,8 @@ class FormValidator extends ConstraintValidator
                     }
                 }
             } else {
+                $groupedConstraints = [];
+
                 foreach ($constraints as $constraint) {
                     // For the "Valid" constraint, validate the data in all groups
                     if ($constraint instanceof Valid) {
@@ -88,7 +90,7 @@ class FormValidator extends ConstraintValidator
                     // matching group
                     foreach ($groups as $group) {
                         if (\in_array($group, $constraint->groups)) {
-                            $validator->atPath('data')->validate($form->getData(), $constraint, $group);
+                            $groupedConstraints[$group][] = $constraint;
 
                             // Prevent duplicate validation
                             if (!$constraint instanceof Composite) {
@@ -96,6 +98,10 @@ class FormValidator extends ConstraintValidator
                             }
                         }
                     }
+                }
+
+                foreach ($groupedConstraints as $group => $constraint) {
+                    $validator->atPath('data')->validate($form->getData(), $constraint, $group);
                 }
             }
         } elseif (!$form->isSynchronized()) {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\Form\SubmitButtonBuilder;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Valid;
@@ -77,10 +78,11 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $object = new \stdClass();
         $constraint1 = new NotNull(['groups' => ['group1', 'group2']]);
         $constraint2 = new NotBlank(['groups' => 'group2']);
+        $constraint3 = new Length(['groups' => 'group2', 'min' => 3]);
 
         $options = [
             'validation_groups' => ['group1', 'group2'],
-            'constraints' => [$constraint1, $constraint2],
+            'constraints' => [$constraint1, $constraint2, $constraint3],
         ];
         $form = $this->getCompoundForm($object, $options);
         $form->submit([]);
@@ -89,8 +91,8 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->expectValidateAt(0, 'data', $object, ['group1', 'group2']);
 
         // Then custom constraints
-        $this->expectValidateValueAt(1, 'data', $object, $constraint1, 'group1');
-        $this->expectValidateValueAt(2, 'data', $object, $constraint2, 'group2');
+        $this->expectValidateValueAt(1, 'data', $object, [$constraint1], 'group1');
+        $this->expectValidateValueAt(2, 'data', $object, [$constraint2, $constraint3], 'group2');
 
         $this->validator->validate($form, new Form());
 
@@ -172,8 +174,8 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $parent->add($form);
         $parent->submit([]);
 
-        $this->expectValidateValueAt(0, 'data', $object, $constraint1, 'group1');
-        $this->expectValidateValueAt(1, 'data', $object, $constraint2, 'group2');
+        $this->expectValidateValueAt(0, 'data', $object, [$constraint1], 'group1');
+        $this->expectValidateValueAt(1, 'data', $object, [$constraint2], 'group2');
 
         $this->validator->validate($form, new Form());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follow up of https://github.com/symfony/symfony/pull/34081
Spotted during the workshop at SymfonyCon, while trying to fix deprecation notices on symfony-demo:
the Form component currently passes constraints one by one for validation, effectively preventing the validator from taking care of cross-constraints dependencies.

This PR fixes it.

This will prevent ppl from having to fix things like
> Using the "Symfony\Component\Validator\Constraints\Length" constraint with the "min" option without setting the "allowEmptyString" one is deprecated and defaults to true. In 5.0, it will become optional and default to false.

