### PR TITLE
[HttpClient] fix scheduling pending NativeResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/NativeClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/NativeClientState.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\HttpClient\Internal;
 
-use Symfony\Component\HttpClient\Response\NativeResponse;
-
 /**
  * Internal representation of the native client's state.
  *
@@ -24,8 +22,6 @@ final class NativeClientState extends ClientState
 {
     /** @var int */
     public $id;
-    /** @var NativeResponse[] */
-    public $pendingResponses = [];
     /** @var int */
     public $maxHostConnections = PHP_INT_MAX;
     /** @var int */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

There must be one pending list per `ResponseStream` instance.
Currently, we start unrelated responses and this can lead to broken iterators when the unrelated response throws because it is a 3/4/5xx.