### PR TITLE
[Cache] Make sure we get the correct number of values from redis::mget()

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -179,7 +179,13 @@ trait RedisTrait
                 }
             });
         } else {
-            $values = array_combine($ids, $this->redis->mget($ids));
+            $values = $this->redis->mget($ids);
+
+            if (!\is_array($values) || \count($values) !== \count($ids)) {
+                return [];
+            }
+
+            $values = array_combine($ids, $values);
         }
 
         foreach ($values as $id => $v) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Redis might not be reachable when invoking `redis->mget($ids)`, the call returns `false` instead of an array.
This change makes sure the return value is properly check, including the correctness of the parameters to invoke  `array_combine($ids, $cacheValues);`.
From the documentation:
> Returns the combined array, FALSE if the number of elements for each array isn't equal. 
