### PR TITLE
[ExpressionLanguage] Process division by zero

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -147,8 +147,16 @@ class BinaryNode extends Node
             case '*':
                 return $left * $right;
             case '/':
+                if (0 == $right) {
+                    throw new \DivisionByZeroError('Division by zero');
+                }
+
                 return $left / $right;
             case '%':
+                if (0 == $right) {
+                    throw new \DivisionByZeroError('Modulo by zero');
+                }
+
                 return $left % $right;
             case 'matches':
                 return preg_match($right, $left);

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^5.5.9|>=7.0.8",
-        "symfony/cache": "~3.1|~4.0"
+        "symfony/cache": "~3.1|~4.0",
+        "symfony/polyfill-php70": "~1.6"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\ExpressionLanguage\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

To be able to catch the error in expression like ` 1 / 0`

**Before PR:**
```
try {
    1 / 0;
} catch (\Throwable $e) {
    // It won't be caught anyway
    // PHP Warning:  Division by zero in...
}

try {
    1 % 0;
} catch (\Throwable $e) {
    // It will be caught since PHP7
    // \DivisionByZeroError with message `Modulo by zero`
}
```
**After PR:**
```
try {
    1 / 0;
} catch (\Throwable $e) {
    // It will be caught
    // \DivisionByZeroError with message `Division by zero`
}

try {
    1 % 0;
} catch (\Throwable $e) {
    // It will be caught
    // \DivisionByZeroError with message `Modulo by zero`
}
```