### PR TITLE
[FrameworkBundle][Cache] Don't deep-merge cache pools configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1014,6 +1014,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->children()
                                     ->arrayNode('adapters')
+                                        ->performNoDeepMerging()
                                         ->info('One or more adapters to chain for creating the pool, defaults to "cache.app".')
                                         ->beforeNormalization()
                                             ->always()->then(function ($values) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34488 
| License       | MIT

Prevents deep-merge of cache.pools.adapters configuration