### PR TITLE
[Security] Revert "AbstractAuthenticationListener.php error instead info"

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -184,7 +184,7 @@ abstract class AbstractAuthenticationListener extends AbstractListener implement
     private function onFailure(Request $request, AuthenticationException $failed): Response
     {
         if (null !== $this->logger) {
-            $this->logger->error('Authentication request failed.', ['exception' => $failed]);
+            $this->logger->info('Authentication request failed.', ['exception' => $failed]);
         }
 
         $token = $this->tokenStorage->getToken();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34836
| License       | MIT

This reverts commit 867eb78cfea8d45334faddbbf1ad62b52fe5ed1a.

After that change, every failed login attempt is logged as an error. It's flooding our errors log channel