### PR TITLE
[Serializer] fix denormalization of xml-values to objects when no xml-attributes are specified

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -329,6 +329,16 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $object = $this->instantiateObject($normalizedData, $type, $context, $reflectionClass, $allowedAttributes, $format);
         $resolvedClass = $this->objectClassResolver ? ($this->objectClassResolver)($object) : \get_class($object);
 
+        if (\is_string($data) && 'xml' === $format && $this->classMetadataFactory->hasMetadataFor($type)) {
+            $attributes = $this->classMetadataFactory->getMetadataFor($type)->getAttributesMetadata();
+            foreach ($attributes as $attribute) {
+                if ('#' === $attribute->getSerializedName()) {
+                    $normalizedData = ['#' => $data];
+                    break;
+                }
+            }
+        }
+
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {
                 $attribute = $this->nameConverter->denormalize($attribute, $resolvedClass, $format, $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Tickets       | Fix #32114 
| License       | MIT
| Doc PR        | 

When deserializing an XML-Node like this to an object, everything works as expected:

`<some-element optionalAttribute="foo">bar</some-element>`

But if all attributes are optional and missing from the node, the deserialization fails

`<some-element>bar</some-element>`

The serializer handles XML-Attributes by prefixing them with '@' and node-data are handled with the special key '#'. But this key is only used, when attributes are present (see [XmlEncoder.php#L175-185](https://github.com/symfony/symfony/blob/4.3/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php#L175-L185)).

I choose to fix this within the denormalize-function of the AbstractObjectNormalizer. Handling it within the NameConverter would also be possible, but the NameConverter's don't know the source-format. 