### PR TITLE
[Security/Http] call auth listeners/guards eagerly when they "support" the request

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -219,6 +219,7 @@ Security
  * The `LdapUserProvider` class has been deprecated, use `Symfony\Component\Ldap\Security\LdapUserProvider` instead.
  * Implementations of `PasswordEncoderInterface` and `UserPasswordEncoderInterface` should add a new `needsRehash()` method
  * Deprecated returning a non-boolean value when implementing `Guard\AuthenticatorInterface::checkCredentials()`. Please explicitly return `false` to indicate invalid credentials.
+ * The `ListenerInterface` is deprecated, extend `AbstractListener` instead.
  * Deprecated passing more than one attribute to `AccessDecisionManager::decide()` and `AuthorizationChecker::isGranted()` (and indirectly the `is_granted()` Twig and ExpressionLanguage function)
 
    **Before**

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -434,7 +434,7 @@ Security
  * `SimpleAuthenticatorInterface`, `SimpleFormAuthenticatorInterface`, `SimplePreAuthenticatorInterface`,
    `SimpleAuthenticationProvider`, `SimpleAuthenticationHandler`, `SimpleFormAuthenticationListener` and
    `SimplePreAuthenticationListener` have been removed. Use Guard instead.
- * The `ListenerInterface` has been removed, turn your listeners into callables instead.
+ * The `ListenerInterface` has been removed, extend `AbstractListener` instead.
  * The `Firewall::handleRequest()` method has been removed, use `Firewall::callListeners()` instead.
  * `\Serializable` interface has been removed from `AbstractToken` and `AuthenticationException`,
    thus `serialize()` and `unserialize()` aren't available.

--- a/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
@@ -50,7 +50,7 @@ final class WrappedListener implements ListenerInterface
         if (\is_callable($this->listener)) {
             ($this->listener)($event);
         } else {
-            @trigger_error(sprintf('Calling the "%s::handle()" method from the firewall is deprecated since Symfony 4.3, implement "__invoke()" instead.', \get_class($this->listener)), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling the "%s::handle()" method from the firewall is deprecated since Symfony 4.3, extend "%s" instead.', \get_class($this->listener), AbstractListener::class), E_USER_DEPRECATED);
             $this->listener->handle($event);
         }
         $this->time = microtime(true) - $startTime;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -409,9 +409,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         }
 
         // Access listener
-        if ($firewall['stateless'] || empty($firewall['anonymous']['lazy'])) {
-            $listeners[] = new Reference('security.access_listener');
-        }
+        $listeners[] = new Reference('security.access_listener');
 
         // Exception listener
         $exceptionListener = new Reference($this->createExceptionListener($container, $firewall, $id, $configuredEntryPoint ?: $defaultEntryPoint, $firewall['stateless']));

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -156,9 +156,7 @@
             <argument type="service" id="security.exception_listener" />
             <argument />  <!-- LogoutListener -->
             <argument />  <!-- FirewallConfig -->
-            <argument type="service" id="security.access_listener" />
             <argument type="service" id="security.untracked_token_storage" />
-            <argument type="service" id="security.access_map" />
         </service>
 
         <service id="security.firewall.config" class="Symfony\Bundle\SecurityBundle\Security\FirewallConfig" abstract="true">

--- a/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
@@ -13,11 +13,8 @@ namespace Symfony\Bundle\SecurityBundle\Security;
 
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
-use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
-use Symfony\Component\Security\Core\Exception\LazyResponseException;
-use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Http\Event\LazyResponseEvent;
-use Symfony\Component\Security\Http\Firewall\AccessListener;
+use Symfony\Component\Security\Http\Firewall\AbstractListener;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
 use Symfony\Component\Security\Http\Firewall\LogoutListener;
 
