### PR TITLE
[Stopwatch] Add micro and macro duration precision getters

### DIFF
--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -199,6 +199,16 @@ class StopwatchEvent
         return $total;
     }
 
+    public function getDurationMacroPrecision(): int
+    {
+        return (int) $this->getDuration();
+    }
+
+    public function getDurationMicroPrecision(): float
+    {
+        return (float) $this->getDuration();
+    }
+
     /**
      * Gets the max memory usage of all periods.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | maybe (improvement)
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/34773
| License       | MIT
| Doc PR        | TODO

**RFC**

This is a **draft PR** for the related issue:

> If we want to be more typesafe, we would need to deprecate the less precise mode (which is currently the default mode) and keep float all the time.

I would like to know the right way of deprecating things,
also does this means that, until 6.X, we can not typehint `:float`? or just for 5.0 but we can do it for 5.1?

Thank you,

# Edit

- New commit add only new functions
- Deprecation will be done only if requested (see https://github.com/symfony/symfony/pull/34844#issuecomment-562589364)
