### PR TITLE
[DependencyInjection] adding datetime and datetime_immutable support in EnvVarProcessor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -44,6 +44,8 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             'bool' => 'bool',
             'const' => 'bool|int|float|string|array',
             'csv' => 'array',
+            'datetime' => 'string',
+            'datetime_immutable' => 'string',
             'file' => 'string',
             'float' => 'float',
             'int' => 'int',
@@ -273,6 +275,22 @@ class EnvVarProcessor implements EnvVarProcessorInterface
 
         if ('trim' === $prefix) {
             return trim($env);
+        }
+
+        if ('datetime' === $prefix) {
+            try {
+                return new \DateTime($env, new \DateTimeZone(date_default_timezone_get()));
+            } catch (\Exception $e) {
+                throw new RuntimeException(sprintf('Invalid DateTime string in env var "%s"', $name), 0, $e);
+            }
+        }
+
+        if ('datetime_immutable' === $prefix) {
+            try {
+                return new \DateTimeImmutable($env, new \DateTimeZone(date_default_timezone_get()));
+            } catch (\Exception $e) {
+                throw new RuntimeException(sprintf('Invalid DateTimeImmutable string in env var "%s"', $name), 0, $e);
+            }
         }
 
         throw new RuntimeException(sprintf('Unsupported env var prefix "%s".', $prefix));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -34,6 +34,8 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'bool' => ['bool'],
             'const' => ['bool', 'int', 'float', 'string', 'array'],
             'csv' => ['array'],
+            'datetime' => ['string'],
+            'datetime_immutable' => ['string'],
             'file' => ['string'],
             'float' => ['float'],
             'int' => ['int'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #34634
| License       | MIT
| Doc PR        | symfony/symfony-docs#12709

Proposing `datetime` and `datetime_immutable` prefix for EnvVarProcessor

```yaml
    # env processor
    App\System\Clock:
        $now: '%env(datetime:default::NOW)%'
```