### PR TITLE
[HttpClient] In `StreamWrapper::createResource` use the more efficient `Response::toStream` method if safe and available

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
+++ b/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
@@ -49,6 +49,14 @@ class StreamWrapper
      */
     public static function createResource(ResponseInterface $response, HttpClientInterface $client = null)
     {
+        if (null === $client && \is_callable([$response, 'toStream']) && isset(class_uses($response)[ResponseTrait::class])) {
+            $stack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+            if ($response !== ($stack[1]['object'] ?? null)) {
+                return $response->toStream(false);
+            }
+        }
+
         if (null === $client && !method_exists($response, 'stream')) {
             throw new \InvalidArgumentException(sprintf('Providing a client to "%s()" is required when the response doesn\'t have any "stream()" method.', __CLASS__));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34834 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

In `StreamWrapper::createResource` use the more efficient `Response::toStream` method if safe and available.