### PR TITLE
[Translation] Fix FileDumper behavior

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
@@ -67,36 +67,37 @@ abstract class FileDumper implements DumperInterface
             throw new InvalidArgumentException('The file dumper needs a path option.');
         }
 
+        $hasMessageFormatter = class_exists(\MessageFormatter::class);
+
         // save a file for each domain
         foreach ($messages->getDomains() as $domain) {
-            $fullpath = $options['path'].'/'.$this->getRelativePath($domain, $messages->getLocale());
-            if (!file_exists($fullpath)) {
-                $directory = \dirname($fullpath);
+            if ($hasMessageFormatter) {
+                $defaultDomain = $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX;
+                $altDomain = $domain;
+            } else {
+                $defaultDomain = $domain;
+                $altDomain = $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX;
+            }
+            $defaultPath = $options['path'].'/'.$this->getRelativePath($defaultDomain, $messages->getLocale());
+            $altPath = $options['path'].'/'.$this->getRelativePath($altDomain, $messages->getLocale());
+
+            if (!file_exists($defaultPath) && file_exists($altPath)) {
+                [$defaultPath, $altPath] = [$altPath, $defaultPath];
+            }
+
+            if (!file_exists($defaultPath)) {
+                $directory = \dirname($defaultPath);
                 if (!file_exists($directory) && !@mkdir($directory, 0777, true)) {
                     throw new RuntimeException(sprintf('Unable to create directory "%s".', $directory));
                 }
             }
 
-            $intlDomain = $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX;
-            $intlMessages = $messages->all($intlDomain);
-
-            if ($intlMessages) {
-                $intlPath = $options['path'].'/'.$this->getRelativePath($intlDomain, $messages->getLocale());
-                file_put_contents($intlPath, $this->formatCatalogue($messages, $intlDomain, $options));
-
-                $messages->replace([], $intlDomain);
-
-                try {
-                    if ($messages->all($domain)) {
-                        file_put_contents($fullpath, $this->formatCatalogue($messages, $domain, $options));
-                    }
-                    continue;
-                } finally {
-                    $messages->replace($intlMessages, $intlDomain);
-                }
+            if (file_exists($altPath)) {
+                // clear alternative translation file
+                file_put_contents($altPath, $this->formatCatalogue(new MessageCatalogue($messages->getLocale()), $altDomain, $options));
             }
 
-            file_put_contents($fullpath, $this->formatCatalogue($messages, $domain, $options));
+            file_put_contents($defaultPath, $this->formatCatalogue($messages, $domain, $options));
         }
     }
 

--- a/src/Symfony/Component/Translation/Tests/Dumper/FileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/FileDumperTest.php
@@ -27,11 +27,15 @@ class FileDumperTest extends TestCase
         $dumper = new ConcreteFileDumper();
         $dumper->dump($catalogue, ['path' => $tempDir]);
 
-        $this->assertFileExists($tempDir.'/messages.en.concrete');
+        $suffix = class_exists(\MessageFormatter::class) ? '+intl-icu' : '';
+        $this->assertFileExists($tempDir."/messages$suffix.en.concrete");
 
-        @unlink($tempDir.'/messages.en.concrete');
+        @unlink($tempDir."/messages$suffix.en.concrete");
     }
 
+    /**
+     * @requires extension intl
+     */
     public function testDumpIntl()
     {
         $tempDir = sys_get_temp_dir();
@@ -42,13 +46,11 @@ class FileDumperTest extends TestCase
         $catalogue->add(['bar' => 'foo'], 'd2+intl-icu');
 
         $dumper = new ConcreteFileDumper();
-        @unlink($tempDir.'/d2.en.concrete');
         $dumper->dump($catalogue, ['path' => $tempDir]);
 
-        $this->assertStringEqualsFile($tempDir.'/d1.en.concrete', 'foo=bar');
-        @unlink($tempDir.'/d1.en.concrete');
+        $this->assertFileNotExists($tempDir.'/d1.en.concrete');
 
-        $this->assertStringEqualsFile($tempDir.'/d1+intl-icu.en.concrete', 'bar=foo');
+        $this->assertStringEqualsFile($tempDir.'/d1+intl-icu.en.concrete', 'bar=foo&foo=bar');
         @unlink($tempDir.'/d1+intl-icu.en.concrete');
 
         $this->assertFileNotExists($tempDir.'/d2.en.concrete');
@@ -60,7 +62,8 @@ class FileDumperTest extends TestCase
     {
         $tempDir = sys_get_temp_dir();
         $translationsDir = $tempDir.'/test/translations';
-        $file = $translationsDir.'/messages.en.concrete';
+        $suffix = class_exists(\MessageFormatter::class) ? '+intl-icu' : '';
+        $file = $translationsDir."/messages$suffix.en.concrete";
 
         $catalogue = new MessageCatalogue('en');
         $catalogue->add(['foo' => 'bar']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34713
| License       | MIT
| Doc PR        | -

Execute `bin/console translation:update --force en` command:

## Before
See related issue for details #34713

## After
The default translation file name will depend on whether the intl (or polyfill) extension is installed or not.

For exmaple:

| Intl extension (or polyfill) installed | translation file created |
| --- | --- |
| no | messages.en.xlf |
| yes | messages+intl-icu.en.xlf | 

However, if you are currently updating a single file, that file name will be used regardless of whether the Intl extension is installed, i.e. if you have this translation file: `messages.en.xlf`, new translation keys will be stored in it, even if you have installed the intl extension.

Last, if both translation files (`messages.es.xlf` and `messages+intl-icu.en.xlf`) coexist in the same path, rare but possible, we will use the default filename guessed earlier to store all current messages and the another file will be emptied.