### PR TITLE
[String] Add the reverse() method

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -470,6 +470,11 @@ abstract class AbstractString implements \JsonSerializable
     /**
      * @return static
      */
+    abstract public function reverse(): self;
+
+    /**
+     * @return static
+     */
     abstract public function slice(int $start = 0, int $length = null): self;
 
     /**

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -342,6 +342,17 @@ abstract class AbstractUnicodeString extends AbstractString
         return $str;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function reverse(): parent
+    {
+        $str = clone $this;
+        $str->string = implode('', array_reverse(preg_split('/(\X)/u', $str->string, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY)));
+
+        return $str;
+    }
+
     public function snake(): parent
     {
         $str = $this->camel()->title();

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -303,6 +303,17 @@ class ByteString extends AbstractString
         return $str;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function reverse(): parent
+    {
+        $str = clone $this;
+        $str->string = strrev($str->string);
+
+        return $str;
+    }
+
     public function slice(int $start = 0, int $length = null): parent
     {
         $str = clone $this;

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Added the `AbstractString::reverse()` method.
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1377,4 +1377,23 @@ abstract class AbstractAsciiTestCase extends TestCase
 
         self::assertSame('foobar', $instance->toString());
     }
+
+    /**
+     * @dataProvider provideReverse
+     */
+    public function testReverse(string $expected, string $origin)
+    {
+        $instance = static::createFromString($origin)->reverse();
+
+        $this->assertEquals(static::createFromString($expected), $instance);
+    }
+
+    public static function provideReverse()
+    {
+        return [
+            ['', ''],
+            ['oof', 'foo'],
+            ["\n!!!\tTAERG SI     ynofmyS    ", "    Symfony     IS GREAT\t!!!\n"],
+        ];
+    }
 }

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -568,4 +568,16 @@ abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
             ]
         );
     }
+
+    public static function provideReverse()
+    {
+        return array_merge(
+            parent::provideReverse(),
+            [
+                ['äuß⭐erst', 'tsre⭐ßuä'],
+                ['漢字ーユニコードéèΣσς', 'ςσΣèéドーコニユー字漢'],
+                ['नमस्ते', 'तेस्मन'],
+            ]
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Allows to easily reverse a string since `mb_strrev` does not exist.