### PR TITLE
[HttpFoundation] fix redis multi host dsn not recognized

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
@@ -50,13 +50,13 @@ class SessionHandlerFactory
             case 0 === strpos($connection, 'file://'):
                 return new StrictSessionHandler(new NativeFileSessionHandler(substr($connection, 7)));
 
-            case 0 === strpos($connection, 'redis://'):
-            case 0 === strpos($connection, 'rediss://'):
-            case 0 === strpos($connection, 'memcached://'):
+            case 0 === strpos($connection, 'redis:'):
+            case 0 === strpos($connection, 'rediss:'):
+            case 0 === strpos($connection, 'memcached:'):
                 if (!class_exists(AbstractAdapter::class)) {
                     throw new InvalidArgumentException(sprintf('Unsupported DSN "%s". Try running "composer require symfony/cache".', $connection));
                 }
-                $handlerClass = 0 === strpos($connection, 'memcached://') ? MemcachedSessionHandler::class : RedisSessionHandler::class;
+                $handlerClass = 0 === strpos($connection, 'memcached:') ? MemcachedSessionHandler::class : RedisSessionHandler::class;
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);
 
                 return new $handlerClass($connection);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #34477
| License       | MIT

#34177 added support configurating session handlers with DSNs. It was no possible to pass a redis-DSN like
`redis:?host[localhost]&host[localhost:6379]&host[/var/run/redis.sock:]&auth=my-password&redis_cluster=1'`

since the check was 
`case 0 === strpos($connection, 'redis://'):`
