### PR TITLE
[HttpKernel][DataCollectorInterface] Ease compatibility

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
@@ -25,8 +25,10 @@ interface DataCollectorInterface
 {
     /**
      * Collects data for the given Request and Response.
+     *
+     * @param \Throwable|null $exception
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null);
+    public function collect(Request $request, Response $response/*, \Throwable $exception = null*/);
 
     /**
      * Returns the name of the collector.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | https://github.com/symfony/symfony/pull/34230#issuecomment-559011135
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Backport of #34230. This allows data collectors in Symfony 3.4 have the same syntax as in 4.3+. Otherwise it's difficult to create code that's compatible with Symfony 3.4 and 5.0 at the same time.