### PR TITLE
[String] Introduce `underscore()` method

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -480,6 +480,11 @@ abstract class AbstractString implements \JsonSerializable
     /**
      * @return static
      */
+    abstract public function snakeNumeric(): self;
+
+    /**
+     * @return static
+     */
     abstract public function splice(string $replacement, int $start = 0, int $length = null): self;
 
     /**
@@ -635,11 +640,6 @@ abstract class AbstractString implements \JsonSerializable
 
         return $ellipsisLength ? $str->trimEnd()->append($ellipsis) : $str;
     }
-
-    /**
-     * @return static
-     */
-    abstract public function underscore(): self;
 
     /**
      * @return static

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -636,6 +636,9 @@ abstract class AbstractString implements \JsonSerializable
         return $ellipsisLength ? $str->trimEnd()->append($ellipsis) : $str;
     }
 
+    /**
+     * @return static
+     */
     abstract public function underscore(): self;
 
     /**

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -636,6 +636,8 @@ abstract class AbstractString implements \JsonSerializable
         return $ellipsisLength ? $str->trimEnd()->append($ellipsis) : $str;
     }
 
+    abstract public function underscore(): self;
+
     /**
      * @return static
      */

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -473,11 +473,15 @@ abstract class AbstractString implements \JsonSerializable
     abstract public function slice(int $start = 0, int $length = null): self;
 
     /**
+     * Converts to snake case: words separated with underscore.
+     *
      * @return static
      */
     abstract public function snake(): self;
 
     /**
+     * Converts to snake case: words and numbers separated with underscore.
+     *
      * @return static
      */
     abstract public function snakeNumeric(): self;

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -347,10 +347,7 @@ abstract class AbstractUnicodeString extends AbstractString
     public function snakeNumeric(): parent
     {
         $str = $this->camel()->title();
-        $str->string = mb_strtolower(
-            preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u', '/(\p{Ll})([0-9])/u'], '\1_\2', $str->string),
-            'UTF-8'
-        );
+        $str->string = mb_strtolower(preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u', '/(\p{Ll})([0-9])/u'], '\1_\2', $str->string), 'UTF-8');
 
         return $str;
     }

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -401,9 +401,9 @@ abstract class AbstractUnicodeString extends AbstractString
         $str = $this->camel()->title();
         $str->string = mb_strtolower(
             preg_replace(
-                ['~(?<=[a-z])([0-9])~u'],
-                '_$1',
-                preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1_\2', $str->string)
+                ['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u', '/(\p{Ll})([0-9])/u'],
+                '\1_\2',
+                $str->string
             ),
             'UTF-8'
         );

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -396,6 +396,14 @@ abstract class AbstractUnicodeString extends AbstractString
         return $str;
     }
 
+    public function underscore(): parent
+    {
+        $str = $this->camel()->snake();
+        $str->string = mb_strtolower(preg_replace('~(?<=[a-z])([0-9])~u', '_$1', $str->string), 'UTF-8');
+
+        return $str;
+    }
+
     public function upper(): parent
     {
         $str = clone $this;

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -398,8 +398,15 @@ abstract class AbstractUnicodeString extends AbstractString
 
     public function underscore(): parent
     {
-        $str = $this->camel()->snake();
-        $str->string = mb_strtolower(preg_replace('~(?<=[a-z])([0-9])~u', '_$1', $str->string), 'UTF-8');
+        $str = $this->camel()->title();
+        $str->string = mb_strtolower(
+            preg_replace(
+                ['~(?<=[a-z])([0-9])~u'],
+                '_$1',
+                preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1_\2', $str->string)
+            ),
+            'UTF-8'
+        );
 
         return $str;
     }

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -344,6 +344,17 @@ abstract class AbstractUnicodeString extends AbstractString
         return $str;
     }
 
