### PR TITLE
[Process] add tests for php executable finder if file does not exist

### DIFF
--- a/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
@@ -69,4 +69,16 @@ class PhpExecutableFinderTest extends TestCase
             $this->assertEquals($f->findArguments(), [], '::findArguments() returns no arguments');
         }
     }
+
+    public function testNotExitsBinaryFile()
+    {
+        $f = new PhpExecutableFinder();
+        $phpBinaryEnv = PHP_BINARY;
+        putenv('PHP_BINARY=/usr/local/php/bin/php-invalid');
+
+        $this->assertFalse($f->find(), '::find() returns false because of not exist file');
+        $this->assertFalse($f->find(false), '::find(false) returns false because of not exist file');
+
+        putenv('PHP_BINARY='.$phpBinaryEnv);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master?
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

regarding Process component, I just noticed there is no test covers the case when the PHP binary is not valid so I added the test to make sure it works as expected also it increases the coverage of the process component
