### PR TITLE
[Routing] Continue supporting single colon in object route loaders

### DIFF
--- a/src/Symfony/Component/Routing/Loader/ObjectLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectLoader.php
@@ -42,8 +42,13 @@ abstract class ObjectLoader extends Loader
      */
     public function load($resource, $type = null)
     {
-        if (!preg_match('/^[^\:]+(?:::(?:[^\:]+))?$/', $resource)) {
+        if (!preg_match('/^[^\:]+(?:::?(?:[^\:]+))?$/', $resource)) {
             throw new \InvalidArgumentException(sprintf('Invalid resource "%s" passed to the %s route loader: use the format "object_id::method" or "object_id" if your object class has an "__invoke" method.', $resource, \is_string($type) ? '"'.$type.'"' : 'object'));
+        }
+
+        if (1 === substr_count($resource, ':')) {
+            $resource = str_replace(':', '::', $resource);
+            @trigger_error(sprintf('Referencing object route loaders with a single colon is deprecated since Symfony 4.1. Use %s instead.', $resource), E_USER_DEPRECATED);
         }
 
         $parts = explode('::', $resource);

--- a/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Routing\Loader;
 
-use Symfony\Component\Routing\RouteCollection;
-
 @trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.4, use "%s" instead.', ObjectRouteLoader::class, ObjectLoader::class), E_USER_DEPRECATED);
 
 /**
@@ -35,28 +33,6 @@ abstract class ObjectRouteLoader extends ObjectLoader
      * @return object
      */
     abstract protected function getServiceObject($id);
-
-    /**
-     * Calls the service that will load the routes.
-     *
-     * @param string      $resource Some value that will resolve to a callable
-     * @param string|null $type     The resource type
-     *
-     * @return RouteCollection
-     */
-    public function load($resource, $type = null)
-    {
-        if (!preg_match('/^[^\:]+(?:::?(?:[^\:]+))?$/', $resource)) {
-            throw new \InvalidArgumentException(sprintf('Invalid resource "%s" passed to the "service" route loader: use the format "service::method" or "service" if your service has an "__invoke" method.', $resource));
-        }
-
-        if (1 === substr_count($resource, ':')) {
-            $resource = str_replace(':', '::', $resource);
-            @trigger_error(sprintf('Referencing service route loaders with a single colon is deprecated since Symfony 4.1. Use %s instead.', $resource), E_USER_DEPRECATED);
-        }
-
-        return parent::load($resource, $type);
-    }
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Routing\Tests\Fixtures\TestObjectRouteLoader;
 class ObjectRouteLoaderTest extends TestCase
 {
     /**
-     * @expectedDeprecation Referencing service route loaders with a single colon is deprecated since Symfony 4.1. Use my_route_provider_service::loadRoutes instead.
+     * @expectedDeprecation Referencing object route loaders with a single colon is deprecated since Symfony 4.1. Use my_route_provider_service::loadRoutes instead.
      */
     public function testLoadCallsServiceAndReturnsCollectionWithLegacyNotation()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/34612
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/pull/32582#discussion_r304824139 was a bad idea. The new `ObjectLoader` class is used directly on 4.4 since we detagged the old service (and the old one). So we need to support the old notation on it. It changes the exception message but it should be alright.