### PR TITLE
[Messenger] Ignore stamps in in-memory transport

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemoryTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemoryTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Tests\Fixtures\AnEnvelopeStamp;
 use Symfony\Component\Messenger\Transport\InMemoryTransport;
 
 /**
@@ -47,6 +48,19 @@ class InMemoryTransportTest extends TestCase
         $this->transport->ack($envelope1);
         $this->assertSame([$envelope2], $this->transport->get());
         $this->transport->reject($envelope2);
+        $this->assertSame([], $this->transport->get());
+    }
+
+    public function testAcknowledgeSameMessageWithDifferentStamps()
+    {
+        $envelope1 = new Envelope(new \stdClass(), [new AnEnvelopeStamp()]);
+        $this->transport->send($envelope1);
+        $envelope2 = new Envelope(new \stdClass(), [new AnEnvelopeStamp()]);
+        $this->transport->send($envelope2);
+        $this->assertSame([$envelope1, $envelope2], $this->transport->get());
+        $this->transport->ack($envelope1->with(new AnEnvelopeStamp()));
+        $this->assertSame([$envelope2], $this->transport->get());
+        $this->transport->reject($envelope2->with(new AnEnvelopeStamp()));
         $this->assertSame([], $this->transport->get());
     }
 

--- a/src/Symfony/Component/Messenger/Transport/InMemoryTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/InMemoryTransport.php
@@ -55,7 +55,7 @@ class InMemoryTransport implements TransportInterface, ResetInterface
     public function ack(Envelope $envelope): void
     {
         $this->acknowledged[] = $envelope;
-        $id = spl_object_hash($envelope);
+        $id = spl_object_hash($envelope->getMessage());
         unset($this->queue[$id]);
     }
 
@@ -65,7 +65,7 @@ class InMemoryTransport implements TransportInterface, ResetInterface
     public function reject(Envelope $envelope): void
     {
         $this->rejected[] = $envelope;
-        $id = spl_object_hash($envelope);
+        $id = spl_object_hash($envelope->getMessage());
         unset($this->queue[$id]);
     }
 
@@ -75,7 +75,7 @@ class InMemoryTransport implements TransportInterface, ResetInterface
     public function send(Envelope $envelope): Envelope
     {
         $this->sent[] = $envelope;
-        $id = spl_object_hash($envelope);
+        $id = spl_object_hash($envelope->getMessage());
         $this->queue[$id] = $envelope;
 
         return $envelope;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

Stamps can be added/removed to/from message during handling. Ignore stamps so that we can ack/reject them correctly.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
