### PR TITLE
[Workflow] Added `Registry::has()` to check if a workflow exists

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added context to `TransitionException` and its child classes whenever they are thrown in `Workflow::apply()`
+ * Added `Registry::has()` to check if a workflow exists
 
 5.0.0
 -----

--- a/src/Symfony/Component/Workflow/Registry.php
+++ b/src/Symfony/Component/Workflow/Registry.php
@@ -27,6 +27,17 @@ class Registry
         $this->workflows[] = [$workflow, $supportStrategy];
     }
 
+    public function has(object $subject, string $workflowName = null): bool
+    {
+        foreach ($this->workflows as list($workflow, $supportStrategy)) {
+            if ($this->supports($workflow, $supportStrategy, $subject, $workflowName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @return Workflow
      */

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -28,6 +28,16 @@ class RegistryTest extends TestCase
         $this->registry = null;
     }
 
+    public function testHasWithMatch()
+    {
+        $this->assertTrue($this->registry->has(new Subject1()));
+    }
+
+    public function testHasWithoutMatch()
+    {
+        $this->assertFalse($this->registry->has(new Subject1(), 'nope'));
+    }
+
     public function testGetWithSuccess()
     {
         $workflow = $this->registry->get(new Subject1());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #34584
| License       | MIT
| Doc PR        |

---

Allow to use
```php
$registry->has($subject);
// or 
$registry->has($subject, 'workflow_a')
```