### PR TITLE
Add .gitattributes to .gitattributes

### DIFF
--- a/src/Symfony/Bridge/Doctrine/.gitattributes
+++ b/src/Symfony/Bridge/Doctrine/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Bridge/Monolog/.gitattributes
+++ b/src/Symfony/Bridge/Monolog/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Bridge/ProxyManager/.gitattributes
+++ b/src/Symfony/Bridge/ProxyManager/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Bridge/Twig/.gitattributes
+++ b/src/Symfony/Bridge/Twig/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Bundle/DebugBundle/.gitattributes
+++ b/src/Symfony/Bundle/DebugBundle/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Bundle/FrameworkBundle/.gitattributes
+++ b/src/Symfony/Bundle/FrameworkBundle/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Bundle/SecurityBundle/.gitattributes
+++ b/src/Symfony/Bundle/SecurityBundle/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Bundle/TwigBundle/.gitattributes
+++ b/src/Symfony/Bundle/TwigBundle/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
+++ b/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Asset/.gitattributes
+++ b/src/Symfony/Component/Asset/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/BrowserKit/.gitattributes
+++ b/src/Symfony/Component/BrowserKit/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Cache/.gitattributes
+++ b/src/Symfony/Component/Cache/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Config/.gitattributes
+++ b/src/Symfony/Component/Config/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Console/.gitattributes
+++ b/src/Symfony/Component/Console/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/CssSelector/.gitattributes
+++ b/src/Symfony/Component/CssSelector/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/DependencyInjection/.gitattributes
+++ b/src/Symfony/Component/DependencyInjection/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/DomCrawler/.gitattributes
+++ b/src/Symfony/Component/DomCrawler/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Dotenv/.gitattributes
+++ b/src/Symfony/Component/Dotenv/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/ErrorHandler/.gitattributes
+++ b/src/Symfony/Component/ErrorHandler/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/EventDispatcher/.gitattributes
+++ b/src/Symfony/Component/EventDispatcher/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/ExpressionLanguage/.gitattributes
+++ b/src/Symfony/Component/ExpressionLanguage/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Filesystem/.gitattributes
+++ b/src/Symfony/Component/Filesystem/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Finder/.gitattributes
+++ b/src/Symfony/Component/Finder/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Form/.gitattributes
+++ b/src/Symfony/Component/Form/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/HttpClient/.gitattributes
+++ b/src/Symfony/Component/HttpClient/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/HttpFoundation/.gitattributes
+++ b/src/Symfony/Component/HttpFoundation/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/HttpKernel/.gitattributes
+++ b/src/Symfony/Component/HttpKernel/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Inflector/.gitattributes
+++ b/src/Symfony/Component/Inflector/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Intl/.gitattributes
+++ b/src/Symfony/Component/Intl/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Ldap/.gitattributes
+++ b/src/Symfony/Component/Ldap/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Lock/.gitattributes
+++ b/src/Symfony/Component/Lock/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Mailer/.gitattributes
+++ b/src/Symfony/Component/Mailer/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Google/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Google/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Messenger/.gitattributes
+++ b/src/Symfony/Component/Messenger/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Mime/.gitattributes
+++ b/src/Symfony/Component/Mime/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Notifier/.gitattributes
+++ b/src/Symfony/Component/Notifier/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Slack/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/OptionsResolver/.gitattributes
+++ b/src/Symfony/Component/OptionsResolver/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Process/.gitattributes
+++ b/src/Symfony/Component/Process/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/PropertyAccess/.gitattributes
+++ b/src/Symfony/Component/PropertyAccess/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/PropertyInfo/.gitattributes
+++ b/src/Symfony/Component/PropertyInfo/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Routing/.gitattributes
+++ b/src/Symfony/Component/Routing/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Security/Core/.gitattributes
+++ b/src/Symfony/Component/Security/Core/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Security/Csrf/.gitattributes
+++ b/src/Symfony/Component/Security/Csrf/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Security/Guard/.gitattributes
+++ b/src/Symfony/Component/Security/Guard/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Security/Http/.gitattributes
+++ b/src/Symfony/Component/Security/Http/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Serializer/.gitattributes
+++ b/src/Symfony/Component/Serializer/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Stopwatch/.gitattributes
+++ b/src/Symfony/Component/Stopwatch/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/String/.gitattributes
+++ b/src/Symfony/Component/String/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Templating/.gitattributes
+++ b/src/Symfony/Component/Templating/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Translation/.gitattributes
+++ b/src/Symfony/Component/Translation/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Validator/.gitattributes
+++ b/src/Symfony/Component/Validator/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/VarDumper/.gitattributes
+++ b/src/Symfony/Component/VarDumper/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/VarExporter/.gitattributes
+++ b/src/Symfony/Component/VarExporter/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/WebLink/.gitattributes
+++ b/src/Symfony/Component/WebLink/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Workflow/.gitattributes
+++ b/src/Symfony/Component/Workflow/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore

--- a/src/Symfony/Component/Yaml/.gitattributes
+++ b/src/Symfony/Component/Yaml/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

While .gitattributes is great and removes extra files, unless we also exclude it, we add a new file to many clones which is just as annoying :)