### PR TITLE
[Mailer] fixed destination override by envelope in amazon api transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
@@ -119,14 +119,14 @@ class SesApiTransportTest extends TestCase
     private function createMockAwsSendRawEmailResponse(): string
     {
         return <<<XML
-        <SendRawEmailResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
-          <SendRawEmailResult>
-            <MessageId>0102016f1eb7661b-4294e7da-5d64-45c2-8998-e8ade5468d95-000000</MessageId>
-          </SendRawEmailResult>
-          <ResponseMetadata>
-            <RequestId>dc4fb17f-0320-428b-8c03-62f9ec9b98ba</RequestId>
-          </ResponseMetadata>
-        </SendRawEmailResponse>
-        XML;
+<SendRawEmailResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
+  <SendRawEmailResult>
+    <MessageId>0102016f1eb7661b-4294e7da-5d64-45c2-8998-e8ade5468d95-000000</MessageId>
+  </SendRawEmailResult>
+  <ResponseMetadata>
+    <RequestId>dc4fb17f-0320-428b-8c03-62f9ec9b98ba</RequestId>
+  </ResponseMetadata>
+</SendRawEmailResponse>
+XML;
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
@@ -72,8 +72,6 @@ class SesApiTransportTest extends TestCase
         $email = (new Email())
             ->from('sender@example.tld')
             ->to('recipient-to@example.tld')
-            ->cc('recipient-cc@example.tld')
-            ->bcc('recipient-bcc@example.tld')
             ->subject('Test Mail')
             ->text('Text content of the test mail')
             ->html('<p>HTML content of the test mail</p>');
@@ -106,8 +104,6 @@ class SesApiTransportTest extends TestCase
         $email = (new Email())
             ->from('sender@example.tld')
             ->to('recipient-to@example.tld')
-            ->cc('recipient-cc@example.tld')
-            ->bcc('recipient-bcc@example.tld')
             ->subject('Test Mail')
             ->text('Text content of the test mail')
             ->html('<p>HTML content of the test mail</p>');

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
@@ -18,8 +18,6 @@ use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use function GuzzleHttp\Psr7\parse_query;
 
 class SesApiTransportTest extends TestCase
 {

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
@@ -57,7 +57,7 @@ class SesApiTransportTest extends TestCase
     {
         $awsApiCallback = function ($method, $url, $options) {
             $requestParts = [];
-            \parse_str($options['body'], $requestParts);
+            parse_str($options['body'], $requestParts);
 
             $this->assertEquals('POST', $method);
             $this->assertEquals('https://email.eu-west-1.amazonaws.com/', $url);
@@ -87,7 +87,7 @@ class SesApiTransportTest extends TestCase
     {
         $awsApiCallback = function ($method, $url, $options) {
             $requestParts = [];
-            \parse_str($options['body'], $requestParts);
+            parse_str($options['body'], $requestParts);
 
             $this->assertEquals('POST', $method);
             $this->assertEquals('https://email.eu-west-1.amazonaws.com/', $url);
@@ -96,7 +96,7 @@ class SesApiTransportTest extends TestCase
             $this->assertArrayHasKey('Destinations_member', $requestParts);
             $this->assertEquals($requestParts['Destinations_member'], [
                 'envelope-recipient-1@example.tld',
-                'envelope-recipient-2@example.tld'
+                'envelope-recipient-2@example.tld',
             ]);
 
             return new MockResponse($this->createMockAwsSendRawEmailResponse());
@@ -116,7 +116,7 @@ class SesApiTransportTest extends TestCase
 
         $envelope = new Envelope(Address::create('envelope-sender@example.tld'), [
             Address::create('envelope-recipient-1@example.tld'),
-            Address::create('envelope-recipient-2@example.tld')
+            Address::create('envelope-recipient-2@example.tld'),
         ]);
 
         $transport->send($email, $envelope);

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
@@ -12,7 +12,14 @@
 namespace Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiTransport;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use function GuzzleHttp\Psr7\parse_query;
 
 class SesApiTransportTest extends TestCase
 {
@@ -44,5 +51,88 @@ class SesApiTransportTest extends TestCase
                 'ses+api://ACCESS_KEY@example.com:99',
             ],
         ];
+    }
+
+    public function testSendEmail()
+    {
+        $awsApiCallback = function ($method, $url, $options) {
+            $requestParts = [];
+            \parse_str($options['body'], $requestParts);
+
+            $this->assertEquals('POST', $method);
+            $this->assertEquals('https://email.eu-west-1.amazonaws.com/', $url);
+
+            $this->assertEquals($requestParts['Source'], 'sender@example.tld');
+            $this->assertArrayNotHasKey('Destinations.member', $requestParts);
+
+            return new MockResponse($this->createMockAwsSendRawEmailResponse());
+        };
+
+        $httpClient = new MockHttpClient($awsApiCallback);
+        $transport = new SesApiTransport('ACCESS_KEY', 'SECRET_KEY', 'eu-west-1', $httpClient);
+
+        $email = (new Email())
+            ->from('sender@example.tld')
+            ->to('recipient-to@example.tld')
+            ->cc('recipient-cc@example.tld')
+            ->bcc('recipient-bcc@example.tld')
+            ->subject('Test Mail')
+            ->text('Text content of the test mail')
+            ->html('<p>HTML content of the test mail</p>');
+
+        $transport->send($email);
+    }
+
+    public function testSendEmailWithEnvelopeOverride()
+    {
+        $awsApiCallback = function ($method, $url, $options) {
+            $requestParts = [];
+            \parse_str($options['body'], $requestParts);
+
+            $this->assertEquals('POST', $method);
+            $this->assertEquals('https://email.eu-west-1.amazonaws.com/', $url);
+
+            $this->assertEquals($requestParts['Source'], 'envelope-sender@example.tld');
+            $this->assertArrayHasKey('Destinations_member', $requestParts);
+            $this->assertEquals($requestParts['Destinations_member'], [
+                'envelope-recipient-1@example.tld',
+                'envelope-recipient-2@example.tld'
+            ]);
+
+            return new MockResponse($this->createMockAwsSendRawEmailResponse());
+        };
+
+        $httpClient = new MockHttpClient($awsApiCallback);
+        $transport = new SesApiTransport('ACCESS_KEY', 'SECRET_KEY', 'eu-west-1', $httpClient);
+
+        $email = (new Email())
+            ->from('sender@example.tld')
+            ->to('recipient-to@example.tld')
+            ->cc('recipient-cc@example.tld')
+            ->bcc('recipient-bcc@example.tld')
+            ->subject('Test Mail')
+            ->text('Text content of the test mail')
+            ->html('<p>HTML content of the test mail</p>');
+
+        $envelope = new Envelope(Address::create('envelope-sender@example.tld'), [
+            Address::create('envelope-recipient-1@example.tld'),
+            Address::create('envelope-recipient-2@example.tld')
+        ]);
+
+        $transport->send($email, $envelope);
+    }
+
+    private function createMockAwsSendRawEmailResponse(): string
+    {
+        return <<<XML
+        <SendRawEmailResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
+          <SendRawEmailResult>
+            <MessageId>0102016f1eb7661b-4294e7da-5d64-45c2-8998-e8ade5468d95-000000</MessageId>
+          </SendRawEmailResult>
+          <ResponseMetadata>
+            <RequestId>dc4fb17f-0320-428b-8c03-62f9ec9b98ba</RequestId>
+          </ResponseMetadata>
+        </SendRawEmailResponse>
+        XML;
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
@@ -99,13 +99,12 @@ class SesApiTransport extends AbstractApiTransport
         $envelopeRecipients = array_map(static function (Address $recipient) {
             return $recipient->getAddress();
         }, $envelope->getRecipients());
-        $requiresDestinations = count(array_diff($headerRecipients, $envelopeRecipients)) > 0;
+        $requiresDestinations = \count(array_diff($headerRecipients, $envelopeRecipients)) > 0;
 
         if ($requiresDestinations) {
             $payload['Destinations.member'] = $this->stringifyAddresses($envelope->getRecipients());
         }
 
-        dd($email->toString(), $payload);
         return $payload;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4/5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35037
| License       | MIT
| Doc PR        | -

Fixes recipients not being replaced if an email has an attachment and recipients have been set on the envelope. Also ensures recipients from envelope are used as message destination if they differ from the email header recipients. The comparison of the header and envelope recipients ensure the destination is only overridden if required, otherwise the cc/bcc classification would be lost. It is not necessary to have a condition and switching between `SendMail` and `SendRawMail` AWS API endpoints.