### PR TITLE
[String][UnicodeString] Remove unneeded flag in chunk regex pattern

### DIFF
--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -71,7 +71,7 @@ class UnicodeString extends AbstractUnicodeString
             $rx .= '\X{65535}';
             $length -= 65535;
         }
-        $rx .= '\X{'.$length.'})/us';
+        $rx .= '\X{'.$length.'})/u';
 
         $str = clone $this;
         $chunks = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The pattern cannot contain a `.`.