### PR TITLE
[Security] Use supportsClass in addition to UnsupportedUserException

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -68,18 +68,37 @@ class ChainUserProviderTest extends TestCase
         $provider1 = $this->getProvider();
         $provider1
             ->expects($this->once())
-            ->method('refreshUser')
-            ->willThrowException(new UnsupportedUserException('unsupported'))
+            ->method('supportsClass')
+            ->willReturn(false)
         ;
 
         $provider2 = $this->getProvider();
         $provider2
             ->expects($this->once())
+            ->method('supportsClass')
+            ->willReturn(true)
+        ;
+
+        $provider2
+            ->expects($this->once())
+            ->method('refreshUser')
+            ->willThrowException(new UnsupportedUserException('unsupported'))
+        ;
+
+        $provider3 = $this->getProvider();
+        $provider3
+            ->expects($this->once())
+            ->method('supportsClass')
+            ->willReturn(true)
+        ;
+
+        $provider3
+            ->expects($this->once())
             ->method('refreshUser')
             ->willReturn($account = $this->getAccount())
         ;
 
-        $provider = new ChainUserProvider([$provider1, $provider2]);
+        $provider = new ChainUserProvider([$provider1, $provider2, $provider3]);
         $this->assertSame($account, $provider->refreshUser($this->getAccount()));
     }
 
@@ -88,11 +107,23 @@ class ChainUserProviderTest extends TestCase
         $provider1 = $this->getProvider();
         $provider1
             ->expects($this->once())
+            ->method('supportsClass')
+            ->willReturn(true)
+        ;
+
+        $provider1
+            ->expects($this->once())
             ->method('refreshUser')
             ->willThrowException(new UsernameNotFoundException('not found'))
         ;
 
         $provider2 = $this->getProvider();
+        $provider2
+            ->expects($this->once())
+            ->method('supportsClass')
+            ->willReturn(true)
+        ;
+
         $provider2
             ->expects($this->once())
             ->method('refreshUser')
@@ -109,11 +140,23 @@ class ChainUserProviderTest extends TestCase
         $provider1 = $this->getProvider();
         $provider1
             ->expects($this->once())
+            ->method('supportsClass')
+            ->willReturn(true)
+        ;
+
+        $provider1
+            ->expects($this->once())
             ->method('refreshUser')
             ->willThrowException(new UnsupportedUserException('unsupported'))
         ;
 
         $provider2 = $this->getProvider();
+        $provider2
+            ->expects($this->once())
+            ->method('supportsClass')
+            ->willReturn(true)
+        ;
+
         $provider2
             ->expects($this->once())
             ->method('refreshUser')
@@ -173,11 +216,23 @@ class ChainUserProviderTest extends TestCase
         $provider1 = $this->getProvider();
         $provider1
             ->expects($this->once())
+            ->method('supportsClass')
+            ->willReturn(true)
+        ;
+
+        $provider1
+            ->expects($this->once())
             ->method('refreshUser')
             ->willThrowException(new UnsupportedUserException('unsupported'))
         ;
 
         $provider2 = $this->getProvider();
+        $provider2
+            ->expects($this->once())
+            ->method('supportsClass')
+            ->willReturn(true)
+        ;
+
         $provider2
             ->expects($this->once())
             ->method('refreshUser')

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -73,6 +73,10 @@ class ChainUserProvider implements UserProviderInterface
 
         foreach ($this->providers as $provider) {
             try {
+                if (!$provider->supportsClass(\get_class($user))) {
+                    continue;
+                }
+
                 return $provider->refreshUser($user);
             } catch (UnsupportedUserException $e) {
                 // try next one

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -168,10 +168,15 @@ class ContextListener implements ListenerInterface
 
         $userNotFoundByProvider = false;
         $userDeauthenticated = false;
+        $userClass = \get_class($user);
 
         foreach ($this->userProviders as $provider) {
             if (!$provider instanceof UserProviderInterface) {
                 throw new \InvalidArgumentException(sprintf('User provider "%s" must implement "%s".', \get_class($provider), UserProviderInterface::class));
+            }
+
+            if (!$provider->supportsClass($userClass)) {
+                continue;
             }
 
             try {
@@ -233,7 +238,7 @@ class ContextListener implements ListenerInterface
             return null;
         }
 
-        throw new \RuntimeException(sprintf('There is no user provider for user "%s".', \get_class($user)));
+        throw new \RuntimeException(sprintf('There is no user provider for user "%s".', $userClass));
     }
 
     private function safelyUnserialize($serializedToken)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4+
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35045
| License       | MIT
| Doc PR        | ~

This PR fixes the issue where user providers rely on just the UnsupportedUserException from `refreshUser()`, causing a flow where users are wrongfully re-authenticated.

There's one issue where `refreshUser()` can do far more sophisticated checks on the user class, which it will never reach if the class is not supported. As far as I know it was never intended to support instances that are rejected by `supportsClass()`, though people could've implemented this (by accident). So the question is more if we should add a BC layer for this; for example:

```php
try {
    $refreshedUser = $provider->refreshUser($user);
    $newToken = clone $token;
    $newToken->setUser($refreshedUser);

    if (!$provider->supportsClass($userClass)) {
        if ($this->shouldCheckSupportsClass) {
            continue;
        }
        // have to think of a proper deprecation here for 6.0
        @trigger_error('Provider %s does not support user class %s via supportsClass() while it does support it via refreshUser .. please set option X and fix %s::supportsUser() ', E_USER_DEPRECATED);
    }
```
This would prevent behavior from breaking but also means we can't fix this on anything less than 5.1.
