### PR TITLE
[String] Example from the documentation is not working (bug report + failing test)

### DIFF
--- a/src/Symfony/Component/String/Tests/SluggerTest.php
+++ b/src/Symfony/Component/String/Tests/SluggerTest.php
@@ -20,7 +20,7 @@ class SluggerTest extends TestCase
      * @requires extension intl
      * @dataProvider provideSlug
      */
-    public function testSlug(string $string, string $locale, string $expectedSlug)
+    public function testSlug(string $string, ?string $locale, string $expectedSlug)
     {
         $slugger = new AsciiSlugger($locale);
 
@@ -36,6 +36,7 @@ class SluggerTest extends TestCase
             ['Αυτή η τιμή πρέπει να είναι ψευδής', 'el', 'Avti-i-timi-prepi-na-inai-psevdhis'],
             ['该变量的值应为', 'zh', 'gai-bian-liang-de-zhi-ying-wei'],
             ['該變數的值應為', 'zh_TW', 'gai-bian-shu-de-zhi-ying-wei'],
+            ['Wôrķšƥáçè ~~sèťtïñğš~~', null, 'Workspace-settings'],
         ];
     }
 


### PR DESCRIPTION
**Symfony version(s) affected**: 5.0.*

**Description**  
The code example for `AsciiSlugger` is not working as shown in the [documentation](https://symfony.com/doc/current/components/string.html#slugger).

The article shows:

```php
use Symfony\Component\String\Slugger\AsciiSlugger;

$slugger = new AsciiSlugger();
$slug = $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~');
// $slug = 'Workspace-settings'
```

but the actual result is (note the missing "p"):
```
Works-ace-settings
```

Or another possibility is that this is locale dependent, but I have also tried specifying some locales (like `cs`, `de`, `fr`, `el`) but everything with the same result. 

**How to reproduce**  

Either by running the code above or by running the test in the attached PR.