@@ -28,17 +25,13 @@ use Symfony\Component\Security\Http\Firewall\LogoutListener;
  */
 class LazyFirewallContext extends FirewallContext
 {
-    private $accessListener;
     private $tokenStorage;
-    private $map;
 
-    public function __construct(iterable $listeners, ?ExceptionListener $exceptionListener, ?LogoutListener $logoutListener, ?FirewallConfig $config, AccessListener $accessListener, TokenStorage $tokenStorage, AccessMapInterface $map)
+    public function __construct(iterable $listeners, ?ExceptionListener $exceptionListener, ?LogoutListener $logoutListener, ?FirewallConfig $config, TokenStorage $tokenStorage)
     {
         parent::__construct($listeners, $exceptionListener, $logoutListener, $config);
 
-        $this->accessListener = $accessListener;
         $this->tokenStorage = $tokenStorage;
-        $this->map = $map;
     }
 
     public function getListeners(): iterable
@@ -48,26 +41,41 @@ class LazyFirewallContext extends FirewallContext
 
     public function __invoke(RequestEvent $event)
     {
-        $this->tokenStorage->setInitializer(function () use ($event) {
-            $event = new LazyResponseEvent($event);
-            foreach (parent::getListeners() as $listener) {
-                if (\is_callable($listener)) {
-                    $listener($event);
-                } else {
-                    @trigger_error(sprintf('Calling the "%s::handle()" method from the firewall is deprecated since Symfony 4.3, implement "__invoke()" instead.', \get_class($listener)), E_USER_DEPRECATED);
-                    $listener->handle($event);
+        $listeners = [];
+        $request = $event->getRequest();
+        $lazy = $request->isMethodCacheable();
+
+        foreach (parent::getListeners() as $listener) {
+            if (!\is_callable($listener)) {
+                @trigger_error(sprintf('Calling the "%s::handle()" method from the firewall is deprecated since Symfony 4.3, extend "%s" instead.', \get_class($listener), AbstractListener::class), E_USER_DEPRECATED);
+                $listeners[] = [$listener, 'handle'];
+                $lazy = false;
+            } elseif (!$lazy || !$listener instanceof AbstractListener) {
+                $listeners[] = $listener;
+                $lazy = $lazy && $listener instanceof AbstractListener;
+            } elseif (false !== $supports = $listener->supports($request)) {
+                $listeners[] = [$listener, 'authenticate'];
+                $lazy = null === $supports;
+            }
+        }
+
+        if (!$lazy) {
+            foreach ($listeners as $listener) {
+                $listener($event);
+
+                if ($event->hasResponse()) {
+                    return;
                 }
             }
-        });
 
-        try {
-            [$attributes] = $this->map->getPatterns($event->getRequest());
-
-            if ($attributes && [AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] !== $attributes) {
-                ($this->accessListener)($event);
-            }
-        } catch (LazyResponseException $e) {
-            $event->setResponse($e->getResponse());
+            return;
         }
+
+        $this->tokenStorage->setInitializer(function () use ($event, $listeners) {
+            $event = new LazyResponseEvent($event);
+            foreach ($listeners as $listener) {
+                $listener($event);
+            }
+        });
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/GuardedBundle/AppCustomAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/GuardedBundle/AppCustomAuthenticator.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\GuardedBundle;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+
+class AppCustomAuthenticator extends AbstractGuardAuthenticator
+{
+    public function supports(Request $request)
+    {
+        return true;
+    }
+
+    public function getCredentials(Request $request)
+    {
+        throw new AuthenticationException('This should be hit');
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+    }
+
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        return new Response('', 418);
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        return new Response($authException->getMessage(), Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function supportsRememberMe()
+    {
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/GuardedTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/GuardedTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+class GuardedTest extends AbstractWebTestCase
+{
+    public function testGuarded()
+    {
+        $client = $this->createClient(['test_case' => 'Guarded', 'root_config' => 'config.yml']);
+
+        $client->request('GET', '/');
+
+        $this->assertSame(418, $client->getResponse()->getStatusCode());
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/bundles.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/config.yml
@@ -1,0 +1,22 @@
+framework:
+    secret: test
+    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml" }
+    test: ~
+    default_locale: en
+    profiler: false
+    session:
+        storage_id: session.storage.mock_file
+
+services:
+    logger: { class: Psr\Log\NullLogger }
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\GuardedBundle\AppCustomAuthenticator: ~
+
+security:
+    firewalls:
+        secure:
+            pattern: ^/
+            anonymous: lazy
+            stateless: false
+            guard:
+                authenticators:
+                    - Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\GuardedBundle\AppCustomAuthenticator

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/routing.yml
@@ -1,0 +1,5 @@
+main:
+    path: /
+    defaults:
+        _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction
+        path: /app

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -24,7 +24,7 @@
         "symfony/security-core": "^4.4",
         "symfony/security-csrf": "^4.2|^5.0",
         "symfony/security-guard": "^4.2|^5.0",
-        "symfony/security-http": "^4.4"
+        "symfony/security-http": "^4.4.1"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.5|^2.0",

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Deprecated returning a non-boolean value when implementing `Guard\AuthenticatorInterface::checkCredentials()`.
  * Deprecated passing more than one attribute to `AccessDecisionManager::decide()` and `AuthorizationChecker::isGranted()`
  * Added new `argon2id` encoder, undeprecated the `bcrypt` and `argon2i` ones (using `auto` is still recommended by default.)
+ * Added `AbstractListener` which replaces the deprecated `ListenerInterface`
 
 4.3.0
 -----

--- a/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
+use Symfony\Component\Security\Http\Firewall\AbstractListener;
 use Symfony\Component\Security\Http\Firewall\LegacyListenerTrait;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
@@ -33,7 +34,7 @@ use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
  *
  * @final since Symfony 4.3
  */
-class GuardAuthenticationListener implements ListenerInterface
+class GuardAuthenticationListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -62,9 +63,9 @@ class GuardAuthenticationListener implements ListenerInterface
     }
 
     /**
-     * Iterates over each authenticator to see if each wants to authenticate the request.
+     * {@inheritdoc}
      */
-    public function __invoke(RequestEvent $event)
+    public function supports(Request $request): ?bool
     {
         if (null !== $this->logger) {
             $context = ['firewall_key' => $this->providerKey];
@@ -76,7 +77,39 @@ class GuardAuthenticationListener implements ListenerInterface
             $this->logger->debug('Checking for guard authentication credentials.', $context);
         }
 
+        $guardAuthenticators = [];
+
         foreach ($this->guardAuthenticators as $key => $guardAuthenticator) {
+            if (null !== $this->logger) {
+                $this->logger->debug('Checking support on guard authenticator.', ['firewall_key' => $this->providerKey, 'authenticator' => \get_class($guardAuthenticator)]);
+            }
+
+            if ($guardAuthenticator->supports($request)) {
+                $guardAuthenticators[$key] = $guardAuthenticator;
+            } elseif (null !== $this->logger) {
+                $this->logger->debug('Guard authenticator does not support the request.', ['firewall_key' => $this->providerKey, 'authenticator' => \get_class($guardAuthenticator)]);
+            }
+        }
+
+        if (!$guardAuthenticators) {
+            return false;
+        }
+
+        $request->attributes->set('_guard_authenticators', $guardAuthenticators);
+
+        return true;
+    }
+
+    /**
+     * Iterates over each authenticator to see if each wants to authenticate the request.
+     */
+    public function authenticate(RequestEvent $event)
+    {
+        $request = $event->getRequest();
+        $guardAuthenticators = $request->attributes->get('_guard_authenticators');
+        $request->attributes->remove('_guard_authenticators');
+
+        foreach ($guardAuthenticators as $key => $guardAuthenticator) {
             // get a key that's unique to *this* guard authenticator
             // this MUST be the same as GuardAuthenticationProvider
             $uniqueGuardKey = $this->providerKey.'_'.$key;
@@ -97,19 +130,6 @@ class GuardAuthenticationListener implements ListenerInterface
     {
         $request = $event->getRequest();
         try {
-            if (null !== $this->logger) {
-                $this->logger->debug('Checking support on guard authenticator.', ['firewall_key' => $this->providerKey, 'authenticator' => \get_class($guardAuthenticator)]);
-            }
-
-            // abort the execution of the authenticator if it doesn't support the request
-            if (!$guardAuthenticator->supports($request)) {
-                if (null !== $this->logger) {
-                    $this->logger->debug('Guard authenticator does not support the request.', ['firewall_key' => $this->providerKey, 'authenticator' => \get_class($guardAuthenticator)]);
-                }
-
-                return;
-            }
-
             if (null !== $this->logger) {
                 $this->logger->debug('Calling getCredentials() on guard authenticator.', ['firewall_key' => $this->providerKey, 'authenticator' => \get_class($guardAuthenticator)]);
             }

--- a/src/Symfony/Component/Security/Guard/composer.json
+++ b/src/Symfony/Component/Security/Guard/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/security-core": "^3.4.22|^4.2.3|^5.0",
-        "symfony/security-http": "^4.3"
+        "symfony/security-http": "^4.4.1"
     },
     "require-dev": {
         "psr/log": "~1.0"

--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -138,7 +138,7 @@ class Firewall implements EventSubscriberInterface
             if (\is_callable($listener)) {
                 $listener($event);
             } else {
-                @trigger_error(sprintf('Calling the "%s::handle()" method from the firewall is deprecated since Symfony 4.3, implement "__invoke()" instead.', \get_class($listener)), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Calling the "%s::handle()" method from the firewall is deprecated since Symfony 4.3, extend "%s" instead.', \get_class($listener), AbstractListener::class), E_USER_DEPRECATED);
                 $listener->handle($event);
             }
 

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -49,7 +49,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-abstract class AbstractAuthenticationListener implements ListenerInterface
+abstract class AbstractAuthenticationListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -106,18 +106,22 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request): ?bool
+    {
+        return $this->requiresAuthentication($request);
+    }
+
+    /**
      * Handles form based authentication.
      *
      * @throws \RuntimeException
      * @throws SessionUnavailableException
      */
-    public function __invoke(RequestEvent $event)
+    public function authenticate(RequestEvent $event)
     {
         $request = $event->getRequest();
-
-        if (!$this->requiresAuthentication($request)) {
-            return;
-        }
 
         if (!$request->hasSession()) {
             throw new \RuntimeException('This authentication method requires a session.');

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractListener.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Firewall;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+/**
+ * A base class for listeners that can tell whether they should authenticate incoming requests.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+abstract class AbstractListener
+{
+    final public function __invoke(RequestEvent $event)
+    {
+        if (false !== $this->supports($event->getRequest())) {
+            $this->authenticate($event);
+        }
+    }
+
+    /**
+     * Tells whether the authenticate() method should be called or not depending on the incoming request.
+     *
+     * Returning null means authenticate() can be called lazily when accessing the token storage.
+     */
+    abstract public function supports(Request $request): ?bool;
+
+    /**
+     * Does whatever is required to authenticate the request, typically calling $event->setResponse() internally.
+     */
+    abstract public function authenticate(RequestEvent $event);
+}

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Http\AccessMapInterface;
@@ -27,7 +29,7 @@ use Symfony\Component\Security\Http\Event\LazyResponseEvent;
  *
  * @final since Symfony 4.3
  */
-class AccessListener implements ListenerInterface
+class AccessListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -45,12 +47,23 @@ class AccessListener implements ListenerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request): ?bool
+    {
+        [$attributes] = $this->map->getPatterns($request);
+        $request->attributes->set('_access_control_attributes', $attributes);
+
+        return $attributes && [AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] !== $attributes ? true : null;
+    }
+
+    /**
      * Handles access authorization.
      *
      * @throws AccessDeniedException
      * @throws AuthenticationCredentialsNotFoundException
      */
-    public function __invoke(RequestEvent $event)
+    public function authenticate(RequestEvent $event)
     {
         if (!$event instanceof LazyResponseEvent && null === $token = $this->tokenStorage->getToken()) {
             throw new AuthenticationCredentialsNotFoundException('A Token was not found in the TokenStorage.');
@@ -58,9 +71,10 @@ class AccessListener implements ListenerInterface
 
         $request = $event->getRequest();
 
-        list($attributes) = $this->map->getPatterns($request);
+        $attributes = $request->attributes->get('_access_control_attributes');
+        $request->attributes->remove('_access_control_attributes');
 
-        if (!$attributes) {
+        if (!$attributes || ([AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] === $attributes && $event instanceof LazyResponseEvent)) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
@@ -26,7 +27,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  *
  * @final since Symfony 4.3
  */
-class AnonymousAuthenticationListener implements ListenerInterface
+class AnonymousAuthenticationListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -44,9 +45,17 @@ class AnonymousAuthenticationListener implements ListenerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request): ?bool
+    {
+        return null; // always run authenticate() lazily with lazy firewalls
+    }
+
+    /**
      * Handles anonymous authentication.
      */
-    public function __invoke(RequestEvent $event)
+    public function authenticate(RequestEvent $event)
     {
         if (null !== $this->tokenStorage->getToken()) {
             return;

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -29,7 +29,7 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterfa
  *
  * @final since Symfony 4.3
  */
-class BasicAuthenticationListener implements ListenerInterface
+class BasicAuthenticationListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -56,9 +56,17 @@ class BasicAuthenticationListener implements ListenerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request): ?bool
+    {
+        return null !== $request->headers->get('PHP_AUTH_USER');
+    }
+
+    /**
      * Handles basic authentication.
      */
-    public function __invoke(RequestEvent $event)
+    public function authenticate(RequestEvent $event)
     {
         $request = $event->getRequest();
 

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
@@ -24,7 +25,7 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
  *
  * @final since Symfony 4.3
  */
-class ChannelListener implements ListenerInterface
+class ChannelListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -42,10 +43,8 @@ class ChannelListener implements ListenerInterface
     /**
      * Handles channel management.
      */
-    public function __invoke(RequestEvent $event)
+    public function supports(Request $request): ?bool
     {
-        $request = $event->getRequest();
-
         list(, $channel) = $this->map->getPatterns($request);
 
         if ('https' === $channel && !$request->isSecure()) {
@@ -59,11 +58,7 @@ class ChannelListener implements ListenerInterface
                 }
             }
 
-            $response = $this->authenticationEntryPoint->start($request);
-
-            $event->setResponse($response);
-
-            return;
+            return true;
         }
 
         if ('http' === $channel && $request->isSecure()) {
@@ -71,9 +66,18 @@ class ChannelListener implements ListenerInterface
                 $this->logger->info('Redirecting to HTTP.');
             }
 
-            $response = $this->authenticationEntryPoint->start($request);
-
-            $event->setResponse($response);
+            return true;
         }
+
+        return false;
+    }
+
+    public function authenticate(RequestEvent $event)
+    {
+        $request = $event->getRequest();
+
+        $response = $this->authenticationEntryPoint->start($request);
+
+        $event->setResponse($response);
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -41,7 +41,7 @@ use Symfony\Component\Security\Http\Event\DeauthenticatedEvent;
  *
  * @final since Symfony 4.3
  */
-class ContextListener implements ListenerInterface
+class ContextListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -85,9 +85,17 @@ class ContextListener implements ListenerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request): ?bool
+    {
+        return null; // always run authenticate() lazily with lazy firewalls
+    }
+
+    /**
      * Reads the Security Token from the session.
      */
-    public function __invoke(RequestEvent $event)
+    public function authenticate(RequestEvent $event)
     {
         if (!$this->registered && null !== $this->dispatcher && $event->isMasterRequest()) {
             $this->dispatcher->addListener(KernelEvents::RESPONSE, [$this, 'onKernelResponse']);

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -30,7 +30,7 @@ use Symfony\Component\Security\Http\ParameterBagUtils;
  *
  * @final since Symfony 4.3
  */
-class LogoutListener implements ListenerInterface
+class LogoutListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -64,6 +64,14 @@ class LogoutListener implements ListenerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request): ?bool
+    {
+        return $this->requiresLogout($request);
+    }
+
+    /**
      * Performs the logout if requested.
      *
      * If a CsrfTokenManagerInterface instance is available, it will be used to
@@ -72,13 +80,9 @@ class LogoutListener implements ListenerInterface
      * @throws LogoutException   if the CSRF token is invalid
      * @throws \RuntimeException if the LogoutSuccessHandlerInterface instance does not return a response
      */
-    public function __invoke(RequestEvent $event)
+    public function authenticate(RequestEvent $event)
     {
         $request = $event->getRequest();
-
-        if (!$this->requiresLogout($request)) {
-            return;
-        }
 
         if (null !== $this->csrfTokenManager) {
             $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -31,7 +32,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  *
  * @final since Symfony 4.3
  */
-class RememberMeListener implements ListenerInterface
+class RememberMeListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -55,9 +56,17 @@ class RememberMeListener implements ListenerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request): ?bool
+    {
+        return null; // always run authenticate() lazily with lazy firewalls
+    }
+
+    /**
      * Handles remember-me cookie based authentication.
      */
-    public function __invoke(RequestEvent $event)
+    public function authenticate(RequestEvent $event)
     {
         if (null !== $this->tokenStorage->getToken()) {
             return;

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -41,7 +41,7 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterfa
  *
  * @deprecated since Symfony 4.2, use Guard instead.
  */
-class SimplePreAuthenticationListener implements ListenerInterface
+class SimplePreAuthenticationListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -79,10 +79,28 @@ class SimplePreAuthenticationListener implements ListenerInterface
         $this->sessionStrategy = $sessionStrategy;
     }
 
+    public function supports(Request $request): ?bool
+    {
+        if ((null !== $token = $this->tokenStorage->getToken()) && !$this->trustResolver->isAnonymous($token)) {
+            return false;
+        }
+
+        $token = $this->simpleAuthenticator->createToken($request, $this->providerKey);
+
+        // allow null to be returned to skip authentication
+        if (null === $token) {
+            return false;
+        }
+
+        $request->attributes->set('_simple_pre_authenticator_token', $token);
+
+        return true;
+    }
+
     /**
      * Handles basic authentication.
      */
-    public function __invoke(RequestEvent $event)
+    public function authenticate(RequestEvent $event)
     {
         $request = $event->getRequest();
 
@@ -91,16 +109,14 @@ class SimplePreAuthenticationListener implements ListenerInterface
         }
 
         if ((null !== $token = $this->tokenStorage->getToken()) && !$this->trustResolver->isAnonymous($token)) {
+            $request->attributes->remove('_simple_pre_authenticator_token');
+
             return;
         }
 
         try {
-            $token = $this->simpleAuthenticator->createToken($request, $this->providerKey);
-
-            // allow null to be returned to skip authentication
-            if (null === $token) {
-                return;
-            }
+            $token = $request->attributes->get('_simple_pre_authenticator_token');
+            $request->attributes->remove('_simple_pre_authenticator_token');
 
             $token = $this->authenticationManager->authenticate($token);
 

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -44,7 +44,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  *
  * @final since Symfony 4.3
  */
-class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
+class UsernamePasswordJsonAuthenticationListener extends AbstractListener implements ListenerInterface
 {
     use LegacyListenerTrait;
 
@@ -74,22 +74,27 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __invoke(RequestEvent $event)
+    public function supports(Request $request): ?bool
     {
-        $request = $event->getRequest();
         if (false === strpos($request->getRequestFormat(), 'json')
             && false === strpos($request->getContentType(), 'json')
         ) {
-            return;
+            return false;
         }
 
         if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
-            return;
+            return false;
         }
 
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function authenticate(RequestEvent $event)
+    {
+        $request = $event->getRequest();
         $data = json_decode($request->getContent());
 
         try {

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Http\Tests\Firewall;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
@@ -26,7 +27,7 @@ class AccessListenerTest extends TestCase
     public function testHandleWhenTheAccessDecisionManagerDecidesToRefuseAccess()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
-        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $request = new Request();
 
         $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
         $accessMap
@@ -65,19 +66,12 @@ class AccessListenerTest extends TestCase
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock()
         );
 
-        $event = $this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock();
-        $event
-            ->expects($this->any())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $listener($event);
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST));
     }
 
     public function testHandleWhenTheTokenIsNotAuthenticated()
     {
-        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $request = new Request();
 
         $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
         $accessMap
@@ -136,19 +130,12 @@ class AccessListenerTest extends TestCase
             $authManager
         );
 
-        $event = $this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock();
-        $event
-            ->expects($this->any())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $listener($event);
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST));
     }
 
     public function testHandleWhenThereIsNoAccessMapEntryMatchingTheRequest()
     {
-        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $request = new Request();
 
         $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
         $accessMap
@@ -178,19 +165,12 @@ class AccessListenerTest extends TestCase
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock()
         );
 
-        $event = $this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock();
-        $event
-            ->expects($this->any())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $listener($event);
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST));
     }
 
     public function testHandleWhenAccessMapReturnsEmptyAttributes()
     {
-        $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $request = new Request();
 
         $accessMap = $this->getMockBuilder(AccessMapInterface::class)->getMock();
         $accessMap
@@ -213,12 +193,7 @@ class AccessListenerTest extends TestCase
             $this->getMockBuilder(AuthenticationManagerInterface::class)->getMock()
         );
 
-        $event = $this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock();
-        $event
-            ->expects($this->any())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
+        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener(new LazyResponseEvent($event));
     }
@@ -233,7 +208,7 @@ class AccessListenerTest extends TestCase
             ->willReturn(null)
         ;
 
-        $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $request = new Request();
 
         $accessMap = $this->getMockBuilder(AccessMapInterface::class)->getMock();
         $accessMap
@@ -250,13 +225,6 @@ class AccessListenerTest extends TestCase
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock()
         );
 
-        $event = $this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock();
-        $event
-            ->expects($this->any())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $listener($event);
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST));
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener;
 
@@ -38,7 +40,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
         ;
 
         $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheSecret', null, $authenticationManager);
-        $listener($this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock());
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MASTER_REQUEST));
     }
 
     public function testHandleWithTokenStorageHavingNoToken()
@@ -69,7 +71,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
         ;
 
         $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheSecret', null, $authenticationManager);
-        $listener($this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock());
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MASTER_REQUEST));
     }
 
     public function testHandledEventIsLogged()
@@ -84,6 +86,6 @@ class AnonymousAuthenticationListenerTest extends TestCase
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
 
         $listener = new AnonymousAuthenticationListener($tokenStorage, 'TheSecret', $logger, $authenticationManager);
-        $listener($this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock());
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MASTER_REQUEST));
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\RememberMeListener;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -27,7 +28,7 @@ class RememberMeListenerTest extends TestCase
         list($listener, $tokenStorage) = $this->getListener();
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock())
         ;
