### PR TITLE
[Serializer] Adding a new case to better handle circular references

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -213,7 +213,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             return $circularReferenceHandler($object, $format, $context);
         }
 
-        throw new CircularReferenceException(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured limit: %d)', \get_class($object), $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT]));
+        if(method_exists($object, "getId")) {
+            return $object->getId();
+        } else {
+            throw new CircularReferenceException(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured  limit: %d)', \get_class($object), $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT]));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -213,7 +213,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             return $circularReferenceHandler($object, $format, $context);
         }
 
-        if(method_exists($object, "getId")) {
+        if (method_exists($object, "getId")) {
             return $object->getId();
         } else {
             throw new CircularReferenceException(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured  limit: %d)', \get_class($object), $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT]));

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -213,7 +213,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             return $circularReferenceHandler($object, $format, $context);
         }
 
-        if (method_exists($object, "getId")) {
+        if (method_exists($object, 'getId')) {
             return $object->getId();
         } else {
             throw new CircularReferenceException(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured  limit: %d)', \get_class($object), $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT]));

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -215,7 +215,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
         if (method_exists($object, 'getId')) {
             return $object->getId();
-        } 
+        }
         throw new CircularReferenceException(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured  limit: %d)', \get_class($object), $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT]));
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -215,9 +215,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
         if (method_exists($object, 'getId')) {
             return $object->getId();
-        } else {
-            throw new CircularReferenceException(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured  limit: %d)', \get_class($object), $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT]));
-        }
+        } 
+        throw new CircularReferenceException(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured  limit: %d)', \get_class($object), $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT]));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -149,9 +149,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
         }
 
-        if ((isset($this->context['lastCircularObjectFound']) && $this->context['lastCircularObjectFound'] == get_class($object)) 
+        if ((isset($this->context['lastCircularObjectFound']) && $this->context['lastCircularObjectFound'] == \get_class($object))
             || $this->isCircularReference($object, $context)) {
-            $this->context['lastCircularObjectFound'] = get_class($object);
+            $this->context['lastCircularObjectFound'] = \get_class($object);
+        
             return $this->handleCircularReference($object, $format, $context);
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -149,7 +149,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
         }
 
-        if ($this->isCircularReference($object, $context)) {
+        if ((isset($this->context['lastCircularObjectFound']) && $this->context['lastCircularObjectFound'] == get_class($object)) 
+            || $this->isCircularReference($object, $context)) {
+            $this->context['lastCircularObjectFound'] = get_class($object);
             return $this->handleCircularReference($object, $format, $context);
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -149,7 +149,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
         }
 
-        if ((isset($this->context['lastCircularObjectFound']) && $this->context['lastCircularObjectFound'] == \get_class($object))
+        if ((isset($this->context['lastCircularObjectFound']) && $this->context['lastCircularObjectFound'] === \get_class($object))
             || $this->isCircularReference($object, $context)) {
             $this->context['lastCircularObjectFound'] = \get_class($object);
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -152,7 +152,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         if ((isset($this->context['lastCircularObjectFound']) && $this->context['lastCircularObjectFound'] == \get_class($object))
             || $this->isCircularReference($object, $context)) {
             $this->context['lastCircularObjectFound'] = \get_class($object);
-        
+
             return $this->handleCircularReference($object, $format, $context);
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceFirstChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceFirstChild.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Thomas ANDRE <thomandre@gmail.com>
+ */
+class CircularReferenceFirstChild
+{
+	/**
+	 * @var int
+	 */
+	private $id;
+
+	/**
+     * @var CircularReferenceParent
+     */
+	private $parent;
+
+    /**
+     * @var CircularReferenceGrandChild
+     */
+    private $child;
+
+
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	public function setId($id)
+	{
+		$this->id = $id;
+	}
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getChild()
+    {
+        return $this->child;
+    }
+
+    public function setChild($child)
+    {
+        $this->child = $child;
+    }
+
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceGrandChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceGrandChild.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Thomas ANDRE <thomandre@gmail.com>
+ */
+class CircularReferenceGrandChild
+{
+	/**
+	 * @var int
+	 */
+	private $id;
+
+	/**
+     * @var CircularReferenceParent
+     */
+	private $grandParent;
+
+	/**
+     * @var CircularReferenceFirstChild
+     */
+	private $parent;
+
+
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	public function setId($id)
+	{
+		$this->id = $id;
+	}
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getGrandParent()
+    {
+        return $this->grandParent;
+    }
+
+    public function setGrandParent($grandParent)
+    {
+        $this->grandParent = $grandParent;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceParent.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceParent.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Thomas ANDRE <thomandre@gmail.com>
+ */
+class CircularReferenceParent
+{
+
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var CircularReferenceFirstChild
+     */
+    private $child1;
+
+    /**
+     * @var CircularReferenceSecondChild
+     */
+    private $child2;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getChild1()
+    {
+        return $this->child1;
+    }
+
+    public function setChild1($child1)
+    {
+        $this->child1 = $child1;
+    }
+
+    public function getChild2()
+    {
+        return $this->child2;
+    }
+
+    public function setChild2($child2)
+    {
+        $this->child2 = $child2;
+    }
+
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceSecondChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CircularReferenceSecondChild.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Thomas ANDRE <thomandre@gmail.com>
+ */
+class CircularReferenceSecondChild
+{
+	/**
+	 * @var int
+	 */
+	private $id;
+
+	/**
+     * @var CircularReferenceParent
+     */
+	private $parent;
+
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	public function setId($id)
+	{
+		$this->id = $id;
+	}
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -28,6 +28,10 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceFirstChild;
+use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceGrandChild;
+use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceParent;
+use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceSecondChild;
 use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksTestTrait;
@@ -38,10 +42,6 @@ use Symfony\Component\Serializer\Tests\Normalizer\Features\IgnoredAttributesTest
 use Symfony\Component\Serializer\Tests\Normalizer\Features\MaxDepthTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectToPopulateTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\TypeEnforcementTestTrait;
-use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceParent;
-use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceFirstChild;
-use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceSecondChild;
-use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceGrandChild;
 
 class GetSetMethodNormalizerTest extends TestCase
 {
@@ -446,8 +446,8 @@ class GetSetMethodNormalizerTest extends TestCase
 
     /**
      * @group circularId
-    */
-    public function testCircularReferenceHandlerObjectWithId() 
+     */
+    public function testCircularReferenceHandlerObjectWithId()
     {
         $normalizer = $this->getNormalizerForCircularReference();
 
@@ -479,14 +479,12 @@ class GetSetMethodNormalizerTest extends TestCase
 
         //var_dump($parent);
         //var_dump($normilizedParent);
-        $expected = ["id" => 12, 
-                     "child1"=> ["id" => 42,  "parent" => 12, "child" => ["id" => 15, "parent" => 42, "grandParent" => 12]],
-                     "child2"=> ["id" => 144, "parent" => 12]
-                    ];       
+        $expected = ['id' => 12,
+                     'child1' => ['id' => 42,  'parent' => 12, 'child' => ['id' => 15, 'parent' => 42, 'grandParent' => 12]],
+                     'child2' => ['id' => 144, 'parent' => 12],
+                    ];
         $this->assertEquals($expected, $normilizedParent);
     }
-
-
 }
 
 class GetSetDummy


### PR DESCRIPTION
Adding a new case to better handle circular references: by default the normalizer won't throw an error and return the id of the object (if it exists).

| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #
| License       | MIT

<!--

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
