### PR TITLE
more robust initialization from request

### DIFF
--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -67,8 +67,8 @@ class RequestContext
         $this->setMethod($request->getMethod());
         $this->setHost($request->getHost());
         $this->setScheme($request->getScheme());
-        $this->setHttpPort($request->isSecure() ? $this->httpPort : $request->getPort());
-        $this->setHttpsPort($request->isSecure() ? $request->getPort() : $this->httpsPort);
+        $this->setHttpPort($request->isSecure() || null === $request->getPort() ? $this->httpPort : $request->getPort());
+        $this->setHttpsPort($request->isSecure() && null !== $request->getPort() ? $request->getPort() : $this->httpsPort);
         $this->setQueryString($request->server->get('QUERY_STRING', ''));
 
         return $this;


### PR DESCRIPTION
Request::getPort is declared as int|string but can actually return null.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I discovered this problem with a functional test where i dispatch the RequestEvent with a `new Request()`. This used to work in symfony 4 and now triggers an error `Argument 1 passed to Symfony\Component\Routing\RequestContext::setHttpPort() must be of the type int, null given`

In regular web requests, this should probably never happen, but it seems to me if Request is not robust, the RequestContext should be robust about it.