### PR TITLE
[FrameworkBundle] Do not throw exception on value generate key

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
@@ -47,7 +47,9 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
         $this->lastMessage = null;
 
         if (null === $this->encryptionKey && '' !== $this->decryptionKey = (string) $this->decryptionKey) {
-            throw new \LogicException('Cannot generate keys when a decryption key has been provided while instantiating the vault.');
+            $this->lastMessage = 'Cannot generate keys when a decryption key has been provided while instantiating the vault.';
+
+            return false;
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When using env variable instead of key files and creating a new Secret, the check in `generateKeys` (called by the command `SecretsSetCommand`) prevents generating a secret.

reproducer:

```
$ rm config/secrets/prod/prod.decrypt.private.php
$ export SYMFONY_DECRYPTION_SECRET=XXX
$ ./bin/console secret:set FOO

In SodiumVault.php line 50:
                                                                                               
  Cannot generate keys when a decryption key has been provided while instantiating the vault.  
                                                                                               
```

This PR converts the exception in a warning message.