### PR TITLE
[Security] Changed has_role to is_granted for expression in upgrade 4.4

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -230,7 +230,7 @@ Security
 
    **After**
    ```php
-   if ($this->authorizationChecker->isGranted(new Expression("has_role('ROLE_USER') or has_role('ROLE_ADMIN')"))) {}
+   if ($this->authorizationChecker->isGranted(new Expression("is_granted('ROLE_USER') or is_granted('ROLE_ADMIN')"))) {}
 
    // or:
    if ($this->authorizationChecker->isGranted('ROLE_USER')

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -410,7 +410,7 @@ Security
 
    **After**
    ```php
-   if ($this->authorizationChecker->isGranted(new Expression("has_role('ROLE_USER') or has_role('ROLE_ADMIN')"))) {}
+   if ($this->authorizationChecker->isGranted(new Expression("is_granted('ROLE_USER') or is_granted('ROLE_ADMIN')"))) {}
 
    // or:
    if ($this->authorizationChecker->isGranted('ROLE_USER')
@@ -473,6 +473,7 @@ Security
  * Classes implementing the `TokenInterface` must implement the two new methods
    `__serialize` and `__unserialize`
  * Implementations of `Guard\AuthenticatorInterface::checkCredentials()` must return a boolean value now. Please explicitly return `false` to indicate invalid credentials.
+ * Removed the `has_role()` function from security expressions, use `is_granted()` instead.
 
 SecurityBundle
 --------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ~ <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | ~ <!-- required for new features -->

A user on slack was looking for a replacement for the `[ROLE1, ROLE2]` notation on `$this->denyAccessUnlessGranted`. After searching for `has_role`, they pointed out that the function has been deprecated as well: https://github.com/symfony/security/blob/297ac031eeae519c87b400ff6ed7fc1819e64d73/Core/Authorization/ExpressionLanguageProvider.php#L57-L65

This PR fixes the upgrade guide to point to the non-deprecated alternative.

Additionally it turns out that the removal of `has_role()` has not been documented in `UPGRADE-5.0.md`

_remake of #34592, there will be another PR for security/CHANGELOG.md in 5.0_ 