### PR TITLE
[SecurityBundle] Properly escape regex in AddSessionDomainConstraintPass

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSessionDomainConstraintPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSessionDomainConstraintPass.php
@@ -31,7 +31,7 @@ class AddSessionDomainConstraintPass implements CompilerPassInterface
         }
 
         $sessionOptions = $container->getParameter('session.storage.options');
-        $domainRegexp = empty($sessionOptions['cookie_domain']) ? '%s' : sprintf('(?:%%s|(?:.+\.)?%s)', preg_quote(trim($sessionOptions['cookie_domain'], '.')));
+        $domainRegexp = empty($sessionOptions['cookie_domain']) ? '%%s' : sprintf('(?:%%%%s|(?:.+\.)?%s)', preg_quote(trim($sessionOptions['cookie_domain'], '.')));
         $domainRegexp = (empty($sessionOptions['cookie_secure']) ? 'https?://' : 'https://').$domainRegexp;
 
         $container->findDefinition('security.http_utils')->addArgument(sprintf('{^%s$}i', $domainRegexp));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/34774
| License       | MIT
| Doc PR        | -

`%s` should be escaped, so it is dumped as `%%s` (it ends up being properly unescaped at load time, so the passed value to the service is the same).
