### PR TITLE
[PhpUnitBridge][SymfonyTestsListenerTrait] Remove $testsWithWarnings stack

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV5.php
@@ -47,11 +47,6 @@ class SymfonyTestsListenerForV5 extends \PHPUnit_Framework_BaseTestListener
         $this->trait->startTest($test);
     }
 
-    public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time)
-    {
-        $this->trait->addWarning($test, $e, $time);
-    }
-
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
         $this->trait->endTest($test, $time);

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV6.php
@@ -52,11 +52,6 @@ class SymfonyTestsListenerForV6 extends BaseTestListener
         $this->trait->startTest($test);
     }
 
-    public function addWarning(Test $test, Warning $e, $time)
-    {
-        $this->trait->addWarning($test, $e, $time);
-    }
-
     public function endTest(Test $test, $time)
     {
         $this->trait->endTest($test, $time);

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV7.php
@@ -55,11 +55,6 @@ class SymfonyTestsListenerForV7 implements TestListener
         $this->trait->startTest($test);
     }
 
-    public function addWarning(Test $test, Warning $e, float $time): void
-    {
-        $this->trait->addWarning($test, $e, $time);
-    }
-
     public function endTest(Test $test, float $time): void
     {
         $this->trait->endTest($test, $time);

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -37,7 +37,6 @@ class SymfonyTestsListenerTrait
     private $expectedDeprecations = array();
     private $gatheredDeprecations = array();
     private $previousErrorHandler;
-    private $testsWithWarnings;
     private $reportUselessTests;
     private $error;
     private $runsInSeparateProcess = false;
@@ -114,7 +113,6 @@ class SymfonyTestsListenerTrait
             $Test = 'PHPUnit\Util\Test';
         }
         $suiteName = $suite->getName();
-        $this->testsWithWarnings = array();
 
         foreach ($suite->tests() as $test) {
             if (!($test instanceof \PHPUnit\Framework\TestCase || $test instanceof TestCase)) {
@@ -242,13 +240,6 @@ class SymfonyTestsListenerTrait
                 $this->expectedDeprecations = $annotations['method']['expectedDeprecation'];
                 $this->previousErrorHandler = set_error_handler(array($this, 'handleError'));
             }
-        }
-    }
-
-    public function addWarning($test, $e, $time)
-    {
-        if ($test instanceof \PHPUnit\Framework\TestCase || $test instanceof TestCase) {
-            $this->testsWithWarnings[$test->getName()] = true;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As far as I can see, it is unused since 4.0.