### PR TITLE
[EventDispatcher] Freeze events

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -88,6 +88,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('error_controller')
                     ->defaultValue('error_controller')
                 ->end()
+                ->booleanNode('freeze_kernel_events')->defaultValue(false)->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -69,6 +69,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
@@ -223,6 +224,19 @@ class FrameworkExtension extends Extension
         $container->setParameter('kernel.trusted_hosts', $config['trusted_hosts']);
         $container->setParameter('kernel.default_locale', $config['default_locale']);
         $container->setParameter('kernel.error_controller', $config['error_controller']);
+        $container->setParameter(
+            'event_dispatcher.freeze_events',
+            $config['freeze_kernel_events'] ? [
+                KernelEvents::REQUEST,
+                KernelEvents::EXCEPTION,
+                KernelEvents::VIEW,
+                KernelEvents::CONTROLLER,
+                KernelEvents::CONTROLLER_ARGUMENTS,
+                KernelEvents::RESPONSE,
+                KernelEvents::TERMINATE,
+                KernelEvents::FINISH_REQUEST,
+            ] : []
+        );
 
         if (!$container->hasParameter('debug.file_link_format')) {
             $links = [

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -41,6 +41,7 @@
         <xsd:attribute name="default-locale" type="xsd:string" />
         <xsd:attribute name="test" type="xsd:boolean" />
         <xsd:attribute name="error-controller" type="xsd:string" />
+        <xsd:attribute name="freeze-kernel-events" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="form">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -501,6 +501,7 @@ class ConfigurationTest extends TestCase
                 'notification_on_failed_messages' => false,
             ],
             'error_controller' => 'error_controller',
+            'freeze_kernel_events' => false,
             'secrets' => [
                 'enabled' => true,
                 'vault_directory' => '%kernel.project_dir%/config/secrets/%kernel.environment%',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/freeze_events.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/freeze_events.php
@@ -1,0 +1,5 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'freeze_kernel_events' => true,
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/freeze_events.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/freeze_events.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config freeze-kernel-events="true" />
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/freeze_events.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/freeze_events.yml
@@ -1,0 +1,2 @@
+framework:
+    freeze_kernel_events: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -1382,6 +1383,32 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('mailer_with_specific_message_bus');
 
         $this->assertEquals(new Reference('app.another_bus'), $container->getDefinition('mailer.mailer')->getArgument(1));
+    }
+
+    public function testFreezeKernelEvents(): void
+    {
+        $container = $this->createContainerFromFile('freeze_events');
+
+        $this->assertSame(
+            [
+                KernelEvents::REQUEST,
+                KernelEvents::EXCEPTION,
+                KernelEvents::VIEW,
+                KernelEvents::CONTROLLER,
+                KernelEvents::CONTROLLER_ARGUMENTS,
+                KernelEvents::RESPONSE,
+                KernelEvents::TERMINATE,
+                KernelEvents::FINISH_REQUEST,
+            ],
+            $container->getParameter('event_dispatcher.freeze_events')
+        );
+    }
+
+    public function testDontFreezeKernelEventsByDefault(): void
+    {
+        $container = $this->createContainerFromFile('full');
+
+        $this->assertSame([], $container->getParameter('event_dispatcher.freeze_events'));
     }
 
     protected function createContainer(array $data = [])

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -73,6 +73,7 @@
         "symfony/console": "<4.4",
         "symfony/dotenv": "<4.4",
         "symfony/dom-crawler": "<4.4",
+        "symfony/event-dispatcher": "<5.1",
         "symfony/http-client": "<4.4",
         "symfony/form": "<4.4",
         "symfony/lock": "<4.4",

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -14,11 +14,14 @@ namespace Symfony\Component\EventDispatcher\DependencyInjection;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\ListenerProvider\LazyListenerProvider;
+use Symfony\Component\EventDispatcher\ListenerProvider\SimpleListenerProvider;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -30,16 +33,18 @@ class RegisterListenersPass implements CompilerPassInterface
     protected $listenerTag;
     protected $subscriberTag;
     protected $eventAliasesParameter;
+    protected $freezeEventsParameter;
 
     private $hotPathEvents = [];
     private $hotPathTagName;
 
-    public function __construct(string $dispatcherService = 'event_dispatcher', string $listenerTag = 'kernel.event_listener', string $subscriberTag = 'kernel.event_subscriber', string $eventAliasesParameter = 'event_dispatcher.event_aliases')
+    public function __construct(string $dispatcherService = 'event_dispatcher', string $listenerTag = 'kernel.event_listener', string $subscriberTag = 'kernel.event_subscriber', string $eventAliasesParameter = 'event_dispatcher.event_aliases', string $freezeEventsParameter = 'event_dispatcher.freeze_events')
     {
         $this->dispatcherService = $dispatcherService;
         $this->listenerTag = $listenerTag;
         $this->subscriberTag = $subscriberTag;
         $this->eventAliasesParameter = $eventAliasesParameter;
+        $this->freezeEventsParameter = $freezeEventsParameter;
     }
 
     public function setHotPathEvents(array $hotPathEvents, $tagName = 'container.hot_path')
@@ -63,6 +68,13 @@ class RegisterListenersPass implements CompilerPassInterface
             $aliases = [];
         }
         $definition = $container->findDefinition($this->dispatcherService);
