### PR TITLE
fix: notice on potential undefined index

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
@@ -52,8 +52,8 @@ final class SourceContextProvider implements ContextProviderInterface
                 && 'dump' === $trace[$i]['function']
                 && VarDumper::class === $trace[$i]['class']
             ) {
-                $file = $trace[$i]['file'];
-                $line = $trace[$i]['line'];
+                $file = $trace[$i]['file'] ?? null;
+                $line = $trace[$i]['line'] ?? null;
 
                 while (++$i < $this->limit) {
                     if (isset($trace[$i]['function'], $trace[$i]['file']) && empty($trace[$i]['class']) && 0 !== strpos($trace[$i]['function'], 'call_user_func')) {


### PR DESCRIPTION
Fix the following issue : 

```
Notice: Undefined index: file in Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider->getContext() (line 55 of /var/www/app/vendor/symfony/var-dumper/Dumper/ContextProvider/SourceContextProvider.php). 
```

| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4, 4.3, 4.4 or 5.0 for bug fixes <!-- see below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
