### PR TITLE
[Security] Handle null passwords in PlainTextPasswordEncoder

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -47,7 +47,7 @@ class PlaintextPasswordEncoder extends BasePasswordEncoder
      */
     public function isPasswordValid($encoded, $raw, $salt)
     {
-        if ($this->isPasswordTooLong($raw)) {
+        if (null === $encoded || $this->isPasswordTooLong($raw)) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #35040  <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

When UserInterface::$password is null and the encoder is PlainTextPasswordEncoder an exception is thrown