### PR TITLE
doctrine/doctrine-bundle ^1.5 is not compatible with Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/reflection": "~1.0",
-        "doctrine/doctrine-bundle": "^1.5|^2.0",
+        "doctrine/doctrine-bundle": "^2.0",
         "guzzlehttp/promises": "^1.3.1",
         "masterminds/html5": "^2.6",
         "monolog/monolog": "^1.25.1|^2",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -27,7 +27,7 @@
         "symfony/security-http": "^4.4.1|^5.0.1"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^1.5|^2.0",
+        "doctrine/doctrine-bundle": "^2.0",
         "symfony/asset": "^4.4|^5.0",
         "symfony/browser-kit": "^4.4|^5.0",
         "symfony/console": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -