### PR TITLE
[FrameworkBundle][Notifier] Fixing notifier email definition without mailer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1941,7 +1941,9 @@ class FrameworkExtension extends Extension
 
             // as we have a bus, the channels don't need the transports
             $container->getDefinition('notifier.channel.chat')->setArgument(0, null);
-            $container->getDefinition('notifier.channel.email')->setArgument(0, null);
+            if ($container->hasDefinition('notifier.channel.email')) {
+                $container->getDefinition('notifier.channel.email')->setArgument(0, null);
+            }
             $container->getDefinition('notifier.channel.sms')->setArgument(0, null);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I ran into this while having notifier and messenger but no mailer installed. definition `notifier.channel.email` gets removed in line 1934 if mailer is not enabled so we can't replace the argument.

```
In ContainerBuilder.php line 980:
                                                                       
  You have requested a non-existent service "notifier.channel.email".  
                                                                       
```