### PR TITLE
[FrameworkBundle] Fix invalid Windows path normalization in TemplateNameParser

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
@@ -44,7 +44,7 @@ class TemplateNameParser extends BaseTemplateNameParser
         }
 
         // normalize name
-        $name = str_replace(':/', ':', preg_replace('#/{2,}#', '/', str_replace('\\', '/', $name)));
+        $name = preg_replace('#/{2,}#', '/', str_replace('\\', '/', $name));
 
         if (false !== strpos($name, '..')) {
             throw new \RuntimeException(sprintf('Template name "%s" contains invalid characters.', $name));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -98,8 +98,8 @@ class TemplateNameParserTest extends TestCase
     {
         return [
             ['/path/to/section/index.html.php', '/path/to/section/index.html.php', '/path/to/section/index.html.php', new BaseTemplateReference('/path/to/section/index.html.php', 'php')],
-            ['C:\\path\\to\\section\\name.html.php', 'C:path/to/section/name.html.php', 'C:path/to/section/name.html.php', new BaseTemplateReference('C:path/to/section/name.html.php', 'php')],
-            ['C:\\path\\to\\section\\name:foo.html.php', 'C:path/to/section/name:foo.html.php', 'C:path/to/section/name:foo.html.php', new BaseTemplateReference('C:path/to/section/name:foo.html.php', 'php')],
+            ['C:\\path\\to\\section\\name.html.php', 'C:/path/to/section/name.html.php', 'C:/path/to/section/name.html.php', new BaseTemplateReference('C:/path/to/section/name.html.php', 'php')],
+            ['C:\\path\\to\\section\\name:foo.html.php', 'C:/path/to/section/name:foo.html.php', 'C:/path/to/section/name:foo.html.php', new BaseTemplateReference('C:/path/to/section/name:foo.html.php', 'php')],
             ['\\path\\to\\section\\name.html.php', '/path/to/section/name.html.php', '/path/to/section/name.html.php', new BaseTemplateReference('/path/to/section/name.html.php', 'php')],
             ['/path/to/section/name.php', '/path/to/section/name.php', '/path/to/section/name.php', new BaseTemplateReference('/path/to/section/name.php', 'php')],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 - <5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | Fix invalid Windows path normalization

All versions of Symfony until 5.0 (which does no longer do extra file path normalization) normalize Windows paths wrongly.

See https://github.com/PrestaShop/PrestaShop/issues/16736 and https://bugs.php.net/bug.php?id=78939

Currently this issue can be observed when Symfony is run by NTS PHP only, but once the PHP issue will be fixed, this issue will probably affects all Windows users when absolute template name is passed to Symfony templating.