### PR TITLE
[Serializer] Cast numeric/null into xml node value to php type instead of string

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 5.1.0
 -----
- * Cast to PHP type numeric value from node for XML
+ * Cast to PHP type numeric value from node for XML if `XmlEncoder::TYPE_CAST_NODES` set to true into context
 
 5.0.0
 -----

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+ * Cast to PHP type numeric value from node for XML
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -52,6 +52,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     const ROOT_NODE_NAME = 'xml_root_node_name';
     const STANDALONE = 'xml_standalone';
     const TYPE_CAST_ATTRIBUTES = 'xml_type_cast_attributes';
+    const TYPE_CAST_NODES = 'xml_type_cast_nodes';
     const VERSION = 'xml_version';
 
     private $defaultContext = [
@@ -62,6 +63,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::REMOVE_EMPTY_TAGS => false,
         self::ROOT_NODE_NAME => 'response',
         self::TYPE_CAST_ATTRIBUTES => true,
+        self::TYPE_CAST_NODES => true,
     ];
 
     /**
@@ -325,16 +327,18 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             return $node->nodeValue;
         }
 
+        $typeCastNodes = (bool) ($context[self::TYPE_CAST_NODES] ?? $this->defaultContext[self::TYPE_CAST_NODES]);
+
         if (1 === $node->childNodes->length && \in_array($node->firstChild->nodeType, [XML_TEXT_NODE, XML_CDATA_SECTION_NODE])) {
+            if (!is_numeric($node->firstChild->nodeValue) || !$typeCastNodes) {
+                return $node->firstChild->nodeValue;
+            }
+
             if (false !== $val = filter_var($node->firstChild->nodeValue, FILTER_VALIDATE_INT)) {
                 return $val;
             }
 
-            if (false !== $val = filter_var($node->firstChild->nodeValue, FILTER_VALIDATE_FLOAT)) {
-                return $val;
-            }
-
-            return $node->firstChild->nodeValue;
+            return (float) $node->firstChild->nodeValue;
         }
 
         $value = [];

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -323,11 +323,15 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
      */
     private function parseXmlValue(\DOMNode $node, array $context = [])
     {
+        $typeCastNodes = (bool) ($context[self::TYPE_CAST_NODES] ?? $this->defaultContext[self::TYPE_CAST_NODES]);
+
         if (!$node->hasChildNodes()) {
+            if ($typeCastNodes && '' === $node->nodeValue) {
+                return null;
+            }
+
             return $node->nodeValue;
         }
-
-        $typeCastNodes = (bool) ($context[self::TYPE_CAST_NODES] ?? $this->defaultContext[self::TYPE_CAST_NODES]);
 
         if (1 === $node->childNodes->length && \in_array($node->firstChild->nodeType, [XML_TEXT_NODE, XML_CDATA_SECTION_NODE])) {
             if (!is_numeric($node->firstChild->nodeValue) || !$typeCastNodes) {

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -326,6 +326,14 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         }
 
         if (1 === $node->childNodes->length && \in_array($node->firstChild->nodeType, [XML_TEXT_NODE, XML_CDATA_SECTION_NODE])) {
+            if (false !== $val = filter_var($node->firstChild->nodeValue, FILTER_VALIDATE_INT)) {
+                return $val;
+            }
+
+            if (false !== $val = filter_var($node->firstChild->nodeValue, FILTER_VALIDATE_FLOAT)) {
+                return $val;
+            }
+
             return $node->firstChild->nodeValue;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -439,6 +439,22 @@ XML;
         $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
     }
 
+    public function testDecodeNumericNodeValue()
+    {
+        $source = '<?xml version="1.0"?>'."\n".
+            '<response><foo>7643796</foo><bar>3.14</bar></response>'."\n";
+
+        $expected = [
+            'foo' => 7643796,
+            'bar' => 3.14,
+        ];
+
+        $result = $this->encoder->decode($source, 'xml');
+        $this->assertEquals($expected, $result);
+        $this->assertIsInt($result['foo']);
+        $this->assertIsFloat($result['bar']);
+    }
+
     public function testDecodeRootAttributes()
     {
         $source = '<?xml version="1.0"?>'."\n".

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -301,7 +301,11 @@ XML;
 </document>
 XML;
 
-        $data = $this->encoder->decode($source, 'xml', ['xml_type_cast_attributes' => false]);
+        $data = $this->encoder->decode($source, 'xml', [
+            XmlEncoder::TYPE_CAST_ATTRIBUTES => false,
+            XmlEncoder::TYPE_CAST_NODES => false,
+        ]);
+
         $expected = [
             '@a' => '018',
             '@b' => '-12.11',
@@ -453,6 +457,20 @@ XML;
         $this->assertEquals($expected, $result);
         $this->assertIsInt($result['foo']);
         $this->assertIsFloat($result['bar']);
+    }
+
+    public function testDecodeEmptyNodeValue()
+    {
+        $source = '<?xml version="1.0"?>'."\n".
+            '<response><foo/></response>'."\n";
+
+        $expected = [
+            'foo' => null,
+        ];
+
+        $result = $this->encoder->decode($source, 'xml');
+        $this->assertEquals($expected, $result);
+        $this->assertNull($result['foo']);
     }
 
     public function testDecodeRootAttributes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix partial #33849
| License       | MIT
| Doc PR        | none

XML example: 
```xml
<?xml version="1.0"?>
<response>
  <foo>7643796</foo>
  <bar>3.14</bar>
</response>
```
Currently:
```php
array(2) {
  ["foo"]=>
  string(7) "7643796",
  ["bar"]=>
  string(4) "3.14"
}
```

expected
```php
array(2) {
  ["foo"]=>
  int(7643796),
  ["bar"]=>
  float(3.14)
}
```
