### PR TITLE
[Security] Fix clearing remember-me cookie after deauthentication

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -81,7 +81,11 @@ class RememberMeFactory implements SecurityFactoryInterface
                     throw new \RuntimeException('Each "security.remember_me_aware" tag must have a provider attribute.');
                 }
 
-                $userProviders[] = new Reference($attribute['provider']);
+                // context listeners don't need a provider
+                if ('none' !== $attribute['provider']) {
+                    $userProviders[] = new Reference($attribute['provider']);
+                }
+
                 $container
                     ->getDefinition($serviceId)
                     ->addMethodCall('setRememberMeServices', [new Reference($rememberMeServicesId)])

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -374,6 +374,7 @@ class SecurityExtension extends Extension
         $listeners[] = new Reference('security.channel_listener');
 
         $contextKey = null;
+        $contextListenerId = null;
         // Context serializer listener
         if (false === $firewall['stateless']) {
             $contextKey = $id;
@@ -390,7 +391,7 @@ class SecurityExtension extends Extension
             }
 
             $this->logoutOnUserChangeByContextKey[$contextKey] = [$id, $logoutOnUserChange];
-            $listeners[] = new Reference($this->createContextListener($container, $contextKey, $logoutOnUserChange));
+            $listeners[] = new Reference($contextListenerId = $this->createContextListener($container, $contextKey, $logoutOnUserChange));
             $sessionStrategyId = 'security.authentication.session_strategy';
         } else {
             $this->statelessFirewallKeys[] = $id;
@@ -463,7 +464,7 @@ class SecurityExtension extends Extension
         $configuredEntryPoint = isset($firewall['entry_point']) ? $firewall['entry_point'] : null;
 
         // Authentication listeners
-        list($authListeners, $defaultEntryPoint) = $this->createAuthenticationListeners($container, $id, $firewall, $authenticationProviders, $defaultProvider, $providerIds, $configuredEntryPoint);
+        list($authListeners, $defaultEntryPoint) = $this->createAuthenticationListeners($container, $id, $firewall, $authenticationProviders, $defaultProvider, $providerIds, $configuredEntryPoint, $contextListenerId);
 
         $config->replaceArgument(7, $configuredEntryPoint ?: $defaultEntryPoint);
 
@@ -519,7 +520,7 @@ class SecurityExtension extends Extension
         return $this->contextListeners[$contextKey] = $listenerId;
     }
 
-    private function createAuthenticationListeners($container, $id, $firewall, &$authenticationProviders, $defaultProvider = null, array $providerIds, $defaultEntryPoint)
+    private function createAuthenticationListeners($container, $id, $firewall, &$authenticationProviders, $defaultProvider = null, array $providerIds, $defaultEntryPoint, $contextListenerId = null)
     {
         $listeners = [];
         $hasListeners = false;
@@ -537,6 +538,9 @@ class SecurityExtension extends Extension
                     } elseif ('remember_me' === $key) {
                         // RememberMeFactory will use the firewall secret when created
                         $userProvider = null;
+                        if ($contextListenerId) {
+                            $container->getDefinition($contextListenerId)->addTag('security.remember_me_aware', ['id' => $id, 'provider' => 'none']);
+                        }
                     } else {
                         $userProvider = $defaultProvider ?: $this->getFirstProvider($id, $key, $providerIds);
                     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/ClearRememberMeTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/ClearRememberMeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class ClearRememberMeTest extends AbstractWebTestCase
+{
+    public function testUserChangeClearsCookie()
+    {
+        $client = $this->createClient(['test_case' => 'ClearRememberMe', 'root_config' => 'config.yml']);
+
+        $client->request('POST', '/login', [
+            '_username' => 'johannes',
+            '_password' => 'test',
+        ]);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $cookieJar = $client->getCookieJar();
+        $this->assertNotNull($cookieJar->get('REMEMBERME'));
+
+        $client->request('GET', '/foo');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertNull($cookieJar->get('REMEMBERME'));
+    }
+}
+
+class RememberMeFooController
+{
+    public function __invoke(UserInterface $user)
+    {
+        return new Response($user->getUsername());
+    }
+}
+
+class RememberMeUserProvider implements UserProviderInterface
+{
+    private $inner;
+
+    public function __construct(InMemoryUserProvider $inner)
+    {
+        $this->inner = $inner;
+    }
+
+    public function loadUserByUsername($username)
+    {
+        return $this->inner->loadUserByUsername($username);
+    }
+
+    public function refreshUser(UserInterface $user)
+    {
+        $user = $this->inner->refreshUser($user);
+
+        $alterUser = \Closure::bind(function (User $user) { $user->password = 'foo'; }, null, User::class);
+        $alterUser($user);
+
+        return $user;
+    }
+
+    public function supportsClass($class)
+    {
+        return $this->inner->supportsClass($class);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+
+return [
+    new FrameworkBundle(),
+    new SecurityBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/config.yml
@@ -1,0 +1,32 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+security:
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    johannes: { password: test, roles: [ROLE_USER] }
+
+    firewalls:
+        default:
+            form_login:
+                check_path: login
+                remember_me: true
+            remember_me:
+                always_remember_me: true
+                secret: key
+            anonymous: ~
+            logout_on_user_change: true
+
+    access_control:
+        - { path: ^/foo, roles: ROLE_USER }
+
+services:
+    Symfony\Bundle\SecurityBundle\Tests\Functional\RememberMeUserProvider:
+        public: true
+        decorates: security.user.provider.concrete.in_memory
+        arguments: ['@Symfony\Bundle\SecurityBundle\Tests\Functional\RememberMeUserProvider.inner']

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/routing.yml
@@ -1,0 +1,7 @@
+login:
+    path: /login
+
+foo:
+    path: /foo
+    defaults:
+        _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\RememberMeFooController

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5.9|>=7.0.8",
         "ext-xml": "*",
         "symfony/config": "~3.4|~4.0",
-        "symfony/security": "~3.4.15|~4.0.15|^4.1.4",
+        "symfony/security": "~3.4.36|~4.3.9|^4.4.1",
         "symfony/dependency-injection": "^3.4.3|^4.0.3",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/polyfill-php70": "~1.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #26379 
| License       | MIT
| Doc PR        | -

If you are using the `remember_me` listener and the refreshed user is deauthenticated, you are still logged in because the remember-me cookie does not get cleared. 
This fixes it.