### PR TITLE
Deprecate *Response::create() methods

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -7,6 +7,13 @@ FrameworkBundle
  * Marked `MicroKernelTrait::configureRoutes()` as `@internal` and `@final`.
  * Deprecated not overriding `MicroKernelTrait::configureRouting()`.
 
+HttpFoundation
+--------------
+
+ * Deprecate `Response::create()`, `JsonResponse::create()`,
+   `RedirectResponse::create()`, and `StreamedResponse::create()` methods (use
+   `__construct()` instead)
+
 Routing
 -------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -7,6 +7,13 @@ FrameworkBundle
  * Removed `MicroKernelTrait::configureRoutes()`.
  * Made `MicroKernelTrait::configureRouting()` abstract.
 
+HttpFoundation
+--------------
+
+ * Removed `Response::create()`, `JsonResponse::create()`,
+   `RedirectResponse::create()`, and `StreamedResponse::create()` methods (use
+   `__construct()` instead)
+
 Routing
 -------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -33,7 +33,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
     public function onKernelException(ExceptionEvent $event)
     {
         if ($event->getThrowable() instanceof Danger) {
-            $event->setResponse(Response::create('It\'s dangerous to go alone. Take this ⚔'));
+            $event->setResponse(new Response('It\'s dangerous to go alone. Take this ⚔'));
         }
     }
 

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Deprecate `Response::create()`, `JsonResponse::create()`,
+   `RedirectResponse::create()`, and `StreamedResponse::create()` methods (use
+   `__construct()` instead)
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -63,9 +63,13 @@ class JsonResponse extends Response
      * @param array $headers An array of response headers
      *
      * @return static
+     *
+     * @deprecated since Symfony 5.1, use __construct() instead.
      */
     public static function create($data = null, int $status = 200, array $headers = [])
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 5.1; use __construct() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return new static($data, $status, $headers);
     }
 

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -53,9 +53,13 @@ class RedirectResponse extends Response
      * @param string $url The URL to redirect to
      *
      * @return static
+     *
+     * @deprecated since Symfony 5.1, use __construct() instead.
      */
     public static function create($url = '', int $status = 302, array $headers = [])
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 5.1; use __construct() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return new static($url, $status, $headers);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -208,9 +208,13 @@ class Response
      *         ->setSharedMaxAge(300);
      *
      * @return static
+     *
+     * @deprecated since Symfony 5.1, use __construct() instead.
      */
     public static function create(?string $content = '', int $status = 200, array $headers = [])
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 5.1; use __construct() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return new static($content, $status, $headers);
     }
 

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -47,9 +47,13 @@ class StreamedResponse extends Response
      * @param callable|null $callback A valid PHP callback or null to set it later
      *
      * @return static
+     *
+     * @deprecated since Symfony 5.1, use __construct() instead.
      */
     public static function create($callback = null, int $status = 200, array $headers = [])
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated since Symfony 5.1; use __construct() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return new static($callback, $status, $headers);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -90,6 +90,9 @@ class JsonResponseTest extends TestCase
         $this->assertEquals('true', $response->getContent());
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreate()
     {
         $response = JsonResponse::create(['foo' => 'bar'], 204);
@@ -99,6 +102,9 @@ class JsonResponseTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
     }
 
+    /**
+     * @group legacy
+     */
     public function testStaticCreateEmptyJsonObject()
     {
         $response = JsonResponse::create();
@@ -106,6 +112,9 @@ class JsonResponseTest extends TestCase
         $this->assertSame('{}', $response->getContent());
     }
 
+    /**
+     * @group legacy
+     */
     public function testStaticCreateJsonArray()
     {
         $response = JsonResponse::create([0, 1, 2, 3]);
@@ -113,6 +122,9 @@ class JsonResponseTest extends TestCase
         $this->assertSame('[0,1,2,3]', $response->getContent());
     }
 
+    /**
+     * @group legacy
+     */
     public function testStaticCreateJsonObject()
     {
         $response = JsonResponse::create(['foo' => 'bar']);
@@ -120,6 +132,9 @@ class JsonResponseTest extends TestCase
         $this->assertSame('{"foo":"bar"}', $response->getContent());
     }
 
+    /**
+     * @group legacy
+     */
     public function testStaticCreateWithSimpleTypes()
     {
         $response = JsonResponse::create('foo');
@@ -140,18 +155,27 @@ class JsonResponseTest extends TestCase
         $this->assertSame('true', $response->getContent());
     }
 
+    /**
+     * @group legacy
+     */
     public function testStaticCreateWithCustomStatus()
     {
         $response = JsonResponse::create([], 202);
         $this->assertSame(202, $response->getStatusCode());
     }
 
+    /**
+     * @group legacy
+     */
     public function testStaticCreateAddsContentTypeHeader()
     {
         $response = JsonResponse::create();
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testStaticCreateWithCustomHeaders()
     {
         $response = JsonResponse::create([], 200, ['ETag' => 'foo']);
@@ -159,6 +183,9 @@ class JsonResponseTest extends TestCase
         $this->assertSame('foo', $response->headers->get('ETag'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testStaticCreateWithCustomContentType()
     {
         $headers = ['Content-Type' => 'application/vnd.acme.blog-v1+json'];
@@ -169,7 +196,7 @@ class JsonResponseTest extends TestCase
 
     public function testSetCallback()
     {
-        $response = JsonResponse::create(['foo' => 'bar'])->setCallback('callback');
+        $response = (new JsonResponse(['foo' => 'bar']))->setCallback('callback');
 
         $this->assertEquals('/**/callback({"foo":"bar"});', $response->getContent());
         $this->assertEquals('text/javascript', $response->headers->get('Content-Type'));
@@ -217,7 +244,7 @@ class JsonResponseTest extends TestCase
     public function testSetContent()
     {
         $this->expectException('InvalidArgumentException');
-        JsonResponse::create("\xB1\x31");
+        new JsonResponse("\xB1\x31");
     }
 
     public function testSetContentJsonSerializeError()
@@ -230,12 +257,12 @@ class JsonResponseTest extends TestCase
 
         $serializable = new JsonSerializableObject();
 
-        JsonResponse::create($serializable);
+        new JsonResponse($serializable);
     }
 
     public function testSetComplexCallback()
     {
-        $response = JsonResponse::create(['foo' => 'bar']);
+        $response = new JsonResponse(['foo' => 'bar']);
         $response->setCallback('ಠ_ಠ["foo"].bar[0]');
 
         $this->assertEquals('/**/ಠ_ಠ["foo"].bar[0]({"foo":"bar"});', $response->getContent());

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -59,6 +59,9 @@ class RedirectResponseTest extends TestCase
         $this->assertEquals('baz.beep', $response->getTargetUrl());
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreate()
     {
         $response = RedirectResponse::create('foo', 301);

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -20,6 +20,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ResponseTest extends ResponseTestCase
 {
+    /**
+     * @group legacy
+     */
     public function testCreate()
     {
         $response = Response::create('foo', 301, ['Foo' => 'bar']);

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -101,6 +101,9 @@ class StreamedResponseTest extends TestCase
         $this->assertFalse($response->getContent());
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreate()
     {
         $response = StreamedResponse::create(function () {}, 204);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a<!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | -

The `::create()` methods of the `Response` class hierarchy are not needed anymore in modern PHP versions as we can use parenthesis around the new operator. So `Response::create()->...()` is equivalent to `(new Response)->...()`.

Let's deprecate the static method. It's also good as the first parameter type changes depending on the sub-class.
