### PR TITLE
[MonologBridge] Fix debug processor datetime type

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -22,7 +22,7 @@ class DebugProcessor implements DebugLoggerInterface
     public function __invoke(array $record)
     {
         $this->records[] = [
-            'timestamp' => $record['datetime']->getTimestamp(),
+            'timestamp' => $record['datetime'] instanceof \DateTimeInterface ? $record['datetime']->getTimestamp() : strtotime($record['datetime']),
             'message' => $record['message'],
             'priority' => $record['level'],
             'priorityName' => $record['level_name'],

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Processor;
+
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+
+class DebugProcessorTest extends TestCase
+{
+    /**
+     * @dataProvider providerDatetimeFormatTests
+     */
+    public function testDatetimeFormat(array $record, $expectedTimestamp)
+    {
+        $processor = new DebugProcessor();
+        $processor($record);
+
+        $records = $processor->getLogs();
+        self::assertCount(1, $records);
+        self::assertSame($expectedTimestamp, $records[0]['timestamp']);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerDatetimeFormatTests()
+    {
+        $record = $this->getRecord();
+
+        return [
+            [array_merge($record, ['datetime' => new \DateTime('2019-01-01T00:01:00+00:00')]), 1546300860],
+            [array_merge($record, ['datetime' => '2019-01-01T00:01:00+00:00']), 1546300860],
+            [array_merge($record, ['datetime' => 'foo']), false],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function getRecord()
+    {
+        return [
+            'message' => 'test',
+            'context' => [],
+            'level' => Logger::DEBUG,
+            'level_name' => Logger::getLevelName(Logger::DEBUG),
+            'channel' => 'test',
+            'datetime' => new \DateTime(),
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |n/a
| License       | MIT
| Doc PR        | n/a

This PR fixes an eventual `Call to a member function getTimestamp() on string` if any Processor transforms the `datetime` value, and uses the same record conditions as in the [ConsoleFormatter](https://github.com/symfony/monolog-bridge/blob/master/Formatter/ConsoleFormatter.php#L118 )