### PR TITLE
[Dotenv] FIX missing getenv

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -387,7 +387,7 @@ final class Dotenv
             } elseif (isset($this->values[$name])) {
                 $value = $this->values[$name];
             } else {
-                $value = '';
+                $value = (string) getenv($name);
             }
 
             if (!$matches['opening_brace'] && isset($matches['closing_brace'])) {

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -314,4 +314,15 @@ class DotenvTest extends TestCase
             $this->assertSame('foo2_prod', $values['TEST2']);
         }
     }
+
+    public function testGetVariablesValueFromGetenv()
+    {
+        putenv('Foo=Bar');
+
+        $dotenv = new Dotenv(true);
+        $values = $dotenv->parse('Foo=${Foo}');
+        $this->assertSame('Bar', $values['Foo']);
+
+        putenv('Foo');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no>
| Tickets       | Fix #34598
| License       | MIT
| Doc PR        |  -

Revert one line to use getenv because not all environment variables are populated in $_ENV[]