### PR TITLE
[DX] [Workflow] Added a way to specify a message when blocking a transition + better default message in case it is not set

### DIFF
--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -40,7 +40,7 @@ final class GuardEvent extends Event
         return !$this->transitionBlockerList->isEmpty();
     }
 
-    public function setBlocked(bool $blocked): void
+    public function setBlocked(bool $blocked, string $message = null): void
     {
         if (!$blocked) {
             $this->transitionBlockerList->clear();
@@ -48,7 +48,7 @@ final class GuardEvent extends Event
             return;
         }
 
-        $this->transitionBlockerList->add(TransitionBlocker::createUnknown());
+        $this->transitionBlockerList->add(TransitionBlocker::createUnknown($message));
     }
 
     public function getTransitionBlockerList(): TransitionBlockerList

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -233,9 +233,12 @@ class WorkflowTest extends TestCase
         $dispatcher->addListener('workflow.guard', function (GuardEvent $event) {
             $event->setBlocked(true);
         });
+        $dispatcher->addListener('workflow.guard', function (GuardEvent $event) {
+            $event->setBlocked(true, 'You should not pass !!');
+        });
 
         $transitionBlockerList = $workflow->buildTransitionBlockerList($subject, 't1');
-        $this->assertCount(4, $transitionBlockerList);
+        $this->assertCount(5, $transitionBlockerList);
         $blockers = iterator_to_array($transitionBlockerList);
         $this->assertSame('Transition blocker 1', $blockers[0]->getMessage());
         $this->assertSame('blocker_1', $blockers[0]->getCode());
@@ -243,8 +246,10 @@ class WorkflowTest extends TestCase
         $this->assertSame('blocker_2', $blockers[1]->getCode());
         $this->assertSame('Transition blocker 3', $blockers[2]->getMessage());
         $this->assertSame('blocker_3', $blockers[2]->getCode());
-        $this->assertSame('Unknown reason.', $blockers[3]->getMessage());
+        $this->assertSame('The transition has been blocked by a guard (Symfony\Component\Workflow\Tests\WorkflowTest).', $blockers[3]->getMessage());
         $this->assertSame('e8b5bbb9-5913-4b98-bfa6-65dbd228a82a', $blockers[3]->getCode());
+        $this->assertSame('You should not pass !!', $blockers[4]->getMessage());
+        $this->assertSame('e8b5bbb9-5913-4b98-bfa6-65dbd228a82a', $blockers[4]->getCode());
     }
 
     public function testApplyWithNotExisingTransition()

--- a/src/Symfony/Component/Workflow/TransitionBlocker.php
+++ b/src/Symfony/Component/Workflow/TransitionBlocker.php
@@ -66,12 +66,20 @@ final class TransitionBlocker
     /**
      * Creates a blocker that says the transition cannot be made because of an
      * unknown reason.
-     *
-     * This blocker code is chiefly for preserving backwards compatibility.
      */
-    public static function createUnknown(): self
+    public static function createUnknown(string $message = null, int $backtraceFrame = 2): self
     {
-        return new static('Unknown reason.', self::UNKNOWN);
+        if (null !== $message) {
+            return new static($message, self::UNKNOWN);
+        }
+
+        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $backtraceFrame + 1)[$backtraceFrame]['class'] ?? null;
+
+        if (null !== $caller) {
+            return new static("The transition has been blocked by a guard ($caller).", self::UNKNOWN);
+        }
+
+        return new static('The transition has been blocked by a guard.', self::UNKNOWN);
     }
 
     public function getMessage(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34466
| License       | MIT
| Doc PR        |