### PR TITLE
[HttpClient] make pushed responses retry-able

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/PushedResponse.php
+++ b/src/Symfony/Component/HttpClient/Internal/PushedResponse.php
@@ -29,10 +29,13 @@ final class PushedResponse
 
     public $parentOptions = [];
 
-    public function __construct(CurlResponse $response, array $requestHeaders, array $parentOptions)
+    public $handle;
+
+    public function __construct(CurlResponse $response, array $requestHeaders, array $parentOptions, $handle)
     {
         $this->response = $response;
         $this->requestHeaders = $requestHeaders;
         $this->parentOptions = $parentOptions;
+        $this->handle = $handle;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/orgs/symfony/projects/1#card-30499375
| License       | MIT
| Doc PR        | -

This moves the PUSH matching logic down so that the curl handle of pushed responses can be properly configured. This should make pushed requests retry-able when they fail just after the push-promise frame.