### PR TITLE
[Console] Fix trying to access array offset on value of type int

### DIFF
--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -39,8 +39,8 @@ class ArrayInput extends Input
      */
     public function getFirstArgument()
     {
-        foreach ($this->parameters as $key => $value) {
-            if ($key && '-' === $key[0]) {
+        foreach ($this->parameters as $param => $value) {
+            if ($param && \is_string($param) && '-' === $param[0]) {
                 continue;
             }
 
@@ -107,7 +107,7 @@ class ArrayInput extends Input
     {
         $params = [];
         foreach ($this->parameters as $param => $val) {
-            if ($param && '-' === $param[0]) {
+            if ($param && \is_string($param) && '-' === $param[0]) {
                 if (\is_array($val)) {
                     foreach ($val as $v) {
                         $params[] = $param.('' != $v ? '='.$this->escapeToken($v) : '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
|Tests pass?| yes
| License       | MIT

PHP 7.4 throws an error exception when you are trying to access an array by an integer key.
I got this error while I was running a console command:

```
ErrorException: Trying to access array offset on value of type int
at /my/project/vendor/symfony/console/Input/ArrayInput.php:110

Exception trace:
/my/project/vendor/symfony/console/Input/ArrayInput.php:110
/my/project/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:29
/my/project/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:29
/my/project/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:87
/my/project/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:31
/my/project/vendor/laravel/framework/src/Illuminate/Container/Container.php:564
/my/project/vendor/laravel/framework/src/Illuminate/Console/Command.php:179
/my/project/vendor/symfony/console/Command/Command.php:255
/my/project/vendor/laravel/framework/src/Illuminate/Console/Command.php:166
/my/project/vendor/symfony/console/Application.php:934
/my/project/vendor/symfony/console/Application.php:273
/my/project/vendor/symfony/console/Application.php:149
/my/project/vendor/laravel/framework/src/Illuminate/Console/Application.php:89
/my/project/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:122
/my/project/artisan:37

```
