### PR TITLE
[HttpFoundation] Update CHANGELOG for PdoSessionHandler BC BREAK in 4.4

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -104,6 +104,9 @@ HttpFoundation
 
  * `ApacheRequest` is deprecated, use `Request` class instead.
  * Passing a third argument to `HeaderBag::get()` is deprecated since Symfony 4.4, use method `all()` instead
+ * [BC BREAK] `PdoSessionHandler` with MySQL changed the type of the lifetime column,
+   make sure to run `ALTER TABLE sessions MODIFY sess_lifetime INTEGER UNSIGNED NOT NULL` to
+   update your database.
  * `PdoSessionHandler` now precalculates the expiry timestamp in the lifetime column,
     make sure to run `CREATE INDEX EXPIRY ON sessions (sess_lifetime)` to update your database
     to speed up garbage collection of expired sessions.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -271,6 +271,9 @@ HttpFoundation
  * `ApacheRequest` has been removed, use the `Request` class instead.
  * The third argument of the `HeaderBag::get()` method has been removed, use method `all()` instead.
  * Getting the container from a non-booted kernel is not possible anymore.
+ * [BC BREAK] `PdoSessionHandler` with MySQL changed the type of the lifetime column,
+   make sure to run `ALTER TABLE sessions MODIFY sess_lifetime INTEGER UNSIGNED NOT NULL` to
+   update your database.
 
 HttpKernel
 ----------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG
  * passing arguments to `Request::isMethodSafe()` is deprecated.
  * `ApacheRequest` is deprecated, use the `Request` class instead.
  * passing a third argument to `HeaderBag::get()` is deprecated, use method `all()` instead
+ * [BC BREAK] `PdoSessionHandler` with MySQL changed the type of the lifetime column,
+   make sure to run `ALTER TABLE sessions MODIFY sess_lifetime INTEGER UNSIGNED NOT NULL` to
+   update your database.
  * `PdoSessionHandler` now precalculates the expiry timestamp in the lifetime column,
     make sure to run `CREATE INDEX EXPIRY ON sessions (sess_lifetime)` to update your database
     to speed up garbage collection of expired sessions.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34491
| License       | MIT

As explained in https://github.com/symfony/symfony/issues/34491, there was a BC BREAK between 4.3 and 4.4, when using `PdoSessionHandler` with MySQL, where the column `sess_lifetime` was modified from `MEDIUMINT` to `INTEGER UNSIGNED`.

This PR updates `UPGRADE-4.4.md` with a suggested query for updating the database accordingly.