### PR TITLE
Register Singly implemented interfaces through DirectoryLoader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
+use Symfony\Component\DependencyInjection\Definition;
+
 /**
  * DirectoryLoader is a recursive loader to go through directories.
  *
@@ -38,6 +40,14 @@ class DirectoryLoader extends FileLoader
                 $this->import($dir, null, false, $path);
             }
         }
+    }
+
+    /** {@inheritdoc} */
+    public function registerClasses(Definition $prototype, $namespace, $resource, $exclude = null)
+    {
+        parent::registerClasses($prototype, $namespace, $resource, $exclude);
+
+        $this->registerAliasesForSinglyImplementedInterfaces();
     }
 
     /**


### PR DESCRIPTION
Fixes #34524

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34524 
| License       | MIT
| Doc PR        | N/A

Currently `$interfaces` in DirectoryLoader's state are thrown away when `registerClasses()` is called on it.