### PR TITLE
[Security/Core] Fix checking for SHA256/SHA512 passwords

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -80,9 +80,9 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
             return false;
         }
 
-        if (0 === strpos($encoded, '$2')) {
+        if (0 !== strpos($encoded, '$argon')) {
             // BCrypt encodes only the first 72 chars
-            return 72 >= \strlen($raw) && password_verify($raw, $encoded);
+            return (72 >= \strlen($raw) || 0 !== strpos($encoded, '$2')) && password_verify($raw, $encoded);
         }
 
         if (\extension_loaded('sodium') && version_compare(\SODIUM_LIBRARY_VERSION, '1.0.14', '>=')) {

--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -80,9 +80,9 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
             return false;
         }
 
-        if (72 >= \strlen($raw) && 0 === strpos($encoded, '$2')) {
-            // Accept validating BCrypt passwords for seamless migrations
-            return password_verify($raw, $encoded);
+        if (0 !== strpos($encoded, '$argon')) {
+            // Accept validating non-argon passwords for seamless migrations
+            return (72 >= \strlen($raw) || 0 !== strpos($encoded, '$2')) && password_verify($raw, $encoded);
         }
 
         if (\function_exists('sodium_crypto_pwhash_str_verify')) {

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/NativePasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/NativePasswordEncoderTest.php
@@ -55,6 +55,15 @@ class NativePasswordEncoderTest extends TestCase
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));
     }
 
+    public function testNonArgonValidation()
+    {
+        $encoder = new NativePasswordEncoder();
+        $this->assertTrue($encoder->isPasswordValid('$5$abcdefgh$ZLdkj8mkc2XVSrPVjskDAgZPGjtj1VGVaa1aUkrMTU/', 'password', null));
+        $this->assertFalse($encoder->isPasswordValid('$5$abcdefgh$ZLdkj8mkc2XVSrPVjskDAgZPGjtj1VGVaa1aUkrMTU/', 'anotherPassword', null));
+        $this->assertTrue($encoder->isPasswordValid('$6$abcdefgh$yVfUwsw5T.JApa8POvClA1pQ5peiq97DUNyXCZN5IrF.BMSkiaLQ5kvpuEm/VQ1Tvh/KV2TcaWh8qinoW5dhA1', 'password', null));
+        $this->assertFalse($encoder->isPasswordValid('$6$abcdefgh$yVfUwsw5T.JApa8POvClA1pQ5peiq97DUNyXCZN5IrF.BMSkiaLQ5kvpuEm/VQ1Tvh/KV2TcaWh8qinoW5dhA1', 'anotherPassword', null));
+    }
+
     public function testConfiguredAlgorithm()
     {
         $encoder = new NativePasswordEncoder(null, null, null, PASSWORD_BCRYPT);

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
@@ -37,6 +37,15 @@ class SodiumPasswordEncoderTest extends TestCase
         $this->assertTrue($encoder->isPasswordValid('$2y$04$M8GDODMoGQLQRpkYCdoJh.lbiZPee3SZI32RcYK49XYTolDGwoRMm', 'abc', null));
     }
 
+    public function testNonArgonValidation()
+    {
+        $encoder = new SodiumPasswordEncoder();
+        $this->assertTrue($encoder->isPasswordValid('$5$abcdefgh$ZLdkj8mkc2XVSrPVjskDAgZPGjtj1VGVaa1aUkrMTU/', 'password', null));
+        $this->assertFalse($encoder->isPasswordValid('$5$abcdefgh$ZLdkj8mkc2XVSrPVjskDAgZPGjtj1VGVaa1aUkrMTU/', 'anotherPassword', null));
+        $this->assertTrue($encoder->isPasswordValid('$6$abcdefgh$yVfUwsw5T.JApa8POvClA1pQ5peiq97DUNyXCZN5IrF.BMSkiaLQ5kvpuEm/VQ1Tvh/KV2TcaWh8qinoW5dhA1', 'password', null));
+        $this->assertFalse($encoder->isPasswordValid('$6$abcdefgh$yVfUwsw5T.JApa8POvClA1pQ5peiq97DUNyXCZN5IrF.BMSkiaLQ5kvpuEm/VQ1Tvh/KV2TcaWh8qinoW5dhA1', 'anotherPassword', null));
+    }
+
     public function testEncodePasswordLength()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\BadCredentialsException');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
The code to validate bcrypt passwords (#31763) needs to include SHA256 and SHA512-hashed passwords.  These are used on RedHat (and derived) systems.

Since SHA256/512 don't appear to have a limit of 72 characters, I simply created a new if() block.
-->
