### PR TITLE
[Validation][FrameworkBundle] Allow EnableAutoMapping to work without auto-mapping namespaces

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -164,8 +164,8 @@ Lock
  * Deprecated `Symfony\Component\Lock\StoreInterface` in favor of `Symfony\Component\Lock\BlockingStoreInterface` and
    `Symfony\Component\Lock\PersistingStoreInterface`.
  * `Factory` is deprecated, use `LockFactory` instead
- * Deprecated services `lock.store.flock`, `lock.store.semaphore`, `lock.store.memcached.abstract` and `lock.store.redis.abstract`, 
-   use `StoreFactory::createStore` instead. 
+ * Deprecated services `lock.store.flock`, `lock.store.semaphore`, `lock.store.memcached.abstract` and `lock.store.redis.abstract`,
+   use `StoreFactory::createStore` instead.
 
 Mailer
 ------
@@ -360,6 +360,7 @@ TwigBundle
 Validator
 ---------
 
+ * [BC BREAK] Using null as `$classValidatorRegexp` value in `DoctrineLoader::__construct` or `PropertyInfoLoader::__construct` will not enable auto-mapping for all classes anymore, use `'{.*}'` instead.
  * Deprecated passing an `ExpressionLanguage` instance as the second argument of `ExpressionValidator::__construct()`.
  * Deprecated using anything else than a `string` as the code of a `ConstraintViolation`, a `string` type-hint will
    be added to the constructor of the `ConstraintViolation` class and to the `ConstraintViolationBuilder::setCode()`

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.4.0
 -----
 
+ * [BC BREAK] using null as `$classValidatorRegexp` value in `DoctrineLoader::__construct` will not enable auto-mapping for all classes anymore, use `'{.*}'` instead.
  * added `DoctrineClearEntityManagerWorkerSubscriber`
  * deprecated `RegistryInterface`, use `Doctrine\Persistence\ManagerRegistry`
  * added support for invokable event listeners

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -30,7 +30,6 @@ use Symfony\Component\Validator\Mapping\PropertyMetadata;
 use Symfony\Component\Validator\Mapping\TraversalStrategy;
 use Symfony\Component\Validator\Tests\Fixtures\Entity;
 use Symfony\Component\Validator\Validation;
