### PR TITLE
[Console][Command] Adhere to both return type and exception

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -158,7 +158,24 @@ class Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        throw new LogicException('You must override the execute() method in the concrete command class.');
+        $throwOverrideException = false;
+
+        try {
+            $abstractMethodClass = (new \ReflectionClass(self::class))->getMethod('execute')->class;
+            $concreteMethodClass = (new \ReflectionClass(\get_class($this)))->getMethod('execute')->class;
+
+            if ($abstractMethodClass === $concreteMethodClass) {
+                $throwOverrideException = true;
+            }
+        } catch (\ReflectionException $e) {
+            $throwOverrideException = true;
+        }
+
+        if ($throwOverrideException) {
+            throw new LogicException('You must override the execute() method in the concrete command class.');
+        }
+
+        return 0;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -276,12 +276,40 @@ class CommandTest extends TestCase
         $this->assertEquals('execute called'.PHP_EOL, $tester->getDisplay(), '->run() does not call the interact() method if the input is not interactive');
     }
 
-    public function testExecuteMethodNeedsToBeOverridden()
+    public function testExecuteMethodThrowsExceptionWhenNotOverridden()
     {
         $this->expectException('LogicException');
         $this->expectExceptionMessage('You must override the execute() method in the concrete command class.');
         $command = new Command('foo');
         $command->run(new StringInput(''), new NullOutput());
+    }
+
+    public function testExecuteMethodThrowsExceptionWhenExtendedButNotOverridden()
+    {
+        $childCommand = new class() extends Command {
+        };
+
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('You must override the execute() method in the concrete command class.');
+
+        $command = new $childCommand('foo');
+        $exitCode = $command->run(new StringInput(''), new NullOutput());
+    }
+
+    public function testExecuteMethodDoesNotThrowExceptionWhenExtendedAndOverridden()
+    {
+        $childCommand = new class() extends Command {
+            /** {@inheritdoc} */
+            protected function execute(InputInterface $input, OutputInterface $output)
+            {
+                return 0;
+            }
+        };
+
+        $command = new $childCommand('foo');
+        $exitCode = $command->run(new StringInput(''), new NullOutput());
+
+        $this->assertEquals(0, $exitCode);
     }
 
     public function testRunWithInvalidOption()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

https://github.com/symfony/console/commit/cdef5a4a0d8045299adf0a52a625606cb5c3bd5b annotated all core commands to return int values. However, `Console::execute()` does not return anything: it throws an exception. This is was done to make sure the extending class has an overriding function. That's all fine, but in the case of `execute()` the return type is not consistent with the `@returns` in the docblock anymore.

This change keeps the functionality intact, fixes the inconsistent return type and now even allows for testing its intended purpose.