### PR TITLE
[Security] Fix missing defaults for auto-migrating encoders

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
@@ -144,10 +144,10 @@ class EncoderFactory implements EncoderFactoryInterface
                 return [
                     'class' => Pbkdf2PasswordEncoder::class,
                     'arguments' => [
-                        $config['hash_algorithm'],
-                        $config['encode_as_base64'],
-                        $config['iterations'],
-                        $config['key_length'],
+                        $config['hash_algorithm'] ?? 'sha512',
+                        $config['encode_as_base64'] ?? true,
+                        $config['iterations'] ?? 1000,
+                        $config['key_length'] ?? 40,
                     ],
                 ];
 
@@ -205,8 +205,8 @@ class EncoderFactory implements EncoderFactoryInterface
             'class' => MessageDigestPasswordEncoder::class,
             'arguments' => [
                 $config['algorithm'],
-                $config['encode_as_base64'],
-                $config['iterations'],
+                $config['encode_as_base64'] ?? true,
+                $config['iterations'] ?? 5000,
             ],
         ];
     }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
@@ -162,6 +162,11 @@ class EncoderFactoryTest extends TestCase
             (new EncoderFactory([SomeUser::class => ['class' => NativePasswordEncoder::class, 'arguments' => []]]))->getEncoder(SomeUser::class)
         );
 
+        $this->assertInstanceOf(
+            MigratingPasswordEncoder::class,
+            (new EncoderFactory([SomeUser::class => ['algorithm' => 'bcrypt', 'cost' => 11]]))->getEncoder(SomeUser::class)
+        );
+
         if (!SodiumPasswordEncoder::isSupported()) {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes #35058
| License       | MIT
| Doc PR        | -
