### PR TITLE
[Cache] Fix wrong classname in deprecation message

### DIFF
--- a/src/Symfony/Component/Cache/Simple/ApcuCache.php
+++ b/src/Symfony/Component/Cache/Simple/ApcuCache.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Cache\Simple;
 
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Traits\ApcuTrait;
+use Symfony\Contracts\Cache\CacheInterface;
 
 @trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.3, use "%s" and type-hint for "%s" instead.', ApcuCache::class, ApcuAdapter::class, CacheInterface::class), E_USER_DEPRECATED);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 


Actually the deprecation message points to classes that doesn't exists do to missing use statements

before:
```
The "Symfony\Component\Cache\Simple\ApcuCache" class is deprecated since Symfony 4.3, use "Symfony\Component\Cache\Simple\ApcuAdapter" and type-hint for "Symfony\Component\Cache\Simple\CacheInterface" instead.'
```

after:
```
The "Symfony\Component\Cache\Simple\ApcuCache" class is deprecated since Symfony 4.3, use "Symfony\Component\Cache\Adapter\ApcuAdapter" and type-hint for "Symfony\Contracts\Cache\CacheInterface" instead.'
```
