### PR TITLE
[HttpFoundation] get currently session.gc_maxlifetime if ttl doesnt exists

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -63,7 +63,7 @@ class RedisSessionHandler extends AbstractSessionHandler
 
         $this->redis = $redis;
         $this->prefix = $options['prefix'] ?? 'sf_s';
-        $this->ttl = $options['ttl'] ?? (int) ini_get('session.gc_maxlifetime');
+        $this->ttl = $options['ttl'] ?? null;
     }
 
     /**
@@ -79,7 +79,7 @@ class RedisSessionHandler extends AbstractSessionHandler
      */
     protected function doWrite($sessionId, $data): bool
     {
-        $result = $this->redis->setEx($this->prefix.$sessionId, $this->ttl, $data);
+        $result = $this->redis->setEx($this->prefix.$sessionId, (int) ($this->ttl ?? ini_get('session.gc_maxlifetime')), $data);
 
         return $result && !$result instanceof ErrorInterface;
     }
@@ -115,6 +115,6 @@ class RedisSessionHandler extends AbstractSessionHandler
      */
     public function updateTimestamp($sessionId, $data)
     {
-        return (bool) $this->redis->expire($this->prefix.$sessionId, $this->ttl);
+        return (bool) $this->redis->expire($this->prefix.$sessionId, (int) ($this->ttl ?? ini_get('session.gc_maxlifetime')));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master / 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #34659 
| License       | MIT

If option `ttl` was not defined in RedisSessionHandler, this got the default `session.gc_maxlifetime`. With this fixed, RedisSessionHandler get the currently `session.gc_maxlifetime`.
