### PR TITLE
[Translation] Use `locale_parse` for computing fallback locales

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -234,13 +234,36 @@ class TranslatorTest extends TestCase
         $this->assertEquals('bar', $translator->trans('foo', [], 'resources'));
     }
 
-    public function testTransWithFallbackLocaleBis()
+    /**
+     * @dataProvider getFallbackLocales
+     */
+    public function testTransWithFallbackLocaleBis($expectedLocale, $locale)
     {
-        $translator = new Translator('en_US');
+        $translator = new Translator($locale);
         $translator->addLoader('array', new ArrayLoader());
-        $translator->addResource('array', ['foo' => 'foofoo'], 'en_US');
-        $translator->addResource('array', ['bar' => 'foobar'], 'en');
+        $translator->addResource('array', ['foo' => 'foofoo'], $locale);
+        $translator->addResource('array', ['bar' => 'foobar'], $expectedLocale);
         $this->assertEquals('foobar', $translator->trans('bar'));
+    }
+
+    public function getFallbackLocales()
+    {
+        $locales = [
+            ['en', 'en_US'],
+            ['en', 'en-US'],
+            ['sl_Latn_IT', 'sl_Latn_IT_nedis'],
+            ['sl_Latn', 'sl_Latn_IT'],
+        ];
+
+        if (\function_exists('locale_parse')) {
+            $locales[] = ['sl_Latn_IT', 'sl-Latn-IT-nedis'];
+            $locales[] = ['sl_Latn', 'sl-Latn-IT'];
+        } else {
+            $locales[] = ['sl-Latn-IT', 'sl-Latn-IT-nedis'];
+            $locales[] = ['sl-Latn', 'sl-Latn-IT'];
+        }
+
+        return $locales;
     }
 
     public function testTransWithFallbackLocaleTer()

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -412,8 +412,19 @@ EOF
             $locales[] = $fallback;
         }
 
-        if (false !== strrchr($locale, '_')) {
+        if (\function_exists('locale_parse')) {
+            $localeSubTags = locale_parse($locale);
+            if (1 < \count($localeSubTags)) {
+                array_pop($localeSubTags);
+                $fallback = locale_compose($localeSubTags);
+                if (false !== $fallback) {
+                    array_unshift($locales, $fallback);
+                }
+            }
+        } elseif (false !== strrchr($locale, '_')) {
             array_unshift($locales, substr($locale, 0, -\strlen(strrchr($locale, '_'))));
+        } elseif (false !== strrchr($locale, '-')) {
+            array_unshift($locales, substr($locale, 0, -\strlen(strrchr($locale, '-'))));
         }
 
         return array_unique($locales);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

As done in this PR https://github.com/symfony/symfony/pull/24157 for the `Intl` component, the `Translation` component should use `locale_parse` as well when available.

It will allow to manage [BCP 47](https://tools.ietf.org/html/bcp47) locales, which is why it is considered a bugfix ([locale_set_default](https://www.php.net/manual/en/locale.setdefault.php) is using BCP 47 compliant locale).

As done with the forementioned PR, there is also a fallback to make it work with `-`.

Sadly, I think it will create some conflicts when merging it upstream since the modified code has changed little by little.