### PR TITLE
Allow copy instead of symlink for ./link script

### DIFF
--- a/link
+++ b/link
@@ -23,11 +23,14 @@ use Symfony\Component\Filesystem\Filesystem;
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 
+$copy = false !== $k = array_search('--copy', $argv, true);
+$copy && array_splice($argv, $k, 1);
 $pathToProject = $argv[1] ?? getcwd();
 
 if (!is_dir("$pathToProject/vendor/symfony")) {
-    echo 'Link dependencies to components to a local clone of the main symfony/symfony GitHub repository.'.PHP_EOL.PHP_EOL;
-    echo "Usage: $argv[0] /path/to/the/project".PHP_EOL.PHP_EOL;
+    echo 'Link (or copy) dependencies to components to a local clone of the main symfony/symfony GitHub repository.'.PHP_EOL.PHP_EOL;
+    echo "Usage: $argv[0] /path/to/the/project".PHP_EOL;
+    echo '       Use `--copy` to copy dependencies instead of symlink'.PHP_EOL.PHP_EOL;
     echo "The directory \"$pathToProject\" does not exist or the dependencies are not installed, did you forget to run \"composer install\" in your project?".PHP_EOL;
     exit(1);
 }
@@ -48,7 +51,7 @@ foreach ($directories as $dir) {
 
 foreach (glob("$pathToProject/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
     $package = 'symfony/'.basename($dir);
-    if (is_link($dir)) {
+    if (!$copy && is_link($dir)) {
         echo "\"$package\" is already a symlink, skipping.".PHP_EOL;
         continue;
     }
@@ -57,11 +60,17 @@ foreach (glob("$pathToProject/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as 
         continue;
     }
 
-    $sfDir = '\\' === DIRECTORY_SEPARATOR ? $sfPackages[$package] : $filesystem->makePathRelative($sfPackages[$package], dirname(realpath($dir)));
+    $sfDir = ('\\' === DIRECTORY_SEPARATOR || $copy) ? $sfPackages[$package] : $filesystem->makePathRelative($sfPackages[$package], dirname(realpath($dir)));
 
     $filesystem->remove($dir);
-    $filesystem->symlink($sfDir, $dir);
-    echo "\"$package\" has been linked to \"$sfPackages[$package]\".".PHP_EOL;
+
+    if ($copy) {
+        $filesystem->mirror($sfDir, $dir);
+        echo "\"$package\" has been copied from \"$sfPackages[$package]\".".PHP_EOL;
+    } else {
+        $filesystem->symlink($sfDir, $dir);
+        echo "\"$package\" has been linked to \"$sfPackages[$package]\".".PHP_EOL;
+    }
 }
 
 foreach (glob("$pathToProject/var/cache/*", GLOB_NOSORT) as $cacheDir) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | N/A

Not the most efficient way to work, but sometimes it helps to test a bug fix/feature within an existing project for which symlinks can't be resolved due to the dev environment (e.g: a Vagrant where only the current project directory is mounted). 
