### PR TITLE
[HttpClient][Psr18Client] Remove Psr18ExceptionTrait

### DIFF
--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -105,7 +105,7 @@ final class Psr18Client implements ClientInterface
 /**
  * @internal
  */
-trait Psr18ExceptionTrait
+class Psr18NetworkException extends \RuntimeException implements NetworkExceptionInterface
 {
     private $request;
 
@@ -124,15 +124,18 @@ trait Psr18ExceptionTrait
 /**
  * @internal
  */
-class Psr18NetworkException extends \RuntimeException implements NetworkExceptionInterface
-{
-    use Psr18ExceptionTrait;
-}
-
-/**
- * @internal
- */
 class Psr18RequestException extends \InvalidArgumentException implements RequestExceptionInterface
 {
-    use Psr18ExceptionTrait;
+    private $request;
+
+    public function __construct(TransportExceptionInterface $e, RequestInterface $request)
+    {
+        parent::__construct($e->getMessage(), 0, $e);
+        $this->request = $request;
+    }
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Interesting case. Declared trait are instantly loaded by PHP. When ClassExistenceResource fails to load this class because of a thrown \LogicException (when a dependency is missing, cf the top of this class) the trait is loaded. Then, to display the exception, this class is reaccessed (I guess by the duplicated request 🤔) and it results in a fatal error "Cannot redeclare trait...". Basically ClassExistenceResource does not support this kind of structure (thrown exception + trait). Let's do the easy fix first, and then revert if someone finds a fix for the root problem? 