### PR TITLE
[DI] Improve performance of processDefinition

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -64,9 +64,10 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
         $definition->setInstanceofConditionals([]);
         $parent = $shared = null;
         $instanceofTags = [];
+        $reflectionClass = null;
 
         foreach ($conditionals as $interface => $instanceofDefs) {
-            if ($interface !== $class && (!$container->getReflectionClass($class, false))) {
+            if ($interface !== $class && !(null === $reflectionClass ? $reflectionClass = ($container->getReflectionClass($class, false) ?: false) : $reflectionClass)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | 

Saves some time during container compilation by instantiating the reflection class only once. In my case this speeds up container compilation in dev mode by ~10% (saves almost 100k calls to `getReflectionClass`).

Tests still run locally and my compiled container was identical pre and post change, but I found this improvement by Blackfire profiling and am not familiar with the surrounding code, so it would be great if someone could doublecheck if the change causes problems.