### PR TITLE
[Translation] fix memoryleak in PhpFileLoader

### DIFF
--- a/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
@@ -18,11 +18,25 @@ namespace Symfony\Component\Translation\Loader;
  */
 class PhpFileLoader extends FileLoader
 {
+    private static $cache = [];
+
     /**
      * {@inheritdoc}
      */
     protected function loadResource($resource)
     {
-        return require $resource;
+        if ([] === self::$cache && \function_exists('opcache_invalidate') && filter_var(ini_get('opcache.enable'), FILTER_VALIDATE_BOOLEAN) && (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) || filter_var(ini_get('opcache.enable_cli'), FILTER_VALIDATE_BOOLEAN))) {
+            self::$cache = null;
+        }
+
+        if (null === self::$cache) {
+            return require $resource;
+        }
+
+        if (isset(self::$cache[$resource])) {
+            return self::$cache[$resource];
+        }
+
+        return self::$cache[$resource] = require $resource;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This happens when running the test suite with opcache disabled (as it is the case by default since `opcache.enable_cli=0`).
Doing this "require" in a loop (for each test case) compiles the file at each iteration and doesn't reclaim memory (there is no garbage collector for opcodes).