### PR TITLE
[CI] Replace php7.4snapshot with php7.4 in Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 git:
     depth: 2
@@ -24,9 +24,10 @@ matrix:
     include:
         - php: 5.5
           env: php_extra="5.6 7.0 7.1 7.2"
+          dist: trusty
         - php: 7.3
           env: deps=high
-        - php: 7.4snapshot
+        - php: 7.4
           env: deps=low
     fast_finish: true
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

There is a php7.4 already supported on Travis CI. This pull request replaces previous `7.4snapshot` with `7.4` in Travis config.
