### PR TITLE
[Mailer] Send email tag to Postmark API

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -64,7 +64,7 @@ class PostmarkApiTransportTest extends TestCase
         $response
             ->expects($this->once())
             ->method('toArray')
-            ->willReturn(["ErrorCode" => 0, "Message" => "OK", "MessageID" => "123", "To" => "bar@example.com"]);
+            ->willReturn(['ErrorCode' => 0, 'Message' => 'OK', 'MessageID' => '123', 'To' => 'bar@example.com']);
 
         $httpClient = $this->createMock(HttpClientInterface::class);
 

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Mailer\Bridge\Postmark\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkApiTransport;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class PostmarkApiTransportTest extends TestCase
 {
@@ -40,5 +43,57 @@ class PostmarkApiTransportTest extends TestCase
                 'postmark+api://example.com:99',
             ],
         ];
+    }
+
+    public function testSend()
+    {
+        $email = new Email();
+        $email->from('foo@example.com')
+            ->to('bar@example.com')
+            ->bcc('baz@example.com')
+            ->subject('testing email')
+            ->text('content');
+        $email->getHeaders()->addTextHeader('Tag', 'example-tag');
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+        $response
+            ->expects($this->once())
+            ->method('toArray')
+            ->willReturn(["ErrorCode" => 0, "Message" => "OK", "MessageID" => "123", "To" => "bar@example.com"]);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://api.postmarkapp.com/email', [
+                'json' => [
+                    'From' => 'foo@example.com',
+                    'To' => 'bar@example.com',
+                    'Cc' => '',
+                    'Bcc' => 'baz@example.com',
+                    'ReplyTo' => '',
+                    'Subject' => 'testing email',
+                    'TextBody' => 'content',
+                    'HtmlBody' => null,
+                    'Attachments' => [],
+                    'Tag' => 'example-tag',
+                ],
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'X-Postmark-Server-Token' => 'foo',
+                ],
+            ])
+            ->willReturn($response);
+
+        $mailer = new PostmarkApiTransport('foo', $httpClient);
+        $sentMessage = $mailer->send($email);
+
+        $this->assertSame('123', $sentMessage->getMessageId());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -74,9 +74,10 @@ class PostmarkApiTransport extends AbstractApiTransport
             'TextBody' => $email->getTextBody(),
             'HtmlBody' => $email->getHtmlBody(),
             'Attachments' => $this->getAttachments($email),
+            'Tag' => $email->getHeaders()->getHeaderBody('Tag'),
         ];
 
-        $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender', 'reply-to'];
+        $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender', 'reply-to', 'tag'];
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT

Postmark has some helpful functionality to tag emails, to make is easier to sort or filter in their UI.
<img width="943" alt="Screenshot 2019-11-30 at 17 17 50" src="https://user-images.githubusercontent.com/263021/69992202-76506e80-1549-11ea-8e5d-1c0ce1748fc8.png">

At the moment, tags can't be added when using the API transport. If adding a header "Tag: email-tag" to current email, the JSON payload is generated with that tag in "Headers" line and doesn't work.

This PR would allow the "Tag" header to be added at the root of JSON payload, ensuring valid payload for Postmark API https://postmarkapp.com/developer/api/email-api making this work properly:
```php
// creates $email
$email->getHeaders()->addTextHeader('Tag', 'account-emails');
```

Cheers
