### PR TITLE
[Security] SwitchUser is broken when the User Provider always returns a valid user

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -153,7 +153,6 @@ class SwitchUserListener implements ListenerInterface
 
             try {
                 $this->provider->loadUserByUsername($nonExistentUsername);
-                throw new \LogicException('AuthenticationException expected');
             } catch (AuthenticationException $e) {
             }
         } catch (AuthenticationException $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Since bcfc282d42798860ac6a81c062ee6ff2ce65c80f, if a UserProvider always returns a valid User object (which can happen in some OAuth workflow), switching user is not possible anymore as we hit the `LogicException`.

This patch should be safe as the timing-attack prevention is kept.