### PR TITLE
Migrate server:log command away from WebServerBundle

### DIFF
--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * The `RouteProcessor` class has been made final
 * Added `ElasticsearchLogstashHandler`
+* Added the `ServerLogCommand`. Backport from the deprecated WebServerBundle
 
 4.3.0
 -----

--- a/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
+++ b/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\WebServerBundle\Command;
+namespace Symfony\Bridge\Monolog\Command;
 
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Logger;
@@ -25,8 +25,6 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
- *
- * @deprecated since Symfony 4.4, to be removed in 5.0; use ServerLogCommand from symfony/monolog-bridge instead
  */
 class ServerLogCommand extends Command
 {
@@ -80,8 +78,6 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        @trigger_error('Using the WebserverBundle is deprecated since Symfony 4.4. Use the DebugBundle combined with MonologBridge instead.', E_USER_DEPRECATED);
-
         $filter = $input->getOption('filter');
         if ($filter) {
             if (!class_exists(ExpressionLanguage::class)) {

--- a/src/Symfony/Bundle/DebugBundle/DebugBundle.php
+++ b/src/Symfony/Bundle/DebugBundle/DebugBundle.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\DebugBundle;
 
 use Symfony\Bundle\DebugBundle\DependencyInjection\Compiler\DumpDataCollectorPass;
+use Symfony\Bundle\DebugBundle\DependencyInjection\Compiler\RemoveWebServerBundleLoggerPass;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -52,6 +53,7 @@ class DebugBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new DumpDataCollectorPass());
+        $container->addCompilerPass(new RemoveWebServerBundleLoggerPass());
     }
 
     public function registerCommands(Application $application)

--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/Compiler/RemoveWebServerBundleLoggerPass.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/Compiler/RemoveWebServerBundleLoggerPass.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DebugBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class RemoveWebServerBundleLoggerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('web_server.command.server_log') && $container->hasDefinition('monolog.command.server_log')) {
+            $container->removeDefinition('web_server.command.server_log');
+        }
+    }
+}

--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\DebugBundle\DependencyInjection;
 
+use Symfony\Bridge\Monolog\Command\ServerLogCommand;
 use Symfony\Bundle\DebugBundle\Command\ServerDumpPlaceholderCommand;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -89,6 +90,10 @@ class DebugExtension extends Extension
                     'fileLinkFormat' => new Reference('debug.file_link_formatter', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE),
                 ]])
             ;
+        }
+
+        if (!class_exists(ServerLogCommand::class)) {
+            $container->removeDefinition('monolog.command.server_log');
         }
     }
 

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -107,5 +107,9 @@
             </argument>
             <tag name="console.command" command="server:dump" />
         </service>
+
+        <service id="monolog.command.server_log" class="Symfony\Bridge\Monolog\Command\ServerLogCommand">
+            <tag name="console.command" command="server:log" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #34657
| License       | MIT
| Doc PR        | NA

Duplicate ServerLogCommand in MonologBridge (currently in deprecated WebServerBundle) which does not have alternative in `symfony` bin.

Targeted 4.4 in order to provide a migration path to users.