### PR TITLE
[Cache] Propagate expiry when syncing items in ChainAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -28,7 +28,7 @@ class ChainAdapterTest extends AdapterTestCase
     public function createCachePool($defaultLifetime = 0, $testMethod = null)
     {
         if ('testGetMetadata' === $testMethod) {
-            return new ChainAdapter([new FilesystemAdapter('', $defaultLifetime)], $defaultLifetime);
+            return new ChainAdapter([new FilesystemAdapter('a', $defaultLifetime), new FilesystemAdapter('b', $defaultLifetime)], $defaultLifetime);
         }
 
         return new ChainAdapter([new ArrayAdapter($defaultLifetime), new ExternalAdapter(), new FilesystemAdapter('', $defaultLifetime)], $defaultLifetime);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

If a lower adapter provides item metadata, propagate the expiry time when syncing the item to upper ones.