### PR TITLE
[HttpClient] Add stream_set_option method to StreamWrapper

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
+++ b/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
@@ -178,6 +178,28 @@ class StreamWrapper
         return '';
     }
 
+    public function stream_set_option(int $option, int $arg1, ?int $arg2): bool
+    {
+        if (null === $this->handle || 'stream' !== get_resource_type($this->handle)) {
+            trigger_error(sprintf('The "$handle" property of "%s" need to be a stream.', __CLASS__), E_USER_WARNING);
+
+            return false;
+        }
+
+        switch ($option) {
+            case STREAM_OPTION_BLOCKING:
+                return \stream_set_blocking($this->handle, $arg1);
+            case STREAM_OPTION_READ_TIMEOUT:
+                return \stream_set_timeout($this->handle, $arg1, $arg2);
+            case STREAM_OPTION_WRITE_BUFFER:
+                return \stream_set_write_buffer($this->handle, $arg1);
+            default:
+                trigger_error(sprintf('The option "%s" is unknown for "stream_set_option" method', $option), E_ERROR);
+
+                return false;
+        }
+    }
+
     public function stream_tell(): int
     {
         return $this->offset;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `4.4` & `5.0`
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34943
| License       | MIT
| Doc PR        | -

Add the structure of the method `stream_set_option` which is called before usage 

Currently, these methods aren't implemented, but the errors & `return code` are handled.

Please feel free to suggest anything, I'm nooby of streams