### PR TITLE
Use spaces correctly to display options in DebugCommand

### DIFF
--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -108,9 +108,9 @@ EOF
 
         $optionsMapping = [];
         foreach ($options as $key => $value) {
-            $optionsMapping[] = ' '.$key.'='.$value;
+            $optionsMapping[] = $key.'='.$value;
         }
 
-        return ' (when'.implode(', ', $optionsMapping).')';
+        return ' (when '.implode(', ', $optionsMapping).')';
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -40,7 +40,7 @@ class DebugCommandTest extends TestCase
     {
         $command = new DebugCommand([
             'command_bus' => [
-                DummyCommand::class => [[DummyCommandHandler::class, []]],
+                DummyCommand::class => [[DummyCommandHandler::class, ['option1' => '1', 'option2' => '2']]],
                 MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, []]],
             ],
             'query_bus' => [
@@ -62,12 +62,12 @@ command_bus
 
  The following messages can be dispatched:
 
- --------------------------------------------------------------------------------------- 
-  Symfony\Component\Messenger\Tests\Fixtures\DummyCommand                                
-      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler          
-  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                        
-      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler  
- --------------------------------------------------------------------------------------- 
+ ----------------------------------------------------------------------------------------------------------- 
+  Symfony\Component\Messenger\Tests\Fixtures\DummyCommand                                                    
+      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler (when option1=1, option2=2)  
+  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                                            
+      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler                      
+ ----------------------------------------------------------------------------------------------------------- 
 
 query_bus
 ---------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| License       | MIT

Messenger ships with a DebugCommand. It doesn't properly place spaces for every option.

```diff
- handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler (when option1=1,  option2=2)
+ handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler (when option1=1, option2=2)
```