### PR TITLE
[Notifier] Added possibility to extract path from provided DSN

### DIFF
--- a/src/Symfony/Component/Notifier/Transport/Dsn.php
+++ b/src/Symfony/Component/Notifier/Transport/Dsn.php
@@ -26,8 +26,9 @@ final class Dsn
     private $password;
     private $port;
     private $options;
+    private $path;
 
-    public function __construct(string $scheme, string $host, ?string $user = null, ?string $password = null, ?int $port = null, array $options = [])
+    public function __construct(string $scheme, string $host, ?string $user = null, ?string $password = null, ?int $port = null, array $options = [], ?string $path = null)
     {
         $this->scheme = $scheme;
         $this->host = $host;
@@ -35,6 +36,7 @@ final class Dsn
         $this->password = $password;
         $this->port = $port;
         $this->options = $options;
+        $this->path = $path;
     }
 
     public static function fromString(string $dsn): self
@@ -54,9 +56,10 @@ final class Dsn
         $user = isset($parsedDsn['user']) ? urldecode($parsedDsn['user']) : null;
         $password = isset($parsedDsn['pass']) ? urldecode($parsedDsn['pass']) : null;
         $port = $parsedDsn['port'] ?? null;
+        $path = $parsedDsn['path'] ?? null;
         parse_str($parsedDsn['query'] ?? '', $query);
 
-        return new self($parsedDsn['scheme'], $parsedDsn['host'], $user, $password, $port, $query);
+        return new self($parsedDsn['scheme'], $parsedDsn['host'], $user, $password, $port, $query, $path);
     }
 
     public function getScheme(): string
@@ -87,5 +90,10 @@ final class Dsn
     public function getOption(string $key, $default = null)
     {
         return $this->options[$key] ?? $default;
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->path;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34746
| License       | MIT

I'm currently working on Microsoft Teams Webhook Notifier (https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#setting-up-a-custom-incoming-webhook), and there is no way to provide DSN for it, because of missing parse_url()['path'] option

It looks like 
`teams://outlook.office.com/webhook/{uuid}@{uuid}/IncomingWebhook/{id}/{uuid}`
and I'd like to be able to build Notifier Transport endpoint from it

