### PR TITLE
[WIP][FrameworkBundle] Add hyperlink to commands of command list

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
  * Made `framework.session.handler_id` accept a DSN
  * Marked the `RouterDataCollector` class as `@final`.
  * [BC Break] The `framework.messenger.buses.<name>.middleware` config key is not deeply merged anymore.
+ * Added new `ListCommand` commnd to add hyperlinks to commands
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ListCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ListCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Command\ListCommand as BaseListCommand;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
+
+class ListCommand extends ContainerDebugCommand
+{
+    private $fileLinkFormatter;
+    private $listCommand;
+    private $supportsHref;
+    private $hyperlinkedCommands = [];
+
+    public function __construct(BaseListCommand $listCommand, FileLinkFormatter $fileLinkFormatter = null)
+    {
+        $this->fileLinkFormatter = $fileLinkFormatter;
+        $this->listCommand = $listCommand;
+        $this->supportsHref = method_exists(OutputFormatterStyle::class, 'setHref');
+        parent::__construct($this->listCommand->getName());
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName($this->listCommand->getName())
+            ->setDefinition($this->listCommand->getNativeDefinition())
+            ->setDescription($this->listCommand->getDescription())
+            ->setHelp($this->listCommand->getHelp())
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->addCommandHyperlinks();
+
+        $this->listCommand->setApplication($this->getApplication());
+        return $this->listCommand->execute($input, $output);
+    }
+
+    private function getFileLink(string $class): string
+    {
+        if (null === $this->fileLinkFormatter
+            || (null === $r = $this->getContainerBuilder()->getReflectionClass($class, false))) {
+            return '';
+        }
+
+        return (string) $this->fileLinkFormatter->format($r->getFileName(), $r->getStartLine());
+    }
+
+    protected function addCommandHyperlinks(): void
+    {
+        if (!($this->supportsHref && $this->fileLinkFormatter && $this->getApplication())) {
+            return;
+        }
+
+        foreach ($this->getApplication()->all() as $command) {
+            $id = spl_object_id($command);
+            if (isset($this->hyperlinkedCommands[$id])) {
+                continue;
+            }
+            $fileLink = $this->getFileLink(get_class($command));
+            if (!$fileLink) {
+                continue;
+            }
+            $command->setDescription(sprintf(
+                '<href=%s>^</> %s',
+                $fileLink,
+                $command->getDescription()
+            ));
+            $this->hyperlinkedCommands[$id] = $command;
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -13,7 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Command\ListCommand;
+use Symfony\Component\Console\Command\HelpCommand;
+use Symfony\Bundle\FrameworkBundle\Command\ListCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -217,5 +218,10 @@ class Application extends BaseApplication
                 $this->doRenderException($error, $output);
             }
         }
+    }
+
+    protected function getDefaultCommands()
+    {
+        return [new HelpCommand()];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -21,6 +21,14 @@
             <tag name="console.command" command="about" />
         </service>
 
+        <service id="console.command.list" class="Symfony\Bundle\FrameworkBundle\Command\ListCommand">
+            <argument type="service">
+                <service class="Symfony\Component\Console\Command\ListCommand"/>
+            </argument>
+            <argument type="service" id="debug.file_link_formatter" on-invalid="null"/>
+            <tag name="console.command" command="list" />
+        </service>
+
         <service id="console.command.assets_install" class="Symfony\Bundle\FrameworkBundle\Command\AssetsInstallCommand">
             <argument type="service" id="filesystem" />
             <argument>%kernel.project_dir%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/ListCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command\ListCommand;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\AbstractWebTestCase;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+/**
+ * @group functional
+ */
+class ListCommandTest extends AbstractWebTestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        static::deleteTmpDir();
+    }
+
+    public function testNotDisplaysHyperlinkIfNoDebugFileLinkFormatter()
+    {
+        static::bootKernel(['test_case' => 'ListCommand', 'root_config' => 'config_with_no_framework_ide.yml']);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'list']);
+
+        $this->assertStringContainsString('list Lists commands', preg_replace('/ +/', ' ', $tester->getDisplay()));
+    }
+
+    public function testDisplaysHyperlinkIfDebugFileLinkFormatter()
+    {
+        static::bootKernel(['test_case' => 'ListCommand', 'root_config' => 'config_with_framework_ide.yml']);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'list']);
+
+        $this->assertStringContainsString('list ^ Lists commands', preg_replace('/ +/', ' ', $tester->getDisplay()));
+    }
+
+    public function testDisplaysHyperlinkOnlyOnce()
+    {
+        static::bootKernel(['test_case' => 'ListCommand', 'root_config' => 'config_with_framework_ide.yml']);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'list']);
+        $tester->run(['command' => 'list']);
+
+        $this->assertStringContainsString('list ^ Lists commands', preg_replace('/ +/', ' ', $tester->getDisplay()));
+        $this->assertStringNotContainsString('list ^^ Lists commands', preg_replace('/ +/', ' ', $tester->getDisplay()));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ListCommand/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ListCommand/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ListCommand/config_with_framework_ide.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ListCommand/config_with_framework_ide.yml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    ide:  "debug://open?url=file://%%f&line=%%l"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ListCommand/config_with_no_framework_ide.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ListCommand/config_with_no_framework_ide.yml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    ide:  ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

Add hyperlinks to commands of the command `bin/console list`, the hyperlink is at the beginning of the description ( character `^`)

![symfony_hyperlinks](https://user-images.githubusercontent.com/163941/70869091-80319300-1f87-11ea-8fd4-c47bcb45c4a6.png)
 
it may be better to add it at the command name

![symfony_hyperlinks_on_name](https://user-images.githubusercontent.com/163941/70869161-4d3bcf00-1f88-11ea-8b5c-74195b37adcb.png)

But, It seems necessary to duplicate `\Symfony\Component\Console\Descriptor\TextDescriptor::describeApplication` https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Descriptor/TextDescriptor.php#L242
