### PR TITLE
Add note about HTTP status code change

### DIFF
--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -306,7 +306,7 @@ TwigBundle
    The new default exception controller will also change the error response content according to
    https://tools.ietf.org/html/rfc7807 for `json`, `xml`, `atom` and `txt` formats:
 
-   Before:
+   Before (HTTP status code `200`):
    ```json
    {
        "error": {
@@ -316,7 +316,7 @@ TwigBundle
    }
    ```
 
-   After:
+   After (HTTP status code `404`):
    ```json
    {
        "title": "Not Found",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/34731
| License       | MIT
| Doc PR        | -

> https://tools.ietf.org/html/rfc7807
> The "status" member, if present, is only advisory; it conveys the
   HTTP status code used for the convenience of the consumer.
   **Generators MUST use the same status code in the actual HTTP response,**
   to assure that generic HTTP software that does not understand this
   format still behaves correctly.