### PR TITLE
[Translator] fix performance issue in MessageCatalogue and catalogue operations

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -130,7 +130,9 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
         if (!isset($this->messages[$domain])) {
             $this->messages[$domain] = $messages;
         } else {
-            $this->messages[$domain] = array_replace($this->messages[$domain], $messages);
+            foreach ($messages as $id => $message) {
+                $this->messages[$domain][$id] = $message;
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In our project we use lots of catalogue operations during importing of translations to our system and we ran into performance issue. Code profiler showed lots or `array_replace` calls in  [MessageCatalogue::add](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Translation/MessageCatalogue.php#L128) method. This method is actually called by [MessageCatalogue::set](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Translation/MessageCatalogue.php#L70), which is quite an overkill, because `MessageCatalogue::set` is meant to set only one translation at a time. Method was reworked. `MergeOperation` and `TargetOperation` was reworked as well to use this improved `MessageCatalogue::set` method instead of constructing array with only one translation and passing it to `MessageCatalogue::add` method. 

Table shows execution time before and after 

|  | Time in seconds (avg. of 10 executions)
----------- | ------
Before | 50
After | 8

Looks like 4.* and 5.* versions can also be improved by the same changes.
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
