### PR TITLE
[Console][FormatterHelper] Use helper strlen statically and remove duplicated code

### DIFF
--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -54,12 +54,12 @@ class FormatterHelper extends Helper
         foreach ($messages as $message) {
             $message = OutputFormatter::escape($message);
             $lines[] = sprintf($large ? '  %s  ' : ' %s ', $message);
-            $len = max($this->strlen($message) + ($large ? 4 : 2), $len);
+            $len = max(self::strlen($message) + ($large ? 4 : 2), $len);
         }
 
         $messages = $large ? [str_repeat(' ', $len)] : [];
         for ($i = 0; isset($lines[$i]); ++$i) {
-            $messages[] = $lines[$i].str_repeat(' ', $len - $this->strlen($lines[$i]));
+            $messages[] = $lines[$i].str_repeat(' ', $len - self::strlen($lines[$i]));
         }
         if ($large) {
             $messages[] = str_repeat(' ', $len);
@@ -83,17 +83,13 @@ class FormatterHelper extends Helper
      */
     public function truncate($message, $length, $suffix = '...')
     {
-        $computedLength = $length - $this->strlen($suffix);
+        $computedLength = $length - self::strlen($suffix);
 
-        if ($computedLength > $this->strlen($message)) {
+        if ($computedLength > self::strlen($message)) {
             return $message;
         }
 
-        if (false === $encoding = mb_detect_encoding($message, null, true)) {
-            return substr($message, 0, $length).$suffix;
-        }
-
-        return mb_substr($message, 0, $length, $encoding).$suffix;
+        return self::substr($message, 0, $length).$suffix;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

All those helpers methods are static and are accessed with `self::` everywhere else. They are not an extension point.