### PR TITLE
[VarDumper][HtmlDumper] Take care of maxDepth display option if provided

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -142,6 +142,11 @@ class HtmlDumper extends CliDumper
     public function dump(Data $data, $output = null, array $extraDisplayOptions = [])
     {
         $this->extraDisplayOptions = $extraDisplayOptions;
+
+        if (isset($this->extraDisplayOptions['maxDepth']) && is_numeric($this->extraDisplayOptions['maxDepth'])) {
+            $data = $data->withMaxDepth($this->extraDisplayOptions['maxDepth']);
+        }
+
         $result = parent::dump($data, $output);
         $this->dumpId = 'sf-dump-'.mt_rand();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tests pass? | yes
| Tickets       | ~ 
| License       | MIT
| Doc PR        | ~ 

When using HtmlDumper for a deep object and with option maxDepth=n, the dumped object is printed fully, and doesn't care of maxDepth option. A a consequence, browser can be blocked while printing the dumped object (seen in profiler).
