### PR TITLE
[Mailer][Mailchimp Bridge] Throwing undefined index _id when setting message id

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
@@ -60,7 +60,7 @@ class MandrillHttpTransport extends AbstractHttpTransport
             throw new HttpTransportException(sprintf('Unable to send an email (code %s).', $result['code']), $response);
         }
 
-        $message->setMessageId($result['_id']);
+        $message->setMessageId($result[0]['_id']);
 
         return $response;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 4.4 or 5.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | (no ticket created)
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

When I set the DSN:
`MAILER_DSN=mandrill://KEY@default`

and try to send an email:

```php
$reportEmail = (new Email())
            ->subject('this is a test')
            ->addFrom('test@test.com')
            ->addTo('test-2@test.com')
            ->text('this is just a test.');

$mailer->send($reportEmail);        
```

it returns an exception:

<img width="1059" alt="Captura de ecrã 2019-11-25, às 14 31 59" src="https://user-images.githubusercontent.com/74459/69549352-0a8e6480-0f91-11ea-8d6e-ecb1ecb8caa5.png">

Stacktrace:

```
ErrorException:
Notice: Undefined index: _id

  at /Users/mac/Documents/workspace/spotahome/code/opensource/symfony/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php:64
  at Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillHttpTransport->doSendHttp(object(SentMessage))
     (/Users/mac/Documents/workspace/spotahome/code/opensource/symfony/src/Symfony/Component/Mailer/Transport/AbstractHttpTransport.php:71)
  at Symfony\Component\Mailer\Transport\AbstractHttpTransport->doSend(object(SentMessage))
     (/Users/mac/Documents/workspace/spotahome/code/opensource/symfony/src/Symfony/Component/Mailer/Transport/AbstractTransport.php:71)
  at Symfony\Component\Mailer\Transport\AbstractTransport->send(object(SentMessage), object(DelayedEnvelope))
     (/Users/mac/Documents/workspace/spotahome/code/opensource/symfony/src/Symfony/Component/Mailer/Transport/Transports.php:51)
  at Symfony\Component\Mailer\Transport\Transports->send(object(Email), null)
     (/Users/mac/Documents/workspace/spotahome/code/opensource/symfony/src/Symfony/Component/Mailer/Mailer.php:41)
  at Symfony\Component\Mailer\Mailer->send(object(Email))
     (src/Controller/MailerController.php:20)
  at App\Controller\MailerController->index(object(Mailer))
```

## The fix, how does it work:

According to [documentation](https://mandrillapp.com/api/docs/messages.html), the endpoint `https://mandrillapp.com/api/1.0/messages/send-raw.json` returns an array of results in case of success:

```
[
    {
        "email": "recipient.email@example.com",
        "status": "sent",
        "reject_reason": "hard-bounce",
        "_id": "abc123abc123abc123abc123abc123"
    }
]
``` 

in case of an error:

```
{
    "status": "error",
    "code": 12,
    "name": "Unknown_Subaccount",
    "message": "No subaccount exists with the id 'customer-123'"
}
```

The fix just sets the right message id. 

