### PR TITLE
[Mailer] redundant event dispatch - fix

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Mime\RawMessage;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class MailerTest extends TestCase
 {
@@ -25,7 +24,7 @@ class MailerTest extends TestCase
     {
         $this->expectException(LogicException::class);
 
-        $transport = new Mailer($this->createMock(TransportInterface::class), $this->createMock(MessageBusInterface::class), $this->createMock(EventDispatcherInterface::class));
+        $transport = new Mailer($this->createMock(TransportInterface::class), $this->createMock(MessageBusInterface::class));
         $transport->send(new RawMessage('Some raw email message'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34972 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->


Small bugfix proposal to keep only one MessageEvent dispatch in AbstractTransport, when used with Messenger component.