### PR TITLE
[Form] Refactoring `getParent` method in form types to use `::class` constant

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
@@ -31,7 +31,7 @@ class BirthdayType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\DateType';
+        return DateType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -47,7 +47,7 @@ class CountryType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -44,7 +44,7 @@ class CurrencyType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
@@ -20,7 +20,7 @@ class EmailType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -73,7 +73,7 @@ class LanguageType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
@@ -44,7 +44,7 @@ class LocaleType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -44,7 +44,7 @@ class PasswordType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
@@ -20,7 +20,7 @@ class RadioType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\CheckboxType';
+        return CheckboxType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -20,7 +20,7 @@ class RangeType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/ResetType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ResetType.php
@@ -26,7 +26,7 @@ class ResetType extends AbstractType implements ButtonTypeInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ButtonType';
+        return ButtonType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
@@ -20,7 +20,7 @@ class SearchType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/SubmitType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SubmitType.php
@@ -47,7 +47,7 @@ class SubmitType extends AbstractType implements SubmitButtonTypeInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ButtonType';
+        return ButtonType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -30,7 +30,7 @@ class TextareaType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -89,7 +89,7 @@ class TimezoneType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -56,7 +56,7 @@ class UrlType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Form component has a lot of built-in form types. Some of them were implemented from the very beginning. In most of them there is a such method

```php
    /**
     * {@inheritdoc}
     */
    public function getParent()
    {
        return __NAMESPACE__.'\TextType';
    }
```

This `getParent()` method was refactored in Symfony 2.8. The upgrade instructions are given here https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form

I think the `__NAMESPACE__.'\TextType';` expression was used because Symfony 2.8 was using `"php": ">=5.3.9"`, and the constant `::class` was added only in PHP 5.5

Now this line can be refactored into
```php
    /**
     * {@inheritdoc}
     */
    public function getParent()
    {
        return TextType::class;
    }
```

For example new form types, that were added later, already using the `::class` constant.
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Type/ColorType.php#L23
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Type/TelType.php#L23

So, in this pull request I propose to refactor all old form types to use `::class` constant. It will give a benefit during the future refactoring, because IDE or static analysers will find all usages of parent class. Unlike the `__NAMESPACE__.'\TextType';` line, which doesn't show the real link to the class for IDE or static analysers, and it could complicate finding all usages of parent class.