-use Symfony\Component\Validator\ValidatorBuilder;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -152,10 +151,6 @@ class DoctrineLoaderTest extends TestCase
 
     public function testFieldMappingsConfiguration()
     {
-        if (!method_exists(ValidatorBuilder::class, 'addLoader')) {
-            $this->markTestSkipped('Auto-mapping requires symfony/validation 4.2+');
-        }
-
         $validator = Validation::createValidatorBuilder()
             ->addMethodMapping('loadValidatorMetadata')
             ->enableAnnotationMapping()
@@ -180,7 +175,7 @@ class DoctrineLoaderTest extends TestCase
      */
     public function testClassValidator(bool $expected, string $classValidatorRegexp = null)
     {
-        $doctrineLoader = new DoctrineLoader(DoctrineTestHelper::createTestEntityManager(), $classValidatorRegexp);
+        $doctrineLoader = new DoctrineLoader(DoctrineTestHelper::createTestEntityManager(), $classValidatorRegexp, false);
 
         $classMetadata = new ClassMetadata(DoctrineLoaderEntity::class);
         $this->assertSame($expected, $doctrineLoader->loadClassMetadata($classMetadata));
@@ -189,7 +184,8 @@ class DoctrineLoaderTest extends TestCase
     public function regexpProvider()
     {
         return [
-            [true, null],
+            [false, null],
+            [true, '{.*}'],
             [true, '{^'.preg_quote(DoctrineLoaderEntity::class).'$|^'.preg_quote(Entity::class).'$}'],
             [false, '{^'.preg_quote(Entity::class).'$}'],
         ];
@@ -197,13 +193,9 @@ class DoctrineLoaderTest extends TestCase
 
     public function testClassNoAutoMapping()
     {
-        if (!method_exists(ValidatorBuilder::class, 'addLoader')) {
-            $this->markTestSkipped('Auto-mapping requires symfony/validation 4.2+');
-        }
-
         $validator = Validation::createValidatorBuilder()
             ->enableAnnotationMapping()
-            ->addLoader(new DoctrineLoader(DoctrineTestHelper::createTestEntityManager()))
+            ->addLoader(new DoctrineLoader(DoctrineTestHelper::createTestEntityManager(), '{.*}'))
             ->getValidator();
 
         $classMetadata = $validator->getMetadataFor(new DoctrineLoaderNoAutoMappingEntity());

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -861,7 +861,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                         ->arrayNode('auto_mapping')
-                            ->info('A collection of namespaces for which auto-mapping will be enabled.')
+                            ->info('A collection of namespaces for which auto-mapping will be enabled by default, or null to opt-in with the EnableAutoMapping constraint.')
                             ->example([
                                 'App\\Entity\\' => [],
                                 'App\\WithSpecificLoaders\\' => ['validator.property_info_loader'],

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1312,7 +1312,7 @@ class FrameworkExtension extends Extension
         }
 
         $container->setParameter('validator.auto_mapping', $config['auto_mapping']);
-        if (!$propertyInfoEnabled || !$config['auto_mapping'] || !class_exists(PropertyInfoLoader::class)) {
+        if (!$propertyInfoEnabled || !class_exists(PropertyInfoLoader::class)) {
             $container->removeDefinition('validator.property_info_loader');
         }
 

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,19 +4,20 @@ CHANGELOG
 4.4.0
 -----
 
- * added `EnableAutoMapping` and `DisableAutoMapping` constraints to enable or disable auto mapping for class or a property 
+ * [BC BREAK] using null as `$classValidatorRegexp` value in `PropertyInfoLoader::__construct` will not enable auto-mapping for all classes anymore, use `'{.*}'` instead.
+ * added `EnableAutoMapping` and `DisableAutoMapping` constraints to enable or disable auto mapping for class or a property
  * using anything else than a `string` as the code of a `ConstraintViolation` is deprecated, a `string` type-hint will
    be added to the constructor of the `ConstraintViolation` class and to the `ConstraintViolationBuilder::setCode()`
    method in 5.0
  * deprecated passing an `ExpressionLanguage` instance as the second argument of `ExpressionValidator::__construct()`. Pass it as the first argument instead.
- * added the `compared_value_path` parameter in violations when using any 
+ * added the `compared_value_path` parameter in violations when using any
    comparison constraint with the `propertyPath` option.
  * added support for checking an array of types in `TypeValidator`
  * added a new `allowEmptyString` option to the `Length` constraint to allow rejecting empty strings when `min` is set, by setting it to `false`.
  * Added new `minPropertyPath` and `maxPropertyPath` options
    to `Range` constraint in order to get the value to compare
    from an array or object
- * added the `min_limit_path` and `max_limit_path` parameters in violations when using 
+ * added the `min_limit_path` and `max_limit_path` parameters in violations when using
    `Range` constraint with respectively the `minPropertyPath` and
    `maxPropertyPath` options
  * added a new `notInRangeMessage` option to the `Range` constraint that will

--- a/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
@@ -59,13 +59,8 @@ class AddAutoMappingConfigurationPass implements CompilerPassInterface
         $validatorBuilder = $container->getDefinition($this->validatorBuilderService);
         foreach ($container->findTaggedServiceIds($this->tag) as $id => $tags) {
             $regexp = $this->getRegexp(array_merge($globalNamespaces, $servicesToNamespaces[$id] ?? []));
-            if (null === $regexp) {
-                $container->removeDefinition($id);
-                continue;
-            }
-
-            $container->getDefinition($id)->setArgument('$classValidatorRegexp', $regexp);
             $validatorBuilder->addMethodCall('addLoader', [new Reference($id)]);
+            $container->getDefinition($id)->setArgument('$classValidatorRegexp', $regexp);
         }
 
         $container->getParameterBag()->remove('validator.auto_mapping');

--- a/src/Symfony/Component/Validator/Mapping/Loader/AutoMappingTrait.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AutoMappingTrait.php
@@ -29,6 +29,6 @@ trait AutoMappingTrait
         }
 
         // Fallback on the config
-        return null === $classValidatorRegexp || preg_match($classValidatorRegexp, $metadata->getClassName());
+        return null !== $classValidatorRegexp && preg_match($classValidatorRegexp, $metadata->getClassName());
     }
 }

--- a/src/Symfony/Component/Validator/Tests/DependencyInjection/AddAutoMappingConfigurationPassTest.php
+++ b/src/Symfony/Component/Validator/Tests/DependencyInjection/AddAutoMappingConfigurationPassTest.php
@@ -81,6 +81,6 @@ class AddAutoMappingConfigurationPassTest extends TestCase
 
         (new AddAutoMappingConfigurationPass())->process($container);
 
-        $this->assertFalse($container->hasDefinition('loader'));
+        $this->assertNull($container->getDefinition('loader')->getArguments()['$classValidatorRegexp'] ?? null);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -86,7 +86,7 @@ class PropertyInfoLoaderTest extends TestCase
             ))
         ;
 
-        $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub);
+        $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{.*}');
 
         $validator = Validation::createValidatorBuilder()
             ->enableAnnotationMapping()
@@ -197,7 +197,8 @@ class PropertyInfoLoaderTest extends TestCase
     public function regexpProvider()
     {
         return [
-            [true, null],
+            [false, null],
+            [true, '{.*}'],
             [true, '{^'.preg_quote(PropertyInfoLoaderEntity::class).'$|^'.preg_quote(Entity::class).'$}'],
             [false, '{^'.preg_quote(Entity::class).'$}'],
         ];
@@ -217,7 +218,7 @@ class PropertyInfoLoaderTest extends TestCase
                 [new Type(Type::BUILTIN_TYPE_BOOL)]
             );
 
-        $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub);
+        $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{.*}');
         $validator = Validation::createValidatorBuilder()
             ->enableAnnotationMapping()
             ->addLoader($propertyInfoLoader)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes?
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | N/A

Currently, when no `framework.validation.auto_mapping` namespaces are configured, the `EnableAutoMapping` annotation has no effect on its own, because the loaders were removed by the fwb extension and the compiler pass.
Simply adding a namespace (even a foolish one) will make it work:

```yml
    validation:
        auto_mapping:
            '*': ~ # this does not really map anything, but allows `EnableAutoMapping` to work as loaders won't be removed.
```

So for those only wanting to use the auto-mapping feature by explicitly setting the `EnableAutoMapping` annotation, it'll be counter-intuitive, as it cannot work without declaring at least one namespace.