### PR TITLE
[HttpKernel] ignore failures generated by opcache.restrict_api

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -552,7 +552,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                             }
 
                             if (\function_exists('opcache_invalidate') && filter_var(ini_get('opcache.enable'), FILTER_VALIDATE_BOOLEAN)) {
-                                opcache_invalidate($this->getPath(), true);
+                                @opcache_invalidate($this->getPath(), true);
                             }
                         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34947
| License       | MIT
| Doc PR        | -