### PR TITLE
Shutdown kernel for surrogates and handle as master request

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\HttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Abstract class implementing Surrogate capabilities to Request and Response instances.
@@ -93,7 +94,13 @@ abstract class AbstractSurrogate implements SurrogateInterface
         $subRequest = Request::create($uri, Request::METHOD_GET, [], $cache->getRequest()->cookies->all(), [], $cache->getRequest()->server->all());
 
         try {
-            $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
+            $kernel = $cache->getKernel();
+
+            if ($kernel instanceof KernelInterface) {
+                $kernel->shutdown();
+            }
+
+            $response = $cache->handle($subRequest, HttpKernelInterface::MASTER_REQUEST, true);
 
             if (!$response->isSuccessful()) {
                 throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $subRequest->getUri(), $response->getStatusCode()));

--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\HttpKernel\HttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Abstract class implementing Surrogate capabilities to Request and Response instances.
@@ -94,13 +93,7 @@ abstract class AbstractSurrogate implements SurrogateInterface
         $subRequest = Request::create($uri, Request::METHOD_GET, [], $cache->getRequest()->cookies->all(), [], $cache->getRequest()->server->all());
 
         try {
-            $kernel = $cache->getKernel();
-
-            if ($kernel instanceof KernelInterface) {
-                $kernel->shutdown();
-            }
-
-            $response = $cache->handle($subRequest, HttpKernelInterface::MASTER_REQUEST, true);
+            $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
 
             if (!$response->isSuccessful()) {
                 throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $subRequest->getUri(), $response->getStatusCode()));

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\HttpKernel\HttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
 
 /**
@@ -465,6 +466,12 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      */
     protected function forward(Request $request, $catch = false, Response $entry = null)
     {
+        // Shut down the kernel for every forwarded request so services etc. are fresh
+        $kernel = $this->getKernel();
+        if ($kernel instanceof KernelInterface) {
+            $kernel->shutdown();
+        }
+
         if ($this->surrogate) {
             $this->surrogate->addSurrogateCapability($request);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I feel like the current surrogate handling is incorrect.
The main issue here really is about surrogate requests. So let's think about a page structure that contains two ESI fragments like so:

```
/about-us
├── /_fragment?_controller=controller1......&_hash=supersecure1
└── /_fragment?_controller=controller2......&_hash=supersecure2
```

So let's see what `HttpCache` does:

1. Requests `/about-us` (real HTTP request, Symfony treats it as master request).
2. Requests `/_fragment?_controller=controller1`  (Internal surrogate request, Symfony treats it as sub request).
3. Requests `/_fragment?_controller=controller2`  (Internal surrogate request, Symfony treats it as sub request).

So we have only 1 PHP process that is started. Things might be shared across fragments.

Now let's think about what Varnish does:

1. Requests `/about-us` (real HTTP request, Symfony treats it as master request).
2. Requests `/_fragment?_controller=controller1`  (real HTTP request, Symfony treats it as master request).
3. Requests `/_fragment?_controller=controller2`  (real HTTP request, Symfony treats it as master request).

So we have 3 separate PHP processes, nothing can be shared!

Because of that, if we had no special handling for e.g. the request stack and also the session, the fragment requests would not be isolated. And especially for the session handling, this turns out to be pretty complicated. The `SessionListener` (or `AbstractSessionListener` to be specific) tries to keep track of every request and response, increasing and decreasing the stack etc.

However, apart from the fact that it is very complicated to understand, Symfony also behaves differently when running behind `HttpCache` or Varnish.
If we would reset the whole kernel for every surrogate request and actually execute them as master requests, it would behave the same as if Varnish requested the fragments (provided we reset and shutdown everything correctly).
This of course has effects on every listener that checks for `if (!$event->isMasterRequest())` such as firewall listeners etc.

But wouldn't it be actually correct? Because that's exactly what happens when Symfony runs behind Varnish. Wouldn't we want to try and behave exactly the same, no matter what kind of reverse proxy is put in front of the app?

This is just a draft PR and again, no idea about the implications but I would like to get some feedback on this 😊 