### PR TITLE
Restores preview mode support for Html and Serializer error renderers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.xml
@@ -6,11 +6,22 @@
 
     <services>
         <service id="error_handler.error_renderer.html" class="Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer">
-            <argument>%kernel.debug%</argument>
+            <argument type="service">
+                <service>
+                    <factory class="Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer" method="isDebug" />
+                    <argument type="service" id="request_stack" />
+                    <argument>%kernel.debug%</argument>
+                </service>
+            </argument>
             <argument>%kernel.charset%</argument>
             <argument type="service" id="debug.file_link_formatter" on-invalid="null" />
             <argument>%kernel.project_dir%</argument>
-            <argument type="service" id="request_stack" />
+            <argument type="service">
+                <service>
+                    <factory class="Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer" method="getAndCleanOutputBuffer" />
+                    <argument type="service" id="request_stack" />
+                </service>
+            </argument>
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -163,6 +163,13 @@
                 </service>
             </argument>
             <argument type="service" id="error_renderer.html" />
+            <argument type="service">
+                <service>
+                    <factory class="Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer" method="isDebug" />
+                    <argument type="service" id="request_stack" />
+                    <argument>%kernel.debug%</argument>
+                </service>
+            </argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
@@ -26,19 +26,26 @@ class SerializerErrorRenderer implements ErrorRendererInterface
     private $serializer;
     private $format;
     private $fallbackErrorRenderer;
+    private $debug;
 
     /**
      * @param string|callable(FlattenException) $format The format as a string or a callable that should return it
+     * @param bool|callable                     $debug  The debugging mode as a boolean or a callable that should return it
      */
-    public function __construct(SerializerInterface $serializer, $format, ErrorRendererInterface $fallbackErrorRenderer = null)
+    public function __construct(SerializerInterface $serializer, $format, ErrorRendererInterface $fallbackErrorRenderer = null, $debug = false)
     {
         if (!\is_string($format) && !\is_callable($format)) {
             throw new \TypeError(sprintf('Argument 2 passed to %s() must be a string or a callable, %s given.', __METHOD__, \is_object($format) ? \get_class($format) : \gettype($format)));
         }
 
+        if (!\is_bool($debug) && !\is_callable($debug)) {
+            throw new \TypeError(sprintf('Argument 4 passed to %s() must be a boolean or a callable, %s given.', __METHOD__, \is_object($debug) ? \get_class($debug) : \gettype($debug)));
+        }
+
         $this->serializer = $serializer;
         $this->format = $format;
         $this->fallbackErrorRenderer = $fallbackErrorRenderer ?? new HtmlErrorRenderer();
+        $this->debug = $debug;
     }
 
     /**
@@ -51,7 +58,10 @@ class SerializerErrorRenderer implements ErrorRendererInterface
         try {
             $format = \is_string($this->format) ? $this->format : ($this->format)($flattenException);
 
-            return $flattenException->setAsString($this->serializer->serialize($flattenException, $format, ['exception' => $exception]));
+            return $flattenException->setAsString($this->serializer->serialize($flattenException, $format, [
+                'exception' => $exception,
+                'debug' => \is_bool($this->debug) ? $this->debug : ($this->debug)($exception),
+            ]));
         } catch (NotEncodableValueException $e) {
             return $this->fallbackErrorRenderer->render($exception);
         }

--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -41,14 +41,15 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     public function normalize($exception, $format = null, array $context = [])
     {
         $context += $this->defaultContext;
+        $debug = $this->debug && $context['debug'] ?? true;
 
         $data = [
             'type' => $context['type'],
             'title' => $context['title'],
             'status' => $context['status'] ?? $exception->getStatusCode(),
-            'detail' => $this->debug ? $exception->getMessage() : $exception->getStatusText(),
+            'detail' => $debug ? $exception->getMessage() : $exception->getStatusText(),
         ];
-        if ($this->debug) {
+        if ($debug) {
             $data['class'] = $exception->getClass();
             $data['trace'] = $exception->getTrace();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34602
| License       | MIT
| Doc PR        | -

This restores the preview mode support for all error renderers.