### PR TITLE
[BrowserKit] Fix HttpBrowser ignoring ScopingHttpClient base uri

### DIFF
--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\BrowserKit;
 
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
@@ -51,6 +52,18 @@ class HttpBrowser extends AbstractBrowser
         ]);
 
         return new Response($response->getContent(false), $response->getStatusCode(), $response->getHeaders(false));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAbsoluteUri($uri)
+    {
+        if ($this->client instanceof ScopingHttpClient) {
+            return $uri;
+        }
+
+        return parent::getAbsoluteUri($uri);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35159
| License       | MIT
| Doc PR        | -

Not sure whether this is the right approach, so if anyone has a better idea I'm open to suggestions.