+    public function snakeNumeric(): parent
+    {
+        $str = $this->camel()->title();
+        $str->string = mb_strtolower(
+            preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u', '/(\p{Ll})([0-9])/u'], '\1_\2', $str->string),
+            'UTF-8'
+        );
+
+        return $str;
+    }
+
     public function title(bool $allWords = false): parent
     {
         $str = clone $this;
@@ -392,21 +403,6 @@ abstract class AbstractUnicodeString extends AbstractString
 
         $str = clone $this;
         $str->string = preg_replace("{^[$chars]++}uD", '', $str->string);
-
-        return $str;
-    }
-
-    public function underscore(): parent
-    {
-        $str = $this->camel()->title();
-        $str->string = mb_strtolower(
-            preg_replace(
-                ['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u', '/(\p{Ll})([0-9])/u'],
-                '\1_\2',
-                $str->string
-            ),
-            'UTF-8'
-        );
 
         return $str;
     }

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -442,13 +442,7 @@ class ByteString extends AbstractString
     public function snakeNumeric(): parent
     {
         $str = $this->camel()->title();
-        $str->string = strtolower(
-            preg_replace(
-                ['/([A-Z]+)([A-Z][a-z])/u', '/([[a-z0-9])([A-Z])/u', '/([a-z])([0-9])/u'],
-                '\1_\2',
-                $str->string
-            )
-        );
+        $str->string = strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/u', '/([[a-z0-9])([A-Z])/u', '/([a-z])([0-9])/u'], '\1_\2', $str->string));
 
         return $str;
     }

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -439,6 +439,14 @@ class ByteString extends AbstractString
         return $str;
     }
 
+    public function underscore(): parent
+    {
+        $str = $this->camel()->snake();
+        $str->string = mb_strtolower(preg_replace('~(?<=[a-z])([0-9])~u', '_$1', $str->string), 'UTF-8');
+
+        return $str;
+    }
+
     public function upper(): parent
     {
         $str = clone $this;

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -441,8 +441,14 @@ class ByteString extends AbstractString
 
     public function underscore(): parent
     {
-        $str = $this->camel()->snake();
-        $str->string = mb_strtolower(preg_replace('~(?<=[a-z])([0-9])~u', '_$1', $str->string), 'UTF-8');
+        $str = $this->camel()->title();
+        $str->string = strtolower(
+            preg_replace(
+                ['~(?<=[a-z])([0-9])~u'],
+                '_$1',
+                preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1_\2', $str->string)
+            )
+        );
 
         return $str;
     }

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -439,7 +439,7 @@ class ByteString extends AbstractString
         return $str;
     }
 
