### PR TITLE
[TwigBridge] Fix invalid typehint for subject in is_granted Twig function

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -31,7 +31,10 @@ final class SecurityExtension extends AbstractExtension
         $this->securityChecker = $securityChecker;
     }
 
-    public function isGranted($role, object $object = null, string $field = null): bool
+    /**
+     * @param mixed $object
+     */
+    public function isGranted($role, $object = null, string $field = null): bool
     {
         if (null === $this->securityChecker) {
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35026
| License       | MIT
| Doc PR        | N/A

Twig function `is_granted` does not accept `mixed` any more for its second argument, instead requiring `object` or `null` with a PHP typehint. `AuthorizationCheckerInterface::isGranted`, where this argument is passed, has no typehint in code and is typehinted as `mixed` in PHPDoc.

This makes it impossible to have a check in Twig template with code similar to this:

`{% if is_granted('ROLE_MY_APP', {foo: 'bar', bar: 'baz'}) %}...{% endif %}`