### PR TITLE
[SecurityBundle] Don't require a user provider for the anonymous listener

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -464,8 +464,8 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                             throw new InvalidConfigurationException(sprintf('Invalid firewall "%s": user provider "%s" not found.', $id, $firewall[$key]['provider']));
                         }
                         $userProvider = $providerIds[$normalizedName];
-                    } elseif ('remember_me' === $key) {
-                        // RememberMeFactory will use the firewall secret when created
+                    } elseif ('remember_me' === $key || 'anonymous' === $key) {
+                        // RememberMeFactory will use the firewall secret when created, AnonymousAuthenticationListener does not load users.
                         $userProvider = null;
                     } elseif ($defaultProvider) {
                         $userProvider = $defaultProvider;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -210,7 +210,7 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
     }
 
-    public function testPerListenerProviderWithRememberMe()
+    public function testPerListenerProviderWithRememberMeAndAnonymous()
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
@@ -223,6 +223,7 @@ class SecurityExtensionTest extends TestCase
                 'default' => [
                     'form_login' => ['provider' => 'second'],
                     'remember_me' => ['secret' => 'baz'],
+                    'anonymous' => true,
                 ],
             ],
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34504 
| License       | MIT
| Doc PR        | -

Forgotten when adding the AnonymousFactory in #33503