### PR TITLE
[Mailer] Allow to configure or disable the message bus to use

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Marked `MicroKernelTrait::configureRoutes()` as `@internal` and `@final`.
  * Deprecated not overriding `MicroKernelTrait::configureRouting()`.
+ * Added a new `mailer.message_bus` option to configure or disable the message bus to use to send mails.
 
 5.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1469,6 +1469,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->fixXmlConfig('transport')
                     ->children()
+                        ->scalarNode('message_bus')->defaultNull()->info('The message bus to use. Defaults to the default bus if the Messenger component is installed.')->end()
                         ->scalarNode('dsn')->defaultNull()->end()
                         ->arrayNode('transports')
                             ->useAttributeAsKey('name')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1884,6 +1884,13 @@ class FrameworkExtension extends Extension
         $container->getDefinition('mailer.transports')->setArgument(0, $transports);
         $container->getDefinition('mailer.default_transport')->setArgument(0, current($transports));
 
+        $mailer = $container->getDefinition('mailer.mailer');
+        if (false === $messageBus = $config['message_bus']) {
+            $mailer->replaceArgument(1, null);
+        } else {
+            $mailer->replaceArgument(1, $messageBus ? new Reference($messageBus) : new Reference('messenger.default_bus', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        }
+
         $classToServices = [
             SesTransportFactory::class => 'mailer.transport_factory.amazon',
             GmailTransportFactory::class => 'mailer.transport_factory.gmail',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="mailer.mailer" class="Symfony\Component\Mailer\Mailer">
             <argument type="service" id="mailer.transports" />
-            <argument type="service" id="messenger.default_bus" on-invalid="ignore" />
+            <argument /> <!-- message bus-->
             <argument type="service" id="event_dispatcher" on-invalid="ignore" />
         </service>
         <service id="mailer" alias="mailer.mailer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -549,6 +549,7 @@
             <xsd:element name="envelope" type="mailer_envelope" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
         <xsd:attribute name="dsn" type="xsd:string" />
+        <xsd:attribute name="message-bus" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="mailer_envelope">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -469,6 +469,7 @@ class ConfigurationTest extends TestCase
                 'dsn' => null,
                 'transports' => [],
                 'enabled' => !class_exists(FullStack::class) && class_exists(Mailer::class),
+                'message_bus' => null,
             ],
             'notifier' => [
                 'enabled' => !class_exists(FullStack::class) && class_exists(Notifier::class),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_disabled_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_disabled_message_bus.php
@@ -1,0 +1,8 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'mailer' => [
+        'dsn' => 'smtp://example.com',
+        'message_bus' => false,
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_specific_message_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_specific_message_bus.php
@@ -1,0 +1,8 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'mailer' => [
+        'dsn' => 'smtp://example.com',
+        'message_bus' => 'app.another_bus',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_disabled_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_disabled_message_bus.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:mailer dsn="smtp://example.com" message-bus="false">
+        </framework:mailer>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_specific_message_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_specific_message_bus.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:mailer dsn="smtp://example.com" message-bus="app.another_bus">
+        </framework:mailer>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_disabled_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_disabled_message_bus.yml
@@ -1,0 +1,4 @@
+framework:
+    mailer:
+        dsn: 'smtp://example.com'
+        message_bus: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_specific_message_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_specific_message_bus.yml
@@ -1,0 +1,4 @@
+framework:
+    mailer:
+        dsn: 'smtp://example.com'
+        message_bus: app.another_bus

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1367,6 +1367,21 @@ abstract class FrameworkExtensionTest extends TestCase
         $l = $container->getDefinition('mailer.envelope_listener');
         $this->assertSame('sender@example.org', $l->getArgument(0));
         $this->assertSame(['redirected@example.org', 'redirected1@example.org'], $l->getArgument(1));
+        $this->assertEquals(new Reference('messenger.default_bus', ContainerInterface::NULL_ON_INVALID_REFERENCE), $container->getDefinition('mailer.mailer')->getArgument(1));
+    }
+
+    public function testMailerWithDisabledMessageBus(): void
+    {
+        $container = $this->createContainerFromFile('mailer_with_disabled_message_bus');
+
+        $this->assertNull($container->getDefinition('mailer.mailer')->getArgument(1));
+    }
+
+    public function testMailerWithSpecificMessageBus(): void
+    {
+        $container = $this->createContainerFromFile('mailer_with_specific_message_bus');
+
+        $this->assertEquals(new Reference('app.another_bus'), $container->getDefinition('mailer.mailer')->getArgument(1));
     }
 
     protected function createContainer(array $data = [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | #34633 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | todo

A new `mailer.message_bus` option allowing to choose the message bus to use instead of using the default one.
Also allows to set it to `false` so no message bus is used and the transport will be called directly.
