### PR TITLE
[Mailer] added tag/metadata support

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Mailer\Bridge\Mailchimp\Tests\Transport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillApiTransport;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 
@@ -60,5 +62,43 @@ class MandrillApiTransportTest extends TestCase
         $this->assertArrayHasKey('headers', $payload['message']);
         $this->assertCount(1, $payload['message']['headers']);
         $this->assertEquals('foo: bar', $payload['message']['headers'][0]);
+    }
+
+    public function testTagAndMetadataHeaders()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('password-reset'));
+        $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
+        $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('message', $payload);
+        $this->assertArrayNotHasKey('headers', $payload['message']);
+        $this->assertArrayHasKey('tags', $payload['message']);
+        $this->assertSame(['password-reset'], $payload['message']['tags']);
+        $this->assertArrayHasKey('metadata', $payload['message']);
+        $this->assertSame(['Color' => 'blue', 'Client-ID' => '12345'], $payload['message']['metadata']);
+    }
+
+    public function testCanHaveMultipleTags()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('password-reset,user'));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('message', $payload);
+        $this->assertArrayNotHasKey('headers', $payload['message']);
+        $this->assertArrayHasKey('tags', $payload['message']);
+        $this->assertSame(['password-reset', 'user'], $payload['message']['tags']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillSmtpTransportTest.php
@@ -12,39 +12,13 @@
 namespace Symfony\Component\Mailer\Bridge\Mailchimp\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillHttpTransport;
+use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillSmtpTransport;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Email;
 
-class MandrillHttpTransportTest extends TestCase
+class MandrillSmtpTransportTest extends TestCase
 {
-    /**
-     * @dataProvider getTransportData
-     */
-    public function testToString(MandrillHttpTransport $transport, string $expected)
-    {
-        $this->assertSame($expected, (string) $transport);
-    }
-
-    public function getTransportData()
-    {
-        return [
-            [
-                new MandrillHttpTransport('KEY'),
-                'mandrill+https://mandrillapp.com',
-            ],
-            [
-                (new MandrillHttpTransport('KEY'))->setHost('example.com'),
-                'mandrill+https://example.com',
-            ],
-            [
-                (new MandrillHttpTransport('KEY'))->setHost('example.com')->setPort(99),
-                'mandrill+https://example.com:99',
-            ],
-        ];
-    }
-
     public function testTagAndMetadataHeaders()
     {
         $email = new Email();
@@ -53,8 +27,8 @@ class MandrillHttpTransportTest extends TestCase
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
-        $transport = new MandrillHttpTransport('key');
-        $method = new \ReflectionMethod(MandrillHttpTransport::class, 'addMandrillHeaders');
+        $transport = new MandrillSmtpTransport('user', 'password');
+        $method = new \ReflectionMethod(MandrillSmtpTransport::class, 'addMandrillHeaders');
         $method->setAccessible(true);
         $method->invoke($transport, $email);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Mailer\Bridge\Mailchimp\Transport;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
@@ -108,6 +110,18 @@ class MandrillApiTransport extends AbstractApiTransport
         $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type'];
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
+                continue;
+            }
+
+            if ($header instanceof TagHeader) {
+                $payload['message']['tags'] = explode(',', $header->getValue());
+
+                continue;
+            }
+
+            if ($header instanceof MetadataHeader) {
+                $payload['message']['metadata'][$header->getKey()] = $header->getValue();
+
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHeadersTrait.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHeadersTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Mailchimp\Transport;
+
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\RawMessage;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+trait MandrillHeadersTrait
+{
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    {
+        if ($message instanceof Message) {
+            $this->addMandrillHeaders($message);
+        }
+
+        return parent::send($message, $envelope);
+    }
+
+    private function addMandrillHeaders(Message $message): void
+    {
+        $headers = $message->getHeaders();
+        $metadata = [];
+
+        foreach ($headers->all() as $name => $header) {
+            if ($header instanceof TagHeader) {
+                $headers->addTextHeader('X-MC-Tags', $header->getValue());
+                $headers->remove($name);
+            } elseif ($header instanceof MetadataHeader) {
+                $metadata[$header->getKey()] = $header->getValue();
+                $headers->remove($name);
+            }
+        }
+
+        if ($metadata) {
+            $headers->addTextHeader('X-MC-Metadata', json_encode($metadata));
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
@@ -24,6 +24,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class MandrillHttpTransport extends AbstractHttpTransport
 {
+    use MandrillHeadersTrait;
+
     private const HOST = 'mandrillapp.com';
     private $key;
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillSmtpTransport.php
@@ -20,6 +20,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class MandrillSmtpTransport extends EsmtpTransport
 {
+    use MandrillHeadersTrait;
+
     public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp.mandrillapp.com', 587, true, $dispatcher, $logger);

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "symfony/mailer": "^4.4|^5.0"
+        "symfony/mailer": "^5.1"
     },
     "require-dev": {
         "symfony/http-client": "^4.4|^5.0"

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunSmtpTransportTest.php
@@ -12,43 +12,16 @@
 namespace Symfony\Component\Mailer\Bridge\Mailgun\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunHttpTransport;
+use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunSmtpTransport;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Email;
 
-class MailgunHttpTransportTest extends TestCase
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class MailgunSmtpTransportTest extends TestCase
 {
-    /**
-     * @dataProvider getTransportData
-     */
-    public function testToString(MailgunHttpTransport $transport, string $expected)
-    {
-        $this->assertSame($expected, (string) $transport);
-    }
-
-    public function getTransportData()
-    {
-        return [
-            [
-                new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'),
-                'mailgun+https://api.mailgun.net?domain=DOMAIN',
-            ],
-            [
-                new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN', 'us-east-1'),
-                'mailgun+https://api.us-east-1.mailgun.net?domain=DOMAIN',
-            ],
-            [
-                (new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com'),
-                'mailgun+https://example.com?domain=DOMAIN',
-            ],
-            [
-                (new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com')->setPort(99),
-                'mailgun+https://example.com:99?domain=DOMAIN',
-            ],
-        ];
-    }
-
     public function testTagAndMetadataHeaders()
     {
         $email = new Email();
@@ -57,8 +30,8 @@ class MailgunHttpTransportTest extends TestCase
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
-        $transport = new MailgunHttpTransport('key', 'domain');
-        $method = new \ReflectionMethod(MailgunHttpTransport::class, 'addMailgunHeaders');
+        $transport = new MailgunSmtpTransport('user', 'password');
+        $method = new \ReflectionMethod(MailgunSmtpTransport::class, 'addMailgunHeaders');
         $method->setAccessible(true);
         $method->invoke($transport, $email);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Mailer\Bridge\Mailgun\Transport;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
@@ -111,6 +113,18 @@ class MailgunApiTransport extends AbstractApiTransport
         $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type'];
         foreach ($headers->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
+                continue;
+            }
+
+            if ($header instanceof TagHeader) {
+                $payload['o:tag'] = $header->getValue();
+
+                continue;
+            }
+
+            if ($header instanceof MetadataHeader) {
+                $payload['v:'.$header->getKey()] = $header->getValue();
+
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHeadersTrait.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHeadersTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Mailgun\Transport;
+
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\RawMessage;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+trait MailgunHeadersTrait
+{
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    {
+        if ($message instanceof Message) {
+            $this->addMailgunHeaders($message);
+        }
+
+        return parent::send($message, $envelope);
+    }
+
+    private function addMailgunHeaders(Message $message): void
+    {
+        $headers = $message->getHeaders();
+        $metadata = [];
+
+        foreach ($headers->all() as $name => $header) {
+            if ($header instanceof TagHeader) {
+                $headers->addTextHeader('X-Mailgun-Tag', $header->getValue());
+                $headers->remove($name);
+            } elseif ($header instanceof MetadataHeader) {
+                $metadata[$header->getKey()] = $header->getValue();
+                $headers->remove($name);
+            }
+        }
+
+        if ($metadata) {
+            $headers->addTextHeader('X-Mailgun-Variables', json_encode($metadata));
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
@@ -26,6 +26,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class MailgunHttpTransport extends AbstractHttpTransport
 {
+    use MailgunHeadersTrait;
+
     private const HOST = 'api.%region_dot%mailgun.net';
 
     private $key;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunSmtpTransport.php
@@ -20,6 +20,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class MailgunSmtpTransport extends EsmtpTransport
 {
+    use MailgunHeadersTrait;
+
     public function __construct(string $username, string $password, string $region = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('us' !== ($region ?: 'us') ? sprintf('smtp.%s.mailgun.org', $region) : 'smtp.mailgun.org', 465, true, $dispatcher, $logger);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "symfony/mailer": "^4.4|^5.0"
+        "symfony/mailer": "^5.1"
     },
     "require-dev": {
         "symfony/http-client": "^4.4|^5.0"

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkSmtpTransportTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Postmark\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkSmtpTransport;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mime\Email;
+
+class PostmarkSmtpTransportTest extends TestCase
+{
+    public function testCustomHeader()
+    {
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('foo', 'bar');
+
+        $transport = new PostmarkSmtpTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(PostmarkSmtpTransport::class, 'addPostmarkHeaders');
+        $method->setAccessible(true);
+        $method->invoke($transport, $email);
+
+        $this->assertCount(2, $email->getHeaders()->toArray());
+        $this->assertSame('X-PM-KeepID: true', $email->getHeaders()->get('X-PM-KeepID')->toString());
+        $this->assertSame('foo: bar', $email->getHeaders()->get('FOO')->toString());
+    }
+
+    public function testTagAndMetadataHeaders()
+    {
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('foo', 'bar');
+        $email->getHeaders()->add(new TagHeader('password-reset'));
+        $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
+        $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
+
+        $transport = new PostmarkSmtpTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(PostmarkSmtpTransport::class, 'addPostmarkHeaders');
+        $method->setAccessible(true);
+        $method->invoke($transport, $email);
+
+        $this->assertCount(5, $email->getHeaders()->toArray());
+        $this->assertSame('foo: bar', $email->getHeaders()->get('FOO')->toString());
+        $this->assertSame('X-PM-KeepID: true', $email->getHeaders()->get('X-PM-KeepID')->toString());
+        $this->assertSame('X-PM-Tag: password-reset', $email->getHeaders()->get('X-PM-Tag')->toString());
+        $this->assertSame('X-PM-Metadata-Color: blue', $email->getHeaders()->get('X-PM-Metadata-Color')->toString());
+        $this->assertSame('X-PM-Metadata-Client-ID: 12345', $email->getHeaders()->get('X-PM-Metadata-Client-ID')->toString());
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Mailer\Bridge\Postmark\Transport;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
@@ -79,6 +81,18 @@ class PostmarkApiTransport extends AbstractApiTransport
         $headersToBypass = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender', 'reply-to'];
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
+                continue;
+            }
+
+            if ($header instanceof TagHeader) {
+                $payload['Tag'] = $header->getValue();
+
+                continue;
+            }
+
+            if ($header instanceof MetadataHeader) {
+                $payload['Metadata'][$header->getKey()] = $header->getValue();
+
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Mailer\Bridge\Postmark\Transport;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mime\Message;
@@ -35,9 +37,28 @@ class PostmarkSmtpTransport extends EsmtpTransport
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         if ($message instanceof Message) {
-            $message->getHeaders()->addTextHeader('X-PM-KeepID', 'true');
+            $this->addPostmarkHeaders($message);
         }
 
         return parent::send($message, $envelope);
+    }
+
+    private function addPostmarkHeaders(Message $message): void
+    {
+        $message->getHeaders()->addTextHeader('X-PM-KeepID', 'true');
+
+        $headers = $message->getHeaders();
+
+        foreach ($headers->all() as $name => $header) {
+            if ($header instanceof TagHeader) {
+                $headers->addTextHeader('X-PM-Tag', $header->getValue());
+                $headers->remove($name);
+            }
+
+            if ($header instanceof MetadataHeader) {
+                $headers->addTextHeader('X-PM-Metadata-'.$header->getKey(), $header->getValue());
+                $headers->remove($name);
+            }
+        }
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "symfony/mailer": "^4.4|^5.0"
+        "symfony/mailer": "^5.1"
     },
     "require-dev": {
         "symfony/http-client": "^4.4|^5.0"

--- a/src/Symfony/Component/Mailer/Header/MetadataHeader.php
+++ b/src/Symfony/Component/Mailer/Header/MetadataHeader.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Header;
+
+use Symfony\Component\Mime\Header\UnstructuredHeader;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MetadataHeader extends UnstructuredHeader
+{
+    private $key;
+
+    public function __construct(string $key, string $value)
+    {
+        $this->key = $key;
+
+        parent::__construct('X-Metadata-'.$key, $value);
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+}

--- a/src/Symfony/Component/Mailer/Header/TagHeader.php
+++ b/src/Symfony/Component/Mailer/Header/TagHeader.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Header;
+
+use Symfony\Component\Mime\Header\UnstructuredHeader;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class TagHeader extends UnstructuredHeader
+{
+    public function __construct(string $value)
+    {
+        parent::__construct('X-Tag', $value);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35047
| License       | MIT
| Doc PR        | todo

This is an alternative to #34766 for adding tag and metadata support in a more generalized way.

Most transports allow for open/click tracking headers - maybe this should be handled in a similar way?

I added implementations for the Postmark (SMTP and API) and Mailgun (SMTP and API) transports. I can add others and tests/docs if this is acceptable.

### Example:

```php
use Symfony\Component\Mailer\Header\MetadataHeader;
use Symfony\Component\Mailer\Header\TagHeader;

$email->getHeaders()->add(new TagHeader('password-reset'));
$email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
$email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
```

The Postmark/Mailgun providers will parse these into their own headers/payload. For transports that don't support tags/metadata, these are just added as custom headers:

```
X-Tag: password-reset
X-Metadata-Color: blue
X-Metadata-Client-ID: 12345
```