### PR TITLE
[VarDumper] ignore failing __debugInfo()

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -54,6 +54,15 @@ class Caster
             $class = $class->name;
         }
 
+        if ($hasDebugInfo) {
+            try {
+                $debugInfo = $obj->__debugInfo();
+            } catch (\Exception $e) {
+                // ignore failing __debugInfo()
+                $hasDebugInfo = false;
+            }
+        }
+
         $a = $obj instanceof \Closure ? [] : (array) $obj;
 
         if ($obj instanceof \__PHP_Incomplete_Class) {
@@ -89,7 +98,7 @@ class Caster
             }
         }
 
-        if ($hasDebugInfo && \is_array($debugInfo = $obj->__debugInfo())) {
+        if ($hasDebugInfo && \is_array($debugInfo)) {
             foreach ($debugInfo as $k => $v) {
                 if (!isset($k[0]) || "\0" !== $k[0]) {
                     $k = self::PREFIX_VIRTUAL.$k;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34993
| License       | MIT
| Doc PR        | -