### PR TITLE
Added access decision strategy to respect voter priority

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Added security configuration for priority-based access decision strategy
+
 5.0.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -76,7 +76,7 @@ class MainConfiguration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->enumNode('strategy')
-                            ->values([AccessDecisionManager::STRATEGY_AFFIRMATIVE, AccessDecisionManager::STRATEGY_CONSENSUS, AccessDecisionManager::STRATEGY_UNANIMOUS])
+                            ->values($this->getAccessDecisionStrategies())
                         ->end()
                         ->scalarNode('service')->end()
                         ->booleanNode('allow_if_all_abstain')->defaultFalse()->end()
@@ -385,5 +385,20 @@ class MainConfiguration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    private function getAccessDecisionStrategies()
+    {
+        $strategies = [
+            AccessDecisionManager::STRATEGY_AFFIRMATIVE,
+            AccessDecisionManager::STRATEGY_CONSENSUS,
+            AccessDecisionManager::STRATEGY_UNANIMOUS,
+        ];
+
+        if (\defined(AccessDecisionManager::class.'::STRATEGY_PRIORITY')) {
+            $strategies[] = AccessDecisionManager::STRATEGY_PRIORITY;
+        }
+
+        return $strategies;
     }
 }

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Added access decision strategy to override access decisions by voter service priority
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -26,6 +26,7 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
     const STRATEGY_AFFIRMATIVE = 'affirmative';
     const STRATEGY_CONSENSUS = 'consensus';
     const STRATEGY_UNANIMOUS = 'unanimous';
+    const STRATEGY_PRIORITY = 'priority';
 
     private $voters;
     private $strategy;
@@ -177,6 +178,30 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
         // no deny votes
         if ($grant > 0) {
             return true;
+        }
+
+        return $this->allowIfAllAbstainDecisions;
+    }
+
+    /**
+     * Grant or deny access depending on the first voter that does not abstain.
+     * The priority of voters can be used to overrule a decision.
+     *
+     * If all voters abstained from voting, the decision will be based on the
+     * allowIfAllAbstainDecisions property value (defaults to false).
+     */
+    private function decidePriority(TokenInterface $token, array $attributes, $object = null)
+    {
+        foreach ($this->voters as $voter) {
+            $result = $voter->vote($token, $object, $attributes);
+
+            if (VoterInterface::ACCESS_GRANTED === $result) {
+                return true;
+            }
+
+            if (VoterInterface::ACCESS_DENIED === $result) {
+                return false;
+            }
         }
 
         return $this->allowIfAllAbstainDecisions;

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -66,6 +66,31 @@ class AccessDecisionManagerTest extends TestCase
 
             [AccessDecisionManager::STRATEGY_UNANIMOUS, $this->getVoters(0, 0, 2), false, true, false],
             [AccessDecisionManager::STRATEGY_UNANIMOUS, $this->getVoters(0, 0, 2), true, true, true],
+
+            // priority
+            [AccessDecisionManager::STRATEGY_PRIORITY, [
+                $this->getVoter(VoterInterface::ACCESS_ABSTAIN),
+                $this->getVoter(VoterInterface::ACCESS_GRANTED),
+                $this->getVoter(VoterInterface::ACCESS_DENIED),
+                $this->getVoter(VoterInterface::ACCESS_DENIED),
+            ], true, true, true],
+
+            [AccessDecisionManager::STRATEGY_PRIORITY, [
+                $this->getVoter(VoterInterface::ACCESS_ABSTAIN),
+                $this->getVoter(VoterInterface::ACCESS_DENIED),
+                $this->getVoter(VoterInterface::ACCESS_GRANTED),
+                $this->getVoter(VoterInterface::ACCESS_GRANTED),
+            ], true, true, false],
+
+            [AccessDecisionManager::STRATEGY_PRIORITY, [
+                $this->getVoter(VoterInterface::ACCESS_ABSTAIN),
+                $this->getVoter(VoterInterface::ACCESS_ABSTAIN),
+            ], false, true, false],
+
+            [AccessDecisionManager::STRATEGY_PRIORITY, [
+                $this->getVoter(VoterInterface::ACCESS_ABSTAIN),
+                $this->getVoter(VoterInterface::ACCESS_ABSTAIN),
+            ], true, true, true],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | _will happily do if this is of interest/to be merged 🙃_

The priority-based access decision strategy will decide based on the first voter that does not abstain from the decision. Security voters can be registered with priority (`PriorityTaggedServiceTrait`), so a voter with higher priority can overrule other voters.

In [Contao CMS](https://github.com/contao/contao), the core system should provide security voters that provide the "default permissions", but extensions/bundles can override almost anything and therefore need to be able to override the core decision. None of the existing strategies allow for something like that.

/ping @chalasr @Toflar @leofeyer @ausi 
#SymfonyHackday