+
+        $frozenEvents = [];
+        if ($container->hasParameter($this->freezeEventsParameter)) {
+            foreach ($container->getParameter($this->freezeEventsParameter) as $event) {
+                $frozenEvents[$event] = [];
+            }
+        }
 
         foreach ($container->findTaggedServiceIds($this->listenerTag, true) as $id => $events) {
             foreach ($events as $event) {
@@ -91,7 +103,11 @@ class RegisterListenersPass implements CompilerPassInterface
                     }
                 }
 
-                $definition->addMethodCall('addListener', [$event['event'], [new ServiceClosureArgument(new Reference($id)), $event['method']], $priority]);
+                if (isset($frozenEvents[$event['event']])) {
+                    $frozenEvents[$event['event']][$priority][] = [new Reference($id), $event['method']];
+                } else {
+                    $definition->addMethodCall('addListener', [$event['event'], [new ServiceClosureArgument(new Reference($id)), $event['method']], $priority]);
+                }
 
                 if (isset($this->hotPathEvents[$event['event']])) {
                     $container->getDefinition($id)->addTag($this->hotPathTagName);
@@ -119,8 +135,12 @@ class RegisterListenersPass implements CompilerPassInterface
             ExtractingEventDispatcher::$subscriber = $class;
             $extractingDispatcher->addSubscriber($extractingDispatcher);
             foreach ($extractingDispatcher->listeners as $args) {
-                $args[1] = [new ServiceClosureArgument(new Reference($id)), $args[1]];
-                $definition->addMethodCall('addListener', $args);
+                if (isset($frozenEvents[$args[0]])) {
+                    $frozenEvents[$args[0]][$args[2]][] = [new Reference($id), $args[1]];
+                } else {
+                    $args[1] = [new ServiceClosureArgument(new Reference($id)), $args[1]];
+                    $definition->addMethodCall('addListener', $args);
+                }
 
                 if (isset($this->hotPathEvents[$args[0]])) {
                     $container->getDefinition($id)->addTag($this->hotPathTagName);
@@ -128,6 +148,15 @@ class RegisterListenersPass implements CompilerPassInterface
             }
             $extractingDispatcher->listeners = [];
             ExtractingEventDispatcher::$aliases = [];
+        }
+
+        foreach ($frozenEvents as $event => $listeners) {
+            krsort($listeners, SORT_NUMERIC);
+            $providerId = sprintf('__%s.listener_provider.%s', $this->dispatcherService, $event);
+            $container->register($providerId, SimpleListenerProvider::class)
+                ->setArguments([array_merge(...array_values($listeners))]);
+
+            $definition->addMethodCall('setListenerProvider', [$event, new Definition(LazyListenerProvider::class, [new ServiceClosureArgument(new Reference($providerId))])]);
         }
     }
 

