### PR TITLE
[Messenger] Adding exception to amqp transport in case amqp ext is not installed

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportFactoryTest.php
@@ -28,6 +28,9 @@ class AmqpTransportFactoryTest extends TestCase
         $this->assertFalse($factory->supports('invalid-dsn', []));
     }
 
+    /**
+     * @requires extension amqp
+     */
     public function testItCreatesTheTransport()
     {
         $factory = new AmqpTransportFactory();

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Exception\LogicException;
 
 /**
  * An AMQP connection.
@@ -60,6 +61,10 @@ class Connection
 
     public function __construct(array $connectionOptions, array $exchangeOptions, array $queuesOptions, AmqpFactory $amqpFactory = null)
     {
+        if (!\extension_loaded('amqp')) {
+            throw new LogicException(sprintf('You cannot use the "%s" as the "amqp" extension is not installed.', __CLASS__));
+        }
+
         $this->connectionOptions = array_replace_recursive([
             'delay' => [
                 'exchange_name' => 'delays',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

While setting up a new dev environment with symfony messenger and rabbitmq i got this error message:

<img width="725" alt="Bildschirmfoto 2019-11-24 um 18 56 23" src="https://user-images.githubusercontent.com/2852185/69499113-26412e80-0eef-11ea-9e40-11528db2afee.png">

i think it would be great to give an explicit pointer in this case.

but not sure though if the place where i added the exception is the right spot or if we should even add a suggest in `composer.json` of the component

new:
<img width="1247" alt="Bildschirmfoto 2019-11-24 um 19 45 08" src="https://user-images.githubusercontent.com/2852185/69499569-b08b9180-0ef3-11ea-9ceb-3936dbd39cb7.png">

