### PR TITLE
[Form] Update the 'post_max_size_message'

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -183,7 +183,7 @@ class FormType extends BaseType
             // section 4.2., empty URIs are considered same-document references
             'action' => '',
             'attr' => [],
-            'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
+            'post_max_size_message' => 'The combination of submitted content and uploaded files was too large. Please try to reduce the size of the submitted content or upload smaller files.',
             'upload_max_size_message' => $uploadMaxSizeMessage, // internal
             'allow_file_upload' => false,
             'help' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35011
| License       | MIT
| Doc PR        | 

Small validation message update to avoid confusion when a form doesn't contain uploaded files and still results in a POST action with content that exceeds the `post_max_size` limit of PHP.