### PR TITLE
[Workflow] Deprecate `GuardEvent::setBlocked()` method

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -372,6 +372,11 @@ WebServerBundle
 
  * The bundle is deprecated and will be removed in 5.0.
 
+Workflow
+--------
+
+  * Deprecated `GuardEvent::setBlocked()` method, use `GuardEvent::addTransitionBlocker()` instead.
+
 Yaml
 ----
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -660,6 +660,8 @@ Workflow
                type: state_machine
    ```
 
+  * Deprecated `GuardEvent::setBlocked()` method, use `GuardEvent::addTransitionBlocker()` instead.
+
 Yaml
 ----
 

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Marked all dispatched event classes as `@final`
+ * Deprecated `GuardEvent::setBlocked()` method, use `GuardEvent::addTransitionBlocker()` instead.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -41,8 +41,15 @@ class GuardEvent extends Event
         return !$this->transitionBlockerList->isEmpty();
     }
 
+    /**
+     * @deprecated Deprecated since Symfony 5.0, use addTransitionBlocker instead.
+     *
+     * @param  bool  $blocked
+     */
     public function setBlocked($blocked)
     {
+        @trigger_error(sprintf('The "%s" function is deprecated since Symfony 5.0, use "%s" instead.', 'setBlocked' , 'addTransitionBlocker'), E_USER_DEPRECATED);
+
         if (!$blocked) {
             $this->transitionBlockerList->clear();
 

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -44,11 +44,11 @@ class GuardEvent extends Event
     /**
      * @deprecated Deprecated since Symfony 5.0, use addTransitionBlocker instead.
      *
-     * @param  bool  $blocked
+     * @param bool $blocked
      */
     public function setBlocked($blocked)
     {
-        @trigger_error(sprintf('The "%s" function is deprecated since Symfony 5.0, use "%s" instead.', 'setBlocked' , 'addTransitionBlocker'), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" function is deprecated since Symfony 5.0, use "%s" instead.', 'setBlocked', 'addTransitionBlocker'), E_USER_DEPRECATED);
 
         if (!$blocked) {
             $this->transitionBlockerList->clear();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      |no
| New feature?  | no
| Deprecations? | yes
| Tickets       |
| License       | MIT
| Doc PR        | 

GuardEvent::setBlocked appears to exist for backwards compatibility. If it is called externally, addTransitionBlocker is called with an 'unknown reason' message, which is difficult to debug. Deprecating setBlocked will help users call addTransitionBlocker instead.