### PR TITLE
[SecurityBundle] Fix TokenStorage::reset not called in stateless firewall

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterTokenUsageTrackingPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterTokenUsageTrackingPass.php
@@ -43,6 +43,7 @@ class RegisterTokenUsageTrackingPass implements CompilerPassInterface
 
         if (!$container->has('session')) {
             $container->setAlias('security.token_storage', 'security.untracked_token_storage')->setPublic(true);
+            $container->getDefinition('security.untracked_token_storage')->addTag('kernel.reset', ['method' => 'reset']);
         } elseif ($container->hasDefinition('security.context_listener')) {
             $container->getDefinition('security.context_listener')
                 ->setArgument(6, [new Reference('security.token_storage'), 'enableUsageTracking']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | NA
| License       | MIT
| Doc PR        | NA

By default, the service `security.token_storage` is resetable. https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml#L22-L24

But when using a stateless application without session, the `RegisterTokenUsageTrackingPass` replace the service `security.token_storage` by an alias to `security.untracked_token_storage` (which is not tagged as resetable.