### PR TITLE
improve upgrade instructions for twig.exception_controller configuration

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -269,7 +269,17 @@ TwigBridge
 TwigBundle
 ----------
 
- * Deprecated `twig.exception_controller` configuration option, set it to "null" and use `framework.error_controller` instead:
+ * Deprecated `twig.exception_controller` configuration option.
+
+   If you were not using this option previously, set it to `null`:
+
+   After:
+   ```yaml
+   twig:
+       exception_controller: null
+   ```
+
+   If you were using this option previously, set it to `null` and use `framework.error_controller` instead:
 
    Before:
    ```yaml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This improves the upgrade instructions for the deprecated configuration of `twig.exception_controller`.

Or would it be better to make the default `null` on 4.4?
https://github.com/symfony/symfony/blob/a8a9e69488fdaf609fecacba66e056ffb8f25da8/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php#L41