### PR TITLE
[Messenger] Add method HandlerFailedException::getNestedExceptionOfClass

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
@@ -49,4 +49,16 @@ class HandlerFailedException extends RuntimeException
     {
         return $this->exceptions;
     }
+
+    public function getNestedExceptionOfClass(string $exceptionClassName): array
+    {
+        return array_values(
+            array_filter(
+                $this->exceptions,
+                function ($exception) use ($exceptionClassName) {
+                    return is_a($exception, $exceptionClassName);
+                }
+            )
+        );
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Exception/HandlerFailedExceptionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Exception/HandlerFailedExceptionTest.php
@@ -5,6 +5,8 @@ namespace Symfony\Component\Messenger\Tests\Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Tests\Fixtures\MyOwnChildException;
+use Symfony\Component\Messenger\Tests\Fixtures\MyOwnException;
 
 class HandlerFailedExceptionTest extends TestCase
 {
@@ -27,5 +29,32 @@ class HandlerFailedExceptionTest extends TestCase
         $this->assertSame(0, $handlerException->getCode(), 'String code (HY000) converted to int must be 0');
         $this->assertIsString($originalException->getCode(), 'Original exception code still with original type (string)');
         $this->assertSame($exception->getCode(), $originalException->getCode(), 'Original exception code is not modified');
+    }
+
+    public function testThatNestedExceptionClassAreFound()
+    {
+        $envelope = new Envelope(new \stdClass());
+        $exception = new MyOwnException();
+
+        $handlerException = new HandlerFailedException($envelope, [new \LogicException(), $exception]);
+        $this->assertSame([$exception], $handlerException->getNestedExceptionOfClass(MyOwnException::class));
+    }
+
+    public function testThatNestedExceptionClassAreFoundWhenUsingChildException()
+    {
+        $envelope = new Envelope(new \stdClass());
+        $exception = new MyOwnChildException();
+
+        $handlerException = new HandlerFailedException($envelope, [$exception]);
+        $this->assertSame([$exception], $handlerException->getNestedExceptionOfClass(MyOwnException::class));
+    }
+
+    public function testThatNestedExceptionClassAreNotFoundIfNotPresent()
+    {
+        $envelope = new Envelope(new \stdClass());
+        $exception = new \LogicException();
+
+        $handlerException = new HandlerFailedException($envelope, [$exception]);
+        $this->assertCount(0, $handlerException->getNestedExceptionOfClass(MyOwnException::class));
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/MyOwnChildException.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/MyOwnChildException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class MyOwnChildException extends MyOwnException
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/MyOwnException.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/MyOwnException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class MyOwnException extends \Exception
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT
| Doc PR        | in progress

I have many times use this kind of code on my own development. It helps when dealing with specific exception through a Messenger usage. 

Example in an ExceptionListener, the exception you get could be a `HandlerFailedException` but you want a specific treatment when the original exception is different (like a RedirectResponse, or Http error code different).

edit: I finally also added a getNestedExceptionOfClass that could be useful too
