### PR TITLE
[Console] Add SingleCommandApplication to ease creation of Single Command Application

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Add `SingleCommandApplication`
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Console/SingleCommandApplication.php
+++ b/src/Symfony/Component/Console/SingleCommandApplication.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class SingleCommandApplication extends Command
+{
+    private $version = 'UNKNOWN';
+    private $running = false;
+
+    public function setVersion(string $version): self
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    public function run(InputInterface $input = null, OutputInterface $output = null): int
+    {
+        if ($this->running) {
+            return parent::run($input, $output);
+        }
+
+        // We use the command name as the application name
+        $application = new Application($this->getName() ?: 'UNKNOWN', $this->version);
+        // Fix the usage of the command displayed with "--help"
+        $this->setName($_SERVER['argv'][0]);
+        $application->add($this);
+        $application->setDefaultCommand($this->getName(), true);
+
+        $this->running = true;
+        try {
+            $ret = $application->run($input, $output);
+        } finally {
+            $this->running = false;
+        }
+
+        return $ret ?? 1;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/arg.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/arg.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Single Application can be executed
+--ARGS--
+You
+--FILE--
+<?php
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+(new SingleCommandApplication())
+    ->addArgument('who', InputArgument::OPTIONAL, 'Who', 'World')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $output->writeln(sprintf('Hello %s!', $input->getArgument('who')));
+
+        return 0;
+    })
+    ->run()
+;
+?>
+--EXPECT--
+Hello You!

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/default.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/default.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Single Application can be executed
+--FILE--
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+(new SingleCommandApplication())
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $output->writeln('Hello World!');
+
+        return 0;
+    })
+    ->run()
+;
+?>
+--EXPECT--
+Hello World!

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Single Application can be executed
+--ARGS--
+--help --no-ansi
+--FILE--
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+(new SingleCommandApplication())
+    ->setName('My Super Command')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        return 0;
+    })
+    ->run()
+;
+?>
+--EXPECTF--
+Usage:
+  %s
+
+Options:
+  -h, --help            Display this help message
+  -q, --quiet           Do not output any message
+  -V, --version         Display this application version
+      --ansi            Force ANSI output
+      --no-ansi         Disable ANSI output
+  -n, --no-interaction  Do not ask any interactive question
+  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/version_default_name.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/version_default_name.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Single Application can be executed
+--ARGS--
+--version --no-ansi
+--FILE--
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+(new SingleCommandApplication())
+    ->setName('My Super Command')
+    ->setVersion('1.0.0')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        return 0;
+    })
+    ->run()
+;
+?>
+--EXPECT--
+My Super Command 1.0.0

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/version_name.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/version_name.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Single Application can be executed
+--ARGS--
+--version
+--FILE--
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+(new SingleCommandApplication())
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        return 0;
+    })
+    ->run()
+;
+?>
+--EXPECT--
+Console Tool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #34293
| License       | MIT
| Doc PR        |

---

```php
<?php

require __DIR__.'/vendor/autoload.php';

use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Console\SingleCommandApplication;

(new SingleCommandApplication())
    ->setName('My Super Command') // Optional
    ->setVersion('1.0.0') // Optional
    ->setProcessTitle('my_proc_title') // Optional
    ->addArgument('who', InputArgument::OPTIONAL, 'Who', 'World')  // Optional
    ->setCode(function(InputInterface $input, OutputInterface $output) {
        $output->writeln(sprintf('Hello %s!', $input->getArgument('who')));
    })
    ->run()
;

```

---

Note: I tried this too, and it works as expected:

```php

class MyCommand extends SingleCommandApplication
{
    public function execute(InputInterface $input, OutputInterface $output)
    {
        $output->writeln('hello');

        return 0;
    }
}

new MyCommand();
```