### PR TITLE
[Serializer] add xml name converter to use objects instead of arrays

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/XmlAttributesConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/XmlAttributesConverter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\NameConverter;
+
+final class XmlAttributesConverter implements NameConverterInterface
+{
+    const ATTRIBUTE_PREFIX = 'attr';
+    const NODE_VALUE_ATTRIBUTE_NAME = 'value';
+
+    private $attributePrefix;
+    private $nodeValueAttributeName;
+
+    public function __construct(string $attributePrefix = self::ATTRIBUTE_PREFIX, string $nodeValueAttributeName = self::NODE_VALUE_ATTRIBUTE_NAME)
+    {
+        $this->attributePrefix = $attributePrefix;
+        $this->nodeValueAttributeName = $nodeValueAttributeName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($propertyName): string
+    {
+        if (0 === strncmp($this->nodeValueAttributeName, $propertyName, \strlen($this->nodeValueAttributeName))) {
+            return '#';
+        }
+
+        if (0 === strncmp($this->attributePrefix, $propertyName, \strlen($this->attributePrefix))) {
+            return '@'.substr($propertyName, \strlen($this->attributePrefix));
+        }
+
+        return $propertyName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($propertyName): string
+    {
+        $propertyName = (string) $propertyName;
+
+        if (0 === strpos($propertyName, '#')) {
+            return $this->nodeValueAttributeName;
+        }
+
+        if (0 === strpos($propertyName, '@')) {
+            return $this->attributePrefix.substr($propertyName, 1);
+        }
+
+        return $propertyName;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/XmlAttributesConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/XmlAttributesConverterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\NameConverter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\NameConverter\XmlAttributesConverter;
+
+class XmlAttributesConverterTest extends TestCase
+{
+    /**
+     * @dataProvider normalizeDataProvider
+     */
+    public function testNormalize(?string $attributePrefix, ?string $nodeValueAttributeName, string $propertyName, string $expectedPropertyName): void
+    {
+        $xmlAttributeConverter = $this->createXmlAttributesConverter($attributePrefix, $nodeValueAttributeName);
+        $result = $xmlAttributeConverter->normalize($propertyName);
+        $this->assertEquals($expectedPropertyName, $result);
+    }
+
+    /**
+     * @dataProvider denormalizeDataProvider
+     */
+    public function testDenormalize(?string $attributePrefix, ?string $nodeValueAttributeName, string $propertyName, string $expectedPropertyName): void
+    {
+        $xmlAttributeConverter = $this->createXmlAttributesConverter($attributePrefix, $nodeValueAttributeName);
+        $result = $xmlAttributeConverter->denormalize($propertyName);
+        $this->assertEquals($expectedPropertyName, $result);
+    }
+
+    public function normalizeDataProvider()
+    {
+        return [
+            'defaults to attr extra attribute' => [null, null, 'attrOwnerID', '@OwnerID'],
+            'no extra attributes' => [null, null, 'someOtherParam', 'someOtherParam'],
+            'node value' => [null, null, 'value', '#'],
+            'custom extra attribute prefix' => ['someAttributePrefix', 'nodeValue', 'someAttributePrefixOwnerID', '@OwnerID'],
+            'custom node value attribute' => ['someAttributePrefix', 'nodeValue', 'nodeValue', '#'],
+        ];
+    }
+
+    public function denormalizeDataProvider()
+    {
+        return [
+            'defaults to attr extra attribute' => [null, null, '@OwnerID', 'attrOwnerID'],
+            'no extra attributes' => [null, null, 'SomeOtherParam', 'SomeOtherParam'],
+            'no extra attributes lowercase' => [null, null, 'someOtherParam', 'someOtherParam'],
+            'node value' => [null, null, '#', 'value'],
+            'custom extra attribute prefix' => ['someAttributePrefix', 'nodeValue', '@OwnerID', 'someAttributePrefixOwnerID'],
+            'custom node value attribute' => ['someAttributePrefix', 'nodeValue', '#', 'nodeValue'],
+        ];
+    }
+
+    private function createXmlAttributesConverter(?string $attributePrefix, ?string $nodeValueAttributeName): XmlAttributesConverter
+    {
+        if (null === $attributePrefix && null === $nodeValueAttributeName) {
+            return new XmlAttributesConverter();
+        }
+
+        return new XmlAttributesConverter($attributePrefix, $nodeValueAttributeName);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #34579 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | I have still to create it. If this gets accepted, I will! <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

**Description**  
<!-- A clear and concise description of the new feature. -->
Currently, using JSON is the facto standard and well supported for all normalizers.
What I found is that the `XmlEncoder` decodes/encodes the XML to array, but converts extra attributes with a `@` prefix and uses `#` to identity the node value. 

This conversion makes it extremely difficult to use the `ObjectNormalizer` and fill out DTOs with specific XML data instead of consuming just the array returned by the `XmlEncoder`.

Example:

The array: 
`['foo' => ['@bar' => 'value', '#' => 'baz']];`
generates the following XML output:

```xml
<?xml version="1.0"?>
 <response>
     <foo bar="value">
        baz
     </foo>
</response>
```

*What if I want to use my own DTOs?*

## Possible solution

Create a custom name converter that handles the extra attributes and XML node values. That way you can out of the box, use the `ObjectNormalizer` to set specific attributes in a specific object.

**Example**  
<!-- A simple example of the new feature in action (include PHP code, YAML config, etc.)
     If the new feature changes an existing feature, include a simple before/after comparison. -->

We can use custom prefixes for attributes and node values, so we match them with our DTOs:

By using this name converter, we can configure the `ObjectNormalizer`:

```php
$objectNormalizer  = new ObjectNormalizer(null, new SpecialAttributesConverter(), null, $phpDocExtractor);
```

**Conclusion**

By using this PR, it's possible to manage XML requests/responses just by using DTOs with types, instead of relying on arrays to build your XML requests and read from XML responses with extra attributes.