### PR TITLE
Create method in AbstractController for resolve multiple template 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -267,7 +267,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     /**
      * Returns a rendered view resolved for several templates.
      */
-    protected function resolveRenderView(array $views, array $parameters = []): Response
+    protected function resolveRenderView(array $views, array $parameters = []): string
     {
         if (!$views) {
             throw new \InvalidArgumentException('No templates to resolve.');

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -265,6 +265,38 @@ abstract class AbstractController implements ServiceSubscriberInterface
     }
 
     /**
+     * Returns a rendered view resolved for several templates.
+     */
+    protected function resolveRenderView(array $views, array $parameters = []): Response
+    {
+        if (!$views) {
+            throw new \InvalidArgumentException('No templates to resolve.');
+        }
+
+        if (!$this->container->has('twig')) {
+            throw new \LogicException('You can not use the "renderView" method if the Twig Bundle is not available. Try running "composer require symfony/twig-bundle".');
+        }
+
+        return $this->container->get('twig')->resolveTemplate($views)->render($parameters);
+    }
+
+    /**
+     * Renders a view resolved for several templates.
+     */
+    protected function resolveRender(array $views, array $parameters = [], Response $response = null): Response
+    {
+        $content = $this->resolveRenderView($views, $parameters);
+
+        if (null === $response) {
+            $response = new Response();
+        }
+
+        $response->setContent($content);
+
+        return $response;
+    }
+
+    /**
      * Streams a view.
      */
     protected function stream(string $view, array $parameters = [], StreamedResponse $response = null): StreamedResponse


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix #9071
| License       | MIT
| Doc PR        | <!-- symfony/symfony-docs#... required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->


Usage like this:

```php
return $this->resolveRender([
    sprintf('@Frontend/Broadcast/skin/%s/show.html.twig', $broadcast->getLayout()),
    '@Frontend/Broadcast/skin/default/show.html.twig',
]);
```

While this is a feature for discussion.