### PR TITLE
[Form] Allowing plural message on extra data validation failure

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -148,6 +148,7 @@ class FormValidator extends ConstraintValidator
             $this->context->setConstraint($formConstraint);
             $this->context->buildViolation($config->getOption('extra_fields_message', ''))
                 ->setParameter('{{ extra_fields }}', '"'.implode('", "', array_keys($form->getExtraData())).'"')
+                ->setPlural(\count($form->getExtraData()))
                 ->setInvalidValue($form->getExtraData())
                 ->setCode(Form::NO_SUCH_FIELD_ERROR)
                 ->addViolation();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -648,7 +648,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
     public function testViolationIfExtraData()
     {
-        $form = $this->getBuilder('parent', null, ['extra_fields_message' => 'Extra!'])
+        $form = $this->getBuilder('parent', null, ['extra_fields_message' => 'Extra!|Extras!'])
             ->setCompound(true)
             ->setDataMapper(new PropertyPathMapper())
             ->add($this->getBuilder('child'))
@@ -662,16 +662,17 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($form, new Form());
 
-        $this->buildViolation('Extra!')
+        $this->buildViolation('Extra!|Extras!')
             ->setParameter('{{ extra_fields }}', '"foo"')
             ->setInvalidValue(['foo' => 'bar'])
+            ->setPlural(1)
             ->setCode(Form::NO_SUCH_FIELD_ERROR)
             ->assertRaised();
     }
 
     public function testViolationFormatIfMultipleExtraFields()
     {
-        $form = $this->getBuilder('parent', null, ['extra_fields_message' => 'Extra!'])
+        $form = $this->getBuilder('parent', null, ['extra_fields_message' => 'Extra!|Extras!!'])
             ->setCompound(true)
             ->setDataMapper(new PropertyPathMapper())
             ->add($this->getBuilder('child'))
@@ -685,9 +686,10 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($form, new Form());
 
-        $this->buildViolation('Extra!')
+        $this->buildViolation('Extra!|Extras!!')
             ->setParameter('{{ extra_fields }}', '"foo", "baz", "quux"')
             ->setInvalidValue(['foo' => 'bar', 'baz' => 'qux', 'quux' => 'quuz'])
+            ->setPlural(3)
             ->setCode(Form::NO_SUCH_FIELD_ERROR)
             ->assertRaised();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | -

When using allow_extra_fields feature (and set to false) with an extra_fields_message, this message may now support pluralization regarding count of extra fields (extra data). e.g. "extra field found|extra fields found"
