### PR TITLE
[Security] Check UserInterface::getPassword is not null before calling needsRehash

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
@@ -56,6 +56,10 @@ class UserPasswordEncoder implements UserPasswordEncoderInterface
      */
     public function needsRehash(UserInterface $user): bool
     {
+        if (null === $user->getPassword()) {
+            return false;
+        }
+
         $encoder = $this->encoderFactory->getEncoder($user);
 
         return method_exists($encoder, 'needsRehash') && $encoder->needsRehash($user->getPassword());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface::needsRehash()` expects a string as the input argument. In some cases `Symfony\Component\Security\Core\User\UserInterface::getPassword()` is used as the input argument, but this function can return `null` resulting in a potential type error.
