### PR TITLE
[Security-Guard] fix missing name tag in param docblock

### DIFF
--- a/src/Symfony/Component/Security/Guard/PasswordAuthenticatedInterface.php
+++ b/src/Symfony/Component/Security/Guard/PasswordAuthenticatedInterface.php
@@ -19,7 +19,7 @@ interface PasswordAuthenticatedInterface
     /**
      * Returns the clear-text password contained in credentials if any.
      *
-     * @param mixed The user credentials
+     * @param mixed $credentials The user credentials
      */
     public function getPassword($credentials): ?string;
 }


### PR DESCRIPTION
Added missing $credentials name tag to @param for getPassword()
to resolve PHPStan error and comply with the docBlock spec.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35203 
| License       | MIT
| Doc PR        | 

Added `[name]` tag to `@param` dockBlock for `PasswordAuthenticatedInterface::getPassword()`  to comply with the docBlock "standard" and to eliminate PHPStan error's when analyzing `PasswordAuthenticatedInterface.php`
