### PR TITLE
[DI] Enable auto alias compiler pass by default

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -49,6 +49,7 @@ class PassConfig
         ];
 
         $this->optimizationPasses = [[
+            new AutoAliasServicePass(),
             new ValidateEnvPlaceholdersPass(),
             new ResolveChildDefinitionsPass(),
             new RegisterServiceSubscribersPass(),

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1601,6 +1601,24 @@ class ContainerBuilderTest extends TestCase
         $wither = $container->get('wither');
         $this->assertInstanceOf(Foo::class, $wither->foo);
     }
+
+    public function testAutoAliasing()
+    {
+        $container = new ContainerBuilder();
+        $container->register(C::class);
+        $container->register(D::class);
+
+        $container->setParameter('foo', D::class);
+
+        $definition = new Definition(X::class);
+        $definition->setPublic(true);
+        $definition->addTag('auto_alias', ['format' => '%foo%']);
+        $container->setDefinition(X::class, $definition);
+
+        $container->compile();
+
+        $this->assertInstanceOf(D::class, $container->get(X::class));
+    }
 }
 
 class FooClass
@@ -1616,4 +1634,16 @@ class B
     public function __construct(A $a)
     {
     }
+}
+
+interface X
+{
+}
+
+class C implements X
+{
+}
+
+class D implements X
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  |
| Deprecations? | no
| Tickets       | Fix #34194
| License       | MIT
| Doc PR        |

I'm sending this PR to trigger a discussion as @nicolas-grekas suggested in #34194 

I'm using this quite a lot in one of my applications and I don't see any reasons why it shouldn't be enabled by default.
