### PR TITLE
Messenger: validate options for AMQP and Redis Connections

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -35,6 +35,7 @@ Messenger
  * Deprecated AmqpExt transport. It has moved to a separate package. Run `composer require symfony/amqp-messenger` to use the new classes.
  * Deprecated Doctrine transport. It has moved to a separate package. Run `composer require symfony/doctrine-messenger` to use the new classes.
  * Deprecated RedisExt transport. It has moved to a separate package. Run `composer require symfony/redis-messenger` to use the new classes.
+ * Deprecated use of invalid options in Redis and AMQP connections.
 
 Routing
 -------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -35,6 +35,7 @@ Messenger
  * Removed AmqpExt transport. Run `composer require symfony/amqp-messenger` to keep the transport in your application.
  * Removed Doctrine transport. Run `composer require symfony/doctrine-messenger` to keep the transport in your application.
  * Removed RedisExt transport. Run `composer require symfony/redis-messenger` to keep the transport in your application.
+ * Use of invalid options in Redis and AMQP connections now throws an error.
 
 Routing
 -------

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 -----
 
  * Introduced the AMQP bridge.
+ * Deprecated use of invalid options

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportFactoryTest.php
@@ -36,8 +36,8 @@ class AmqpTransportFactoryTest extends TestCase
         $factory = new AmqpTransportFactory();
         $serializer = $this->createMock(SerializerInterface::class);
 
-        $expectedTransport = new AmqpTransport(Connection::fromDsn('amqp://localhost', ['foo' => 'bar']), $serializer);
+        $expectedTransport = new AmqpTransport(Connection::fromDsn('amqp://localhost', ['host' => 'localhost']), $serializer);
 
