### PR TITLE
[Messenger] Added check if json_encode succeeded

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -102,11 +102,12 @@ final class ContainerLintCommand extends Command
             $refl->setAccessible(true);
             $refl->setValue($parameterBag, true);
 
-            $passConfig = $container->getCompilerPassConfig();
-            $passConfig->setRemovingPasses([]);
-            $passConfig->setAfterRemovingPasses([]);
-
-            $skippedIds = $kernelContainer->getRemovedIds();
+            $skippedIds = [];
+            foreach ($container->getServiceIds() as $serviceId) {
+                if (0 === strpos($serviceId, '.errored.')) {
+                    $skippedIds[$serviceId] = true;
+                }
+            }
         }
 
         $container->setParameter('container.build_hash', 'lint_container');

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -103,7 +103,12 @@ class CachePoolPass implements CompilerPassInterface
             if (ChainAdapter::class === $class) {
                 $adapters = [];
                 foreach ($adapter->getArgument(0) as $provider => $adapter) {
-                    $chainedPool = $adapter = new ChildDefinition($adapter);
+                    if ($adapter instanceof ChildDefinition) {
+                        $chainedPool = $adapter;
+                    } else {
+                        $chainedPool = $adapter = new ChildDefinition($adapter);
+                    }
+
                     $chainedTags = [\is_int($provider) ? [] : ['provider' => $provider]];
                     $chainedClass = '';
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
@@ -216,6 +217,10 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
         }
 
         if ('callable' === $type && \is_array($value) && isset($value[0]) && ($value[0] instanceof Reference || $value[0] instanceof Definition)) {
+            return;
+        }
+
+        if (\in_array($type, ['callable', 'Closure'], true) && $value instanceof ServiceClosureArgument) {
             return;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CheckTypeDeclarationsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -692,6 +693,30 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $container
             ->register('foobar', BarMethodCall::class)
             ->addMethodCall('setCallable', [$closureDefinition]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingServiceClosureArgumentToCallable()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', BarMethodCall::class)
+            ->addMethodCall('setCallable', [new ServiceClosureArgument(new Reference('foo'))]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingServiceClosureArgumentToClosure()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', BarMethodCall::class)
+            ->addMethodCall('setClosure', [new ServiceClosureArgument(new Reference('foo'))]);
 
         (new CheckTypeDeclarationsPass(true))->process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
@@ -40,4 +40,8 @@ class BarMethodCall
     public function setCallable(callable $callable): void
     {
     }
+
+    public function setClosure(\Closure $closure): void
+    {
+    }
 }

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Request;
@@ -68,9 +69,13 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
             throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\Psr18Client" as no PSR-17 factories have been provided. Try running "composer require nyholm/psr7".');
         }
 
-        $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
-        $this->responseFactory = $this->responseFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findResponseFactory();
-        $this->streamFactory = $this->streamFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
+        try {
+            $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
+            $this->responseFactory = $this->responseFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findResponseFactory();
+            $this->streamFactory = $this->streamFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
+        } catch (NotFoundException $e) {
+            throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\HttplugClient" as no PSR-17 factories have been found. Try running "composer require nyholm/psr7".', 0, $e);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -186,6 +186,20 @@ class ConnectionTest extends TestCase
         $redis->del('messenger-getnonblocking');
     }
 
+    public function testJsonError()
+    {
+        $redis = new \Redis();
+
+        $connection = Connection::fromDsn('redis://localhost/json-error', [], $redis);
+
+        try {
+            $connection->add("\xB1\x31", []);
+        } catch (TransportException $e) {
+        }
+
+        $this->assertSame('Malformed UTF-8 characters, possibly incorrectly encoded', $e->getMessage());
+    }
+
     public function testMaxEntries()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -248,6 +248,10 @@ class Connection
                     'uniqid' => uniqid('', true),
                 ]);
 
+                if (false === $message) {
+                    throw new TransportException(json_last_error_msg());
+                }
+
                 $score = (int) ($this->getCurrentTimeInMilliseconds() + $delayInMs);
                 $added = $this->connection->zadd($this->queue, ['NX'], $score, $message);
             } else {
@@ -255,6 +259,10 @@ class Connection
                     'body' => $body,
                     'headers' => $headers,
                 ]);
+
+                if (false === $message) {
+                    throw new TransportException(json_last_error_msg());
+                }
 
                 if ($this->maxEntries) {
                     $added = $this->connection->xadd($this->stream, '*', ['message' => $message], $this->maxEntries, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When trying to add a message to redis transport which can not be encoded with `json_encode` there is now a `TransportException` containing the `json_last_error_msg` as the message.
I had an issue where I tried to send an email through messenger by symfony mailer which contains a pdf attachment. Instead of an error while sending i got an error `Encoded envelope should have at least a "body"` which happened because the encoded message was `false`.

This is not exactly a bugfix, but IMO also not a feature worth being mentioned in the changelog so I am not sure I've filled out the Q/A correctly.