### PR TITLE
[Cache] fix memory leak when using PhpFilesAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterAppendOnlyTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterAppendOnlyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
+
+/**
+ * @group time-sensitive
+ */
+class PhpFilesAdapterAppendOnlyTest extends PhpFilesAdapterTest
+{
+    protected $skippedTests = [
+        'testDefaultLifeTime' => 'PhpFilesAdapter does not allow configuring a default lifetime.',
+        'testExpiration' => 'PhpFilesAdapter in append-only mode does not expiration.',
+    ];
+
+    public function createCachePool(): CacheItemPoolInterface
+    {
+        return new PhpFilesAdapter('sf-cache', 0, null, true);
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -26,7 +26,7 @@ trait FilesystemCommonTrait
     private function init($namespace, $directory)
     {
         if (!isset($directory[0])) {
-            $directory = sys_get_temp_dir().'/symfony-cache';
+            $directory = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'symfony-cache';
         } else {
             $directory = realpath($directory) ?: $directory;
         }
@@ -55,8 +55,8 @@ trait FilesystemCommonTrait
     {
         $ok = true;
 
-        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->directory, \FilesystemIterator::SKIP_DOTS)) as $file) {
-            $ok = ($file->isDir() || $this->doUnlink($file) || !file_exists($file)) && $ok;
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->directory, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::CURRENT_AS_PATHNAME), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
+            $ok = ($this->doUnlink($file) || !file_exists($file)) && $ok;
         }
 
         return $ok;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34687
| License       | MIT
| Doc PR        | -

Similar to #34839 but for `PhpFilesAdapter`, as the "appendOnly" mode is a v4-only feature.