### PR TITLE
[DI] Fix Preload

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -209,7 +209,7 @@ class PhpDumper extends Dumper
 
             if (3 <= $i) {
                 $regex = '';
-                $lastOptionalDir = $i > 8 ? $i - 5 : 3;
+                $lastOptionalDir = $i > 8 ? $i - 5 : $i - 3;
                 $this->targetDirMaxMatches = $i - $lastOptionalDir;
 
                 while (--$i >= $lastOptionalDir) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The regexp to targetDir was malformatted when the number of folder was lower than 8
Here is the value of Regexp.
```
/foo                => /foo/var(/cache(/prod)?)? <=== this is my issue. `var` is compulsory here
/foo/bar            => /foo/bar(/var(/cache(/swoole)?)?)?
/foo/bar/baz        => /foo/bar(/baz(/var(/cache(/swoole)?)?)?)?
/foo/bar/baz/x/y/z: => /foo/bar/baz/x(/y(/z(/var(/cache(/swoole)?)?)?)?)?"
```