### PR TITLE
[DI] Add "force_parameters_escape" option to dumpers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -29,7 +29,9 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
     {
         $cache = new ConfigCache($container->getParameter('debug.container.dump'), true);
         if (!$cache->isFresh()) {
-            $cache->write((new XmlDumper($container))->dump(), $container->getResources());
+            $cache->write((new XmlDumper($container))->dump([
+                'force_parameters_escape' => true,
+            ]), $container->getResources());
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "symfony/cache": "~3.4.31|^4.3.4",
         "symfony/class-loader": "~3.2",
-        "symfony/dependency-injection": "^3.4.24|^4.2.5",
+        "symfony/dependency-injection": "^3.4.36|^4.3.9",
         "symfony/config": "^3.4.31|^4.3.4",
         "symfony/debug": "~2.8|~3.0|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -49,7 +49,7 @@ class XmlDumper extends Dumper
         $container->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
         $container->setAttribute('xsi:schemaLocation', 'http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd');
 
-        $this->addParameters($container);
+        $this->addParameters($container, isset($options['force_parameters_escape']) ? $options['force_parameters_escape'] : false);
         $this->addServices($container);
 
         $this->document->appendChild($container);
@@ -59,14 +59,17 @@ class XmlDumper extends Dumper
         return $this->container->resolveEnvPlaceholders($xml);
     }
 
-    private function addParameters(\DOMElement $parent)
+    /**
+     * @param bool $forceEscape
+     */
+    private function addParameters(\DOMElement $parent, $forceEscape)
     {
         $data = $this->container->getParameterBag()->all();
         if (!$data) {
             return;
         }
 
-        if ($this->container->isCompiled()) {
+        if ($this->container->isCompiled() || $forceEscape) {
             $data = $this->escape($data);
         }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -51,7 +51,7 @@ class YamlDumper extends Dumper
             $this->dumper = new YmlDumper();
         }
 
-        return $this->container->resolveEnvPlaceholders($this->addParameters()."\n".$this->addServices());
+        return $this->container->resolveEnvPlaceholders($this->addParameters(isset($options['force_parameters_escape']) ? $options['force_parameters_escape'] : false)."\n".$this->addServices());
     }
 
     /**
@@ -212,15 +212,17 @@ class YamlDumper extends Dumper
     /**
      * Adds parameters.
      *
+     * @param bool $forceEscape
+     *
      * @return string
      */
-    private function addParameters()
+    private function addParameters($forceEscape)
     {
         if (!$this->container->getParameterBag()->all()) {
             return '';
         }
 
-        $parameters = $this->prepareParameters($this->container->getParameterBag()->all(), $this->container->isCompiled());
+        $parameters = $this->prepareParameters($this->container->getParameterBag()->all(), $this->container->isCompiled() || $forceEscape);
 
         return $this->dumper->dump(['parameters' => $parameters], 2);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/34526
| License       | MIT
| Doc PR        | -

In `ContainerBuilderDebugDumpPass` we dump an uncompiled container. That means the dumpers do not escape parameters. I guess we need to add an easy way to force this escaping. That fixes the problem with the new lint command. It was not detected before because the `debug:container` command never compiles the container (contrary to the new one).

If it's too complicated, we could just rebuild a fresh container everytime in the lint command.

#SymfonyHackday