### PR TITLE
[Serializer] add array cache in front of serializer cache

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
@@ -32,6 +32,8 @@ class CacheClassMetadataFactory implements ClassMetadataFactoryInterface
      */
     private $cacheItemPool;
 
+    private $loadedClasses = [];
+
     public function __construct(ClassMetadataFactoryInterface $decorated, CacheItemPoolInterface $cacheItemPool)
     {
         $this->decorated = $decorated;
@@ -44,18 +46,23 @@ class CacheClassMetadataFactory implements ClassMetadataFactoryInterface
     public function getMetadataFor($value)
     {
         $class = $this->getClass($value);
+
+        if (isset($this->loadedClasses[$class])) {
+            return $this->loadedClasses[$class];
+        }
+
         // Key cannot contain backslashes according to PSR-6
         $key = strtr($class, '\\', '_');
 
         $item = $this->cacheItemPool->getItem($key);
         if ($item->isHit()) {
-            return $item->get();
+            return $this->loadedClasses[$class] = $item->get();
         }
 
         $metadata = $this->decorated->getMetadataFor($value);
         $this->cacheItemPool->save($item->set($metadata));
 
-        return $metadata;
+        return $this->loadedClasses[$class] = $metadata;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | performance
| New feature?  | ...
| Deprecations? | no
| Tickets       | #35041
| License       | MIT
| Doc PR        |

This is another implementation of #35041, after #35046. 

The DI solution is cleaner, but 10ms slower on my scenario (13 vs 3) and this data is not supposed to change at all (even in the original method there is a local cache).

Diff from master (without warmup):

![image](https://user-images.githubusercontent.com/84887/71313592-2cb5be00-243b-11ea-8983-b30abb7d0698.png)

Diff form master (with warmup):

![image](https://user-images.githubusercontent.com/84887/71313633-8e762800-243b-11ea-8044-003c810d3c0b.png)

Diff from #35046:

![image](https://user-images.githubusercontent.com/84887/71313668-312ea680-243c-11ea-9768-8531f4f33f3c.png)



Ping @nicolas-grekas