### PR TITLE
Fix the translation commands when a template contains a syntax error

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -16,7 +16,6 @@ use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Translation\TwigExtractor;
 use Symfony\Component\Translation\MessageCatalogue;
 use Twig\Environment;
-use Twig\Error\Error;
 use Twig\Loader\ArrayLoader;
 
 class TwigExtractorTest extends TestCase
@@ -78,23 +77,15 @@ class TwigExtractorTest extends TestCase
     /**
      * @dataProvider resourcesWithSyntaxErrorsProvider
      */
-    public function testExtractSyntaxError($resources)
+    public function testExtractSyntaxError($resources, array $messages)
     {
-        $this->expectException('Twig\Error\Error');
         $twig = new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock());
         $twig->addExtension(new TranslationExtension($this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock()));
 
         $extractor = new TwigExtractor($twig);
-
-        try {
-            $extractor->extract($resources, new MessageCatalogue('en'));
-        } catch (Error $e) {
-            $this->assertSame(\dirname(__DIR__).strtr('/Fixtures/extractor/syntax_error.twig', '/', \DIRECTORY_SEPARATOR), $e->getFile());
-            $this->assertSame(1, $e->getLine());
-            $this->assertSame('Unclosed "block".', $e->getMessage());
-
-            throw $e;
-        }
+        $catalogue = new MessageCatalogue('en');
+        $extractor->extract($resources, $catalogue);
+        $this->assertSame($messages, $catalogue->all());
     }
 
     /**
@@ -103,9 +94,9 @@ class TwigExtractorTest extends TestCase
     public function resourcesWithSyntaxErrorsProvider()
     {
         return [
-            [__DIR__.'/../Fixtures'],
-            [__DIR__.'/../Fixtures/extractor/syntax_error.twig'],
-            [new \SplFileInfo(__DIR__.'/../Fixtures/extractor/syntax_error.twig')],
+            [__DIR__.'/../Fixtures', ['messages' => ['Hi!' => 'Hi!']]],
+            [__DIR__.'/../Fixtures/extractor/syntax_error.twig', []],
+            [new \SplFileInfo(__DIR__.'/../Fixtures/extractor/syntax_error.twig'), []],
         ];
     }
 

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Twig\Translation;
 
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Translation\Extractor\AbstractFileExtractor;
 use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -58,13 +57,7 @@ class TwigExtractor extends AbstractFileExtractor implements ExtractorInterface
             try {
                 $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
             } catch (Error $e) {
-                if ($file instanceof \SplFileInfo) {
-                    $path = $file->getRealPath() ?: $file->getPathname();
-                    $name = $file instanceof SplFileInfo ? $file->getRelativePathname() : $path;
-                    $e->setSourceContext(new Source('', $name, $path));
-                }
-
-                throw $e;
+                // ignore errors, these should be fixed by using the linter
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34586
| License       | MIT
| Doc PR        | n/a

When using `debug:translation` or `translation:update`, we should catch exceptions to avoid breaking the command. It was not really an issue before Symfony 4.4/5 as we didn't have templates in the core that use features from optional dependencies.