--- a/src/Symfony/Component/EventDispatcher/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/EventDispatcher/Exception/ExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/src/Symfony/Component/EventDispatcher/Exception/RuntimeException.php
+++ b/src/Symfony/Component/EventDispatcher/Exception/RuntimeException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Exception;
+
+final class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/EventDispatcher/ListenerProvider/LazyListenerProvider.php
+++ b/src/Symfony/Component/EventDispatcher/ListenerProvider/LazyListenerProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\ListenerProvider;
+
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+/**
+ * A lazy proxy for listener providers.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class LazyListenerProvider implements ListenerProviderInterface
+{
+    private $factory;
+
+    /**
+     * @var ListenerProviderInterface
+     */
+    private $delegate;
+
+    public function __construct(callable $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenersForEvent(object $event): iterable
+    {
+        if (!$this->delegate) {
+            $this->delegate = ($this->factory)();
+        }
+
+        return $this->delegate->getListenersForEvent($event);
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        if (!$this->delegate) {
+            $this->delegate = ($this->factory)();
+        }
+
+        return $this->delegate->$name(...$arguments);
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/ListenerProvider/SimpleListenerProvider.php
+++ b/src/Symfony/Component/EventDispatcher/ListenerProvider/SimpleListenerProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\ListenerProvider;
+
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+/**
+ * A minimal listener provider that always returns all configured listeners.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class SimpleListenerProvider implements ListenerProviderInterface
+{
+    private $listeners;
+
+    /**
+     * @param iterable|callable[] $listeners
+     */
+    public function __construct(iterable $listeners)
+    {
+        $this->listeners = $listeners;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenersForEvent(object $event): iterable
+    {
+        return $this->listeners;
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/ListenerProvider/LazyListenerProviderTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ListenerProvider/LazyListenerProviderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Symfony\Component\EventDispatcher\Tests\ListenerProvider;
+
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Symfony\Component\EventDispatcher\ListenerProvider\LazyListenerProvider;
+
+final class LazyListenerProviderTest extends TestCase
+{
+    public function testGetListenersForEvent(): void
+    {
+        $calls = 0;
+
+        $expectedEvent = new class() {
+        };
+        $expectedResult = new \EmptyIterator();
+
+        $innerProvider = $this->createMock(ListenerProviderInterface::class);
+        $innerProvider
+            ->expects($this->exactly(2))
+            ->method('getListenersForEvent')
+            ->with($this->identicalTo($expectedEvent))
+            ->willReturn($expectedResult);
+
+        $provider = new LazyListenerProvider(static function () use (&$calls, $innerProvider): ListenerProviderInterface {
+            ++$calls;
+
+            return $innerProvider;
+        });
+
+        $this->assertSame(0, $calls);
+        $this->assertSame($expectedResult, $provider->getListenersForEvent($expectedEvent));
+        $this->assertSame($expectedResult, $provider->getListenersForEvent($expectedEvent));
+        $this->assertSame(1, $calls);
+    }
+
+    public function testPassthrough(): void
+    {
+        $innerProvider = new class() implements ListenerProviderInterface {
+            private $calls = 0;
+
+            public function getListenersForEvent(object $event): iterable
+            {
+                return [];
+            }
+
+            public function increment(): int
+            {
+                return ++$this->calls;
+            }
+        };
+
+        $provider = new LazyListenerProvider(static function () use ($innerProvider): ListenerProviderInterface {
+            return $innerProvider;
+        });
+
+        $this->assertSame(1, $provider->increment());
+        $this->assertSame(2, $provider->increment());
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/ListenerProvider/SimpleListenerProviderTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ListenerProvider/SimpleListenerProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Symfony\Component\EventDispatcher\Tests\ListenerProvider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\ListenerProvider\SimpleListenerProvider;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class SimpleListenerProviderTest extends TestCase
+{
+    public function testEmptyProvider(): void
+    {
+        $dispatcher = new SimpleListenerProvider([]);
+
+        $this->assertSame([], $dispatcher->getListenersForEvent(new Event()));
+    }
+
+    public function testArray(): void
+    {
+        $dispatcher = new SimpleListenerProvider([
+            $one = static function (): void {},
+            $two = static function (): void {},
+            $three = static function (): void {},
+        ]);
+
+        $this->assertSame([$one, $two, $three], $dispatcher->getListenersForEvent(new Event()));
+    }
+
+    public function testIterator(): void
+    {
+        $dispatcher = new SimpleListenerProvider(new \ArrayIterator([
+            $one = static function (): void {},
+            $two = static function (): void {},
+            $three = static function (): void {},
+        ]));
+
+        $this->assertSame([$one, $two, $three], iterator_to_array($dispatcher->getListenersForEvent(new Event())));
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "symfony/event-dispatcher-contracts": "^2"
+        "symfony/event-dispatcher-contracts": "^2.1"
     },
     "require-dev": {
         "symfony/dependency-injection": "^4.4|^5.0",

--- a/src/Symfony/Contracts/Cache/composer.json
+++ b/src/Symfony/Contracts/Cache/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }

--- a/src/Symfony/Contracts/EventDispatcher/ListenerProviderAwareInterface.php
+++ b/src/Symfony/Contracts/EventDispatcher/ListenerProviderAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\EventDispatcher;
+
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+interface ListenerProviderAwareInterface
+{
+    /**
+     * Registers a listener provider for an given event name.
+     */
+    public function setListenerProvider(string $eventName, ListenerProviderInterface $listenerProvider): void;
+}

--- a/src/Symfony/Contracts/EventDispatcher/composer.json
+++ b/src/Symfony/Contracts/EventDispatcher/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }

--- a/src/Symfony/Contracts/HttpClient/composer.json
+++ b/src/Symfony/Contracts/HttpClient/composer.json
@@ -27,7 +27,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }

--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }

--- a/src/Symfony/Contracts/Translation/composer.json
+++ b/src/Symfony/Contracts/Translation/composer.json
@@ -27,7 +27,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -47,7 +47,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR is an attempt to improve the event dispatcher's runtime performance through immutability. Making the whole event dispatcher immutable would be a heavy task, especially when it comes to events in the form component.

In this PR, the event dispatcher allows to freeze specific events. This means that we provide an initial ordered list of listeners for each of those events which cannot be modified through `addListener()` et al afterwards. This way, potentially heavy sorting work can be moved to the container compilation and some runtime checks become obsolete. A new config option `framework.freeze_kernel_events` is introduced that enables this mode for all kernel events (defaults to `false`).

I'm making use of PSR-14-style listener providers for the frozen events. This could (in a later PR) be extended further to be more PSR-14 compatible. If we decide that PSR-14 listener provider are never going to happen in Symfony, we can of course simplify that part.

I've tested this change on a rather extreme application with a thousand event listeners on a hello world application.

Test repository with 1000 listeners on `kernel.request`:
https://github.com/derrabus/heavy-event-dispatcher-test

Blackfire comparison master vs this branch with `freeze_kernel_events` enabled:
https://blackfire.io/profiles/compare/46257d02-db67-4c54-9bfb-e98c5ec2d942/graph

<img width="461" alt="Bildschirmfoto 2019-12-15 um 22 01 00" src="https://user-images.githubusercontent.com/1506493/70868992-8bd08a00-1f86-11ea-8bed-0de8582fd196.png">

TODO:
* [ ] Polish some edge cases.
* [ ] Adjust the profiler page.
* [ ] Check console and security events.
* [ ] Allow applications and third-party bundles to enable this mode for their custom events.