### PR TITLE
[Serializer] Fix MetadataAwareNameConverter usage with string group

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -123,7 +123,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             if (!$groups && ($context[AbstractNormalizer::GROUPS] ?? [])) {
                 continue;
             }
-            if ($groups && !array_intersect($groups, $context[AbstractNormalizer::GROUPS] ?? [])) {
+            if ($groups && !array_intersect($groups, (array) ($context[AbstractNormalizer::GROUPS] ?? []))) {
                 continue;
             }
 

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -146,6 +146,8 @@ final class MetadataAwareNameConverterTest extends TestCase
         return [
             ['buz', 'buz', ['groups' => ['a']]],
             ['buzForExport', 'buz', ['groups' => ['b']]],
+            ['buz', 'buz', ['groups' => 'a']],
+            ['buzForExport', 'buz', ['groups' => 'b']],
             ['buz', 'buz', ['groups' => ['c']]],
             ['buz', 'buz', []],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34455
| License       | MIT
| Doc PR        | 

Allow to use the short syntax for serialization context group like `['groups' => 'user']`