### PR TITLE
[Notifier] added "callback" support for texter transports

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/NexmoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/NexmoTransportFactory.php
@@ -28,12 +28,13 @@ final class NexmoTransportFactory extends AbstractTransportFactory
         $scheme = $dsn->getScheme();
         $apiKey = $this->getUser($dsn);
         $apiSecret = $this->getPassword($dsn);
+        $callback = $dsn->getOption('callback');
         $from = $dsn->getOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
         if ('nexmo' === $scheme) {
-            return (new NexmoTransport($apiKey, $apiSecret, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+            return (new NexmoTransport($apiKey, $apiSecret, $from, $callback, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
         }
 
         throw new UnsupportedSchemeException($dsn, 'nexmo', $this->getSupportedSchemes());

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransportFactory.php
@@ -28,12 +28,13 @@ final class TwilioTransportFactory extends AbstractTransportFactory
         $scheme = $dsn->getScheme();
         $accountSid = $this->getUser($dsn);
         $authToken = $this->getPassword($dsn);
+        $callback = $dsn->getOption('callback');
         $from = $dsn->getOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
         if ('twilio' === $scheme) {
-            return (new TwilioTransport($accountSid, $authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+            return (new TwilioTransport($accountSid, $authToken, $from, $callback, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
         }
 
         throw new UnsupportedSchemeException($dsn, 'twilio', $this->getSupportedSchemes());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a 
| License       | MIT
| Doc PR        | n/a

Adding support for Twilio/Nexmo webhook endpoints used to monitor status changes.
It adds a `callback` parameter to the DSN.

e.g `twilio://SID:TOKEN@default?from=PHONE&callback=http://domain.tld/path`
 
- [ ] fix the tests (if there are any)