### PR TITLE
[PropertyInfo] Fix BC issue in phpDoc Reflection library

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -212,6 +212,8 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             return $this->docBlockFactory->create($reflectionProperty, $this->contextFactory->createFromReflector($reflectionProperty->getDeclaringClass()));
         } catch (\InvalidArgumentException $e) {
             return null;
+        } catch (\RuntimeException $e) {
+            return null;
         }
     }
 
@@ -256,6 +258,8 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         try {
             return [$this->docBlockFactory->create($reflectionMethod, $this->contextFactory->createFromReflector($reflectionMethod)), $prefix];
         } catch (\InvalidArgumentException $e) {
+            return null;
+        } catch (\RuntimeException $e) {
             return null;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35077
| License       | MIT

The used phpDocumentor library DocBlockReflection contained a BC break
that broke this component. The patch was applied in the recently released v4.3.4
version. But since it is unclear how long this issue existed it is not possible
to exclude a certain version. Therefor also `\RuntimeExpception` needs to be caught.

The BC break is possibly caused by a change in the TypeResolver library used by the
DocBlockReflection which is now supporting the more popular generics notation for arrays.

This PR might need some tests but the current test cases are not very clear to me. Instead of patching the code we could also try to ban the broken versions of the used phpdoc libraries, but that would require much more testing, and doesn't really add any value. Especially because the DocBlockReflection and TypeResolver are used by over half a million projects. It would raise more questions than just patching the behavior of the PropertyInfo component. 

We are sorry that this issue slipt through our QA pipeline. The linked issue already showed that the issue is now fixed by just doing a `composer update` but it is not very convenient to leave this known issue in symfony.