### PR TITLE
[FrameworkBundle] Check non-null type for numeric type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -75,17 +75,17 @@ class TemplateController implements ContainerAwareInterface
             throw new \LogicException('You can not use the TemplateController if the Templating Component or the Twig Bundle are not available.');
         }
 
-        if ($maxAge) {
+        if (null !== $maxAge) {
             $response->setMaxAge($maxAge);
         }
 
-        if ($sharedAge) {
+        if (null !== $sharedAge) {
             $response->setSharedMaxAge($sharedAge);
         }
 
         if ($private) {
             $response->setPrivate();
-        } elseif (false === $private || (null === $private && ($maxAge || $sharedAge))) {
+        } elseif (false === $private || (null === $private && (null !== $maxAge || null !== $sharedAge))) {
             $response->setPublic();
         }
 


### PR DESCRIPTION
$maxAge and $sharedAge can both be zero

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT




