### PR TITLE
[Profiler][RFC] Allow to purge all profiles data from the profiler GUI

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -64,6 +64,25 @@ class ProfilerController
     }
 
     /**
+     * Purges all data from the storage.
+     *
+     * @return RedirectResponse A RedirectResponse instance
+     *
+     * @throws NotFoundHttpException
+     */
+    public function purgeAction()
+    {
+        if (null === $this->profiler) {
+            throw new NotFoundHttpException('The profiler must be enabled.');
+        }
+
+        $this->profiler->disable();
+        $this->profiler->purge();
+
+        return new RedirectResponse($this->generator->generate('_profiler_search_results', ['token' => 'empty', 'limit' => 10]), 302, ['Content-Type' => 'text/html']);
+    }
+
+    /**
      * Renders a profiler panel for the given token.
      *
      * @return Response A Response instance

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -8,6 +8,10 @@
         <default key="_controller">web_profiler.controller.profiler::homeAction</default>
     </route>
 
+    <route id="_profiler_purge" path="/purge">
+        <default key="_controller">web_profiler.controller.profiler::purgeAction</default>
+    </route>
+
     <route id="_profiler_search" path="/search">
         <default key="_controller">web_profiler.controller.profiler::searchAction</default>
     </route>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -52,5 +52,9 @@
         <div class="form-group">
             <button type="submit" class="btn btn-sm">Search</button>
         </div>
+
+        <div class="form-group">
+            <a href="{{ path('_profiler_purge') }}" class="btn btn-sm">Purge</a>
+        </div>
     </form>
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes (env dev)
| Deprecations? | no
| Tickets       | See description
| License       | MIT
| Doc PR        | Needed?

Hi,

**RFC PR**

The feature `Profiler::purge` was already existing, I only use it now from the web profiler GUI.
Usefull when you keep a profiler open, and you have a request that made several subs, or when having differents projets that made request to each others while the profiler is opened.

![profiler_purge](https://user-images.githubusercontent.com/13205768/71584553-53e34e00-2b13-11ea-879d-4cd41a466293.png)

Thnak you,