-        $this->assertEquals($expectedTransport, $factory->createTransport('amqp://localhost', ['foo' => 'bar'], $serializer));
+        $this->assertEquals($expectedTransport, $factory->createTransport('amqp://localhost', ['host' => 'localhost'], $serializer));
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -102,6 +102,42 @@ class ConnectionTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Invalid option(s) "foo" passed to the AMQP Messenger transport. Passing invalid options is deprecated since Symfony 5.1.
+     */
+    public function testDeprecationIfInvalidOptionIsPassedWithDsn()
+    {
+        Connection::fromDsn('amqp://host?foo=bar');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Invalid option(s) "foo" passed to the AMQP Messenger transport. Passing invalid options is deprecated since Symfony 5.1.
+     */
+    public function testDeprecationIfInvalidOptionIsPassedAsArgument()
+    {
+        Connection::fromDsn('amqp://host', ['foo' => 'bar']);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Invalid queue option(s) "foo" passed to the AMQP Messenger transport. Passing invalid queue options is deprecated since Symfony 5.1.
+     */
+    public function testDeprecationIfInvalidQueueOptionIsPassed()
+    {
+        Connection::fromDsn('amqp://host', ['queues' => ['queueName' => ['foo' => 'bar']]]);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Invalid exchange option(s) "foo" passed to the AMQP Messenger transport. Passing invalid exchange options is deprecated since Symfony 5.1.
+     */
+    public function testDeprecationIfInvalidExchangeOptionIsPassed()
+    {
+        Connection::fromDsn('amqp://host', ['exchange' => ['foo' => 'bar']]);
+    }
+
     public function testSetsParametersOnTheQueueAndExchange()
     {
         $factory = new TestAmqpFactory(

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -22,7 +22,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
 
-
 class ConnectionTest extends TestCase
 {
     public function testGetAMessageWillChangeItsStatus()
@@ -247,12 +246,14 @@ class ConnectionTest extends TestCase
     public function testItThrowsAnExceptionIfAnExtraOptionsInDefined()
     {
         $this->expectException('Symfony\Component\Messenger\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Unknown option found: [new_option]. Allowed options are [table_name, queue_name, redeliver_timeout, auto_setup]');
         Connection::buildConfiguration('doctrine://default', ['new_option' => 'woops']);
     }
 
     public function testItThrowsAnExceptionIfAnExtraOptionsInDefinedInDSN()
     {
         $this->expectException('Symfony\Component\Messenger\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Unknown option found in DSN: [new_option]. Allowed options are [table_name, queue_name, redeliver_timeout, auto_setup]');
         Connection::buildConfiguration('doctrine://default?new_option=woops');
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -85,7 +85,7 @@ class Connection
         // check for extra keys in options
         $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
         if (0 < \count($optionsExtraKeys)) {
-            throw new InvalidArgumentException(sprintf('Unknown option found : [%s]. Allowed options are [%s]', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
+            throw new InvalidArgumentException(sprintf('Unknown option found: [%s]. Allowed options are [%s]', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 
         // check for extra keys in options

--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -6,3 +6,4 @@ CHANGELOG
 
  * Introduced the Redis bridge.
  * Added TLS option in the DSN. Example: `redis://127.0.0.1?tls=1`
+ * Deprecated use of invalid options

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -108,6 +108,15 @@ class ConnectionTest extends TestCase
         );
     }
 
+    /**
+     * @expectedDeprecation Invalid option(s) "foo" passed to the Redis Messenger transport. Passing invalid options is deprecated since Symfony 5.1.
+     * @group legacy
+     */
+    public function testDeprecationIfInvalidOptionIsPassedWithDsn()
+    {
+        Connection::fromDsn('redis://localhost/queue?foo=bar');
+    }
+
     public function testKeepGettingPendingMessages()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportFactoryTest.php
@@ -35,8 +35,8 @@ class RedisTransportFactoryTest extends TestCase
     {
         $factory = new RedisTransportFactory();
         $serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
-        $expectedTransport = new RedisTransport(Connection::fromDsn('redis://localhost', ['foo' => 'bar']), $serializer);
+        $expectedTransport = new RedisTransport(Connection::fromDsn('redis://localhost', ['stream' => 'bar']), $serializer);
 
-        $this->assertEquals($expectedTransport, $factory->createTransport('redis://localhost', ['foo' => 'bar'], $serializer));
+        $this->assertEquals($expectedTransport, $factory->createTransport('redis://localhost', ['stream' => 'bar'], $serializer));
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -34,6 +34,7 @@ class Connection
         'auto_setup' => true,
         'stream_max_entries' => 0, // any value higher than 0 defines an approximate maximum number of stream entries
         'dbindex' => 0,
+        'tls' => false,
     ];
 
     private $connection;
@@ -85,6 +86,8 @@ class Connection
         if (isset($parsedUrl['query'])) {
             parse_str($parsedUrl['query'], $redisOptions);
         }
+
+        self::validateOptions($redisOptions);
 
         $autoSetup = null;
         if (\array_key_exists('auto_setup', $redisOptions)) {
@@ -142,6 +145,16 @@ class Connection
         }
 
         return new self($configuration, $connectionCredentials, $redisOptions, $redis);
+    }
+
+    private static function validateOptions(array $options): void
+    {
+        $availableOptions = array_keys(self::DEFAULT_OPTIONS);
+        $availableOptions[] = 'serializer';
+
+        if (0 < \count($invalidOptions = array_diff(array_keys($options), $availableOptions))) {
+            @trigger_error(sprintf('Invalid option(s) "%s" passed to the Redis Messenger transport. Passing invalid options is deprecated since Symfony 5.1.', implode('", "', $invalidOptions)), E_USER_DEPRECATED);
+        }
     }
 
     public function get(): ?array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| Ticket | https://github.com/symfony/symfony/issues/32575
| New feature?  | yes
| Deprecations? | yes 
| License       | MIT

This PR validates options for AMQP and Redis connections.

Regarding AMQP, I've merged symfony's specific options (`exchange`, `delay`...) with the ones available in the [AMQP Extension](https://github.com/pdezwart/php-amqp/blob/master/amqp_connection.c#L177-L192) and i've enhanced the phpdoc with the one found [here](https://github.com/pdezwart/php-amqp/blob/master/stubs/AMQPConnection.php#L27-L54)
