### PR TITLE
[Notifier] Remove superfluous parameters in *Message::fromNotification()

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -18,6 +18,14 @@ HttpFoundation
    `RedirectResponse::create()`, and `StreamedResponse::create()` methods (use
    `__construct()` instead)
 
+Notifier
+--------
+
+ * [BC BREAK] The `ChatMessage::fromNotification()` method's `$recipient` and `$transport`
+   arguments were removed.
+ * [BC BREAK] The `EmailMessage::fromNotification()` and `SmsMessage::fromNotification()`
+   methods' `$transport` argument was removed.
+
 Routing
 -------
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -21,7 +21,6 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Notification\Notification;
-use Symfony\Component\Notifier\Recipient\Recipient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -145,7 +144,7 @@ final class SlackTransportTest extends TestCase
             ->willReturn(json_encode(['ok' => true]));
 
         $notification = new Notification($message);
-        $chatMessage = ChatMessage::fromNotification($notification, new Recipient('test-email@example.com'));
+        $chatMessage = ChatMessage::fromNotification($notification);
         $options = SlackOptions::fromNotification($notification);
 
         $expectedBody = http_build_query([

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.0"
+        "symfony/notifier": "^5.1"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+* [BC BREAK] The `ChatMessage::fromNotification()` method's `$recipient` and `$transport`
+  arguments were removed.
+* [BC BREAK] The `EmailMessage::fromNotification()` and `SmsMessage::fromNotification()`
+  methods' `$transport` argument was removed.
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Notifier/Channel/ChatChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/ChatChannel.php
@@ -36,7 +36,7 @@ class ChatChannel extends AbstractChannel
         }
 
         if (null === $message) {
-            $message = ChatMessage::fromNotification($notification, $recipient, $transportName);
+            $message = ChatMessage::fromNotification($notification);
         }
 
         $message->transport($transportName);

--- a/src/Symfony/Component/Notifier/Channel/SmsChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/SmsChannel.php
@@ -32,7 +32,7 @@ class SmsChannel extends AbstractChannel
         }
 
         if (null === $message) {
-            $message = SmsMessage::fromNotification($notification, $recipient, $transportName);
+            $message = SmsMessage::fromNotification($notification, $recipient);
         }
 
         if (null !== $transportName) {

--- a/src/Symfony/Component/Notifier/Message/ChatMessage.php
+++ b/src/Symfony/Component/Notifier/Message/ChatMessage.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Notifier\Message;
 
 use Symfony\Component\Notifier\Notification\Notification;
-use Symfony\Component\Notifier\Recipient\Recipient;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -32,7 +31,7 @@ final class ChatMessage implements MessageInterface
         $this->options = $options;
     }
 
-    public static function fromNotification(Notification $notification, Recipient $recipient, string $transport = null): self
+    public static function fromNotification(Notification $notification): self
     {
         $message = new self($notification->getSubject());
         $message->notification = $notification;

--- a/src/Symfony/Component/Notifier/Message/EmailMessage.php
+++ b/src/Symfony/Component/Notifier/Message/EmailMessage.php
@@ -35,7 +35,7 @@ final class EmailMessage implements MessageInterface
         $this->envelope = $envelope;
     }
 
-    public static function fromNotification(Notification $notification, Recipient $recipient, string $transport = null): self
+    public static function fromNotification(Notification $notification, Recipient $recipient): self
     {
         if (!class_exists(NotificationEmail::class)) {
             $email = (new Email())

--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -34,10 +34,10 @@ final class SmsMessage implements MessageInterface
         $this->phone = $phone;
     }
 
-    public static function fromNotification(Notification $notification, Recipient $recipient, string $transport = null): self
+    public static function fromNotification(Notification $notification, Recipient $recipient): self
     {
         if (!$recipient instanceof SmsRecipientInterface) {
-            throw new LogicException(sprintf('To send a SMS message, "%s" should implement "%s" or the recipient should implement "%s".', get_class($notification), SmsNotificationInterface::class, SmsRecipientInterface::class));
+            throw new LogicException(sprintf('To send a SMS message, "%s" should implement "%s" or the recipient should implement "%s".', \get_class($notification), SmsNotificationInterface::class, SmsRecipientInterface::class));
         }
 
         return new self($recipient->getPhone(), $notification->getSubject());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Those classes are final so I think we don't need those extra arguments.