### PR TITLE
[SecurityBundle][FirewallMap] Remove unused property

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -107,13 +107,11 @@ class _FirewallMap
 {
     private $container;
     private $map;
-    private $contexts;
 
     public function __construct(ContainerInterface $container, $map)
     {
         $this->container = $container;
         $this->map = $map;
-        $this->contexts = new \SplObjectStorage();
     }
 
     public function getListeners(Request $request)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | -

This property is unused. It was removed in https://github.com/symfony/symfony/pull/22943. It was likely reintroduced in a merge commit. It is still on master.