### PR TITLE
[Mailer] Added the ability to configure mailer component to send messages without bus

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1633,6 +1633,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->scalarNode('use_bus')->defaultTrue()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2023,6 +2023,12 @@ class FrameworkExtension extends Extension
         $container->getDefinition('mailer.transports')->setArgument(0, $transports);
         $container->getDefinition('mailer.default_transport')->setArgument(0, current($transports));
 
+        if (!$config['use_bus']) {
+            $container->getDefinition('mailer.mailer')
+                ->setArgument(1, null)
+                ->setArgument(2, null);
+        }
+
         $classToServices = [
             SesTransportFactory::class => 'mailer.transport_factory.amazon',
             GmailTransportFactory::class => 'mailer.transport_factory.gmail',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | no
| License       | MIT
| Doc PR        | no

There is no way to configure the mailer component without a bus.   
If I have `messenger.default_bus` provided by [symfony/messenger](https://github.com/symfony/messenger) in my app - mailer automatically works via bus. Because [it](https://github.com/symfony/framework-bundle/blob/4.4/Resources/config/mailer.xml#L10) is injected as an argument. 
I want to use the mailer component without a bus, even if I have the bus in the project.
Is there any other way to set `MessageBusInterface` as null directly?

I propose to add a configuration to the [mailer](https://github.com/symfony/mailer) component. Something like that:
```
framework:
    mailer:
        use_bus: false # default value - true.
```

P.s. I'm doing a pull request first time in the Symfony repository, so let me know if something is wrong. Any feedback

