### PR TITLE
Add support for safe HTTP preference - RFC 8674

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Deprecate `Response::create()`, `JsonResponse::create()`,
    `RedirectResponse::create()`, and `StreamedResponse::create()` methods (use
    `__construct()` instead)
+ * added `Request::preferSafeContent()` and `Response::setContentSafe()` to handle "safe" HTTP preference
+   according to [RFC 8674](https://tools.ietf.org/html/rfc8674)
 
 5.0.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1211,6 +1211,22 @@ class Response
     }
 
     /**
+     * Mark a response as safe according to RFC8674.
+     *
+     * @see https://tools.ietf.org/html/rfc8674
+     */
+    public function setContentSafe(bool $safe = true): void
+    {
+        if ($safe) {
+            $this->headers->set('Preference-Applied', 'safe');
+        } elseif ('safe' === $this->headers->get('Preference-Applied')) {
+            $this->headers->remove('Preference-Applied');
+        }
+
+        $this->setVary('Prefer', false);
+    }
+
+    /**
      * Checks if we need to remove Cache-Control for SSL encrypted downloads when using IE < 9.
      *
      * @see http://support.microsoft.com/kb/323308

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2325,6 +2325,64 @@ class RequestTest extends TestCase
             [null, ['REMOTE_ADDR', '2.2.2.2'], ['2.2.2.2']],
         ];
     }
+
+    /**
+     * @dataProvider preferSafeContentData
+     */
+    public function testPreferSafeContent($server, bool $safePreferenceExpected)
+    {
+        $request = new Request([], [], [], [], [], $server);
+
+        $this->assertEquals($safePreferenceExpected, $request->preferSafeContent());
+    }
+
+    public function preferSafeContentData()
+    {
+        return [
+            [[], false],
+            [
+                [
+                    'HTTPS' => 'on',
+                ],
+                false,
+            ],
+            [
+                [
+                    'HTTPS' => 'off',
+                    'HTTP_PREFER' => 'safe',
+                ],
+                false,
+            ],
+            [
+                [
+                    'HTTPS' => 'on',
+                    'HTTP_PREFER' => 'safe',
+                ],
+                true,
+            ],
+            [
+                [
+                    'HTTPS' => 'on',
+                    'HTTP_PREFER' => 'unknown-preference',
+                ],
+                false,
+            ],
+            [
+                [
+                    'HTTPS' => 'on',
+                    'HTTP_PREFER' => 'unknown-preference=42, safe',
+                ],
+                true,
+            ],
+            [
+                [
+                    'HTTPS' => 'on',
+                    'HTTP_PREFER' => 'safe, unknown-preference=42',
+                ],
+                true,
+            ],
+        ];
+    }
 }
 
 class RequestContentProxy extends Request

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -1040,6 +1040,24 @@ class ResponseTest extends ResponseTestCase
     {
         $this->assertEquals($reasonPhrase, Response::$statusTexts[$code]);
     }
+
+    public function testSetContentSafe()
+    {
+        $response = new Response();
+
+        $this->assertFalse($response->headers->has('Preference-Applied'));
+        $this->assertFalse($response->headers->has('Vary'));
+
+        $response->setContentSafe();
+
+        $this->assertSame('safe', $response->headers->get('Preference-Applied'));
+        $this->assertSame('Prefer', $response->headers->get('Vary'));
+
+        $response->setContentSafe(false);
+
+        $this->assertFalse($response->headers->has('Preference-Applied'));
+        $this->assertSame('Prefer', $response->headers->get('Vary'));
+    }
 }
 
 class StringableObject


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

[RFC 8674](https://tools.ietf.org/html/rfc8674) (not a IETF standard at the moment) defines a way for user agents to ask for "safe" content to a server. This PR add helper methods to :
- know if the user agent prefers a safe content
- mark the response as safe
