### PR TITLE
[Mailer][MailchimpBridge] Fix missing attachments when sending via Mandrill API

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/Api/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/Api/MandrillTransport.php
@@ -79,10 +79,14 @@ class MandrillTransport extends AbstractApiTransport
                 'type' => $headers->get('Content-Type')->getBody(),
             ];
 
+            if ($name = $headers->getHeaderParameter('Content-Disposition', 'name')) {
+                $att['name'] = $name;
+            }
+
             if ('inline' === $disposition) {
-                $payload['images'][] = $att;
+                $payload['message']['images'][] = $att;
             } else {
-                $payload['attachments'][] = $att;
+                $payload['message']['attachments'][] = $att;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Previous code tries to pass attachments to API, but uses incorrect structure and as a result all attachments are missing when the email is sent.

This also adds previously missing attachment names.
