### PR TITLE
[Yaml] Fail properly when the !php/const tag is used in a mapping key

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -797,4 +797,29 @@ class InlineTest extends TestCase
             'negative octal number' => [-28, '-034'],
         ];
     }
+
+    public function testParseScalarDoesNotFailWithAnEmptyString()
+    {
+        $this->assertSame('', Inline::parseScalar(''));
+    }
+
+    /**
+     * @dataProvider phpConstTagInAMappingKeyThrowsProvider
+     */
+    public function testPhpConstTagInAMappingKeyThrows($extra)
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('The !php/const tag is not supported in a mapping key at line 1 (near "!php/const").');
+
+        Inline::parse(sprintf('{!php/const%s: foo}', $extra), Yaml::PARSE_CONSTANT);
+    }
+
+    public function phpConstTagInAMappingKeyThrowsProvider()
+    {
+        return [
+            [''],
+            [' '],
+            [' MyConst'],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/35179#issuecomment-570618450
| License       | MIT
| Doc PR        | -

This PR improves the DX of the linked issue case + fixes the parseScalar method + fixes some cases that call it with non string values.