### PR TITLE
[VarDumper] notice on potential undefined index

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
@@ -52,8 +52,8 @@ final class SourceContextProvider implements ContextProviderInterface
                 && 'dump' === $trace[$i]['function']
                 && VarDumper::class === $trace[$i]['class']
             ) {
-                $file = $trace[$i]['file'];
-                $line = $trace[$i]['line'];
+                $file = $trace[$i]['file'] ?? $file;
+                $line = $trace[$i]['line'] ?? $line;
 
                 while (++$i < $this->limit) {
                     if (isset($trace[$i]['function'], $trace[$i]['file']) && empty($trace[$i]['class']) && 0 !== strpos($trace[$i]['function'], 'call_user_func')) {


### PR DESCRIPTION
Fix the following issue that can happen (Drupal 8 project for context, with the [Twig vardumper](https://www.drupal.org/project/twig_vardumper) module) : 

```
Notice: Undefined index: file in Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider->getContext() (line 55 of /var/www/app/vendor/symfony/var-dumper/Dumper/ContextProvider/SourceContextProvider.php). 
```

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | N/A

