### PR TITLE
[Notifier] added Sinch texter transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -95,6 +95,7 @@ use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
 use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransportFactory;
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
+use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
@@ -2007,6 +2008,7 @@ class FrameworkExtension extends Extension
             TwilioTransportFactory::class => 'notifier.transport_factory.twilio',
             FirebaseTransportFactory::class => 'notifier.transport_factory.firebase',
             OvhCloudTransportFactory::class => 'notifier.transport_factory.ovhcloud',
+            SinchTransportFactory::class => 'notifier.transport_factory.sinch',
         ];
 
         foreach ($classToServices as $class => $service) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.xml
@@ -42,6 +42,10 @@
             <tag name="texter.transport_factory" />
         </service>
 
+        <service id="notifier.transport_factory.sinch" class="Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory" parent="notifier.transport_factory.abstract">
+            <tag name="texter.transport_factory" />
+        </service>
+
         <service id="notifier.transport_factory.null" class="Symfony\Component\Notifier\Transport\NullTransportFactory" parent="notifier.transport_factory.abstract">
             <tag name="notifier.transport_factory" />
         </service>

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.1
+-----
+
+ * Added the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/README.md
@@ -1,0 +1,12 @@
+Sinch Notifier
+==============
+
+Provides Sinch integration for Symfony Notifier.
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sinch;
+
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Iliya Miroslavov Iliev <i.miroslavov@gmail.com>
+ *
+ * @experimental in 5.1
+ */
+final class SinchTransport extends AbstractTransport
+{
+    protected const HOST = 'sms.api.sinch.com';
+
+    private $accountSid;
+    private $authToken;
+    private $from;
+
+    public function __construct(string $accountSid, string $authToken, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->accountSid = $accountSid;
+        $this->authToken = $authToken;
+        $this->from = $from;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('sinch://%s?from=%s', $this->getEndpoint(), $this->from);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage;
+    }
+
+    protected function doSend(MessageInterface $message): void
+    {
+        if (!$message instanceof SmsMessage) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, \get_class($message)));
+        }
+
+        $endpoint = sprintf('https://%s/xms/v1/%s/batches', $this->getEndpoint(), $this->accountSid);
+        $response = $this->client->request('POST', $endpoint, [
+            'auth_bearer' => $this->authToken,
+            'json' => [
+                'from' => $this->from,
+                'to' => [$message->getPhone()],
+                'body' => $message->getSubject(),
+            ],
+        ]);
+
+        if (201 !== $response->getStatusCode()) {
+            $error = $response->toArray(false);
+
+            throw new TransportException(sprintf('Unable to send the SMS: %s (%s).', $error['text'], $error['code']), $response);
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransportFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sinch;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author Iliya Miroslavov Iliev <i.miroslavov@gmail.com>
+ *
+ * @experimental in 5.1
+ */
+final class SinchTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+        $accountSid = $this->getUser($dsn);
+        $authToken = $this->getPassword($dsn);
+        $from = $dsn->getOption('from');
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        if ('sinch' === $scheme) {
+            return (new SinchTransport($accountSid, $authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        }
+
+        throw new UnsupportedSchemeException($dsn, 'sinch', $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['sinch'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "symfony/sinch-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony Sinch Notifier Bridge",
+    "keywords": ["sms", "sinch", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": "^7.2.5",
+        "ext-json": "*",
+        "symfony/http-client": "^4.3|^5.0",
+        "symfony/notifier": "^5.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sinch\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.1-dev"
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Sinch Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -54,6 +54,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\OvhCloud\OvhCloudTransportFactory::class,
             'package' => 'symfony/ovhcloud-notifier',
         ],
+        'sinch' => [
+            'class' => Bridge\Sinch\SinchTransportFactory::class,
+            'package' => 'symfony/sinch-notifier',
+        ],
     ];
 
     /**

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -16,6 +16,7 @@ use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
 use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransportFactory;
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
+use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
@@ -46,6 +47,7 @@ class Transport
         TwilioTransportFactory::class,
         OvhCloudTransportFactory::class,
         FirebaseTransportFactory::class,
+        SinchTransportFactory::class,
     ];
 
     private $factories;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This PR adds adapter for Sinch messaging gateway to the texter transport.

Example configuration:
`sinch://SID:TOKEN@default?from=PHONE`
