### PR TITLE
[Messenger] Replace senders env

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1816,14 +1816,16 @@ class FrameworkExtension extends Extension
                 throw new LogicException(sprintf('Invalid Messenger routing configuration: class or interface "%s" not found.', $message));
             }
 
+            $senders = $container->resolveEnvPlaceholders($messageConfiguration['senders'], true);
+
             // make sure senderAliases contains all senders
-            foreach ($messageConfiguration['senders'] as $sender) {
+            foreach ($senders as $sender) {
                 if (!isset($senderReferences[$sender])) {
                     throw new LogicException(sprintf('Invalid Messenger routing configuration: the "%s" class is being routed to a sender called "%s". This is not a valid transport or service id.', $message, $sender));
                 }
             }
 
-            $messageToSendersMapping[$message] = $messageConfiguration['senders'];
+            $messageToSendersMapping[$message] = $senders;
         }
 
         $sendersServiceLocator = ServiceLocatorTagPass::register($container, $senderReferences);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
@@ -1,5 +1,7 @@
 <?php
 
+$container->setParameter('env(FOO_MESSAGE_SENDER)', 'amqp');
+
 $container->loadFromExtension('framework', [
     'serializer' => true,
     'messenger' => [
@@ -11,6 +13,7 @@ $container->loadFromExtension('framework', [
             'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage' => [
                 'senders' => ['amqp', 'audit'],
             ],
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage' => ['%env(FOO_MESSAGE_SENDER)%'],
             '*' => 'amqp',
         ],
         'transports' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
@@ -5,6 +5,10 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
+    <parameters>
+        <parameter key="env(FOO_MESSAGE_SENDER)">amqp</parameter>
+    </parameters>
+
     <framework:config>
         <framework:serializer enabled="true" />
         <framework:messenger>
@@ -16,6 +20,9 @@
             <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage">
                 <framework:sender service="amqp" />
                 <framework:sender service="audit" />
+            </framework:routing>
+            <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage">
+                <framework:sender service="%env(FOO_MESSAGE_SENDER)%" />
             </framework:routing>
             <framework:routing message-class="*">
                 <framework:sender service="amqp" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
@@ -1,3 +1,6 @@
+parameters:
+    env(FOO_MESSAGE_SENDER): amqp
+
 framework:
     serializer: true
     messenger:
@@ -7,6 +10,7 @@ framework:
             'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage': [amqp, messenger.transport.audit]
             'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage':
                 senders: [amqp, audit]
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage': '%env(FOO_MESSAGE_SENDER)%'
             '*': amqp
         transports:
             amqp: 'amqp://localhost/%2f/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerAwareInterface;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAnnotationsCachedReaderPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
@@ -720,6 +721,8 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $sendersMapping = $senderLocatorDefinition->getArgument(0);
         $this->assertEquals(['amqp', 'messenger.transport.audit'], $sendersMapping[DummyMessage::class]);
+        $this->assertEquals(['amqp'], $sendersMapping[FooMessage::class]);
+        $this->assertEquals(['amqp'], $sendersMapping['*']);
         $sendersLocator = $container->getDefinition((string) $senderLocatorDefinition->getArgument(1));
         $this->assertSame(['amqp', 'audit', 'messenger.transport.amqp', 'messenger.transport.audit'], array_keys($sendersLocator->getArgument(0)));
         $this->assertEquals(new Reference('messenger.transport.amqp'), $sendersLocator->getArgument(0)['amqp']->getValues()[0]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR is a proposition to allow ENV variables usage in messenger senders list.

Use case:

```yaml
framework:
    messenger:
        transports:
            sync: sync://
            async: 'amqp://localhost/%2f/messages'
        routing:
             '*': '%env(MESSENGER_DEFAULT_TRANSPORT)%'           #"sync" or "async"
```