### PR TITLE
[Console] Adds php version to console output

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -190,7 +190,7 @@ class Application implements ResetInterface
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         if (true === $input->hasParameterOption(['--version', '-V'], true)) {
-            $output->writeln($this->getLongVersion());
+            $output->writeln($this->getLongVersion().', '.$this->getPhpVersion());
 
             return 0;
         }
@@ -327,7 +327,7 @@ class Application implements ResetInterface
      */
     public function getHelp()
     {
-        return $this->getLongVersion();
+        return $this->getLongVersion().', '.$this->getPhpVersion();
     }
 
     /**
@@ -1183,5 +1183,10 @@ class Application implements ResetInterface
         foreach ($this->getDefaultCommands() as $command) {
             $this->add($command);
         }
+    }
+
+    private function getPhpVersion(): string
+    {
+        return sprintf('PHP <info>%s</info> (binary: %s)', PHP_VERSION, PHP_BINARY);
     }
 }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1187,6 +1187,6 @@ class Application implements ResetInterface
 
     private function getPhpVersion(): string
     {
-        return sprintf('PHP <info>%s</info> (binary: %s)', PHP_VERSION, PHP_BINARY);
+        return sprintf('PHP <info>%s.%s.%s</info>', PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34656 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | tbd. <!-- required for new features -->

This PR will add the current used PHP Version to the console output when running `php bin/console` and `php bin/console --version`.


