### PR TITLE
[FrameworkBundle][Secrets] Hook configured local dotenv file

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -129,7 +129,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeDisabled()
                     ->children()
                         ->scalarNode('vault_directory')->defaultValue('%kernel.project_dir%/config/secrets/%kernel.environment%')->cannotBeEmpty()->end()
-                        ->scalarNode('local_dotenv_file')->defaultValue('%kernel.project_dir%/.env.local')->end()
+                        ->scalarNode('local_dotenv_file')->defaultValue('%kernel.project_dir%/.env.%kernel.environment%.local')->end()
                         ->scalarNode('decryption_env_var')->defaultValue('base64:default::SYMFONY_DECRYPTION_SECRET')->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1478,7 +1478,9 @@ class FrameworkExtension extends Extension
 
         $container->getDefinition('secrets.vault')->replaceArgument(0, $config['vault_directory']);
 
-        if (!$config['local_dotenv_file']) {
+        if ($config['local_dotenv_file']) {
+            $container->getDefinition('secrets.local_vault')->replaceArgument(0, $config['local_dotenv_file']);
+        } else {
             $container->removeDefinition('secrets.local_vault');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/secrets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/secrets.xml
@@ -7,12 +7,12 @@
     <services>
         <service id="secrets.vault" class="Symfony\Bundle\FrameworkBundle\Secrets\SodiumVault">
             <tag name="container.env_var_loader" />
-            <argument>%kernel.project_dir%/config/secrets/%kernel.environment%</argument>
-            <argument>%env(base64:default::SYMFONY_DECRYPTION_SECRET)%</argument>
+            <argument />
+            <argument />
         </service>
 
         <service id="secrets.local_vault" class="Symfony\Bundle\FrameworkBundle\Secrets\DotenvVault">
-            <argument>%kernel.project_dir%/.env.local</argument>
+            <argument />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -519,7 +519,7 @@ class ConfigurationTest extends TestCase
             'secrets' => [
                 'enabled' => true,
                 'vault_directory' => '%kernel.project_dir%/config/secrets/%kernel.environment%',
-                'local_dotenv_file' => '%kernel.project_dir%/.env.local',
+                'local_dotenv_file' => '%kernel.project_dir%/.env.%kernel.environment%.local',
                 'decryption_env_var' => 'base64:default::SYMFONY_DECRYPTION_SECRET',
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/34905
| License       | MIT
| Doc PR        | -

Configured local_dotenv_file does not currently substitute the secrets.vault service definition first argument value, rendering this configuration option useless + we don't need to set defaults in secrets.xml since everything is overriden in FrameworkExtension with the same default values (from the configuration).
