### PR TITLE
[Mailer] Add UPGRADE entries about Envelope and MessageEvent

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -168,6 +168,8 @@ Mailer
 ------
 
  * [BC BREAK] Changed the DSN to use for disabling delivery (using the `NullTransport`) from `smtp://null` to `null://null` (host doesn't matter).
+ * [BC BREAK] Renamed class `SmtpEnvelope` to `Envelope` and `DelayedSmtpEnvelope` to `DelayedEnvelope`.
+ * [BC BREAK] Added a required `string $transport` argument to `MessageEvent::__construct`.
 
 Messenger
 ---------


### PR DESCRIPTION
* Class `SmtpEnvelope` has been renamed to `Envelope` in #33562
* A required `$transport` argument has been added to `MessageEvent` in  #32927

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | already up-to-date