### PR TITLE
Fixing bad order of operations with null coalescing operator

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -41,7 +41,7 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     public function normalize($exception, $format = null, array $context = [])
     {
         $context += $this->defaultContext;
-        $debug = $this->debug && $context['debug'] ?? true;
+        $debug = $this->debug && ($context['debug'] ?? true);
 
         $data = [
             'type' => $context['type'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | not needed

Hi!

Reported by a user on SymfonyCasts :). Apparently without the parentheses, the order of operations is incorrect: https://3v4l.org/UZ7GU

Thanks!