### PR TITLE
Added stub to at least prevent hard exceptions when using tags: true and using the default auto-wiring and env=dev

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -224,7 +224,7 @@ class TraceableAdapter implements AdapterInterface, PruneableInterface, Resettab
     public function invalidateTags(array $tags)
     {
         // TODO: add logic here and in the rest of this class to trace tags for profiler.
-        // This stub was only added to prevent issue https://github.com/symfony/symfony/issues/34800
+        // This stub was only added to prevent issue https://github.com/symfony/symfony/issues/34800.
     }
 }
 

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -22,7 +22,7 @@ use Symfony\Component\Cache\ResettableInterface;
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class TraceableAdapter implements AdapterInterface, PruneableInterface, ResettableInterface
+class TraceableAdapter implements AdapterInterface, PruneableInterface, ResettableInterface, TagAwareAdapterInterface
 {
     protected $pool;
     private $calls = [];
@@ -219,6 +219,12 @@ class TraceableAdapter implements AdapterInterface, PruneableInterface, Resettab
         $event->start = microtime(true);
 
         return $event;
+    }
+
+    public function invalidateTags(array $tags)
+    {
+        // TODO: add logic here and in the rest of this class to trace tags for profiler.
+        // This stub was only added to prevent issue https://github.com/symfony/symfony/issues/34800
     }
 }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34800 
| License       | MIT
| Doc PR        | 

Fixed hard exception (see related issue), without adding new functionality. This can be done in a separate Issue/PR.