### PR TITLE
Add method to get the user's machine remote port

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -930,7 +930,7 @@ class Request
     }
 
     /**
-     * Returns the port being used on the user's machine to communicate with the web server
+     * Returns the port being used on the user's machine to communicate with the web server.
      *
      * @return string
      */

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -930,6 +930,16 @@ class Request
     }
 
     /**
+     * Returns the port being used on the user's machine to communicate with the web server
+     *
+     * @return string
+     */
+    public function getRemotePort()
+    {
+        return $this->server->get('REMOTE_PORT');
+    }
+
+    /**
      * Returns the user.
      *
      * @return string|null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Tickets       | -
| License       | MIT
| Doc PR        | 

Adding method to get the remote port from user's machine.

Reason: brazilian law

http://www.stj.jus.br/sites/portalp/Paginas/Comunicacao/Noticias/Provedor-deve-fornecer-porta-logica-para-identificar-usuario-acusado-de-atividade-irregular-na-internet.aspx
