### PR TITLE
[FrameworkBundle][DependencyInjection] Skip removed ids in the lint container command and its associated pass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -42,16 +42,19 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
     private const SCALAR_TYPES = ['int', 'float', 'bool', 'string'];
 
     private $autoload;
+    private $skippedIds;
 
     private $expressionLanguage;
 
     /**
-     * @param bool $autoload Whether services who's class in not loaded should be checked or not.
-     *                       Defaults to false to save loading code during compilation.
+     * @param bool  $autoload   Whether services who's class in not loaded should be checked or not.
+     *                          Defaults to false to save loading code during compilation.
+     * @param array $skippedIds An array indexed by the service ids to skip
      */
-    public function __construct(bool $autoload = false)
+    public function __construct(bool $autoload = false, array $skippedIds = [])
     {
         $this->autoload = $autoload;
+        $this->skippedIds = $skippedIds;
     }
 
     /**
@@ -59,6 +62,10 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
      */
     protected function processValue($value, $isRoot = false)
     {
+        if (isset($this->skippedIds[$this->currentId])) {
+            return $value;
+        }
+
         if (!$value instanceof Definition || $value->hasErrors()) {
             return parent::processValue($value, $isRoot);
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -669,4 +669,16 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
         $this->addToAssertionCount(1);
     }
+
+    public function testProcessSkipSkippedIds()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foobar', BarMethodCall::class)
+            ->addMethodCall('setArray', ['a string']);
+
+        (new CheckTypeDeclarationsPass(true, ['foobar' => true]))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/34858
| License       | MIT
| Doc PR        | -

We remove the "removing" passes again and to avoid what https://github.com/symfony/symfony/pull/34502 fixed, we skip validating the "live" container removed ids in the pass (the "live" container is supposed to have the same definitions than the "debug container" one).

Logically, an errored service cannot pass the "live" container compilation without being removed. Consequently, it also skips the errored services that ended up being removed in the "live" container.