### PR TITLE
[Mailer] Fixed undefined index when sending via Mandrill API

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -57,7 +57,8 @@ class MandrillApiTransport extends AbstractApiTransport
             throw new HttpTransportException(sprintf('Unable to send an email (code %s).', $result['code']), $response);
         }
 
-        $sentMessage->setMessageId($result['_id']);
+        $firstRecipient = reset($result);
+        $sentMessage->setMessageId($firstRecipient['_id']);
 
         return $response;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34892
| License       | MIT

When a [Mandrill API send request](https://www.mandrillapp.com/api/docs/messages.JSON.html#method=send) is succesful, it returns an array of results, one for each recipient. To get rid of the undefined index error, we grab the message ID from the first recipient in the array.