### PR TITLE
[Validator] Label regex in date validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
  */
 class DateValidator extends ConstraintValidator
 {
-    const PATTERN = '/^(\d{4})-(\d{2})-(\d{2})$/';
+    const PATTERN = '/^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/';
 
     /**
      * Checks whether a date is valid.
@@ -61,7 +61,11 @@ class DateValidator extends ConstraintValidator
             return;
         }
 
-        if (!self::checkDate($matches[1], $matches[2], $matches[3])) {
+        if (!self::checkDate(
+          $matches['year'] ?? $matches[1],
+          $matches['month'] ?? $matches[2],
+          $matches['day'] ?? $matches[3]
+        )) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Date::INVALID_DATE_ERROR)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | 

This change makes sure that when extending the DateValidator you can easily change the format withouth changing anything else. 
eg. you can change the pattern to 
`/^(?<day>\d{2})/(?<month>\d{2})/(?<year>\d{4})$/` but the implementation still checks your date correctly.
