### PR TITLE
Revert "feature #32126 [Process] Allow writing portable "prepared" command lines (Simperfit)"

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -288,12 +288,6 @@ class Process implements \IteratorAggregate
         $this->hasCallback = null !== $callback;
         $descriptors = $this->getDescriptors();
 
-        if ($this->env) {
-            $env += $this->env;
-        }
-
-        $env += $this->getDefaultEnv();
-
         if (\is_array($commandline = $this->commandline)) {
             $commandline = implode(' ', array_map([$this, 'escapeArgument'], $commandline));
 
@@ -301,9 +295,12 @@ class Process implements \IteratorAggregate
                 // exec is mandatory to deal with sending a signal to the process
                 $commandline = 'exec '.$commandline;
             }
-        } else {
-            $commandline = $this->replacePlaceholders($commandline, $env);
         }
+
+        if ($this->env) {
+            $env += $this->env;
+        }
+        $env += $this->getDefaultEnv();
 
         $options = ['suppress_errors' => true];
 
@@ -1639,17 +1636,6 @@ class Process implements \IteratorAggregate
         $argument = preg_replace('/(\\\\+)$/', '$1$1', $argument);
 
         return '"'.str_replace(['"', '^', '%', '!', "\n"], ['""', '"^^"', '"^%"', '"^!"', '!LF!'], $argument).'"';
-    }
-
-    private function replacePlaceholders(string $commandline, array $env)
-    {
-        return preg_replace_callback('/"\$([_a-zA-Z]++[_a-zA-Z0-9]*+)"/', function ($matches) use ($commandline, $env) {
-            if (!isset($env[$matches[1]]) || false === $env[$matches[1]]) {
-                throw new InvalidArgumentException(sprintf('Command line is missing a value for key %s: %s.', $matches[0], $commandline));
-            }
-
-            return '\\' === \DIRECTORY_SEPARATOR ? $this->escapeArgument($env[$matches[1]]) : $matches[0];
-        }, $commandline);
     }
 
     private function getDefaultEnv(): array

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1461,46 +1461,6 @@ EOTXT;
         yield [1.1];
     }
 
-    public function testPreparedCommand()
-    {
-        $p = Process::fromShellCommandline('echo "$abc"DEF');
-        $p->run(null, ['abc' => 'ABC']);
-
-        $this->assertSame('ABCDEF', rtrim($p->getOutput()));
-    }
-
-    public function testPreparedCommandMulti()
-    {
-        $p = Process::fromShellCommandline('echo "$abc""$def"');
-        $p->run(null, ['abc' => 'ABC', 'def' => 'DEF']);
-
-        $this->assertSame('ABCDEF', rtrim($p->getOutput()));
-    }
-
-    public function testPreparedCommandWithQuoteInIt()
-    {
-        $p = Process::fromShellCommandline('php -r "$code" "$def"');
-        $p->run(null, ['code' => 'echo $argv[1];', 'def' => '"DEF"']);
-
-        $this->assertSame('"DEF"', rtrim($p->getOutput()));
-    }
-
-    public function testPreparedCommandWithMissingValue()
-    {
-        $this->expectException('Symfony\Component\Process\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Command line is missing a value for key "$abc": echo "$abc".');
-        $p = Process::fromShellCommandline('echo "$abc"');
-        $p->run(null, ['bcd' => 'BCD']);
-    }
-
-    public function testPreparedCommandWithNoValues()
-    {
-        $this->expectException('Symfony\Component\Process\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Command line is missing a value for key "$abc": echo "$abc".');
-        $p = Process::fromShellCommandline('echo "$abc"');
-        $p->run(null, []);
-    }
-
     public function testEnvArgument()
     {
         $env = ['FOO' => 'Foo', 'BAR' => 'Bar'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34838
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/12769

This reverts commit bd8ad3f7172606e7fc7e794624730bbcfb89e3f7, reversing
changes made to f15722dd84eefaaf64dccf247f20ea743e209057.

This was my idea, and it happens it was a bad one - I totally missed this would break running actual shell scripts.

When this is merged, we'll have to update https://symfony.com/blog/new-in-symfony-4-1-prepared-commands too /cc @javiereguiluz 