### PR TITLE
[Messenger] "set up" typo fix

### DIFF
--- a/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
@@ -59,7 +59,7 @@ EOF
         $io = new SymfonyStyle($input, $output);
 
         $transportNames = $this->transportNames;
-        // do we want to setup only one transport?
+        // do we want to set up only one transport?
         if ($transport = $input->getArgument('transport')) {
             if (!$this->transportLocator->has($transport)) {
                 throw new \RuntimeException(sprintf('The "%s" transport does not exist.', $transport));
@@ -71,7 +71,7 @@ EOF
             $transport = $this->transportLocator->get($transportName);
             if ($transport instanceof SetupableTransportInterface) {
                 $transport->setup();
-                $io->success(sprintf('The "%s" transport was setup successfully.', $transportName));
+                $io->success(sprintf('The "%s" transport was set up successfully.', $transportName));
             } else {
                 $io->note(sprintf('The "%s" transport does not support setup.', $transportName));
             }

--- a/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
@@ -42,7 +42,7 @@ class SetupTransportsCommandTest extends TestCase
         $tester->execute([]);
         $display = $tester->getDisplay();
 
-        $this->assertStringContainsString('The "amqp" transport was setup successfully.', $display);
+        $this->assertStringContainsString('The "amqp" transport was set up successfully.', $display);
         $this->assertStringContainsString('The "other_transport" transport does not support setup.', $display);
     }
 
@@ -66,7 +66,7 @@ class SetupTransportsCommandTest extends TestCase
         $tester->execute(['transport' => 'amqp']);
         $display = $tester->getDisplay();
 
-        $this->assertStringContainsString('The "amqp" transport was setup successfully.', $display);
+        $this->assertStringContainsString('The "amqp" transport was set up successfully.', $display);
     }
 
     public function testReceiverNameArgumentNotFound()

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -334,7 +334,7 @@ class Connection
             }
         } catch (\AMQPQueueException $e) {
             if (404 === $e->getCode() && $this->shouldSetup()) {
-                // If we get a 404 for the queue, it means we need to setup the exchange & queue.
+                // If we get a 404 for the queue, it means we need to set up the exchange & queue.
                 $this->setupExchangeAndQueues();
 
                 return $this->get();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4, 4.3, 4.4 or 5.0 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

![image](https://user-images.githubusercontent.com/13940752/70231803-1b4a9180-176c-11ea-9faf-b7addf81190a.png)
There's a typo, `setup` is a noun, but it should be a verb `set up`.
