### PR TITLE
[PhpUnitBridge] Use regex configuration

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -145,7 +145,7 @@ class Configuration
     {
         parse_str($serializedConfiguration, $normalizedConfiguration);
         foreach (array_keys($normalizedConfiguration) as $key) {
-            if (!\in_array($key, ['max', 'disabled', 'verbose'], true)) {
+            if (!\in_array($key, ['max', 'disabled', 'verbose', 'regex'], true)) {
                 throw new \InvalidArgumentException(sprintf('Unknown configuration option "%s"', $key));
             }
         }
@@ -161,7 +161,7 @@ class Configuration
 
         return new self(
             isset($normalizedConfiguration['max']) ? $normalizedConfiguration['max'] : [],
-            '',
+            $normalizedConfiguration['regex'] ?? '',
             $verboseOutput
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

I just setup the bridge on a project and I tried https://symfony.com/doc/4.3/components/phpunit_bridge.html#configuration. Using the "regex" option is broken. Or the doc is wrong.