### PR TITLE
[FrameworkBundle] Allow using the kernel as a registry of controllers and service factories

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\HttpFoundation\Request;
 
+require_once __DIR__.'/flex-style/src/FlexStyleMicroKernel.php';
+
 class MicroKernelTraitTest extends TestCase
 {
     public function test()
@@ -55,5 +57,16 @@ class MicroKernelTraitTest extends TestCase
         $kernel = new ConcreteMicroKernel('test', false);
         $kernel->registerContainerConfiguration(new ClosureLoader($container));
         $this->assertTrue($container->getDefinition('kernel')->hasTag('routing.route_loader'));
+    }
+
+    public function testFlexStyle()
+    {
+        $kernel = new FlexStyleMicroKernel('test', false);
+        $kernel->boot();
+
+        $request = Request::create('/');
+        $response = $kernel->handle($request);
+
+        $this->assertEquals('Have a great day!', $response->getContent());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/config/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/config/bundles.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    FrameworkBundle::class => ['all' => true],
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Kernel;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class FlexStyleMicroKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    private $cacheDir;
+
+    public function halloweenAction(\stdClass $o)
+    {
+        return new Response($o->halloween);
+    }
+
+    public function createHalloween(LoggerInterface $logger, string $halloween)
+    {
+        $o = new \stdClass();
+        $o->logger = $logger;
+        $o->halloween = $halloween;
+
+        return $o;
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->cacheDir = sys_get_temp_dir().'/sf_flex_kernel';
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->cacheDir;
+    }
+
+    public function __sleep(): array
+    {
+        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+    }
+
+    public function __wakeup()
+    {
+        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+    }
+
+    public function __destruct()
+    {
+        $fs = new Filesystem();
+        $fs->remove($this->cacheDir);
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->add('halloween', '/')->controller([$this, 'halloweenAction']);
+    }
+
+    protected function configureContainer(ContainerConfigurator $c)
+    {
+        $c->parameters()
+            ->set('halloween', 'Have a great day!');
+
+        $c->services()
+            ->set('logger', NullLogger::class)
+            ->set('stdClass', 'stdClass')
+                ->factory([$this, 'createHalloween'])
+                ->arg('$halloween', '%halloween%');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "symfony/cache": "^4.4|^5.0",
         "symfony/config": "^5.0",
-        "symfony/dependency-injection": "^5.0.1",
+        "symfony/dependency-injection": "^5.1",
         "symfony/error-handler": "^4.4.1|^5.0.1",
         "symfony/http-foundation": "^4.4|^5.0",
         "symfony/http-kernel": "^5.0",

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -22,6 +22,11 @@ abstract class AbstractConfigurator
 {
     const FACTORY = 'unknown';
 
+    /**
+     * @var callable(mixed $value, bool $allowService)|null
+     */
+    public static $valuePreProcessor;
+
     /** @internal */
     protected $definition;
 
@@ -49,7 +54,11 @@ abstract class AbstractConfigurator
                 $value[$k] = static::processValue($v, $allowServices);
             }
 
-            return $value;
+            return self::$valuePreProcessor ? (self::$valuePreProcessor)($value, $allowServices) : $value;
+        }
+
+        if (self::$valuePreProcessor) {
+            $value = (self::$valuePreProcessor)($value, $allowServices);
         }
 
         if ($value instanceof ReferenceConfigurator) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -34,14 +34,16 @@ class ContainerConfigurator extends AbstractConfigurator
     private $path;
     private $file;
     private $anonymousCount = 0;
+    private $defaultDefinition;
 
-    public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path, string $file)
+    public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path, string $file, Definition $defaultDefinition = null)
     {
         $this->container = $container;
         $this->loader = $loader;
         $this->instanceof = &$instanceof;
         $this->path = $path;
         $this->file = $file;
+        $this->defaultDefinition = $defaultDefinition;
     }
 
     final public function extension(string $namespace, array $config)
