### PR TITLE
[DotEnv] Remove `usePutEnv` property default value

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -35,7 +35,7 @@ final class Dotenv
     private $data;
     private $end;
     private $values;
-    private $usePutenv = true;
+    private $usePutenv;
 
     /**
      * @var bool If `putenv()` should be used to define environment variables or not.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The default value is already set in the constructor (and changes in 5.0, see https://github.com/symfony/symfony/pull/31957/files#diff-3dc82e6e990428b0c71cf2112d02269fR44) and the class is final.
