### PR TITLE
[Mailer][MailchimpBridge] Fix incorrect sender address when sender has name

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/MandrillTransport.php
@@ -42,7 +42,7 @@ class MandrillTransport extends AbstractHttpTransport
             'json' => [
                 'key' => $this->key,
                 'to' => $this->stringifyAddresses($envelope->getRecipients()),
-                'from_email' => $envelope->getSender()->toString(),
+                'from_email' => $envelope->getSender()->getAddress(),
                 'raw_message' => $message->toString(),
             ],
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This fixes the same problem as https://github.com/symfony/symfony/commit/6dbac13a07c23f321b04489b6a9773 but for HTTP transport.

I am also not sure that `from_email` parameter is needed here at all as it is optional for this API call.