### PR TITLE
[Mailer] Fix SMTP Authentication when using STARTTLS

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -115,6 +115,7 @@ class EsmtpTransport extends SmtpTransport
 
             try {
                 $response = $this->executeCommand(sprintf("EHLO %s\r\n", $this->getLocalDomain()), [250]);
+                $capabilities = $this->getCapabilities($response);
             } catch (TransportExceptionInterface $e) {
                 parent::doHeloCommand();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34522
| License       | MIT

When the mail server uses STARTTLS, the SMTP Authentication is not performed because the AUTH capabilities are not send during the first EHLO call, but during the second one.

Example of problematic exchange solved by this PR:
```
      < 220 mydomain.tld ESMTP Postcow
      > EHLO [127.0.0.1]
      < 250-mydomain.tld
      < 250-PIPELINING
      < 250-SIZE 104857600
      < 250-ETRN
      < 250-STARTTLS
      < 250-ENHANCEDSTATUSCODES
      < 250-8BITMIME
      < 250-DSN
      < 250 CHUNKING
      > STARTTLS
      < 220 2.0.0 Ready to start TLS
      > EHLO [127.0.0.1]
      < 250-mydomain.tld
      < 250-PIPELINING
      < 250-SIZE 104857600
      < 250-ETRN
      < 250-AUTH PLAIN LOGIN
      < 250-AUTH=PLAIN LOGIN
      < 250-ENHANCEDSTATUSCODES
      < 250-8BITMIME
      < 250-DSN
      < 250 CHUNKING
      > MAIL FROM:<noreply@XXX>
      < 250 2.1.0 Ok
      > RCPT TO:<XXX>
      < 554 5.7.1 <XXX>: Client host rejected: Access denied
```