### PR TITLE
[Messenger] remove several messages with command messenger:failed:remove

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 
 class FailedMessagesRemoveCommandTest extends TestCase
 {
-    public function testBasicRun()
+    public function testRemoveUniqueMessage()
     {
         $receiver = $this->createMock(ListableReceiverInterface::class);
         $receiver->expects($this->once())->method('find')->with(20)->willReturn(new Envelope(new \stdClass()));
@@ -30,8 +30,53 @@ class FailedMessagesRemoveCommandTest extends TestCase
         );
 
         $tester = new CommandTester($command);
-        $tester->execute(['id' => 20, '--force' => true]);
+        $tester->execute(['id' => [20], '--force' => true]);
 
-        $this->assertStringContainsString('Message removed.', $tester->getDisplay());
+        $this->assertStringContainsString('Failed Message Details', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+    }
+
+    public function testRemoveMultipleMessages()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->exactly(3))->method('find')->withConsecutive([20], [30], [40])->willReturnOnConsecutiveCalls(
+            new Envelope(new \stdClass()),
+            null,
+            new Envelope(new \stdClass())
+        );
+
+        $command = new FailedMessagesRemoveCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => [20, 30, 40], '--force' => true]);
+
+        $this->assertStringNotContainsString('Failed Message Details', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+        $this->assertStringContainsString('The message with id "30" was not found.', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 40 removed.', $tester->getDisplay());
+    }
+
+    public function testRemoveMultipleMessagesAndDisplayMessages()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->exactly(2))->method('find')->withConsecutive([20], [30])->willReturnOnConsecutiveCalls(
+            new Envelope(new \stdClass()),
+            new Envelope(new \stdClass())
+        );
+
+        $command = new FailedMessagesRemoveCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => [20, 30], '--force' => true, '--show-messages' => true]);
+
+        $this->assertStringContainsString('Failed Message Details', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 30 removed.', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #34940
| License       | MIT

command `messenger:failed:remove` now accepts an array of ids. If several provided, they are not displayed unless option `--show-messages` is passed