### PR TITLE
[Mailer] Add encryption and port support for gmail transport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/polyfill-intl-idn": "^1.10",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php72": "~1.5",
-        "symfony/polyfill-php73": "^1.11"
+        "symfony/polyfill-php73": "^1.11",
+        "symfony/google-mailer": "4.3.x-dev"
     },
     "replace": {
         "symfony/asset": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "symfony/polyfill-intl-idn": "^1.10",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php72": "~1.5",
-        "symfony/polyfill-php73": "^1.11",
-        "symfony/google-mailer": "4.3.x-dev"
+        "symfony/polyfill-php73": "^1.11"
     },
     "replace": {
         "symfony/asset": "self.version",

--- a/src/Symfony/Component/Mailer/Bridge/Google/Smtp/GmailTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Google/Smtp/GmailTransport.php
@@ -22,10 +22,9 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 class GmailTransport extends EsmtpTransport
 {
-    public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null, string $encryption = 'ssl', int $port = 465)
     {
-        parent::__construct('smtp.gmail.com', 465, 'ssl', null, $dispatcher, $logger);
-
+        parent::__construct('smtp.gmail.com', $port, $encryption, null, $dispatcher, $logger);
         $this->setUsername($username);
         $this->setPassword($password);
     }

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -95,10 +95,10 @@ class Transport
                 }
 
                 if ('smtp' === $parsedDsn['scheme']) {
-                    if (isset($query['encryption']) && strtolower($query['encryption']) == 'starttls') {
+                    if (isset($query['encryption']) && 'starttls' == strtolower($query['encryption']) ) {
                         return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
                     }
-                    if (isset($parsedDsn['port']) && intval($parsedDsn['port']) == 587) {
+                    if (isset($parsedDsn['port']) && 587 == intval($parsedDsn['port'])) {
                         return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
                     }
                     return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger);

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -95,6 +95,12 @@ class Transport
                 }
 
                 if ('smtp' === $parsedDsn['scheme']) {
+                    if (isset($query['encryption']) && strtolower($query['encryption']) == 'starttls') {
+                        return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
+                    }
+                    if (isset($parsedDsn['port']) && intval($parsedDsn['port']) == 587) {
+                        return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
+                    }
                     return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger);
                 }
 

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -101,6 +101,7 @@ class Transport
                     if (isset($parsedDsn['port']) && 587 == (int) ($parsedDsn['port'])) {
                         return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
                     }
+
                     return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger);
                 }
 

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -95,10 +95,10 @@ class Transport
                 }
 
                 if ('smtp' === $parsedDsn['scheme']) {
-                    if (isset($query['encryption']) && 'starttls' == strtolower($query['encryption']) ) {
+                    if (isset($query['encryption']) && 'starttls' == strtolower($query['encryption'])) {
                         return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
                     }
-                    if (isset($parsedDsn['port']) && 587 == intval($parsedDsn['port'])) {
+                    if (isset($parsedDsn['port']) && 587 == (int) ($parsedDsn['port'])) {
                         return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
                     }
                     return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger);

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -95,14 +95,9 @@ class Transport
                 }
 
                 if ('smtp' === $parsedDsn['scheme']) {
-                    if (isset($query['encryption']) && 'starttls' == strtolower($query['encryption'])) {
-                        return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
-                    }
-                    if (isset($parsedDsn['port']) && 587 == (int) ($parsedDsn['port'])) {
-                        return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, 'tls', 587);
-                    }
-
-                    return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger);
+                    $encryption = isset($query['encryption']) ? $query['encryption'] : 'ssl';
+                    $port = isset($parsedDsn['port']) ? $parsedDsn['port'] : 465;
+                    return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, $encryption, $port);
                 }
 
                 throw new LogicException(sprintf('The "%s" scheme is not supported for mailer "%s".', $parsedDsn['scheme'], $parsedDsn['host']));

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -97,6 +97,7 @@ class Transport
                 if ('smtp' === $parsedDsn['scheme']) {
                     $encryption = isset($query['encryption']) ? $query['encryption'] : 'ssl';
                     $port = isset($parsedDsn['port']) ? $parsedDsn['port'] : 465;
+
                     return new Google\Smtp\GmailTransport($user, $pass, $dispatcher, $logger, $encryption, $port);
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35174  
| License       | MIT
| Doc PR        | none
<!--
Support encryption variable in gmail dns:
MAILER_DSN=smtp://username:***@gmail:587?encryption=starttls

Possible use only port

MAILER_DSN=smtp://username:***@gmail:587
(GmailTransport will use encryption=starttls)

or only encryption

MAILER_DSN=smtp://username:***@gmail?encryption=starttls
(GmailTransport will use port 587)
-->
