### PR TITLE
[HttpClient] remove conflict rule with HttpKernel that prevents using the component in Symfony 3.4

### DIFF
--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -36,9 +36,6 @@
         "symfony/http-kernel": "^4.4",
         "symfony/process": "^4.2|^5.0"
     },
-    "conflict": {
-        "symfony/http-kernel": "<4.4"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpClient\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34698
| License       | MIT
| Doc PR        | -

Fix #34698