### PR TITLE
Use `::class` constants instead of `__NAMESPACE__` when possible

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -44,7 +44,7 @@ class UniqueEntityValidator extends ConstraintValidator
     public function validate($entity, Constraint $constraint)
     {
         if (!$constraint instanceof UniqueEntity) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\UniqueEntity');
+            throw new UnexpectedTypeException($constraint, UniqueEntity::class);
         }
 
         if (!\is_array($constraint->fields) && !\is_string($constraint->fields)) {

--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -24,13 +24,13 @@ class NodeBuilder implements NodeParentInterface
     public function __construct()
     {
         $this->nodeMapping = [
-            'variable' => __NAMESPACE__.'\\VariableNodeDefinition',
-            'scalar' => __NAMESPACE__.'\\ScalarNodeDefinition',
-            'boolean' => __NAMESPACE__.'\\BooleanNodeDefinition',
-            'integer' => __NAMESPACE__.'\\IntegerNodeDefinition',
-            'float' => __NAMESPACE__.'\\FloatNodeDefinition',
-            'array' => __NAMESPACE__.'\\ArrayNodeDefinition',
-            'enum' => __NAMESPACE__.'\\EnumNodeDefinition',
+            'variable' => VariableNodeDefinition::class,
+            'scalar' => ScalarNodeDefinition::class,
+            'boolean' => BooleanNodeDefinition::class,
+            'integer' => IntegerNodeDefinition::class,
+            'float' => FloatNodeDefinition::class,
+            'array' => ArrayNodeDefinition::class,
+            'enum' => EnumNodeDefinition::class,
         ];
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
@@ -35,7 +35,7 @@ class NodeBuilderTest extends TestCase
 
     public function testAddingANewNodeType()
     {
-        $class = __NAMESPACE__.'\\SomeNodeDefinition';
+        $class = SomeNodeDefinition::class;
 
         $builder = new BaseNodeBuilder();
         $node = $builder
@@ -47,7 +47,7 @@ class NodeBuilderTest extends TestCase
 
     public function testOverridingAnExistingNodeType()
     {
-        $class = __NAMESPACE__.'\\SomeNodeDefinition';
+        $class = SomeNodeDefinition::class;
 
         $builder = new BaseNodeBuilder();
         $node = $builder
@@ -66,7 +66,7 @@ class NodeBuilderTest extends TestCase
 
         $this->assertInstanceOf(\get_class($node1), $node2);
 
-        $builder->setNodeClass('CuStOm', __NAMESPACE__.'\\SomeNodeDefinition');
+        $builder->setNodeClass('CuStOm', SomeNodeDefinition::class);
 
         $node1 = $builder->node('', 'CUSTOM');
         $node2 = $builder->node('', 'custom');

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -48,7 +48,7 @@ class XmlUtilsTest extends TestCase
             $this->assertStringContainsString('XSD file or callable', $e->getMessage());
         }
 
-        $mock = $this->getMockBuilder(__NAMESPACE__.'\Validator')->getMock();
+        $mock = $this->getMockBuilder(Validator::class)->getMock();
         $mock->expects($this->exactly(2))->method('validate')->will($this->onConsecutiveCalls(false, true));
 
         try {
@@ -68,7 +68,7 @@ class XmlUtilsTest extends TestCase
         $this->expectExceptionMessage('The XML is not valid');
         $fixtures = __DIR__.'/../Fixtures/Util/';
 
-        $mock = $this->getMockBuilder(__NAMESPACE__.'\Validator')->getMock();
+        $mock = $this->getMockBuilder(Validator::class)->getMock();
         $mock->expects($this->once())->method('validate')->willReturn(false);
 
         XmlUtils::parse(file_get_contents($fixtures.'valid.xml'), [$mock, 'validate']);

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -64,14 +64,14 @@ class DebugClassLoaderTest extends TestCase
         $this->expectException('Exception');
         $this->expectExceptionMessage('boo');
         try {
-            class_exists(__NAMESPACE__.'\Fixtures\Throwing');
+            class_exists(Fixtures\Throwing::class);
             $this->fail('Exception expected');
         } catch (\Exception $e) {
             $this->assertSame('boo', $e->getMessage());
         }
 
         // the second call also should throw
-        class_exists(__NAMESPACE__.'\Fixtures\Throwing');
+        class_exists(Fixtures\Throwing::class);
     }
 
     public function testUnsilencing()
@@ -90,7 +90,7 @@ class DebugClassLoaderTest extends TestCase
 
         // See below: this will fail with parse error
         // but this should not be @-silenced.
-        @class_exists(__NAMESPACE__.'\TestingUnsilencing', true);
+        @class_exists(TestingUnsilencing::class, true);
 
         $output = ob_get_clean();
 
@@ -141,7 +141,7 @@ class DebugClassLoaderTest extends TestCase
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Case mismatch between loaded and declared class names');
-        class_exists(__NAMESPACE__.'\TestingCaseMismatch', true);
+        class_exists(TestingCaseMismatch::class, true);
     }
 
     public function testFileCaseMismatch()
@@ -152,7 +152,7 @@ class DebugClassLoaderTest extends TestCase
             $this->markTestSkipped('Can only be run on case insensitive filesystems');
         }
 
-        class_exists(__NAMESPACE__.'\Fixtures\CaseMismatch', true);
+        class_exists(Fixtures\CaseMismatch::class, true);
     }
 
     public function testPsr4CaseMismatch()
