### PR TITLE
[Form] Remove redundant checks of IntlDateFormatter/IntlTimeZone

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -109,16 +109,10 @@ class DateType extends AbstractType
                 \Locale::getDefault(),
                 $dateFormat,
                 $timeFormat,
-                // see https://bugs.php.net/66323
-                class_exists('IntlTimeZone', false) ? \IntlTimeZone::createDefault() : null,
+                \IntlTimeZone::createDefault(),
                 $calendar,
                 $pattern
             );
-
-            // new \IntlDateFormatter may return null instead of false in case of failure, see https://bugs.php.net/66323
-            if (!$formatter) {
-                throw new InvalidOptionsException(intl_get_error_message(), intl_get_error_code());
-            }
 
             $formatter->setLenient(false);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        |

IntlTimeZone was added in php 5.5. (IntlDateFormatter in php 5.3)

`new X()` will always either return an object or throw an exception/error as of
PHP 7.0 - For IntlDateFormatter, it throws IntlException

These additional checks are harmless, but no longer needed. (Symfony's master branch targets php 7.2, so the class_exists and object checks are redundant)

- https://www.php.net/manual/en/class.intldateformatter.php
- https://www.php.net/intltimezone

https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.error-handling.constructors

> Previously, some internal classes would return NULL or an unusable object when the constructor failed. All internal classes will now throw an Exception in this case in the same way that user classes already had to.