@@ -67,7 +69,7 @@ class ContainerConfigurator extends AbstractConfigurator
 
     final public function services(): ServicesConfigurator
     {
-        return new ServicesConfigurator($this->container, $this->loader, $this->instanceof, $this->path, $this->anonymousCount);
+        return new ServicesConfigurator($this->container, $this->loader, $this->instanceof, $this->path, $this->anonymousCount, $this->defaultDefinition);
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -32,16 +32,19 @@ class ServicesConfigurator extends AbstractConfigurator
     private $path;
     private $anonymousHash;
     private $anonymousCount;
+    private $defaultDefinition;
 
-    public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path = null, int &$anonymousCount = 0)
+    public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path = null, int &$anonymousCount = 0, Definition $defaultDefinition = null)
     {
-        $this->defaults = new Definition();
+        $defaultDefinition = $defaultDefinition ?? new Definition();
+        $this->defaults = clone $defaultDefinition;
         $this->container = $container;
         $this->loader = $loader;
         $this->instanceof = &$instanceof;
         $this->path = $path;
         $this->anonymousHash = ContainerBuilder::hash($path ?: mt_rand());
         $this->anonymousCount = &$anonymousCount;
+        $this->defaultDefinition = $defaultDefinition;
         $instanceof = [];
     }
 
@@ -50,7 +53,7 @@ class ServicesConfigurator extends AbstractConfigurator
      */
     final public function defaults(): DefaultsConfigurator
     {
-        return new DefaultsConfigurator($this, $this->defaults = new Definition(), $this->path);
+        return new DefaultsConfigurator($this, $this->defaults = clone $this->defaultDefinition, $this->path);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -170,11 +170,14 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                             $message .= ' Did you forget to add a use statement?';
                         }
 
-                        throw new InvalidArgumentException($message);
-                    }
+                        $container->register($erroredId = '.errored.'.$container->hash($message), $type)
+                            ->addError($message);
 
-                    $target = ltrim($target, '\\');
-                    $args[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, $p->name) : new Reference($target, $invalidBehavior);
+                        $args[$p->name] = new Reference($erroredId, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE);
+                    } else {
+                        $target = ltrim($target, '\\');
+                        $args[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, $p->name) : new Reference($target, $invalidBehavior);
+                    }
                 }
                 // register the maps as a per-method service-locators
                 if ($args) {

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -197,7 +197,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
     public function testExceptionOnNonExistentTypeHint()
     {
-        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Cannot determine controller argument for "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClassController::fooAction()": the $nonExistent argument is type-hinted with the non-existent class or interface: "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClass". Did you forget to add a use statement?');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
@@ -207,11 +207,17 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $pass = new RegisterControllerArgumentLocatorsPass();
         $pass->process($container);
+
+        $error = $container->getDefinition('argument_resolver.service')->getArgument(0);
+        $error = $container->getDefinition($error)->getArgument(0)['foo::fooAction']->getValues()[0];
+        $error = $container->getDefinition($error)->getArgument(0)['nonExistent']->getValues()[0];
+
+        $container->get($error);
     }
 
     public function testExceptionOnNonExistentTypeHintDifferentNamespace()
     {
-        $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Cannot determine controller argument for "Symfony\Component\HttpKernel\Tests\DependencyInjection\NonExistentClassDifferentNamespaceController::fooAction()": the $nonExistent argument is type-hinted with the non-existent class or interface: "Acme\NonExistentClass".');
         $container = new ContainerBuilder();
         $container->register('argument_resolver.service')->addArgument([]);
@@ -221,6 +227,12 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $pass = new RegisterControllerArgumentLocatorsPass();
         $pass->process($container);
+
+        $error = $container->getDefinition('argument_resolver.service')->getArgument(0);
+        $error = $container->getDefinition($error)->getArgument(0)['foo::fooAction']->getValues()[0];
+        $error = $container->getDefinition($error)->getArgument(0)['nonExistent']->getValues()[0];
+
+        $container->get($error);
     }
 
     public function testNoExceptionOnNonExistentTypeHintOptionalArg()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #28992, fix #29997
| License       | MIT
| Doc PR        | -

This PR builds on #34873 and #34872 and allows using the `Kernel` as a registry of autowired controllers and service factories. The `ContainerConfigurator` passed to `configureContainer()` defaults to declaring autowired and autoconfigured services.

TL;DR: Silex is back but in a much more powerful way \o/

Here is a Kernel that just works and displays `Hello App\Foo` on the `/` route:
```php
class Kernel extends BaseKernel
{
    use MicroKernelTrait;

    protected function configureContainer(ContainerConfigurator $container): void
    {
        $container->services()
            ->load('App\\', '../src')
            ->set(Foo::class)
                ->factory([$this, 'createFoo']);
    }

    public function createFoo(Bar $bar)
    {
        return new Foo($bar);
    }

    protected function configureRoutes(RoutingConfigurator $routes): void
    {
        $routes->add('home', '/')->controller([$this, 'helloAction']);
    }

    public function helloAction(Foo $foo)
    {
        return new Response('Hello '.get_class($foo));
    }
}
```