@@ -45,7 +46,7 @@ class RememberMeListenerTest extends TestCase
         list($listener, $tokenStorage, $service) = $this->getListener();
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn(null)
         ;
@@ -57,11 +58,6 @@ class RememberMeListenerTest extends TestCase
         ;
 
         $event = $this->getGetResponseEvent();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn(new Request())
-        ;
 
         $this->assertNull($listener($event));
     }
@@ -73,7 +69,7 @@ class RememberMeListenerTest extends TestCase
         $exception = new AuthenticationException('Authentication failed.');
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn(null)
         ;
@@ -96,12 +92,7 @@ class RememberMeListenerTest extends TestCase
             ->willThrowException($exception)
         ;
 
-        $event = $this->getGetResponseEvent();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
+        $event = $this->getGetResponseEvent($request);
 
         $listener($event);
     }
@@ -113,7 +104,7 @@ class RememberMeListenerTest extends TestCase
         list($listener, $tokenStorage, $service, $manager) = $this->getListener(false, false);
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn(null)
         ;
@@ -137,11 +128,6 @@ class RememberMeListenerTest extends TestCase
         ;
 
         $event = $this->getGetResponseEvent();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn(new Request())
-        ;
 
         $listener($event);
     }
@@ -151,7 +137,7 @@ class RememberMeListenerTest extends TestCase
         list($listener, $tokenStorage, $service, $manager) = $this->getListener();
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn(null)
         ;
