### PR TITLE
[Security] Rework firewall access denied rule

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -150,8 +150,6 @@ class ExceptionListener
             } catch (\Exception $e) {
                 $event->setThrowable($e);
             }
-
-            return;
         }
 
         if (null !== $this->logger) {
@@ -169,7 +167,7 @@ class ExceptionListener
                 $subRequest = $this->httpUtils->createRequest($event->getRequest(), $this->errorPage);
                 $subRequest->attributes->set(Security::ACCESS_DENIED_ERROR, $exception);
 
-                $event->setResponse($event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true));
+                $event->setResponse($event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST));
                 $event->allowCustomResponseCode();
             }
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -130,10 +130,8 @@ class ExceptionListenerTest extends TestCase
     {
         $event = $this->createEvent($exception);
 
-        $accessDeniedHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface')->getMock();
-        $accessDeniedHandler->expects($this->once())->method('handle')->willReturn(new Response('error'));
+        $listener = $this->createExceptionListener(null, $this->createTrustResolver(true), null, null, null, $this->createCustomAccessDeniedHandler(new Response('error')));
 
-        $listener = $this->createExceptionListener(null, $this->createTrustResolver(true), null, null, null, $accessDeniedHandler);
         $listener->onKernelException($event);
 
         $this->assertEquals('error', $event->getResponse()->getContent());
@@ -147,13 +145,48 @@ class ExceptionListenerTest extends TestCase
     {
         $event = $this->createEvent($exception);
 
-        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
-        $tokenStorage->expects($this->once())->method('getToken')->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
-
-        $listener = $this->createExceptionListener($tokenStorage, $this->createTrustResolver(false), null, $this->createEntryPoint());
+        $listener = $this->createExceptionListener($this->createTokenStorage(), $this->createTrustResolver(false), null, $this->createEntryPoint());
         $listener->onKernelException($event);
 
         $this->assertEquals('OK', $event->getResponse()->getContent());
+        $this->assertSame(null === $eventException ? $exception : $eventException, $event->getThrowable()->getPrevious());
+    }
+
+    /**
+     * @dataProvider getAccessDeniedExceptionProvider
+     */
+    public function testAccessDeniedExceptionNotFullFledgedAndWithAccessDeniedHandlerAndWithoutErrorPage(\Exception $exception, \Exception $eventException = null)
+    {
+        $event = $this->createEvent($exception);
+
+        $listener = $this->createExceptionListener($this->createTokenStorage(), $this->createTrustResolver(false), null, $this->createEntryPoint(), null, $this->createCustomAccessDeniedHandler(new Response('denied', 403)));
+        $listener->onKernelException($event);
+
+        $this->assertEquals('denied', $event->getResponse()->getContent());
+        $this->assertEquals(403, $event->getResponse()->getStatusCode());
+        $this->assertSame(null === $eventException ? $exception : $eventException, $event->getThrowable()->getPrevious());
+    }
+
+    /**
+     * @dataProvider getAccessDeniedExceptionProvider
+     */
+    public function testAccessDeniedExceptionNotFullFledgedAndWithoutAccessDeniedHandlerAndWithErrorPage(\Exception $exception, \Exception $eventException = null)
+    {
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
+        $kernel->expects($this->once())->method('handle')->willReturn(new Response('Unauthorized', 401));
+
+        $event = $this->createEvent($exception, $kernel);
+
+        $httpUtils = $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')->getMock();
+        $httpUtils->expects($this->once())->method('createRequest')->willReturn(Request::create('/error'));
+
+        $listener = $this->createExceptionListener($this->createTokenStorage(), $this->createTrustResolver(true), $httpUtils, null, '/error');
+        $listener->onKernelException($event);
+
+        $this->assertTrue($event->isAllowingCustomResponseCode());
+
+        $this->assertEquals('Unauthorized', $event->getResponse()->getContent());
+        $this->assertEquals(401, $event->getResponse()->getStatusCode());
         $this->assertSame(null === $eventException ? $exception : $eventException, $event->getThrowable()->getPrevious());
     }
 
@@ -166,6 +199,22 @@ class ExceptionListenerTest extends TestCase
             [new \LogicException('random', 0, $e = new AccessDeniedException('embed', new AuthenticationException())), $e],
             [new AccessDeniedException('random', new \LogicException())],
         ];
+    }
+
+    private function createTokenStorage()
+    {
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $tokenStorage->expects($this->once())->method('getToken')->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
+
+        return $tokenStorage;
+    }
+
+    private function createCustomAccessDeniedHandler(Response $response)
+    {
+        $accessDeniedHandler = $this->getMockBuilder('Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface')->getMock();
+        $accessDeniedHandler->expects($this->once())->method('handle')->willReturn($response);
+
+        return $accessDeniedHandler;
     }
 
     private function createEntryPoint(Response $response = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #28229
| License       | MIT
| Doc PR        | _n/a_

It's currently impossible to provide a AccessDeniedHandler to Symfony, it will just be ignored. See #28229 for details.

@dimabory submitted a PR (#30423) to fix this, which was merged, but then reverted (#31142) due to a BC break in 3.4 branch (#31136).

Since the bug reported in #28229 still exists, I was planning to do a PR in the master branch before the 5.0 release, however time passed and I didn't see it would be released that soon. I hope this could still be merged as a hotfix in the 5.0 branch (despite the BC break) since I find this bug _really_ annoying.