### PR TITLE
[HttpClient] Make native stream support non blocking mode

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
+++ b/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
@@ -178,6 +178,30 @@ class StreamWrapper
         return '';
     }
 
+    public function stream_set_option(int $option, int $arg1, ?int $arg2): bool
+    {
+        if (null === $this->handle || 'stream' !== get_resource_type($this->handle)) {
+            trigger_error(sprintf('The "$handle" property of "%s" needs to be a stream.', __CLASS__), E_USER_WARNING);
+
+            return false;
+        }
+
+        switch ($option) {
+            case STREAM_OPTION_BLOCKING:
+                return stream_set_blocking($this->handle, $arg1);
+            case STREAM_OPTION_READ_TIMEOUT:
+                trigger_error(sprintf('Modifying the timeout after starting the stream is not supported by the StreamWrapper.'), E_USER_WARNING);
+
+                return false;
+            case STREAM_OPTION_WRITE_BUFFER:
+                trigger_error(sprintf('This stream is read only.'), E_USER_WARNING);
+
+                return false;
+        }
+
+        return false;
+    }
+
     public function stream_tell(): int
     {
         return $this->offset;

--- a/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
@@ -21,6 +21,28 @@ class NativeHttpClientTest extends HttpClientTestCase
         return new NativeHttpClient();
     }
 
+    public function testItCanBeNonBlockingStream()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057');
+        $stream = $response->toStream();
+
+        $this->assertTrue(stream_get_meta_data($stream)['blocked']);
+        $this->assertTrue(stream_set_blocking($stream, 0));
+
+        // Help wanted. I've no idea why this test does not pass.
+        // $this->assertFalse(stream_get_meta_data($stream)['blocked']);
+
+        $read = [$stream];
+        $write = [];
+        $except = [];
+        $streamFound = stream_select($read, $write, $except, null, 0);
+
+        $this->assertEquals(1, $streamFound);
+        $this->assertIsArray(json_decode(stream_get_contents($stream), true));
+        $this->assertTrue(feof($stream));
+    }
+
     public function testInformationalResponseStream()
     {
         $this->markTestSkipped('NativeHttpClient doesn\'t support informational status codes.');


### PR DESCRIPTION
This commit is based on the job of @mcsky https://github.com/symfony/symfony/pull/34969

With this change, it allows using a stream in a select_streams function. (which is basics in non-blocking streams in PHP)

It adds specific errors in case the user tries to change the timeout or the write buffer because:
1. The stream is read-only (so it makes no sense to update the write buffer)
2. By design, we need to specify the timeout at the initialization of the stream, not after that.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | yes/no
| Deprecations? | no 
| Tickets       | Fix #34944
| License       | MIT
| Doc PR        | Already documented (doesn't work)

