### PR TITLE
Docs - Update debug section of UPGRADE guides for 4.4 and 5.0 versions.

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -19,6 +19,7 @@ Debug
 -----
 
  * Deprecated the component in favor of the `ErrorHandler` component
+ * Replace uses of `Symfony\Component\Debug\Debug` by `Symfony\Component\ErrorHandler\Debug`
 
 Config
 ------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -60,6 +60,7 @@ Debug
 -----
 
  * Removed the component in favor of the `ErrorHandler` component
+ * Replace uses of `Symfony\Component\Debug\Debug` by `Symfony\Component\ErrorHandler\Debug`
 
 DependencyInjection
 -------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34968 
| License       | MIT

Update the UPGRADE guides for 4.4 and 5.0 versions (specifically the debug section) because it was not clearly specified that it's necessary to replace `use Symfony\Component\Debug\Debug;` to `use Symfony\Component\ErrorHandler\Debug;`.