### PR TITLE
[DependencyInjection][Xml] Fix the attribute 'tag' is not allowed in 'bind' tag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -222,6 +222,7 @@
     <xsd:attribute name="key" type="xsd:string" use="required" />
     <xsd:attribute name="on-invalid" type="invalid_sequence" />
     <xsd:attribute name="method" type="xsd:string" />
+    <xsd:attribute name="tag" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="argument" mixed="true">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Bar.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Bar.php
@@ -15,7 +15,7 @@ class Bar implements BarInterface
 {
     public $quz;
 
-    public function __construct($quz = null, \NonExistent $nonExistent = null, BarInterface $decorated = null, array $foo = [])
+    public function __construct($quz = null, \NonExistent $nonExistent = null, BarInterface $decorated = null, array $foo = [], iterable $baz = [])
     {
         $this->quz = $quz;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_bindings.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_bindings.xml
@@ -12,6 +12,7 @@
             <bind key="$foo" type="collection">
                 <bind>null</bind>
             </bind>
+            <bind key="iterable $baz" type="tagged_iterator" tag="bar"/>
         </service>
 
         <service id="Symfony\Component\DependencyInjection\Tests\Fixtures\Bar">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_bindings.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_bindings.yml
@@ -12,6 +12,7 @@ services:
         bind:
             Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface: '@Symfony\Component\DependencyInjection\Tests\Fixtures\Bar'
             $foo: [ ~ ]
+            iterable $baz: !tagged_iterator bar
 
     Symfony\Component\DependencyInjection\Tests\Fixtures\Bar:
         factory: [ ~, 'create' ]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -879,12 +879,14 @@ class XmlFileLoaderTest extends TestCase
             '$foo' => [null],
             '$quz' => 'quz',
             '$factory' => 'factory',
+            'iterable $baz' => new TaggedIteratorArgument('bar'),
         ], array_map(function (BoundArgument $v) { return $v->getValues()[0]; }, $definition->getBindings()));
         $this->assertEquals([
             'quz',
             null,
             new Reference(Bar::class),
             [null],
+            new TaggedIteratorArgument('bar'),
         ], $definition->getArguments());
 
         $definition = $container->getDefinition(Bar::class);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -801,12 +801,14 @@ class YamlFileLoaderTest extends TestCase
             '$foo' => [null],
             '$quz' => 'quz',
             '$factory' => 'factory',
+            'iterable $baz' => new TaggedIteratorArgument('bar'),
         ], array_map(function (BoundArgument $v) { return $v->getValues()[0]; }, $definition->getBindings()));
         $this->assertEquals([
             'quz',
             null,
             new Reference(Bar::class),
             [null],
+            new TaggedIteratorArgument('bar'),
         ], $definition->getArguments());
 
         $definition = $container->getDefinition(Bar::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs/pull/12741 <!-- required for new features -->

Add test case for https://symfony.com/blog/new-in-symfony-4-4-dependency-injection-improvements-part-1#allow-binding-tagged-services and fix a bug with attribute 'tag' is not allowed
