### PR TITLE
[TwigBundle] fix broken FilesystemLoader::exists() with Twig 3

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -96,7 +96,7 @@ class FilesystemLoader extends BaseFilesystemLoader
                 throw $twigLoaderException;
             }
 
-            return false;
+            return null;
         }
 
         return $this->cache[$logicalName] = $file;

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -123,6 +123,6 @@ class FilesystemLoaderTest extends TestCase
 
         $method = new \ReflectionMethod('Symfony\Bundle\TwigBundle\Loader\FilesystemLoader', 'findTemplate');
         $method->setAccessible(true);
-        $this->assertFalse($method->invoke($loader, 'name.format.engine', false));
+        $this->assertNull($method->invoke($loader, 'name.format.engine', false));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34877 
| License       | MIT
| Doc PR        | 

This fix adapts the declaration of Twig 3 `\Twig\Loader\FilesystemLoader::findTemplate()` which expects to return `string|null` and returns `null` instead of `false`.

Returning `false` breaks `\Twig\Loader\FilesystemLoader::exists()` which returns `true` if `findTemplate()` does not return `null`.

Twig 2 should not be affected by this patch. The `exists()` method expects `null` or `false` for not found templates: <https://github.com/twigphp/Twig/blob/fdb691a424682a524555f73b2c665c06971c4ed5/src/Loader/FilesystemLoader.php#L169>