### PR TITLE
[Mailer] read default timeout from ini configurations 

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php
@@ -26,7 +26,7 @@ final class SocketStream extends AbstractStream
     private $url;
     private $host = 'localhost';
     private $port = 465;
-    private $timeout = 5;
+    private $timeout;
     private $tls = true;
     private $sourceIp;
     private $streamContextOptions = [];
@@ -40,7 +40,7 @@ final class SocketStream extends AbstractStream
 
     public function getTimeout(): float
     {
-        return $this->timeout;
+        return $this->timeout ?? (float) ini_get('default_socket_timeout');
     }
 
     /**
@@ -134,17 +134,18 @@ final class SocketStream extends AbstractStream
         $options['ssl']['crypto_method'] = $options['ssl']['crypto_method'] ?? STREAM_CRYPTO_METHOD_TLS_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
         $streamContext = stream_context_create($options);
 
+        $timeout = $this->getTimeout();
         set_error_handler(function ($type, $msg) {
             throw new TransportException(sprintf('Connection could not be established with host "%s": %s.', $this->url, $msg));
         });
         try {
-            $this->stream = stream_socket_client($this->url, $errno, $errstr, $this->timeout, STREAM_CLIENT_CONNECT, $streamContext);
+            $this->stream = stream_socket_client($this->url, $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, $streamContext);
         } finally {
             restore_error_handler();
         }
 
         stream_set_blocking($this->stream, true);
-        stream_set_timeout($this->stream, $this->timeout);
+        stream_set_timeout($this->stream, $timeout);
         $this->in = &$this->stream;
         $this->out = &$this->stream;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #35138 
| License       | MIT
| Doc PR        | n/a

```env
MAILER_DSN=mandrill+https://foo@default?timeout=30
```