### PR TITLE
[Messenger] Add HeaderStamp to add custom headers

### DIFF
--- a/CHANGELOG-5.1.md
+++ b/CHANGELOG-5.1.md
@@ -1,0 +1,12 @@
+CHANGELOG for 5.1.x
+===================
+
+This changelog references the relevant changes (bug and security fixes) done
+in 5.1 minor versions.
+
+To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
+To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.1.0...v5.1.1
+
+* 5.1.0-BETA1
+
+ * feature #34481 [Messenger] Add HeaderStamp to add custom headers in the encoded message (alanpoulain)

--- a/src/Symfony/Component/Messenger/Stamp/HeaderStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/HeaderStamp.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Stamp to add a custom header to be used by the transport.
+ *
+ * @author Alan Poulain <contact@alanpoulain.eu>
+ */
+final class HeaderStamp implements StampInterface
+{
+    private $headerName;
+    private $headerValue;
+
+    public function __construct(string $headerName, string $headerValue)
+    {
+        $this->headerName = $headerName;
+        $this->headerValue = $headerValue;
+    }
+
+    public function getHeaderName(): string
+    {
+        return $this->headerName;
+    }
+
+    public function getHeaderValue(): string
+    {
+        return $this->headerValue;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\HeaderStamp;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Stamp\ValidationStamp;
@@ -104,6 +105,23 @@ class SerializerTest extends TestCase
         $this->assertArrayHasKey('type', $encoded['headers']);
         $this->assertArrayHasKey('X-Message-Stamp-'.SerializerStamp::class, $encoded['headers']);
         $this->assertArrayHasKey('X-Message-Stamp-'.ValidationStamp::class, $encoded['headers']);
+    }
+
+    public function testEncodedWithHeaderStamps()
+    {
+        $serializer = new Serializer();
+
+        $envelope = (new Envelope(new DummyMessage('test')))
+            ->with(new HeaderStamp('X-Custom-Header', 'foo'))
+            ->with(new HeaderStamp('X-Custom-Header-Bis', 'bar'));
+
+        $encoded = $serializer->encode($envelope);
+
+        $this->assertArrayHasKey('headers', $encoded);
+        $this->assertArrayHasKey('X-Custom-Header', $encoded['headers']);
+        $this->assertSame($encoded['headers']['X-Custom-Header'], 'foo');
+        $this->assertArrayHasKey('X-Custom-Header-Bis', $encoded['headers']);
+        $this->assertSame($encoded['headers']['X-Custom-Header-Bis'], 'bar');
     }
 
     public function testDecodeWithSymfonySerializerStamp()

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Transport\Serialization;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\HeaderStamp;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
@@ -136,6 +137,14 @@ class Serializer implements SerializerInterface
 
         $headers = [];
         foreach ($allStamps as $class => $stamps) {
+            if (HeaderStamp::class === $class) {
+                foreach ($stamps as $stamp) {
+                    $headers[$stamp->getHeaderName()] = $stamp->getHeaderValue();
+                }
+
+                continue;
+            }
+
             $headers[self::STAMP_HEADER_PREFIX.$class] = $this->serializer->serialize($stamps, $this->format, $this->context);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TBD

Add a `HeaderStamp` to add custom headers to an encoded message to be used by the transport.

It's a proposal, maybe there is a better way to do this.

This feature would be useful in my case where I need to add a custom header to deduplicate the messages in an AMQP context. This is the RabbitMQ plugin I would like to use: https://github.com/noxdafox/rabbitmq-message-deduplication.

An example of how to use it:
```php
$bus->dispatch(
    (new Envelope($message))->with(new HeaderStamp('x-deduplication-header', $dataUsedToDeduplicateMessages))
);
```