@@ -174,11 +160,6 @@ class RememberMeListenerTest extends TestCase
         ;
 
         $event = $this->getGetResponseEvent();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn(new Request())
-        ;
 
         $listener($event);
     }
@@ -188,7 +169,7 @@ class RememberMeListenerTest extends TestCase
         list($listener, $tokenStorage, $service, $manager) = $this->getListener();
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn(null)
         ;
@@ -213,11 +194,6 @@ class RememberMeListenerTest extends TestCase
         ;
 
         $event = $this->getGetResponseEvent();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn(new Request())
-        ;
 
         $listener($event);
     }
@@ -227,7 +203,7 @@ class RememberMeListenerTest extends TestCase
         list($listener, $tokenStorage, $service, $manager, , , $sessionStrategy) = $this->getListener(false, true, true);
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn(null)
         ;
@@ -258,25 +234,10 @@ class RememberMeListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $request = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Request')->getMock();
-        $request
-            ->expects($this->once())
-            ->method('hasSession')
-            ->willReturn(true)
-        ;
+        $request = new Request();
+        $request->setSession($session);
 
-        $request
-            ->expects($this->once())
-            ->method('getSession')
-            ->willReturn($session)
-        ;
-
-        $event = $this->getGetResponseEvent();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
+        $event = $this->getGetResponseEvent($request);
 
         $sessionStrategy
             ->expects($this->once())
