### PR TITLE
[FrameworkBundle][ContainerLintCommand] Reinitialize bundles when the container is reprepared

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -69,7 +69,11 @@ final class ContainerLintCommand extends Command
         $kernel = $this->getApplication()->getKernel();
 
         if (!$kernel->isDebug() || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
-            $buildContainer = \Closure::bind(function () { return $this->buildContainer(); }, $kernel, \get_class($kernel));
+            $buildContainer = \Closure::bind(function (): ContainerBuilder {
+                $this->initializeBundles();
+
+                return $this->buildContainer();
+            }, $kernel, \get_class($kernel));
             $container = $buildContainer();
         } else {
             (new XmlFileLoader($container = new ContainerBuilder($parameterBag = new EnvPlaceholderParameterBag()), new FileLocator()))->load($kernel->getContainer()->getParameter('debug.container.dump'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Some bundles extensions are "instances dependents", eg they cache service registrations (eg: https://github.com/symfony/symfony/blob/70dec3c8a39181dcf403fb54b92c065f55edfa3c/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php#L743).

Launching the lint command loads all bundles a first time, just to be able to run the command.

Then, when we build the container again for the lint command, it loads all bundles a second time. But since it's the same bundles instances, some services are not registered, leading to missing services in `CheckExceptionOnInvalidReferenceBehaviorPass`.