### PR TITLE
[SecurityBundle] Fix switch_user provider configuration handling

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -681,7 +681,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         return $exceptionListenerId;
     }
 
-    private function createSwitchUserListener(ContainerBuilder $container, string $id, array $config, string $defaultProvider, bool $stateless): string
+    private function createSwitchUserListener(ContainerBuilder $container, string $id, array $config, ?string $defaultProvider, bool $stateless): string
     {
         $userProvider = isset($config['provider']) ? $this->getUserProviderId($config['provider']) : $defaultProvider;
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -390,6 +390,30 @@ class SecurityExtensionTest extends TestCase
         ];
     }
 
+    public function testSwitchUserWithSeveralDefinedProvidersButNoFirewallRootProviderConfigured()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'first' => ['id' => 'foo'],
+                'second' => ['id' => 'bar'],
+            ],
+
+            'firewalls' => [
+                'foobar' => [
+                    'switch_user' => [
+                        'provider' => 'second',
+                    ],
+                    'anonymous' => true,
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertEquals(new Reference('security.user.provider.concrete.second'), $container->getDefinition('security.authentication.switchuser_listener.foobar')->getArgument(1));
+    }
+
     protected function getRawContainer()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The default provider here can be null if there are multiple configured providers configured + the firewall doesn't define its provider at the root level + it is anonymous, ie: 
```yaml
providers:
    my_provider:
        # ...
    monitor_provider:
        # ...
firewalls:
    main:
        switch_user:
            provider: my_provider
        anonymous: true
        # ...
```