### PR TITLE
[ExpressionLanguage][Node][BinaryNode] Process division by zero

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -147,6 +147,10 @@ class BinaryNode extends Node
             case '*':
                 return $left * $right;
             case '/':
+                if (0 == $right) {
+                    throw new \DivisionByZeroError('Division by zero');
+                }
+
                 return $left / $right;
             case '%':
                 return $left % $right;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

[There is the same PR to master (as new feature)](https://github.com/symfony/symfony/pull/34814)
Which way is more correct?

To be able to catch the error in expression like ` 1 / 0`

**Before PR:**
```
try {
    1 / 0;
} catch (\Throwable $e) {
    // It won't be caught
    // PHP Warning:  Division by zero in...
}

try {
    1 % 0;
} catch (\Throwable $e) {
    // It will be caught
    // \DivisionByZeroError with message `Modulo by zero`
}
```
**After PR:**
```
try {
    1 / 0;
} catch (\Throwable $e) {
    // It will be caught
    // \DivisionByZeroError with message `Division by zero`
}
```