### PR TITLE
[Config] Allow null values for numeric & boolean nodes

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Added `allowEmptyValue` method to `NumericNodeDefinition` and `BooleanNodeDefinition` to accept `null` values.
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
- * Added `allowEmptyValue` method to `NumericNodeDefinition` and `BooleanNodeDefinition` to accept `null` values.
+ * Added `allowNull` method to `NumericNodeDefinition` and `BooleanNodeDefinition` to accept `null` values.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -20,11 +20,17 @@ use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
  */
 class BooleanNode extends ScalarNode
 {
+    protected $allowEmptyValue = false;
+
     /**
      * {@inheritdoc}
      */
     protected function validateType($value)
     {
+        if ($this->allowEmptyValue && $this->isValueEmpty($value)) {
+            return;
+        }
+
         if (!\is_bool($value)) {
             $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected boolean, but got %s.', $this->getPath(), \gettype($value)));
             if ($hint = $this->getInfo()) {
@@ -41,8 +47,13 @@ class BooleanNode extends ScalarNode
      */
     protected function isValueEmpty($value)
     {
-        // a boolean value cannot be empty
-        return false;
+        // assume environment variables are never empty (which in practice is likely to be true during runtime)
+        // not doing so breaks many configs that are valid today
+        if ($this->isHandlingPlaceholder()) {
+            return false;
+        }
+
+        return null === $value;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Config\Definition\Builder;
 
 use Symfony\Component\Config\Definition\BooleanNode;
-use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 
 /**
  * This class provides a fluent interface for defining a node.
@@ -29,6 +28,7 @@ class BooleanNodeDefinition extends ScalarNodeDefinition
         parent::__construct($name, $parent);
 
         $this->nullEquivalent = true;
+        $this->allowEmptyValue = false;
     }
 
     /**
@@ -41,13 +41,18 @@ class BooleanNodeDefinition extends ScalarNodeDefinition
         return new BooleanNode($this->name, $this->parent, $this->pathSeparator);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws InvalidDefinitionException
-     */
     public function cannotBeEmpty()
     {
-        throw new InvalidDefinitionException('->cannotBeEmpty() is not applicable to BooleanNodeDefinition.');
+        $this->nullEquivalent = true;
+
+        return parent::cannotBeEmpty();
+    }
+
+    public function allowEmptyValue(): self
+    {
+        $this->allowEmptyValue = true;
+        $this->nullEquivalent = null;
+
+        return $this;
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
@@ -48,7 +48,7 @@ class BooleanNodeDefinition extends ScalarNodeDefinition
         return parent::cannotBeEmpty();
     }
 
-    public function allowEmptyValue(): self
+    public function allowNull(): self
     {
         $this->allowEmptyValue = true;
         $this->nullEquivalent = null;

--- a/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Config\Definition\Builder;
 
-use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
-
 /**
  * Abstract class that contains common code of integer and float node definitions.
  *
@@ -22,6 +20,13 @@ abstract class NumericNodeDefinition extends ScalarNodeDefinition
 {
     protected $min;
     protected $max;
+
+    public function __construct(?string $name, NodeParentInterface $parent = null)
+    {
+        parent::__construct($name, $parent);
+
+        $this->allowEmptyValue = false;
+    }
 
     /**
      * Ensures that the value is smaller than the given reference.
@@ -61,13 +66,10 @@ abstract class NumericNodeDefinition extends ScalarNodeDefinition
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws InvalidDefinitionException
-     */
-    public function cannotBeEmpty()
+    public function allowEmptyValue(): self
     {
-        throw new InvalidDefinitionException('->cannotBeEmpty() is not applicable to NumericNodeDefinition.');
+        $this->allowEmptyValue = true;
+
+        return $this;
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
@@ -66,7 +66,7 @@ abstract class NumericNodeDefinition extends ScalarNodeDefinition
         return $this;
     }
 
-    public function allowEmptyValue(): self
+    public function allowNull(): self
     {
         $this->allowEmptyValue = true;
 

--- a/src/Symfony/Component/Config/Definition/FloatNode.php
+++ b/src/Symfony/Component/Config/Definition/FloatNode.php
@@ -25,6 +25,10 @@ class FloatNode extends NumericNode
      */
     protected function validateType($value)
     {
+        if ($this->allowEmptyValue && $this->isValueEmpty($value)) {
+            return;
+        }
+
         // Integers are also accepted, we just cast them
         if (\is_int($value)) {
             $value = (float) $value;

--- a/src/Symfony/Component/Config/Definition/IntegerNode.php
+++ b/src/Symfony/Component/Config/Definition/IntegerNode.php
@@ -25,6 +25,10 @@ class IntegerNode extends NumericNode
      */
     protected function validateType($value)
     {
+        if ($this->allowEmptyValue && $this->isValueEmpty($value)) {
+            return;
+        }
+
         if (!\is_int($value)) {
             $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected int, but got %s.', $this->getPath(), \gettype($value)));
             if ($hint = $this->getInfo()) {

--- a/src/Symfony/Component/Config/Definition/NumericNode.php
+++ b/src/Symfony/Component/Config/Definition/NumericNode.php
@@ -22,6 +22,7 @@ class NumericNode extends ScalarNode
 {
     protected $min;
     protected $max;
+    protected $allowEmptyValue = false;
 
     public function __construct(?string $name, NodeInterface $parent = null, $min = null, $max = null, string $pathSeparator = BaseNode::DEFAULT_PATH_SEPARATOR)
     {
@@ -36,6 +37,10 @@ class NumericNode extends ScalarNode
     protected function finalizeValue($value)
     {
         $value = parent::finalizeValue($value);
+
+        if ($this->allowEmptyValue && $this->isValueEmpty($value)) {
+            return $value;
+        }
 
         $errorMsg = null;
         if (isset($this->min) && $value < $this->min) {
@@ -58,7 +63,12 @@ class NumericNode extends ScalarNode
      */
     protected function isValueEmpty($value)
     {
-        // a numeric value cannot be empty
-        return false;
+        // assume environment variables are never empty (which in practice is likely to be true during runtime)
+        // not doing so breaks many configs that are valid today
+        if ($this->isHandlingPlaceholder()) {
+            return false;
+        }
+
+        return null === $value;
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
@@ -46,6 +46,14 @@ class BooleanNodeTest extends TestCase
         ];
     }
 
+    public function testValidEmptyValue()
+    {
+        $node = new BooleanNode('test');
+        $node->setAllowEmptyValue(true);
+
+        $this->assertNull($node->finalize(null));
+    }
+
     /**
      * @dataProvider getInvalidValues
      */

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
@@ -13,17 +13,10 @@ namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class BooleanNodeDefinitionTest extends TestCase
 {
-    public function testCannotBeEmptyThrowsAnException()
-    {
-        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidDefinitionException');
-        $this->expectExceptionMessage('->cannotBeEmpty() is not applicable to BooleanNodeDefinition.');
-        $def = new BooleanNodeDefinition('foo');
-        $def->cannotBeEmpty();
-    }
-
     public function testSetDeprecated()
     {
         $def = new BooleanNodeDefinition('foo');
@@ -33,5 +26,24 @@ class BooleanNodeDefinitionTest extends TestCase
 
         $this->assertTrue($node->isDeprecated());
         $this->assertSame('The "foo" node is deprecated.', $node->getDeprecationMessage($node->getName(), $node->getPath()));
+    }
+
+    public function testCannotBeEmpty()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid type for path "foo". Expected boolean, but got NULL.');
+        $node = new BooleanNodeDefinition('foo');
+        $node->allowEmptyValue();
+        $node->cannotBeEmpty();
+
+        $node->getNode()->finalize(null);
+    }
+
+    public function testAllowEmptyValue()
+    {
+        $node = new BooleanNodeDefinition('foo');
+        $node->allowEmptyValue();
+
+        $this->assertNull($node->getNode()->finalize(null));
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
@@ -33,16 +33,16 @@ class BooleanNodeDefinitionTest extends TestCase
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Invalid type for path "foo". Expected boolean, but got NULL.');
         $node = new BooleanNodeDefinition('foo');
-        $node->allowEmptyValue();
+        $node->allowNull();
         $node->cannotBeEmpty();
 
         $node->getNode()->finalize(null);
     }
 
-    public function testAllowEmptyValue()
+    public function testAllowNull()
     {
         $node = new BooleanNodeDefinition('foo');
-        $node->allowEmptyValue();
+        $node->allowNull();
 
         $this->assertNull($node->getNode()->finalize(null));
     }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Config\Tests\Definition\Builder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\FloatNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition as NumericNodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class NumericNodeDefinitionTest extends TestCase
 {
@@ -79,11 +81,22 @@ class NumericNodeDefinitionTest extends TestCase
         $this->assertEquals(4.5, $node->finalize(4.5));
     }
 
-    public function testCannotBeEmptyThrowsAnException()
+    public function testCannotBeEmpty()
     {
-        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidDefinitionException');
-        $this->expectExceptionMessage('->cannotBeEmpty() is not applicable to NumericNodeDefinition.');
-        $def = new IntegerNodeDefinition('foo');
-        $def->cannotBeEmpty();
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid type for path "foo". Expected int, but got NULL.');
+        $node = new NumericNodeDefinition('foo');
+        $node->allowEmptyValue();
+        $node->cannotBeEmpty();
+
+        $node->getNode()->finalize(null);
+    }
+
+    public function testAllowEmptyValue()
+    {
+        $node = new NumericNodeDefinition('foo');
+        $node->allowEmptyValue();
+
+        $this->assertNull($node->getNode()->finalize(null));
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
@@ -86,16 +86,16 @@ class NumericNodeDefinitionTest extends TestCase
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Invalid type for path "foo". Expected int, but got NULL.');
         $node = new NumericNodeDefinition('foo');
-        $node->allowEmptyValue();
+        $node->allowNull();
         $node->cannotBeEmpty();
 
         $node->getNode()->finalize(null);
     }
 
-    public function testAllowEmptyValue()
+    public function testAllowNull()
     {
         $node = new NumericNodeDefinition('foo');
-        $node->allowEmptyValue();
+        $node->allowNull();
 
         $this->assertNull($node->getNode()->finalize(null));
     }

--- a/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
@@ -47,6 +47,14 @@ class IntegerNodeTest extends TestCase
         ];
     }
 
+    public function testValidEmptyValue()
+    {
+        $node = new IntegerNode('test');
+        $node->setAllowEmptyValue(true);
+
+        $this->assertNull($node->finalize(null));
+    }
+
     /**
      * @dataProvider getInvalidValues
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | todo

This PR introduces a new `Numeric/BooleanNodeDefinition::allowNull()` method allowing numeric and boolean nodes to be `null`. On contrary of other node types, float, integer and boolean ones rejects `null` values by default. This can now be opt-out using `->allowNull()` when configuring these nodes.

Use-cases are about performing some auto-configuration when the `null` value is set, either in the bundle extensions or in services in which such values are injected.


```php
#!/usr/bin/env php
<?php

use Symfony\Component\Config\Definition\Builder\TreeBuilder;
use Symfony\Component\Config\Definition\Processor;

require __DIR__.'/vendor/autoload.php';

$tree = new TreeBuilder('foo');
$tree->getRootNode()
    ->children()
        ->booleanNode('bool')->allowNull()->end()
        ->integerNode('integer')->allowNull()->end()
    ->end()
;

$processor = new Processor();
dump($processor->process($tree->buildTree(), [
    'foo' => [
        'bool' => null,
        'integer' => null,
    ]
]));

// Output:
//
//^ array:2 [
//  "bool" => null
//  "integer" => null
//]
```

---

A test is failing currently in DI component:

> 1) Symfony\Component\DependencyInjection\Tests\Compiler\ValidateEnvPlaceholdersPassTest::testEnvIsNotUnset
Symfony\Component\Config\Definition\Exception\InvalidConfigurationException: The path "env_extension.array_node.int_unset_at_zero" cannot contain an environment variable when empty values are not allowed by definition and are validated.

Meaning these changes will prevent using an env var on nodes not having called `->allowNull()`...

One issue also is that previously, `NumericNode` were build without overriding the `VariableNode::$allowEmptyValue = true` value, so these were in a way considered nullable by default... Current changes would be considered a BC break.

I'm failing to find a proper upgrade path without too much hassle for everyone using the Config component (I'd like to avoid a deprec when not calling `->cannotBeEmpty` nor `->allowNull` explicitly). Help appreciated.