@@ -174,7 +174,7 @@ class DebugClassLoaderTest extends TestCase
 
     public function testClassAlias()
     {
-        $this->assertTrue(class_exists(__NAMESPACE__.'\Fixtures\ClassAlias', true));
+        $this->assertTrue(class_exists(Fixtures\ClassAlias::class, true));
     }
 
     /**
@@ -216,7 +216,7 @@ class DebugClassLoaderTest extends TestCase
         $e = error_reporting(0);
         trigger_error('', E_USER_NOTICE);
 
-        class_exists('Test\\'.__NAMESPACE__.'\\NonDeprecatedInterfaceClass', true);
+        class_exists('Test\\'.NonDeprecatedInterfaceClass::class, true);
 
         error_reporting($e);
         restore_error_handler();
@@ -264,7 +264,7 @@ class DebugClassLoaderTest extends TestCase
         $e = error_reporting(0);
         trigger_error('', E_USER_NOTICE);
 
-        class_exists('Test\\'.__NAMESPACE__.'\\Float', true);
+        class_exists('Test\\'.Float::class, true);
 
         error_reporting($e);
         restore_error_handler();
@@ -289,7 +289,7 @@ class DebugClassLoaderTest extends TestCase
         require __DIR__.'/Fixtures/FinalClasses.php';
 
         $i = 1;
-        while (class_exists($finalClass = __NAMESPACE__.'\\Fixtures\\FinalClass'.$i++, false)) {
+        while (class_exists($finalClass = Fixtures\FinalClass::class.$i++, false)) {
             spl_autoload_call($finalClass);
             class_exists('Test\\'.__NAMESPACE__.'\\Extends'.substr($finalClass, strrpos($finalClass, '\\') + 1), true);
         }
@@ -315,7 +315,7 @@ class DebugClassLoaderTest extends TestCase
         set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
         $e = error_reporting(E_USER_DEPRECATED);
 
-        class_exists(__NAMESPACE__.'\\Fixtures\\ExtendedFinalMethod', true);
+        class_exists(Fixtures\ExtendedFinalMethod::class, true);
 
         error_reporting($e);
         restore_error_handler();
@@ -334,7 +334,7 @@ class DebugClassLoaderTest extends TestCase
         $e = error_reporting(0);
         trigger_error('', E_USER_NOTICE);
 
-        class_exists('Test\\'.__NAMESPACE__.'\\ExtendsAnnotatedClass', true);
+        class_exists('Test\\'.ExtendsAnnotatedClass::class, true);
 
         error_reporting($e);
         restore_error_handler();
@@ -351,7 +351,7 @@ class DebugClassLoaderTest extends TestCase
         set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
         $e = error_reporting(E_USER_DEPRECATED);
 
-        class_exists('Test\\'.__NAMESPACE__.'\\ExtendsInternals', true);
+        class_exists('Test\\'.ExtendsInternals::class, true);
 
         error_reporting($e);
         restore_error_handler();
@@ -370,7 +370,7 @@ class DebugClassLoaderTest extends TestCase
         set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
         $e = error_reporting(E_USER_DEPRECATED);
 
-        class_exists('Test\\'.__NAMESPACE__.'\\UseTraitWithInternalMethod', true);
+        class_exists('Test\\'.UseTraitWithInternalMethod::class, true);
 
         error_reporting($e);
         restore_error_handler();
@@ -380,7 +380,7 @@ class DebugClassLoaderTest extends TestCase
 
     public function testEvaluatedCode()
     {
-        $this->assertTrue(class_exists(__NAMESPACE__.'\Fixtures\DefinitionInEvaluatedCode', true));
+        $this->assertTrue(class_exists(Fixtures\DefinitionInEvaluatedCode::class, true));
     }
 }
 
@@ -399,11 +399,11 @@ class ClassLoader
     {
         $fixtureDir = __DIR__.\DIRECTORY_SEPARATOR.'Fixtures'.\DIRECTORY_SEPARATOR;
 
-        if (__NAMESPACE__.'\TestingUnsilencing' === $class) {
+        if (TestingUnsilencing::class === $class) {
             eval('-- parse error --');
-        } elseif (__NAMESPACE__.'\TestingStacking' === $class) {
+        } elseif (TestingStacking::class === $class) {
             eval('namespace '.__NAMESPACE__.'; class TestingStacking { function foo() {} }');
-        } elseif (__NAMESPACE__.'\TestingCaseMismatch' === $class) {
+        } elseif (TestingCaseMismatch::class === $class) {
             eval('namespace '.__NAMESPACE__.'; class TestingCaseMisMatch {}');
         } elseif (__NAMESPACE__.'\Fixtures\Psr4CaseMismatch' === $class) {
             return $fixtureDir.'psr4'.\DIRECTORY_SEPARATOR.'Psr4CaseMismatch.php';
@@ -413,30 +413,30 @@ class ClassLoader
             return $fixtureDir.'notPsr0Bis.php';
         } elseif ('Symfony\Bridge\Debug\Tests\Fixtures\ExtendsDeprecatedParent' === $class) {
             eval('namespace Symfony\Bridge\Debug\Tests\Fixtures; class ExtendsDeprecatedParent extends \\'.__NAMESPACE__.'\Fixtures\DeprecatedClass {}');
-        } elseif ('Test\\'.__NAMESPACE__.'\DeprecatedParentClass' === $class) {
+        } elseif ('Test\\'.DeprecatedParentClass::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class DeprecatedParentClass extends \\'.__NAMESPACE__.'\Fixtures\DeprecatedClass {}');
-        } elseif ('Test\\'.__NAMESPACE__.'\DeprecatedInterfaceClass' === $class) {
+        } elseif ('Test\\'.DeprecatedInterfaceClass::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class DeprecatedInterfaceClass implements \\'.__NAMESPACE__.'\Fixtures\DeprecatedInterface {}');
-        } elseif ('Test\\'.__NAMESPACE__.'\NonDeprecatedInterfaceClass' === $class) {
+        } elseif ('Test\\'.NonDeprecatedInterfaceClass::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class NonDeprecatedInterfaceClass implements \\'.__NAMESPACE__.'\Fixtures\NonDeprecatedInterface {}');
-        } elseif ('Test\\'.__NAMESPACE__.'\Float' === $class) {
+        } elseif ('Test\\'.Float::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class Float {}');
-        } elseif (0 === strpos($class, 'Test\\'.__NAMESPACE__.'\ExtendsFinalClass')) {
+        } elseif (0 === strpos($class, 'Test\\'.ExtendsFinalClass::class)) {
             $classShortName = substr($class, strrpos($class, '\\') + 1);
             eval('namespace Test\\'.__NAMESPACE__.'; class '.$classShortName.' extends \\'.__NAMESPACE__.'\Fixtures\\'.substr($classShortName, 7).' {}');
-        } elseif ('Test\\'.__NAMESPACE__.'\ExtendsAnnotatedClass' === $class) {
+        } elseif ('Test\\'.ExtendsAnnotatedClass::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsAnnotatedClass extends \\'.__NAMESPACE__.'\Fixtures\AnnotatedClass {
                 public function deprecatedMethod() { }
             }');
-        } elseif ('Test\\'.__NAMESPACE__.'\ExtendsInternals' === $class) {
+        } elseif ('Test\\'.ExtendsInternals::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsInternals extends ExtendsInternalsParent {
                 use \\'.__NAMESPACE__.'\Fixtures\InternalTrait;
 
                 public function internalMethod() { }
             }');
-        } elseif ('Test\\'.__NAMESPACE__.'\ExtendsInternalsParent' === $class) {
+        } elseif ('Test\\'.ExtendsInternalsParent::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsInternalsParent extends \\'.__NAMESPACE__.'\Fixtures\InternalClass implements \\'.__NAMESPACE__.'\Fixtures\InternalInterface { }');
-        } elseif ('Test\\'.__NAMESPACE__.'\UseTraitWithInternalMethod' === $class) {
+        } elseif ('Test\\'.UseTraitWithInternalMethod::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class UseTraitWithInternalMethod { use \\'.__NAMESPACE__.'\Fixtures\TraitWithInternalMethod; }');
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -37,7 +37,7 @@ class AutowirePassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register(Foo::class);
-        $barDefinition = $container->register('bar', __NAMESPACE__.'\Bar');
+        $barDefinition = $container->register('bar', Bar::class);
         $barDefinition->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -75,7 +75,7 @@ class AutowirePassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register(B::class);
-        $cDefinition = $container->register('c', __NAMESPACE__.'\C');
+        $cDefinition = $container->register('c', C::class);
         $cDefinition->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -97,7 +97,7 @@ class AutowirePassTest extends TestCase
 
         $container->setAlias(AInterface::class, B::class);
         $container->register(B::class);
-        $cDefinition = $container->register('c', __NAMESPACE__.'\C');
+        $cDefinition = $container->register('c', C::class);
         $cDefinition->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -118,7 +118,7 @@ class AutowirePassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register(F::class);
-        $gDefinition = $container->register('g', __NAMESPACE__.'\G');
+        $gDefinition = $container->register('g', G::class);
         $gDefinition->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -134,9 +134,9 @@ class AutowirePassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('b', __NAMESPACE__.'\B');
+        $container->register('b', B::class);
         $container->register(DInterface::class, F::class);
-        $hDefinition = $container->register('h', __NAMESPACE__.'\H')->addArgument(new Reference('b'));
+        $hDefinition = $container->register('h', H::class)->addArgument(new Reference('b'));
         $hDefinition->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -153,7 +153,7 @@ class AutowirePassTest extends TestCase
 
         $container->register(B::class);
         $container->register(DInterface::class, F::class);
-        $hDefinition = $container->register('h', __NAMESPACE__.'\H')->addArgument('')->addArgument('');
+        $hDefinition = $container->register('h', H::class)->addArgument('')->addArgument('');
         $hDefinition->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -171,10 +171,10 @@ class AutowirePassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('c1', __NAMESPACE__.'\CollisionA');
-        $container->register('c2', __NAMESPACE__.'\CollisionB');
-        $container->register('c3', __NAMESPACE__.'\CollisionB');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
+        $container->register('c1', CollisionA::class);
+        $container->register('c2', CollisionB::class);
+        $container->register('c3', CollisionB::class);
+        $aDefinition = $container->register('a', CannotBeAutowired::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass(false);
@@ -188,7 +188,7 @@ class AutowirePassTest extends TestCase
         $this->expectExceptionMessage('Invalid service "private_service": constructor of class "Symfony\Component\DependencyInjection\Tests\Compiler\PrivateConstructor" must be public.');
         $container = new ContainerBuilder();
 
-        $container->autowire('private_service', __NAMESPACE__.'\PrivateConstructor');
+        $container->autowire('private_service', PrivateConstructor::class);
 
         $pass = new AutowirePass(true);
         $pass->process($container);
@@ -200,10 +200,10 @@ class AutowirePassTest extends TestCase
         $this->expectExceptionMessage('Cannot autowire service "a": argument "$collision" of method "Symfony\Component\DependencyInjection\Tests\Compiler\CannotBeAutowired::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" but no such service exists. You should maybe alias this interface to one of these existing services: "c1", "c2", "c3".');
         $container = new ContainerBuilder();
 
-        $container->register('c1', __NAMESPACE__.'\CollisionA');
-        $container->register('c2', __NAMESPACE__.'\CollisionB');
-        $container->register('c3', __NAMESPACE__.'\CollisionB');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
+        $container->register('c1', CollisionA::class);
+        $container->register('c2', CollisionB::class);
+        $container->register('c3', CollisionB::class);
+        $aDefinition = $container->register('a', CannotBeAutowired::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -216,9 +216,9 @@ class AutowirePassTest extends TestCase
         $this->expectExceptionMessage('Cannot autowire service "a": argument "$k" of method "Symfony\Component\DependencyInjection\Tests\Compiler\NotGuessableArgument::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\Foo" but no such service exists. You should maybe alias this class to one of these existing services: "a1", "a2".');
         $container = new ContainerBuilder();
 
-        $container->register('a1', __NAMESPACE__.'\Foo');
-        $container->register('a2', __NAMESPACE__.'\Foo');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\NotGuessableArgument');
+        $container->register('a1', Foo::class);
+        $container->register('a2', Foo::class);
+        $aDefinition = $container->register('a', NotGuessableArgument::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -231,9 +231,9 @@ class AutowirePassTest extends TestCase
         $this->expectExceptionMessage('Cannot autowire service "a": argument "$k" of method "Symfony\Component\DependencyInjection\Tests\Compiler\NotGuessableArgumentForSubclass::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\A" but no such service exists. You should maybe alias this class to one of these existing services: "a1", "a2".');
         $container = new ContainerBuilder();
 
-        $container->register('a1', __NAMESPACE__.'\B');
-        $container->register('a2', __NAMESPACE__.'\B');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\NotGuessableArgumentForSubclass');
+        $container->register('a1', B::class);
+        $container->register('a2', B::class);
+        $aDefinition = $container->register('a', NotGuessableArgumentForSubclass::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -246,7 +246,7 @@ class AutowirePassTest extends TestCase
         $this->expectExceptionMessage('Cannot autowire service "a": argument "$collision" of method "Symfony\Component\DependencyInjection\Tests\Compiler\CannotBeAutowired::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" but no such service exists.');
         $container = new ContainerBuilder();
 
-        $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
+        $aDefinition = $container->register('a', CannotBeAutowired::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -257,10 +257,10 @@ class AutowirePassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a1', __NAMESPACE__.'\Foo');
-        $container->register('a2', __NAMESPACE__.'\Foo');
+        $container->register('a1', Foo::class);
+        $container->register('a2', Foo::class);
         $container->register(Foo::class, Foo::class);
-        $aDefinition = $container->register('a', __NAMESPACE__.'\NotGuessableArgument');
+        $aDefinition = $container->register('a', NotGuessableArgument::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -274,10 +274,10 @@ class AutowirePassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('c1', __NAMESPACE__.'\CollisionA');
-        $container->register('c2', __NAMESPACE__.'\CollisionB');
+        $container->register('c1', CollisionA::class);
+        $container->register('c2', CollisionB::class);
         $container->setAlias(CollisionInterface::class, 'c2');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
+        $aDefinition = $container->register('a', CannotBeAutowired::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -296,7 +296,7 @@ class AutowirePassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $coopTilleulsDefinition = $container->register('coop_tilleuls', __NAMESPACE__.'\LesTilleuls');
+        $coopTilleulsDefinition = $container->register('coop_tilleuls', LesTilleuls::class);
         $coopTilleulsDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -307,13 +307,13 @@ class AutowirePassTest extends TestCase
         $this->assertEquals('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Dunglas', $container->getDefinition('coop_tilleuls')->getArgument(1));
 
         $dunglasDefinition = $container->getDefinition('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Dunglas');
-        $this->assertEquals(__NAMESPACE__.'\Dunglas', $dunglasDefinition->getClass());
+        $this->assertEquals(Dunglas::class, $dunglasDefinition->getClass());
         $this->assertFalse($dunglasDefinition->isPublic());
         $this->assertCount(1, $dunglasDefinition->getArguments());
         $this->assertEquals('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Lille', $dunglasDefinition->getArgument(0));
 
         $lilleDefinition = $container->getDefinition('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Lille');
-        $this->assertEquals(__NAMESPACE__.'\Lille', $lilleDefinition->getClass());
+        $this->assertEquals(Lille::class, $lilleDefinition->getClass());
     }
 
     public function testResolveParameter()
@@ -337,7 +337,7 @@ class AutowirePassTest extends TestCase
 
         $container->register(A::class);
         $container->register(Foo::class);
-        $optDefinition = $container->register('opt', __NAMESPACE__.'\OptionalParameter');
+        $optDefinition = $container->register('opt', OptionalParameter::class);
         $optDefinition->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -354,7 +354,7 @@ class AutowirePassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register(Foo::class);
-        $container->register('bar', __NAMESPACE__.'\Bar');
+        $container->register('bar', Bar::class);
 
         (new ResolveClassPass())->process($container);
         (new AutowirePass())->process($container);
@@ -368,7 +368,7 @@ class AutowirePassTest extends TestCase
         $this->expectExceptionMessage('Cannot autowire service "a": argument "$r" of method "Symfony\Component\DependencyInjection\Tests\Compiler\BadTypeHintedArgument::__construct()" has type "Symfony\Component\DependencyInjection\Tests\Compiler\NotARealClass" but this class was not found.');
         $container = new ContainerBuilder();
 
-        $aDefinition = $container->register('a', __NAMESPACE__.'\BadTypeHintedArgument');
+        $aDefinition = $container->register('a', BadTypeHintedArgument::class);
         $aDefinition->setAutowired(true);
 
         $container->register(Dunglas::class, Dunglas::class);
@@ -384,7 +384,7 @@ class AutowirePassTest extends TestCase
 
         $container = new ContainerBuilder();
 
-        $aDefinition = $container->register('a', __NAMESPACE__.'\BadParentTypeHintedArgument');
+        $aDefinition = $container->register('a', BadParentTypeHintedArgument::class);
         $aDefinition->setAutowired(true);
 
         $container->register(Dunglas::class, Dunglas::class);
@@ -404,8 +404,8 @@ class AutowirePassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register(Foo::class)->setAbstract(true);
-        $container->register('foo', __NAMESPACE__.'\Foo');
-        $container->register('bar', __NAMESPACE__.'\Bar')->setAutowired(true);
+        $container->register('foo', Foo::class);
+        $container->register('bar', Bar::class)->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
         (new AutowirePass())->process($container);
@@ -418,7 +418,7 @@ class AutowirePassTest extends TestCase
         $container->register('foo', Foo::class);
         $container->register(A::class);
         $container->register(Dunglas::class);
-        $container->register('multiple', __NAMESPACE__.'\MultipleArguments')
+        $container->register('multiple', MultipleArguments::class)
             ->setAutowired(true)
             // set the 2nd (index 1) argument only: autowire the first and third
             // args are: A, Foo, Dunglas
@@ -450,7 +450,7 @@ class AutowirePassTest extends TestCase
 
         $container->register(A::class);
         $container->register(Dunglas::class);
-        $container->register('arg_no_type_hint', __NAMESPACE__.'\MultipleArguments')
+        $container->register('arg_no_type_hint', MultipleArguments::class)
             ->setArguments([1 => 'foo'])
             ->setAutowired(true);
 
@@ -466,7 +466,7 @@ class AutowirePassTest extends TestCase
 
         $container->register(A::class);
         $container->register(Dunglas::class);
-        $container->register('arg_no_type_hint', __NAMESPACE__.'\MultipleArguments')
+        $container->register('arg_no_type_hint', MultipleArguments::class)
             ->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -479,7 +479,7 @@ class AutowirePassTest extends TestCase
 
         $container->register(A::class);
         $container->register(Lille::class);
-        $definition = $container->register('not_really_optional_scalar', __NAMESPACE__.'\MultipleArgumentsOptionalScalarNotReallyOptional')
+        $definition = $container->register('not_really_optional_scalar', MultipleArgumentsOptionalScalarNotReallyOptional::class)
             ->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -494,7 +494,7 @@ class AutowirePassTest extends TestCase
 
         $container->register(A::class);
         $container->register(Lille::class);
-        $container->register('with_optional_scalar', __NAMESPACE__.'\MultipleArgumentsOptionalScalar')
+        $container->register('with_optional_scalar', MultipleArgumentsOptionalScalar::class)
             ->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -518,7 +518,7 @@ class AutowirePassTest extends TestCase
 
         $container->register(A::class);
         $container->register(Lille::class);
-        $container->register('with_optional_scalar_last', __NAMESPACE__.'\MultipleArgumentsOptionalScalarLast')
+        $container->register('with_optional_scalar_last', MultipleArgumentsOptionalScalarLast::class)
             ->setAutowired(true);
 
         (new ResolveClassPass())->process($container);
@@ -659,7 +659,7 @@ class AutowirePassTest extends TestCase
     public function testCreateResourceForClass($className, $isEqual)
     {
         $startingResource = AutowirePass::createResourceForClass(
-            new \ReflectionClass(__NAMESPACE__.'\ClassForResource')
+            new \ReflectionClass(ClassForResource::class)
         );
         $newResource = AutowirePass::createResourceForClass(
             new \ReflectionClass(__NAMESPACE__.'\\'.$className)
@@ -690,9 +690,9 @@ class AutowirePassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('class_not_exist', __NAMESPACE__.'\OptionalServiceClass');
+        $container->register('class_not_exist', OptionalServiceClass::class);
 
-        $barDefinition = $container->register('bar', __NAMESPACE__.'\Bar');
+        $barDefinition = $container->register('bar', Bar::class);
         $barDefinition->setAutowired(true);
 
         $container->register(Foo::class, Foo::class);
@@ -750,8 +750,8 @@ class AutowirePassTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->register('deprecated', 'Symfony\Component\DependencyInjection\Tests\Fixtures\DeprecatedClass')->setDeprecated(true);
-        $container->register('foo', __NAMESPACE__.'\Foo');
-        $container->register('bar', __NAMESPACE__.'\Bar')->setAutowired(true);
+        $container->register('foo', Foo::class);
+        $container->register('bar', Bar::class)->setAutowired(true);
 
         $pass = new AutowirePass();
         $pass->process($container);
@@ -767,7 +767,7 @@ class AutowirePassTest extends TestCase
 
         $container->register(A::class);
         $container->register(Lille::class);
-        $container->register('foo', __NAMESPACE__.'\MultipleArgumentsOptionalScalar')
+        $container->register('foo', MultipleArgumentsOptionalScalar::class)
             ->setAutowired(true)
             ->setArguments(['', '']);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/AutowireServiceResourceTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/AutowireServiceResourceTest.php
@@ -34,7 +34,7 @@ class AutowireServiceResourceTest extends TestCase
         $this->time = time();
         touch($this->file, $this->time);
 
-        $this->class = __NAMESPACE__.'\Foo';
+        $this->class = Foo::class;
         $this->resource = new AutowireServiceResource(
             $this->class,
             $this->file,
@@ -83,7 +83,7 @@ class AutowireServiceResourceTest extends TestCase
     public function testIsFreshSameConstructorArgs()
     {
         $oldResource = AutowirePass::createResourceForClass(
-            new \ReflectionClass(__NAMESPACE__.'\Foo')
+            new \ReflectionClass(Foo::class)
         );
 
         // test with a stale file *but* the resource will not be changed

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1238,7 +1238,7 @@ class ContainerBuilderTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register(A::class)->setPublic(true);
-        $bDefinition = $container->register('b', __NAMESPACE__.'\B');
+        $bDefinition = $container->register('b', B::class);
         $bDefinition->setAutowired(true);
         $bDefinition->setPublic(true);
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
@@ -31,7 +31,7 @@ class BirthdayType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\DateType';
+        return DateType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -391,12 +391,12 @@ class ChoiceType extends AbstractType
         ];
 
         if ($options['multiple']) {
-            $choiceType = __NAMESPACE__.'\CheckboxType';
+            $choiceType = CheckboxType::class;
             // The user can check 0 or more checkboxes. If required
             // is true, they are required to check all of them.
             $choiceOpts['required'] = false;
         } else {
-            $choiceType = __NAMESPACE__.'\RadioType';
+            $choiceType = RadioType::class;
         }
 
         $builder->add($name, $choiceType, $choiceOpts);

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -94,7 +94,7 @@ class CollectionType extends AbstractType
             'prototype' => true,
             'prototype_data' => null,
             'prototype_name' => '__name__',
-            'entry_type' => __NAMESPACE__.'\TextType',
+            'entry_type' => TextType::class,
             'entry_options' => [],
             'delete_empty' => false,
         ]);

--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -55,7 +55,7 @@ class CountryType extends AbstractType implements ChoiceLoaderInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -55,7 +55,7 @@ class CurrencyType extends AbstractType implements ChoiceLoaderInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -158,8 +158,8 @@ class DateTimeType extends AbstractType
                         'time' => $timeParts,
                     ]),
                 ]))
-                ->add('date', __NAMESPACE__.'\DateType', $dateOptions)
-                ->add('time', __NAMESPACE__.'\TimeType', $timeOptions)
+                ->add('date', DateType::class, $dateOptions)
+                ->add('time', TimeType::class, $timeOptions)
             ;
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
@@ -20,7 +20,7 @@ class EmailType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -55,7 +55,7 @@ class LanguageType extends AbstractType implements ChoiceLoaderInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
@@ -55,7 +55,7 @@ class LocaleType extends AbstractType implements ChoiceLoaderInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -44,7 +44,7 @@ class PasswordType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
@@ -20,7 +20,7 @@ class RadioType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\CheckboxType';
+        return CheckboxType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -20,7 +20,7 @@ class RangeType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -47,7 +47,7 @@ class RepeatedType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'type' => __NAMESPACE__.'\TextType',
+            'type' => TextType::class,
             'options' => [],
             'first_options' => [],
             'second_options' => [],

--- a/src/Symfony/Component/Form/Extension/Core/Type/ResetType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ResetType.php
@@ -26,7 +26,7 @@ class ResetType extends AbstractType implements ButtonTypeInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ButtonType';
+        return ButtonType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
@@ -20,7 +20,7 @@ class SearchType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/SubmitType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SubmitType.php
@@ -33,7 +33,7 @@ class SubmitType extends AbstractType implements SubmitButtonTypeInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ButtonType';
+        return ButtonType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -30,7 +30,7 @@ class TextareaType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -77,7 +77,7 @@ class TimezoneType extends AbstractType implements ChoiceLoaderInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -56,7 +56,7 @@ class UrlType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -30,7 +30,7 @@ class FormValidator extends ConstraintValidator
     public function validate($form, Constraint $formConstraint)
     {
         if (!$formConstraint instanceof Form) {
-            throw new UnexpectedTypeException($formConstraint, __NAMESPACE__.'\Form');
+            throw new UnexpectedTypeException($formConstraint, Form::class);
         }
 
         if (!$form instanceof FormInterface) {

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
@@ -17,6 +17,6 @@ class FooSubType extends AbstractType
 {
     public function getParent()
     {
-        return __NAMESPACE__.'\FooType';
+        return FooType::class;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBarExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBarExtension.php
@@ -30,6 +30,6 @@ class FooTypeBarExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return __NAMESPACE__.'\FooType';
+        return FooType::class;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBazExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBazExtension.php
@@ -23,6 +23,6 @@ class FooTypeBazExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return __NAMESPACE__.'\FooType';
+        return FooType::class;
     }
 }

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -350,12 +350,12 @@ class ResolvedFormTypeTest extends TestCase
     public function provideTypeClassBlockPrefixTuples()
     {
         return [
-            [__NAMESPACE__.'\Fixtures\FooType', 'foo'],
-            [__NAMESPACE__.'\Fixtures\Foo', 'foo'],
-            [__NAMESPACE__.'\Fixtures\Type', 'type'],
-            [__NAMESPACE__.'\Fixtures\FooBarHTMLType', 'foo_bar_html'],
+            [Fixtures\FooType::class, 'foo'],
+            [Fixtures\Foo::class, 'foo'],
+            [Fixtures\Type::class, 'type'],
+            [Fixtures\FooBarHTMLType::class, 'foo_bar_html'],
             [__NAMESPACE__.'\Fixtures\Foo1Bar2Type', 'foo1_bar2'],
-            [__NAMESPACE__.'\Fixtures\FBooType', 'f_boo'],
+            [Fixtures\FBooType::class, 'f_boo'],
         ];
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
@@ -71,7 +71,7 @@ class ContainerControllerResolverTest extends ControllerResolverTest
     public function testGetControllerInvokableServiceWithClassNameAsName()
     {
         $invokableController = new InvokableController('bar');
-        $className = __NAMESPACE__.'\InvokableController';
+        $className = InvokableController::class;
 
         $container = $this->createMockContainer();
         $container->expects($this->once())

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -48,7 +48,7 @@ class ArgumentMetadataFactoryTest extends TestCase
 
         $this->assertEquals([
             new ArgumentMetadata('foo', self::class, false, true, null, true),
-            new ArgumentMetadata('bar', __NAMESPACE__.'\FakeClassThatDoesNotExist', false, true, null, true),
+            new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, true, null, true),
             new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, true, null, true),
         ], $arguments);
     }
@@ -58,7 +58,7 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata([$this, 'signature3']);
 
         $this->assertEquals([
-            new ArgumentMetadata('bar', __NAMESPACE__.'\FakeClassThatDoesNotExist', false, false, null),
+            new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, false, null),
             new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, false, null),
         ], $arguments);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -99,7 +99,7 @@ class RequestDataCollectorTest extends TestCase
                 '"Regular" callable',
                 [$this, 'testControllerInspection'],
                 [
-                    'class' => __NAMESPACE__.'\RequestDataCollectorTest',
+                    'class' => RequestDataCollectorTest::class,
                     'method' => 'testControllerInspection',
                     'file' => __FILE__,
                     'line' => $r1->getStartLine(),

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -36,7 +36,7 @@ class UserPasswordValidator extends ConstraintValidator
     public function validate($password, Constraint $constraint)
     {
         if (!$constraint instanceof UserPassword) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\UserPassword');
+            throw new UnexpectedTypeException($constraint, UserPassword::class);
         }
 
         if (null === $password || '' === $password) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -29,7 +29,7 @@ class AbstractObjectNormalizerTest extends TestCase
     public function testDenormalize()
     {
         $normalizer = new AbstractObjectNormalizerDummy();
-        $normalizedData = $normalizer->denormalize(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'], __NAMESPACE__.'\Dummy');
+        $normalizedData = $normalizer->denormalize(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'], Dummy::class);
 
         $this->assertSame('foo', $normalizedData->foo);
         $this->assertNull($normalizedData->bar);
@@ -39,12 +39,12 @@ class AbstractObjectNormalizerTest extends TestCase
     public function testInstantiateObjectDenormalizer()
     {
         $data = ['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'];
-        $class = __NAMESPACE__.'\Dummy';
+        $class = Dummy::class;
         $context = [];
 
         $normalizer = new AbstractObjectNormalizerDummy();
 
-        $this->assertInstanceOf(__NAMESPACE__.'\Dummy', $normalizer->instantiateObject($data, $class, $context, new \ReflectionClass($class), []));
+        $this->assertInstanceOf(Dummy::class, $normalizer->instantiateObject($data, $class, $context, new \ReflectionClass($class), []));
     }
 
     public function testDenormalizeWithExtraAttributes()
@@ -55,7 +55,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizer = new AbstractObjectNormalizerDummy($factory);
         $normalizer->denormalize(
             ['fooFoo' => 'foo', 'fooBar' => 'bar'],
-            __NAMESPACE__.'\Dummy',
+            Dummy::class,
             'any',
             ['allow_extra_attributes' => false]
         );

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -68,7 +68,7 @@ class ArrayDenormalizerTest extends TestCase
     {
         $this->serializer->expects($this->once())
             ->method('supportsDenormalization')
-            ->with($this->anything(), __NAMESPACE__.'\ArrayDummy', $this->anything())
+            ->with($this->anything(), ArrayDummy::class, $this->anything())
             ->willReturn(true);
 
         $this->assertTrue(
@@ -104,7 +104,7 @@ class ArrayDenormalizerTest extends TestCase
         $this->assertFalse(
             $this->denormalizer->supportsDenormalization(
                 ['foo' => 'one', 'bar' => 'two'],
-                __NAMESPACE__.'\ArrayDummy'
+                ArrayDummy::class
             )
         );
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -38,7 +38,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     protected function setUp()
     {
-        $this->serializer = $this->getMockBuilder(__NAMESPACE__.'\SerializerNormalizer')->getMock();
+        $this->serializer = $this->getMockBuilder(SerializerNormalizer::class)->getMock();
         $this->normalizer = new GetSetMethodNormalizer();
         $this->normalizer->setSerializer($this->serializer);
     }
@@ -83,7 +83,7 @@ class GetSetMethodNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'],
-            __NAMESPACE__.'\GetSetDummy',
+            GetSetDummy::class,
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());
@@ -114,21 +114,21 @@ class GetSetMethodNormalizerTest extends TestCase
         $data->foo = 'foo';
         $data->bar = 'bar';
         $data->fooBar = 'foobar';
-        $obj = $this->normalizer->denormalize($data, __NAMESPACE__.'\GetSetDummy', 'any');
+        $obj = $this->normalizer->denormalize($data, GetSetDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
     }
 
     public function testDenormalizeNull()
     {
-        $this->assertEquals(new GetSetDummy(), $this->normalizer->denormalize(null, __NAMESPACE__.'\GetSetDummy'));
+        $this->assertEquals(new GetSetDummy(), $this->normalizer->denormalize(null, GetSetDummy::class));
     }
 
     public function testConstructorDenormalize()
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'],
-            __NAMESPACE__.'\GetConstructorDummy', 'any');
+            GetConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
         $this->assertTrue($obj->isBaz());
@@ -138,7 +138,7 @@ class GetSetMethodNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'foo', 'bar' => null, 'baz' => true],
-            __NAMESPACE__.'\GetConstructorDummy', 'any');
+            GetConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertNull($obj->getBar());
         $this->assertTrue($obj->isBaz());
@@ -148,7 +148,7 @@ class GetSetMethodNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'test', 'baz' => [1, 2, 3]],
-            __NAMESPACE__.'\GetConstructorOptionalArgsDummy', 'any');
+            GetConstructorOptionalArgsDummy::class, 'any');
         $this->assertEquals('test', $obj->getFoo());
         $this->assertEquals([], $obj->getBar());
         $this->assertEquals([1, 2, 3], $obj->getBaz());
@@ -158,7 +158,7 @@ class GetSetMethodNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['bar' => 'test'],
-            __NAMESPACE__.'\GetConstructorArgsWithDefaultValueDummy', 'any');
+            GetConstructorArgsWithDefaultValueDummy::class, 'any');
         $this->assertEquals([], $obj->getFoo());
         $this->assertEquals('test', $obj->getBar());
     }
@@ -192,14 +192,14 @@ class GetSetMethodNormalizerTest extends TestCase
         $data->bar = 'bar';
         $data->baz = true;
         $data->fooBar = 'foobar';
-        $obj = $this->normalizer->denormalize($data, __NAMESPACE__.'\GetConstructorDummy', 'any');
+        $obj = $this->normalizer->denormalize($data, GetConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
     }
 
     public function testConstructorWArgWithPrivateMutator()
     {
-        $obj = $this->normalizer->denormalize(['foo' => 'bar'], __NAMESPACE__.'\ObjectConstructorArgsWithPrivateMutatorDummy', 'any');
+        $obj = $this->normalizer->denormalize(['foo' => 'bar'], ObjectConstructorArgsWithPrivateMutatorDummy::class, 'any');
         $this->assertEquals('bar', $obj->getFoo());
     }
 
@@ -466,7 +466,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
         $obj = $this->normalizer->denormalize(
             ['bar' => 'bar'],
-            __NAMESPACE__.'\GetSetDummy',
+            GetSetDummy::class,
             null,
             [GetSetMethodNormalizer::OBJECT_TO_POPULATE => $dummy]
         );
@@ -480,13 +480,13 @@ class GetSetMethodNormalizerTest extends TestCase
     {
         $this->assertEquals(
             new GetSetDummy(),
-            $this->normalizer->denormalize(['non_existing' => true], __NAMESPACE__.'\GetSetDummy')
+            $this->normalizer->denormalize(['non_existing' => true], GetSetDummy::class)
         );
     }
 
     public function testDenormalizeShouldNotSetStaticAttribute()
     {
-        $obj = $this->normalizer->denormalize(['staticObject' => true], __NAMESPACE__.'\GetSetDummy');
+        $obj = $this->normalizer->denormalize(['staticObject' => true], GetSetDummy::class);
 
         $this->assertEquals(new GetSetDummy(), $obj);
         $this->assertNull(GetSetDummy::getStaticObject());
@@ -504,7 +504,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testPrivateSetter()
     {
-        $obj = $this->normalizer->denormalize(['foo' => 'foobar'], __NAMESPACE__.'\ObjectWithPrivateSetterDummy');
+        $obj = $this->normalizer->denormalize(['foo' => 'foobar'], ObjectWithPrivateSetterDummy::class);
         $this->assertEquals('bar', $obj->getFoo());
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -47,7 +47,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function setUp()
     {
-        $this->serializer = $this->getMockBuilder(__NAMESPACE__.'\ObjectSerializerNormalizer')->getMock();
+        $this->serializer = $this->getMockBuilder(ObjectSerializerNormalizer::class)->getMock();
         $this->normalizer = new ObjectNormalizer();
         $this->normalizer->setSerializer($this->serializer);
     }
@@ -98,7 +98,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'],
-            __NAMESPACE__.'\ObjectDummy',
+            ObjectDummy::class,
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());
@@ -112,21 +112,21 @@ class ObjectNormalizerTest extends TestCase
         $data->foo = 'foo';
         $data->bar = 'bar';
         $data->fooBar = 'foobar';
-        $obj = $this->normalizer->denormalize($data, __NAMESPACE__.'\ObjectDummy', 'any');
+        $obj = $this->normalizer->denormalize($data, ObjectDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->bar);
     }
 
     public function testDenormalizeNull()
     {
-        $this->assertEquals(new ObjectDummy(), $this->normalizer->denormalize(null, __NAMESPACE__.'\ObjectDummy'));
+        $this->assertEquals(new ObjectDummy(), $this->normalizer->denormalize(null, ObjectDummy::class));
     }
 
     public function testConstructorDenormalize()
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'],
-            __NAMESPACE__.'\ObjectConstructorDummy', 'any');
+            ObjectConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->bar);
         $this->assertTrue($obj->isBaz());
@@ -136,7 +136,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'foo', 'bar' => null, 'baz' => true],
-            __NAMESPACE__.'\ObjectConstructorDummy', 'any');
+            ObjectConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertNull($obj->bar);
         $this->assertTrue($obj->isBaz());
@@ -146,7 +146,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'test', 'baz' => [1, 2, 3]],
-            __NAMESPACE__.'\ObjectConstructorOptionalArgsDummy', 'any');
+            ObjectConstructorOptionalArgsDummy::class, 'any');
         $this->assertEquals('test', $obj->getFoo());
         $this->assertEquals([], $obj->bar);
         $this->assertEquals([1, 2, 3], $obj->getBaz());
@@ -156,7 +156,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['bar' => 'test'],
-            __NAMESPACE__.'\ObjectConstructorArgsWithDefaultValueDummy', 'any');
+            ObjectConstructorArgsWithDefaultValueDummy::class, 'any');
         $this->assertEquals([], $obj->getFoo());
         $this->assertEquals('test', $obj->getBar());
     }
@@ -168,7 +168,7 @@ class ObjectNormalizerTest extends TestCase
         $data->bar = 'bar';
         $data->baz = true;
         $data->fooBar = 'foobar';
-        $obj = $this->normalizer->denormalize($data, __NAMESPACE__.'\ObjectConstructorDummy', 'any');
+        $obj = $this->normalizer->denormalize($data, ObjectConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->bar);
     }
@@ -410,7 +410,7 @@ class ObjectNormalizerTest extends TestCase
 
         $this->assertEquals(
             $obj,
-            $this->normalizer->denormalize(['fooBar' => 'fooBar', 'foo' => 'foo', 'baz' => 'baz'], __NAMESPACE__.'\ObjectDummy')
+            $this->normalizer->denormalize(['fooBar' => 'fooBar', 'foo' => 'foo', 'baz' => 'baz'], ObjectDummy::class)
         );
     }
 
@@ -534,7 +534,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $this->assertEquals(
             new ObjectDummy(),
-            $this->normalizer->denormalize(['non_existing' => true], __NAMESPACE__.'\ObjectDummy')
+            $this->normalizer->denormalize(['non_existing' => true], ObjectDummy::class)
         );
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -72,7 +72,7 @@ class PropertyNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'foo', 'bar' => 'bar'],
-            __NAMESPACE__.'\PropertyDummy',
+            PropertyDummy::class,
             'any'
         );
         $this->assertEquals('foo', $obj->foo);
@@ -111,7 +111,7 @@ class PropertyNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => 'foo', 'bar' => 'bar'],
-            __NAMESPACE__.'\PropertyConstructorDummy',
+            PropertyConstructorDummy::class,
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());
@@ -122,7 +122,7 @@ class PropertyNormalizerTest extends TestCase
     {
         $obj = $this->normalizer->denormalize(
             ['foo' => null, 'bar' => 'bar'],
-            __NAMESPACE__.'\PropertyConstructorDummy', '
+            PropertyConstructorDummy::class, '
             any'
         );
         $this->assertNull($obj->getFoo());
@@ -376,13 +376,13 @@ class PropertyNormalizerTest extends TestCase
     {
         $this->assertEquals(
             new PropertyDummy(),
-            $this->normalizer->denormalize(['non_existing' => true], __NAMESPACE__.'\PropertyDummy')
+            $this->normalizer->denormalize(['non_existing' => true], PropertyDummy::class)
         );
     }
 
     public function testDenormalizeShouldIgnoreStaticProperty()
     {
-        $obj = $this->normalizer->denormalize(['outOfScope' => true], __NAMESPACE__.'\PropertyDummy');
+        $obj = $this->normalizer->denormalize(['outOfScope' => true], PropertyDummy::class);
 
         $this->assertEquals(new PropertyDummy(), $obj);
         $this->assertEquals('out_of_scope', PropertyDummy::$outOfScope);

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -40,7 +40,7 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof AbstractComparison) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\AbstractComparison');
+            throw new UnexpectedTypeException($constraint, AbstractComparison::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -26,7 +26,7 @@ class AllValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof All) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\All');
+            throw new UnexpectedTypeException($constraint, All::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -28,7 +28,7 @@ class BicValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Bic) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Bic');
+            throw new UnexpectedTypeException($constraint, Bic::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -26,7 +26,7 @@ class BlankValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Blank) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Blank');
+            throw new UnexpectedTypeException($constraint, Blank::class);
         }
 
         if ('' !== $value && null !== $value) {

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -29,7 +29,7 @@ class CallbackValidator extends ConstraintValidator
     public function validate($object, Constraint $constraint)
     {
         if (!$constraint instanceof Callback) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Callback');
+            throw new UnexpectedTypeException($constraint, Callback::class);
         }
 
         $method = $constraint->callback;

--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -91,7 +91,7 @@ class CardSchemeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof CardScheme) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\CardScheme');
+            throw new UnexpectedTypeException($constraint, CardScheme::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -31,7 +31,7 @@ class ChoiceValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Choice) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Choice');
+            throw new UnexpectedTypeException($constraint, Choice::class);
         }
 
         if (!\is_array($constraint->choices) && !$constraint->callback) {

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -26,7 +26,7 @@ class CollectionValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Collection) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Collection');
+            throw new UnexpectedTypeException($constraint, Collection::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -26,7 +26,7 @@ class CountValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Count) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Count');
+            throw new UnexpectedTypeException($constraint, Count::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -29,7 +29,7 @@ class CountryValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Country) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Country');
+            throw new UnexpectedTypeException($constraint, Country::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
@@ -30,7 +30,7 @@ class CurrencyValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Currency) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Currency');
+            throw new UnexpectedTypeException($constraint, Currency::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -31,7 +31,7 @@ class DateTimeValidator extends DateValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof DateTime) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\DateTime');
+            throw new UnexpectedTypeException($constraint, DateTime::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -44,7 +44,7 @@ class DateValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Date) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Date');
+            throw new UnexpectedTypeException($constraint, Date::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -39,7 +39,7 @@ class EmailValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Email) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Email');
+            throw new UnexpectedTypeException($constraint, Email::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -36,7 +36,7 @@ class ExpressionValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Expression) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Expression');
+            throw new UnexpectedTypeException($constraint, Expression::class);
         }
 
         $variables = [];

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -41,7 +41,7 @@ class FileValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof File) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\File');
+            throw new UnexpectedTypeException($constraint, File::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -142,7 +142,7 @@ class IbanValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Iban) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Iban');
+            throw new UnexpectedTypeException($constraint, Iban::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -31,7 +31,7 @@ class ImageValidator extends FileValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Image) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Image');
+            throw new UnexpectedTypeException($constraint, Image::class);
         }
 
         $violations = \count($this->context->getViolations());

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -29,7 +29,7 @@ class IpValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Ip) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Ip');
+            throw new UnexpectedTypeException($constraint, Ip::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
@@ -26,7 +26,7 @@ class IsFalseValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsFalse) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsFalse');
+            throw new UnexpectedTypeException($constraint, IsFalse::class);
         }
 
         if (null === $value || false === $value || 0 === $value || '0' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
@@ -26,7 +26,7 @@ class IsNullValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsNull) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsNull');
+            throw new UnexpectedTypeException($constraint, IsNull::class);
         }
 
         if (null !== $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
@@ -26,7 +26,7 @@ class IsTrueValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsTrue) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsTrue');
+            throw new UnexpectedTypeException($constraint, IsTrue::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
@@ -32,7 +32,7 @@ class IsbnValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Isbn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Isbn');
+            throw new UnexpectedTypeException($constraint, Isbn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IssnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IssnValidator.php
@@ -31,7 +31,7 @@ class IssnValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Issn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Issn');
+            throw new UnexpectedTypeException($constraint, Issn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -29,7 +29,7 @@ class LanguageValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Language) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Language');
+            throw new UnexpectedTypeException($constraint, Language::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -26,7 +26,7 @@ class LengthValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Length) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Length');
+            throw new UnexpectedTypeException($constraint, Length::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -29,7 +29,7 @@ class LocaleValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Locale) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Locale');
+            throw new UnexpectedTypeException($constraint, Locale::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -39,7 +39,7 @@ class LuhnValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Luhn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Luhn');
+            throw new UnexpectedTypeException($constraint, Luhn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -26,7 +26,7 @@ class NotBlankValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof NotBlank) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\NotBlank');
+            throw new UnexpectedTypeException($constraint, NotBlank::class);
         }
 
         if (false === $value || (empty($value) && '0' != $value)) {

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -26,7 +26,7 @@ class NotNullValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof NotNull) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\NotNull');
+            throw new UnexpectedTypeException($constraint, NotNull::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -27,7 +27,7 @@ class RangeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Range) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Range');
+            throw new UnexpectedTypeException($constraint, Range::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -29,7 +29,7 @@ class RegexValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Regex) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Regex');
+            throw new UnexpectedTypeException($constraint, Regex::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -44,7 +44,7 @@ class TimeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Time) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Time');
+            throw new UnexpectedTypeException($constraint, Time::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -26,7 +26,7 @@ class TypeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Type) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Type');
+            throw new UnexpectedTypeException($constraint, Type::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -45,7 +45,7 @@ class UrlValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Url) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Url');
+            throw new UnexpectedTypeException($constraint, Url::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/UuidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UuidValidator.php
@@ -67,7 +67,7 @@ class UuidValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Uuid) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Uuid');
+            throw new UnexpectedTypeException($constraint, Uuid::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ValidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ValidValidator.php
@@ -23,7 +23,7 @@ class ValidValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Valid) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Valid');
+            throw new UnexpectedTypeException($constraint, Valid::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -33,7 +33,7 @@ class StaticMethodLoaderTest extends TestCase
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderEntity');
+        $metadata = new ClassMetadata(StaticLoaderEntity::class);
 
         $this->assertTrue($loader->loadClassMetadata($metadata));
     }
@@ -49,7 +49,7 @@ class StaticMethodLoaderTest extends TestCase
     public function testLoadClassMetadata()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderEntity');
+        $metadata = new ClassMetadata(StaticLoaderEntity::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -59,12 +59,12 @@ class StaticMethodLoaderTest extends TestCase
     public function testLoadClassMetadataDoesNotRepeatLoadWithParentClasses()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderDocument');
+        $metadata = new ClassMetadata(StaticLoaderDocument::class);
         $loader->loadClassMetadata($metadata);
         $this->assertCount(0, $metadata->getConstraints());
 
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\BaseStaticLoaderDocument');
+        $metadata = new ClassMetadata(BaseStaticLoaderDocument::class);
         $loader->loadClassMetadata($metadata);
         $this->assertCount(1, $metadata->getConstraints());
     }
@@ -72,7 +72,7 @@ class StaticMethodLoaderTest extends TestCase
     public function testLoadClassMetadataIgnoresInterfaces()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderInterface');
+        $metadata = new ClassMetadata(StaticLoaderInterface::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -82,7 +82,7 @@ class StaticMethodLoaderTest extends TestCase
     public function testLoadClassMetadataInAbstractClasses()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticLoader');
+        $metadata = new ClassMetadata(AbstractStaticLoader::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -95,7 +95,7 @@ class StaticMethodLoaderTest extends TestCase
         // strict standards error
         error_reporting(0);
 
-        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticMethodLoader');
+        $metadata = new ClassMetadata(AbstractStaticMethodLoader::class);
 
         $loader = new StaticMethodLoader('loadMetadata');
         $loader->loadClassMetadata($metadata);

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -129,7 +129,7 @@ EOTXT;
 
     public function testReflectionParameter()
     {
-        $var = new \ReflectionParameter(__NAMESPACE__.'\reflectionParameterFixture', 0);
+        $var = new \ReflectionParameter(reflectionParameterFixture::class, 0);
 
         $this->assertDumpMatchesFormat(
             <<<'EOTXT'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Related to #34987
| License       | MIT
| Doc PR        | no

Form component has a lot of built-in form types. Some of them were implemented from the very beginning. In most of them there is a such method

```php
    /**
     * {@inheritdoc}
     */
    public function getParent()
    {
        return __NAMESPACE__.'\TextType';
    }
```

This `getParent()` method was refactored in Symfony 2.8. The upgrade instructions are given here https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form

I think the `__NAMESPACE__.'\TextType';` expression was used because Symfony 2.8 was using `"php": ">=5.3.9"`, and the constant `::class` was added only in PHP 5.5

Now this line can be refactored into
```php
    /**
     * {@inheritdoc}
     */
    public function getParent()
    {
        return TextType::class;
    }
```

For example new form types, that were added later, already using the `::class` constant.
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Type/ColorType.php#L23
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Type/TelType.php#L23

So, in this pull request I propose to refactor all old form types to use `::class` constant. It will give a benefit during the future refactoring, because IDE or static analysers will find all usages of parent class. Unlike the `__NAMESPACE__.'\TextType';` line, which doesn't show the real link to the class for IDE or static analysers, and it could complicate finding all usages of parent class.