### PR TITLE
 [Mailer] Payload sent to Sendgrid doesn't include names

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridApiTransport;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -48,8 +49,8 @@ class SendgridApiTransportTest extends TestCase
     public function testSend()
     {
         $email = new Email();
-        $email->from('foo@example.com')
-            ->to('bar@example.com')
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->to(new Address('bar@example.com', 'Mr. Recipient'))
             ->bcc('baz@example.com')
             ->text('content');
 
@@ -73,12 +74,18 @@ class SendgridApiTransportTest extends TestCase
                 'json' => [
                     'personalizations' => [
                         [
-                            'to' => [['email' => 'bar@example.com']],
+                            'to' => [[
+                                'email' => 'bar@example.com',
+                                'name' => 'Mr. Recipient',
+                            ]],
                             'subject' => null,
                             'bcc' => [['email' => 'baz@example.com']],
                         ],
                     ],
-                    'from' => ['email' => 'foo@example.com'],
+                    'from' => [
+                        'email' => 'foo@example.com',
+                        'name' => 'Ms. Foo Bar',
+                    ],
                     'content' => [
                         ['type' => 'text/plain', 'value' => 'content'],
                     ],

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -63,11 +63,19 @@ class SendgridApiTransport extends AbstractApiTransport
 
     private function getPayload(Email $email, Envelope $envelope): array
     {
-        $addressStringifier = function (Address $address) {return ['email' => $address->toString()]; };
+        $addressStringifier = function (Address $address) {
+            $stringified = ['email' => $address->getAddress()];
+
+            if ($address->getName()) {
+                $stringified['name'] = $address->getName();
+            }
+
+            return $stringified;
+        };
 
         $payload = [
             'personalizations' => [],
-            'from' => ['email' => $envelope->getSender()->toString()],
+            'from' => $addressStringifier($envelope->getSender()),
             'content' => $this->getContent($email),
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When we use the Sendgrid API to send an email, for fields like to, from, bcc... the endpoint expects to receive an associative array composed of an email address and a optionally a name.

![Sendgrid doc extract](https://versgui.fr/files/sendgrid-api-sf.png)
https://sendgrid.com/docs/API_Reference/api_v3.html

Symfony sends only the email address, even when the name is provided. I changed the code to allow the bridge to send the name when it's provided.

I didn't fix it on 4.3 because Address doesn't manage names, and its constructor signature is not the same in 4.4.