### PR TITLE
[HttpClient] turn exception into log when the request has no content-type

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -109,11 +109,18 @@ final class NativeResponse implements ResponseInterface
 
     private function open(): void
     {
-        set_error_handler(function ($type, $msg) { throw new TransportException($msg); });
+        $url = $this->url;
+
+        set_error_handler(function ($type, $msg) use (&$url) {
+            if (E_NOTICE !== $type || 'fopen(): Content-type not specified assuming application/x-www-form-urlencoded' !== $msg) {
+                throw new TransportException($msg);
+            }
+
+            $this->logger && $this->logger->info(sprintf('%s for "%s".', $msg, $url ?? $this->url));
+        });
 
         try {
             $this->info['start_time'] = microtime(true);
-            $url = $this->url;
 
             while (true) {
                 $context = stream_context_get_options($this->context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted while merging a PR with ext-curl disabled:

```
  [Symfony\Component\HttpClient\Exception\TransportException]                     
  fopen(): Content-type not specified assuming application/x-www-form-urlencoded  
```

This is now a log.