### PR TITLE
[Workflow] Apply the same logic of precedence between the apply() and the buildTransitionBlockerList() method

### DIFF
--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -159,25 +159,47 @@ class Workflow implements WorkflowInterface
 
         $marking = $this->getMarking($subject);
 
-        $transitionBlockerList = null;
-        $applied = false;
-        $approvedTransitionQueue = [];
+        $transitionExist = false;
+        $approvedTransitions = [];
+        $bestTransitionBlockerList = null;
 
         foreach ($this->definition->getTransitions() as $transition) {
             if ($transition->getName() !== $transitionName) {
                 continue;
             }
 
-            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition);
-            if (!$transitionBlockerList->isEmpty()) {
+            $transitionExist = true;
+
+            $tmpTransitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition);
+
+            if ($tmpTransitionBlockerList->isEmpty()) {
+                $approvedTransitions[] = $transition;
                 continue;
             }
-            $approvedTransitionQueue[] = $transition;
+
+            if (!$bestTransitionBlockerList) {
+                $bestTransitionBlockerList = $tmpTransitionBlockerList;
+                continue;
+            }
+
+            // We prefer to return transitions blocker by something else than
+            // marking. Because it means the marking was OK. Transitions are
+            // deterministic: it's not possible to have many transitions enabled
+            // at the same time that match the same marking with the same name
+            if (!$tmpTransitionBlockerList->has(TransitionBlocker::BLOCKED_BY_MARKING)) {
+                $bestTransitionBlockerList = $tmpTransitionBlockerList;
+            }
         }
 
-        foreach ($approvedTransitionQueue as $transition) {
-            $applied = true;
+        if (!$transitionExist) {
+            throw new UndefinedTransitionException($subject, $transitionName, $this);
+        }
 
+        if (!$approvedTransitions) {
+            throw new NotEnabledTransitionException($subject, $transitionName, $this, $bestTransitionBlockerList);
+        }
+
+        foreach ($approvedTransitions as $transition) {
             $this->leave($subject, $transition, $marking);
 
             $context = $this->transition($subject, $transition, $marking, $context);
@@ -191,14 +213,6 @@ class Workflow implements WorkflowInterface
             $this->completed($subject, $transition, $marking);
 
             $this->announce($subject, $transition, $marking);
-        }
-
-        if (!$transitionBlockerList) {
-            throw new UndefinedTransitionException($subject, $transitionName, $this);
-        }
-
-        if (!$applied) {
-            throw new NotEnabledTransitionException($subject, $transitionName, $this, $transitionBlockerList);
         }
 
         return $marking;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34489
| License       | MIT
| Doc PR        |