@@ -292,7 +253,7 @@ class RememberMeListenerTest extends TestCase
         list($listener, $tokenStorage, $service, $manager) = $this->getListener(false, true, false);
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn(null)
         ;
@@ -327,25 +288,10 @@ class RememberMeListenerTest extends TestCase
             ->method('migrate')
         ;
 
-        $request = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Request')->getMock();
-        $request
-            ->expects($this->any())
-            ->method('hasSession')
-            ->willReturn(true)
-        ;
+        $request = new Request();
+        $request->setSession($session);
 
-        $request
-            ->expects($this->any())
-            ->method('getSession')
-            ->willReturn($session)
-        ;
-
-        $event = $this->getGetResponseEvent();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
+        $event = $this->getGetResponseEvent($request);
 
         $listener($event);
     }
@@ -355,7 +301,7 @@ class RememberMeListenerTest extends TestCase
         list($listener, $tokenStorage, $service, $manager, , $dispatcher) = $this->getListener(true);
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn(null)
         ;
@@ -380,12 +326,6 @@ class RememberMeListenerTest extends TestCase
         ;
 
         $event = $this->getGetResponseEvent();
-        $request = new Request();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
 
         $dispatcher
             ->expects($this->once())
@@ -399,9 +339,20 @@ class RememberMeListenerTest extends TestCase
         $listener($event);
     }
 
-    protected function getGetResponseEvent()
+    protected function getGetResponseEvent(Request $request = null): RequestEvent
     {
-        return $this->getMockBuilder(RequestEvent::class)->disableOriginalConstructor()->getMock();
+        $request = $request ?? new Request();
+
+        $event = $this->getMockBuilder(RequestEvent::class)
+            ->setConstructorArgs([$this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST])
+            ->getMock();
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($request)
+        ;
+
+        return $event;
     }
 
     protected function getResponseEvent(): ResponseEvent


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34614, Fix #34679
| License       | MIT
| Doc PR        | -

This fixes the form authenticator linked to #34614.
Since laziness is here to provide compatibility with HTTP caching, it should be disabled when the request cannot be cached.

Tests don't pass yet, but I'm on the path to something here.

The PR now introduces a new `AbstractListener` that splits the handling logic in two:
- `supports(Request): ?bool` is always called eagerly and tells whether the listener matches the request for an earger call or a lazy call
- `authenticate(RequestEvent)` does the rest of the job when `supports()` allows so - lazily or not depending on the return value of `supports()`.

Of course, this remains compatible with non-lazy logics, see `AbstractListener::__invoke()`.