### PR TITLE
[FrameworkBundle][ContainerLint] Keep "removing" compiler passes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -70,7 +70,6 @@ final class ContainerLintCommand extends Command
         if (!$kernel->isDebug() || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
             $buildContainer = \Closure::bind(function () { return $this->buildContainer(); }, $kernel, \get_class($kernel));
             $container = $buildContainer();
-            $container->getCompilerPassConfig()->setRemovingPasses([]);
         } else {
             (new XmlFileLoader($container = new ContainerBuilder(), new FileLocator()))->load($kernel->getContainer()->getParameter('debug.container.dump'));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/34498
| License       | MIT
| Doc PR        | -

Removing "removing" compiler passes when debug is off (why only in this case btw?) means that the container is never cleaned (the important thing being the "remove unused definitions" pass), leaving it in a "dirty" state. What is the point of testing a container that is different than the one that will be used anyway? 🤔 

Making this truely work btw means that 100% of Symfony's declared services must end up valid whether they are used or not and in all combinations possible. I guess that should be the goal but from what I could test in the last hour, that will be a lot of work. However, there are definitely some fixes to do in our services declarations that we can detect thanks to this "bug".