### PR TITLE
[Routing][ObjectLoader] Remove forgotten deprecation after merge

### DIFF
--- a/src/Symfony/Component/Routing/Loader/ObjectLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectLoader.php
@@ -42,13 +42,8 @@ abstract class ObjectLoader extends Loader
      */
     public function load($resource, string $type = null)
     {
-        if (!preg_match('/^[^\:]+(?:::?(?:[^\:]+))?$/', $resource)) {
+        if (!preg_match('/^[^\:]+(?:::(?:[^\:]+))?$/', $resource)) {
             throw new \InvalidArgumentException(sprintf('Invalid resource "%s" passed to the %s route loader: use the format "object_id::method" or "object_id" if your object class has an "__invoke" method.', $resource, \is_string($type) ? '"'.$type.'"' : 'object'));
-        }
-
-        if (1 === substr_count($resource, ':')) {
-            $resource = str_replace(':', '::', $resource);
-            @trigger_error(sprintf('Referencing object route loaders with a single colon is deprecated since Symfony 4.1. Use %s instead.', $resource), E_USER_DEPRECATED);
         }
 
         $parts = explode('::', $resource);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/pull/34621 needs to be gone on 5.0. We want to throw here. I think it was forgotten when merging in 5.0.