### PR TITLE
[Cache] add array cache in front of serializer cache 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -109,10 +109,22 @@
             <tag name="kernel.cache_warmer" />
         </service>
 
-        <service id="serializer.mapping.cache.symfony" class="Psr\Cache\CacheItemPoolInterface">
+        <service id="serializer.mapping.cache.symfony.file" class="Psr\Cache\CacheItemPoolInterface">
             <factory class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" method="create" />
             <argument>%serializer.mapping.cache.file%</argument>
             <argument type="service" id="cache.serializer" />
+        </service>
+
+        <service id="serializer.mapping.cache.symfony" class="Symfony\Component\Cache\Adapter\ChainAdapter">
+            <argument type="collection">
+                <argument type="service">
+                    <service class="Symfony\Component\Cache\Adapter\ArrayAdapter">
+                        <argument>0</argument>
+                        <argument>false</argument>
+                    </service>
+                </argument>
+                <argument type="service" id="serializer.mapping.cache.symfony.file" />
+            </argument>
         </service>
 
         <service id="serializer.mapping.cache_class_metadata_factory" decorates="serializer.mapping.class_metadata_factory" class="Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | performance
| New feature?  | ...
| Deprecations? | no
| Tickets       | #35041
| License       | MIT
| Doc PR        | 

Protect serializer apcu/opcache backend with an array cache. It applies only in prod mode.

![image](https://user-images.githubusercontent.com/84887/71180864-57edb100-2273-11ea-9833-62215cd0540a.png)
