### PR TITLE
[ErrorHandler] Enabled the dark theme for exception pages

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -66,7 +66,7 @@
     --metric-unit-color: #999;
     --metric-label-background: #777;
     --metric-label-color: #e0e0e0;
-    --trace-selected-background: #71663a;
+    --trace-selected-background: #71663acc;
     --table-border: #444;
     --table-background: #333;
     --table-header: #555;
@@ -462,8 +462,8 @@ table tbody td.num-col {
 }
 tr.status-error td,
 tr.status-warning td {
-    border-bottom: 1px solid #FAFAFA;
-    border-top: 1px solid #FAFAFA;
+    border-bottom: 1px solid var(--base-2);
+    border-top: 1px solid var(--base-2);
 }
 
 .status-warning .colored {

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -42,13 +42,54 @@
     --base-6: #222;
 }
 
+.theme-dark {
+    --page-background: #36393e;
+    --color-text: #e0e0e0;
+    --color-muted: #777;
+    --color-error: #d43934;
+    --tab-background: #555;
+    --tab-color: #ccc;
+    --tab-active-background: #888;
+    --tab-active-color: #fafafa;
+    --tab-disabled-background: var(--page-background);
+    --tab-disabled-color: #777;
+    --metric-value-background: #555;
+    --metric-value-color: inherit;
+    --metric-unit-color: #999;
+    --metric-label-background: #777;
+    --metric-label-color: #e0e0e0;
+    --trace-selected-background: #71663acc;
+    --table-border: #444;
+    --table-background: #333;
+    --table-header: #555;
+    --info-background: rgba(79, 148, 195, 0.5);
+    --tree-active-background: var(--metric-label-background);
+    --exception-title-color: var(--base-2);
+    --shadow: 0px 0px 1px rgba(32, 32, 32, .2);
+    --border: 1px solid #666;
+    --background-error: #b0413e;
+    --highlight-comment: #dedede;
+    --highlight-default: var(--base-6);
+    --highlight-keyword: #ff413c;
+    --highlight-string: #70a6fd;
+    --base-0: #2e3136;
+    --base-1: #444;
+    --base-2: #666;
+    --base-3: #666;
+    --base-4: #666;
+    --base-5: #e0e0e0;
+    --base-6: #f5f5f5;
+    --card-label-background: var(--tab-active-background);
+    --card-label-color: var(--tab-active-color);
+}
+
 html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}body{margin:0}article,aside,details,figcaption,figure,footer,header,hgroup,main,menu,nav,section,summary{display:block}audio,canvas,progress,video{display:inline-block;vertical-align:baseline}audio:not([controls]){display:none;height:0}[hidden],template{display:none}a{background-color:transparent}a:active,a:hover{outline:0}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:700}dfn{font-style:italic}h1{margin:.67em 0;font-size:2em}mark{color:#000;background:#ff0}small{font-size:80%}sub,sup{position:relative;font-size:75%;line-height:0;vertical-align:baseline}sup{top:-.5em}sub{bottom:-.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:1em 40px}hr{height:0;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}pre{overflow:auto}code,kbd,pre,samp{font-family:monospace,monospace;font-size:1em}button,input,optgroup,select,textarea{margin:0;font:inherit;color:inherit}button{overflow:visible}button,select{text-transform:none}button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}button[disabled],html input[disabled]{cursor:default}button::-moz-focus-inner,input::-moz-focus-inner{padding:0;border:0}input{line-height:normal}input[type="checkbox"],input[type="radio"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:0}input[type="number"]::-webkit-inner-spin-button,input[type="number"]::-webkit-outer-spin-button{height:auto}input[type="search"]{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;-webkit-appearance:textfield}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}fieldset{padding:.35em .625em .75em;margin:0 2px;border:1px solid silver}legend{padding:0;border:0}textarea{overflow:auto}optgroup{font-weight:700}table{border-spacing:0;border-collapse:collapse}td,th{padding:0}
 
 html {
     /* always display the vertical scrollbar to avoid jumps when toggling contents */
     overflow-y: scroll;
 }
-body { background-color: #F9F9F9; color: var(--base-6); font: 14px/1.4 Helvetica, Arial, sans-serif; padding-bottom: 45px; }
+body { background-color: var(--page-background); color: var(--base-6); font: 14px/1.4 Helvetica, Arial, sans-serif; padding-bottom: 45px; }
 
 a { cursor: pointer; text-decoration: none; }
 a:hover { text-decoration: underline; }
@@ -56,8 +97,8 @@ abbr[title] { border-bottom: none; cursor: help; text-decoration: none; }
 
 code, pre { font: 13px/1.5 Consolas, Monaco, Menlo, "Ubuntu Mono", "Liberation Mono", monospace; }
 
-table, tr, th, td { background: #FFF; border-collapse: collapse; vertical-align: top; }
-table { background: #FFF; border: var(--border); box-shadow: 0px 0px 1px rgba(128, 128, 128, .2); margin: 1em 0; width: 100%; }
+table, tr, th, td { background: var(--base-0); border-collapse: collapse; vertical-align: top; }
+table { background: var(--base-0); border: var(--border); box-shadow: 0px 0px 1px rgba(128, 128, 128, .2); margin: 1em 0; width: 100%; }
 table th, table td { border: solid var(--base-2); border-width: 1px 0; padding: 8px 10px; }
 table th { background-color: var(--base-2); font-weight: bold; text-align: left; }
 
@@ -79,7 +120,7 @@ table th { background-color: var(--base-2); font-weight: bold; text-align: left;
 .status-warning { background: rgba(240, 181, 24, 0.3); }
 .status-error { background: rgba(176, 65, 62, 0.2); }
 .status-success td, .status-warning td, .status-error td { background: transparent; }
-tr.status-error td, tr.status-warning td { border-bottom: 1px solid #FAFAFA; border-top: 1px solid #FAFAFA; }
+tr.status-error td, tr.status-warning td { border-bottom: 1px solid var(--base-2); border-top: 1px solid var(--base-2); }
 .status-warning .colored { color: #A46A1F; }
 .status-error .colored  { color: var(--color-error); }
 
@@ -139,7 +180,7 @@ thead.sf-toggle-content.sf-toggle-visible, tbody.sf-toggle-content.sf-toggle-vis
 .container { max-width: 1024px; margin: 0 auto; padding: 0 15px; }
 .container::after { content: ""; display: table; clear: both; }
 
-header { background-color: var(--base-6); color: rgba(255, 255, 255, 0.75); font-size: 13px; height: 33px; line-height: 33px; padding: 0; }
+header { background-color: #222; color: rgba(255, 255, 255, 0.75); font-size: 13px; height: 33px; line-height: 33px; padding: 0; }
 header .container { display: flex; justify-content: space-between; }
 .logo { flex: 1; font-size: 13px; font-weight: normal; margin: 0; padding: 0; }
 .logo svg { height: 18px; width: 18px; opacity: .8; vertical-align: -5px; }
@@ -174,7 +215,7 @@ header .container { display: flex; justify-content: space-between; }
 .trace-head .trace-class { color: var(--base-6); font-size: 18px; font-weight: bold; line-height: 1.3; margin: 0; position: relative; }
 .trace-head .trace-namespace { color: #999; display: block; font-size: 13px; }
 .trace-head .icon { position: absolute; right: 0; top: 0; }
-.trace-head .icon svg { height: 24px; width: 24px; }
+.trace-head .icon svg { fill: var(--base-5); height: 24px; width: 24px; }
 
 .trace-details { background: var(--base-0); border: var(--border); box-shadow: 0px 0px 1px rgba(128, 128, 128, .2); margin: 1em 0; table-layout: fixed; }
 
@@ -185,7 +226,7 @@ header .container { display: flex; justify-content: space-between; }
 .trace-line:hover { background: var(--base-1); }
 .trace-line a { color: var(--base-6); }
 .trace-line .icon { opacity: .4; position: absolute; left: 10px; top: 11px; }
-.trace-line .icon svg { height: 16px; width: 16px; }
+.trace-line .icon svg { fill: var(--base-5); height: 16px; width: 16px; }
 .trace-line-header { padding-left: 36px; padding-right: 10px; }
 
 .trace-file-path, .trace-file-path a { color: var(--base-6); font-size: 13px; }

--- a/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
@@ -11,6 +11,12 @@
         <style><?= $this->include('assets/css/exception_full.css'); ?></style>
     </head>
     <body>
+        <script>
+            document.body.classList.add(
+                localStorage.getItem('symfony/profiler/theme') || (matchMedia('(prefers-color-scheme: dark)').matches ? 'theme-dark' : 'theme-light')
+            );
+        </script>
+
         <?php if (class_exists('Symfony\Component\HttpKernel\Kernel')) { ?>
             <header>
                 <div class="container">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This makes the exception pages compatible with the dark theme. By default, they use the same setting as the Profiler. If no setting is defined, it auto-selects the theme based on the operating system theme.

Some comparison screenshots:

![exception-dark-theme-1](https://user-images.githubusercontent.com/73419/70550842-b087c480-1b76-11ea-9bf5-43a029f1cf6a.png)

![exception-dark-theme-2](https://user-images.githubusercontent.com/73419/70550848-b41b4b80-1b76-11ea-9759-4f31c1c6d5b8.png)