-    public function underscore(): parent
+    public function snakeNumeric(): parent
     {
         $str = $this->camel()->title();
         $str->string = strtolower(

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -444,9 +444,9 @@ class ByteString extends AbstractString
         $str = $this->camel()->title();
         $str->string = strtolower(
             preg_replace(
-                ['~(?<=[a-z])([0-9])~u'],
-                '_$1',
-                preg_replace(['/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '/([\p{Ll}0-9])(\p{Lu})/u'], '\1_\2', $str->string)
+                ['/([A-Z]+)([A-Z][a-z])/u', '/([[a-z0-9])([A-Z])/u', '/([a-z])([0-9])/u'],
+                '\1_\2',
+                $str->string
             )
         );
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -931,6 +931,32 @@ abstract class AbstractAsciiTestCase extends TestCase
     }
 
     /**
+     * @dataProvider provideUnderscore
+     */
+    public function testUnderscore(string $expectedString, string $origin): void
+    {
+        $instance = static::createFromString($origin)->underscore();
+
+        $this->assertEquals(static::createFromString($expectedString), $instance);
+    }
+
+    public static function provideUnderscore(): array
+    {
+        return [
+            ['', ''],
+            ['symfony_is_great', 'symfonyIsGreat'],
+            ['symfony_44_is_great', 'symfony44IsGreat'],
+            ['symfony_is_great_5', 'symfonyIsGreat5'],
+            ['symfony_5_is_great', 'symfony5IsGreat'],
+            ['symfony_5is_great', 'symfony5isGreat'],
+            ['symfony_is_great', 'Symfony is great'],
+            ['symfony_is_a_great_framework', 'symfonyIsAGreatFramework'],
+            ['symfony_is_great', 'symfonyIsGREAT'],
+            ['symfony_is_really_great', 'symfonyIsREALLYGreat'],
+        ];
+    }
+
+    /**
      * @dataProvider provideStartsWith
      */
     public function testStartsWith(bool $expected, string $origin, $prefix, int $form = null)

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -931,16 +931,16 @@ abstract class AbstractAsciiTestCase extends TestCase
     }
 
     /**
-     * @dataProvider provideUnderscore
+     * @dataProvider provideSnakeNumeric
      */
-    public function testUnderscore(string $expectedString, string $origin): void
+    public function testSnakeNumeric(string $expectedString, string $origin): void
     {
-        $instance = static::createFromString($origin)->underscore();
+        $instance = static::createFromString($origin)->snakeNumeric();
 
         $this->assertEquals(static::createFromString($expectedString), $instance);
     }
 
-    public static function provideUnderscore(): array
+    public static function provideSnakeNumeric(): array
     {
         return [
             ['', ''],

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -510,6 +510,16 @@ abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
         );
     }
 
+    public static function provideUnderscore() : array
+    {
+        return array_merge(
+            parent::provideUnderscore(),
+            [
+                ['symfony_5_ist_8_äußerst_cool', 'symfony5Ist8ÄußerstCool'],
+            ]
+        );
+    }
+
     public static function provideEqualsTo()
     {
         return array_merge(

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -510,7 +510,7 @@ abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
         );
     }
 
-    public static function provideUnderscore() : array
+    public static function provideUnderscore(): array
     {
         return array_merge(
             parent::provideUnderscore(),

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -515,7 +515,9 @@ abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
         return array_merge(
             parent::provideUnderscore(),
             [
-                ['symfony_5_ist_8_äußerst_cool', 'symfony5Ist8ÄußerstCool'],
+                ['symfony_5_ist_äußerst_cool', 'symfony5IstÄußerstCool'],
+                ['8_äußerst', '8äußerst'],
+                ['i_reversed_aussert_tsreßuä8', 'iReversedAussertTsreßuä8'],
             ]
         );
     }

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -517,7 +517,7 @@ abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
             [
                 ['symfony_5_ist_äußerst_cool', 'symfony5IstÄußerstCool'],
                 ['8_äußerst', '8äußerst'],
-                ['i_reversed_aussert_tsreßuä8', 'iReversedAussertTsreßuä8'],
+                ['i_reversed_aussert_tsreßuä_8', 'iReversedAussertTsreßuä8'],
             ]
         );
     }

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -510,10 +510,10 @@ abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
         );
     }
 
-    public static function provideUnderscore(): array
+    public static function provideSnakeNumeric(): array
     {
         return array_merge(
-            parent::provideUnderscore(),
+            parent::provideSnakeNumeric(),
             [
                 ['symfony_5_ist_äußerst_cool', 'symfony5IstÄußerstCool'],
                 ['8äußerst', '8äußerst'],

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -516,7 +516,8 @@ abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
             parent::provideUnderscore(),
             [
                 ['symfony_5_ist_äußerst_cool', 'symfony5IstÄußerstCool'],
-                ['8_äußerst', '8äußerst'],
+                ['8äußerst', '8äußerst'],
+                ['8_äußerst', '8Äußerst'],
                 ['i_reversed_aussert_tsreßuä_8', 'iReversedAussertTsreßuä8'],
             ]
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34777 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | TBA symfony/symfony-docs#... <!-- required for new features -->

Provides `underscore()` method to String component. Similar to `snake()` but also adds `_` before numbers.

```php
assertSame('something_1', u('Something1')->underscore()->toString());
```

This pattern is used eg. by [Doctrine ORM UnderscoreNamingStrategy](https://github.com/doctrine/orm/blob/2.8.x/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php) with number aware enabled. 