### PR TITLE
[Messenger] Add AMQP exchange binding to another exchange

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 5.0.0
 -----
+
  * Added support for exchange binding to another exchange in AMQP transport
  * The `LoggingMiddleware` class has been removed, pass a logger to `SendMessageMiddleware` instead.
  * made `SendersLocator` require a `ContainerInterface` as 2nd argument

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 5.0.0
 -----
-
+ * Added support for exchange binding to another exchange in AMQP transport
  * The `LoggingMiddleware` class has been removed, pass a logger to `SendMessageMiddleware` instead.
  * made `SendersLocator` require a `ContainerInterface` as 2nd argument
 

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -94,6 +94,9 @@ class Connection
      *     * type: Type of exchange (Default: fanout)
      *     * default_publish_routing_key: Routing key to use when publishing, if none is specified on the message
      *     * flags: Exchange flags (Default: AMQP_DURABLE)
+     *     * bindings[name]: An array of exchanges to bind, keyed by the name
+     *       * binding_keys: The binding keys (if any) to bind to this exchange
+     *       * binding_arguments: Arguments to be used while binding the exchange
      *     * arguments: Extra arguments
      *   * delay:
      *     * queue_name_pattern: Pattern to use to create the queues (Default: "delay_%exchange_name%_%routing_key%_%delay%")
@@ -422,6 +425,16 @@ class Connection
             $this->amqpExchange->setName($this->exchangeOptions['name']);
             $this->amqpExchange->setType($this->exchangeOptions['type'] ?? AMQP_EX_TYPE_FANOUT);
             $this->amqpExchange->setFlags($this->exchangeOptions['flags'] ?? AMQP_DURABLE);
+
+            foreach ($this->exchangeOptions['bindings'] ?? [null] as $bindingExchangeName => $bindingExchangeOption) {
+                $this->amqpExchange->declareExchange();
+
+                $bindingArguments = $bindingExchangeOption['binding_arguments'] ?? [];
+
+                foreach ($bindingExchangeOption['binding_keys'] ?? [''] as $bindingKey) {
+                    $this->amqpExchange->bind($bindingExchangeName, $bindingKey, $bindingArguments);
+                }
+            }
 
             if (isset($this->exchangeOptions['arguments'])) {
                 $this->amqpExchange->setArguments($this->exchangeOptions['arguments']);

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -426,7 +426,7 @@ class Connection
             $this->amqpExchange->setType($this->exchangeOptions['type'] ?? AMQP_EX_TYPE_FANOUT);
             $this->amqpExchange->setFlags($this->exchangeOptions['flags'] ?? AMQP_DURABLE);
 
-            foreach ($this->exchangeOptions['bindings'] ?? [null] as $bindingExchangeName => $bindingExchangeOption) {
+            foreach ($this->exchangeOptions['bindings'] ?? [] as $bindingExchangeName => $bindingExchangeOption) {
                 $this->amqpExchange->declareExchange();
 
                 $bindingArguments = $bindingExchangeOption['binding_arguments'] ?? [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master  <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->


This PR is adding possiblity to bind exchange to another exchange via transport configuration.

Example:
```
transports:
  first:
    dsn: 'amqp://'
    options:
      exchange:
        name: first_exchange
        type: topic
  second:
    dsn: 'amqp://'
    options:
      queues:
        second:
          binding_keys:
            - 'key.*'
      exchange:
        name: second_exchange
        type: topic
        bindings:
          first_exchange:
            binding_keys: #optional
              - '*'
            binding_arguments: [] #optional
```

In this example, we binding `second_exchange` to `first_exchange` with optional `binding_keys` and `binding_arguments`.

If message will be published on `first_exchange`, `second_exchange` will also have that message, and could be consumed by `second` transport worker.
