### PR TITLE
[HttpClient] Add ResponseInterface::toStream signature

### DIFF
--- a/src/Symfony/Contracts/HttpClient/ResponseInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ResponseInterface.php
@@ -74,6 +74,18 @@ interface ResponseInterface
     public function toArray(bool $throw = true): array;
 
     /**
+     * Casts the response to a PHP stream resource.
+     *
+     * @return resource
+     *
+     * @throws TransportExceptionInterface   When a network error occurs
+     * @throws RedirectionExceptionInterface On a 3xx when $throw is true and the "max_redirects" option has been reached
+     * @throws ClientExceptionInterface      On a 4xx when $throw is true
+     * @throws ServerExceptionInterface      On a 5xx when $throw is true
+     */
+    public function toStream(bool $throw = true);
+
+    /**
      * Closes the response stream and all related buffers.
      *
      * No further chunk will be yielded after this method has been called.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34834
| License       | MIT
| Doc PR        | 

This PR adds ResponseInterface::toStream to the contract. I see the contracts have a separate version scheme. As far as I can tell this should be supported from Symfony 4.4 and up. We should make sure this change is not pulled in for projects depending on HttpClient <= 4.3.

A possible blocker: This breaks all 3rd-party implementations of ResponseInterface not having this method. In this case we can opt for the slightly unfortunate phpdoc `@method` syntax.