### PR TITLE
[Validator] remove return type declaration from __sleep()

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -288,7 +288,7 @@ abstract class Constraint
      *
      * @internal
      */
-    public function __sleep(): array
+    public function __sleep()
     {
         // Initialize "groups" option if it is not set
         $this->groups;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34478
| License       | MIT
| Doc PR        | 