### PR TITLE
[VarDumper] Fix "Undefined index: argv" when using CliContextProvider

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/CliContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/CliContextProvider.php
@@ -25,7 +25,7 @@ final class CliContextProvider implements ContextProviderInterface
         }
 
         return [
-            'command_line' => $commandLine = implode(' ', $_SERVER['argv']),
+            'command_line' => $commandLine = implode(' ', $_SERVER['argv'] ?? []),
             'identifier' => hash('crc32b', $commandLine.$_SERVER['REQUEST_TIME_FLOAT']),
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1, 4.2, 4.3, 4.4 or 5.0<!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #35084
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
