### PR TITLE
[Messenger] Added check if json_encode succeeded

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -177,6 +177,17 @@ class ConnectionTest extends TestCase
         $redis->del('messenger-getnonblocking');
     }
 
+    public function testJsonError()
+    {
+        $redis = new \Redis();
+        $connection = Connection::fromDsn('redis://localhost/json-error', [], $redis);
+        try {
+            $connection->add("\xB1\x31", []);
+        } catch (TransportException $e) {
+        }
+        $this->assertSame('Malformed UTF-8 characters, possibly incorrectly encoded', $e->getMessage());
+    }
+
     public function testLastErrorGetsCleared()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -185,9 +185,16 @@ class Connection
         }
 
         try {
-            $added = $this->connection->xadd($this->stream, '*', ['message' => json_encode(
-                ['body' => $body, 'headers' => $headers]
-            )]);
+            $message = json_encode([
+                'body' => $body,
+                'headers' => $headers,
+            ]);
+
+            if (false === $message) {
+                throw new TransportException(json_last_error_msg());
+            }
+
+            $added = $this->connection->xadd($this->stream, '*', ['message' => $message]);
         } catch (\RedisException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Similar PR as https://github.com/symfony/symfony/pull/35137 but for branch 4.3.

When trying to add a message to redis transport which can not be encoded with `json_encode` there is now a `TransportException` containing the `json_last_error_msg` as the message.
I had an issue where I tried to send an email through messenger by symfony mailer which contains a pdf attachment. Instead of an error while sending i got an error `Encoded envelope should have at least a "body"` which happened because the encoded message was `false`.

This is not exactly a bugfix, but IMO also not a feature worth being mentioned in the changelog so I am not sure I've filled out the Q/A correctly.