### PR TITLE
[Messenger] add tests to FailedMessagesShowCommand

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 /**
  * @group time-sensitive
@@ -93,5 +94,102 @@ EOF
             ,
             $redeliveryStamp2->getRedeliveredAt()->format('Y-m-d H:i:s')),
             $tester->getDisplay(true));
+    }
+
+    public function testReceiverShouldBeListable()
+    {
+        $receiver = $this->createMock(ReceiverInterface::class);
+        $command = new FailedMessagesShowCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $this->expectExceptionMessage('The "failure_receiver" receiver does not support listing or showing specific messages.');
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => 15]);
+    }
+
+    public function testListMessages()
+    {
+        $sentToFailureStamp = new SentToFailureTransportStamp('async');
+        $redeliveryStamp = new RedeliveryStamp(0, 'failure_receiver', 'Things are bad!');
+        $envelope = new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp(15),
+            $sentToFailureStamp,
+            $redeliveryStamp,
+        ]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with()->willReturn([$envelope]);
+
+        $command = new FailedMessagesShowCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+        $this->assertStringContainsString(sprintf(<<<EOF
+15   stdClass   %s   Things are bad!  
+EOF
+            ,
+            $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
+            $tester->getDisplay(true));
+    }
+
+    public function testListMessagesReturnsNoMessagesFound()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with()->willReturn([]);
+
+        $command = new FailedMessagesShowCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+        $this->assertStringContainsString('[OK] No failed messages were found.', $tester->getDisplay(true));
+    }
+
+    public function testListMessagesReturnsPaginatedMessages()
+    {
+        $sentToFailureStamp = new SentToFailureTransportStamp('async');
+        $envelope = new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp(15),
+            $sentToFailureStamp,
+            new RedeliveryStamp(0, 'failure_receiver', 'Things are bad!'),
+        ]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with()->willReturn([$envelope]);
+
+        $command = new FailedMessagesShowCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--max' => 1]);
+        $this->assertStringContainsString('Showing first 1 messages.', $tester->getDisplay(true));
+    }
+
+    public function testInvalidMessagesThrowsException()
+    {
+        $sentToFailureStamp = new SentToFailureTransportStamp('async');
+        $envelope = new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp(15),
+            $sentToFailureStamp,
+        ]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+
+        $command = new FailedMessagesShowCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $this->expectExceptionMessage('The message "15" was not found.');
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => 15]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Add missing tests to FailedMessagesShowCommand in Messenger component
