### PR TITLE
[Dev] improve default welcome page

### DIFF
--- a/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
+++ b/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
@@ -64,8 +64,8 @@
 <body>
 <div class="wrapper">
     <div class="warning">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="32"><path fill="currentColor" d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z" class=""></path></svg>
-        You're seeing this page because you haven't configured any homepage URL.
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" width="32"><path fill="currentColor" d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z" class=""></path></svg>
+        You're seeing this default page because you haven't configured yet any homepage URL.
     </div>
 
     <div class="container">
@@ -109,7 +109,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/></svg>
                 <h2>Community</h2>
                 <a href="https://symfony.com/community">
-                    Connect, get help, or contribute
+                    Connect, get help or contribute
                 </a>
             </div>
         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

I was installing a fresh install, and checked this new landing page for the first time (btw very cool :))
but i saw the warning icon, and IMO it is no that "warn", but more an "info"? wdyt?
also reword a little bit

I've taken the svg source from https://fontawesome.com/icons/info-circle

thanks

before
<img width="925" alt="Capture d’écran 2019-12-17 à 19 16 13" src="https://user-images.githubusercontent.com/13205768/71022834-bf83ef00-2101-11ea-847a-fefa1ec275e8.png">

after
<img width="1019" alt="Capture d’écran 2019-12-17 à 19 12 34" src="https://user-images.githubusercontent.com/13205768/71022791-9cf1d600-2101-11ea-9091-ddc7abbc7c09.png">
