### PR TITLE
[HttpFoundation] added withers to Cookie class

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 5.1.0
 -----
 
+ * added `Cookie::withValue`, `Cookie::withDomain`, `Cookie::withExpires`,
+   `Cookie::withPath`, `Cookie::withSecure`, `Cookie::withHttpOnly`,
+   `Cookie::withRaw`, `Cookie::withSameSite`
  * Deprecate `Response::create()`, `JsonResponse::create()`,
    `RedirectResponse::create()`, and `StreamedResponse::create()` methods (use
    `__construct()` instead)

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -99,6 +99,52 @@ class Cookie
             throw new \InvalidArgumentException('The cookie name cannot be empty.');
         }
 
+        $this->name = $name;
+        $this->value = $value;
+        $this->domain = $domain;
+        $this->expire = $this->withExpires($expire)->expire;
+        $this->path = empty($path) ? '/' : $path;
+        $this->secure = $secure;
+        $this->httpOnly = $httpOnly;
+        $this->raw = $raw;
+        $this->sameSite = $this->withSameSite($sameSite)->sameSite;
+    }
+
+    /**
+     * Creates a cookie copy with a new value.
+     *
+     * @return static
+     */
+    public function withValue(?string $value): self
+    {
+        $cookie = clone $this;
+        $cookie->value = $value;
+
+        return $cookie;
+    }
+
+    /**
+     * Creates a cookie copy with a new domain that the cookie is available to.
+     *
+     * @return static
+     */
+    public function withDomain(?string $domain): self
+    {
+        $cookie = clone $this;
+        $cookie->domain = $domain;
+
+        return $cookie;
+    }
+
+    /**
+     * Creates a cookie copy with a new time the cookie expires.
+     *
+     * @param int|string|\DateTimeInterface $expire
+     *
+     * @return static
+     */
+    public function withExpires($expire = 0): self
+    {
         // convert expiration time to a Unix timestamp
         if ($expire instanceof \DateTimeInterface) {
             $expire = $expire->format('U');
@@ -110,15 +156,75 @@ class Cookie
             }
         }
 
-        $this->name = $name;
-        $this->value = $value;
-        $this->domain = $domain;
-        $this->expire = 0 < $expire ? (int) $expire : 0;
-        $this->path = empty($path) ? '/' : $path;
-        $this->secure = $secure;
-        $this->httpOnly = $httpOnly;
-        $this->raw = $raw;
+        $cookie = clone $this;
+        $cookie->expire = 0 < $expire ? (int) $expire : 0;
 
+        return $cookie;
+    }
+
+    /**
+     * Creates a cookie copy with a new path on the server in which the cookie will be available on.
+     *
+     * @return static
+     */
+    public function withPath(string $path): self
+    {
+        $cookie = clone $this;
+        $cookie->path = '' === $path ? '/' : $path;
+
+        return $cookie;
+    }
+
+    /**
+     * Creates a cookie copy that only be transmitted over a secure HTTPS connection from the client.
+     *
+     * @return static
+     */
+    public function withSecure(bool $secure = true): self
+    {
+        $cookie = clone $this;
+        $cookie->secure = $secure;
+
+        return $cookie;
+    }
+
+    /**
+     * Creates a cookie copy that be accessible only through the HTTP protocol.
+     *
+     * @return static
+     */
+    public function withHttpOnly(bool $httpOnly = true): self
+    {
+        $cookie = clone $this;
+        $cookie->httpOnly = $httpOnly;
+
+        return $cookie;
+    }
+
+    /**
+     * Creates a cookie copy that uses no url encoding.
+     *
+     * @return static
+     */
+    public function withRaw(bool $raw = true): self
+    {
+        if ($raw && false !== strpbrk($this->name, self::$reservedCharsList)) {
+            throw new \InvalidArgumentException(sprintf('The cookie name "%s" contains invalid characters.', $this->name));
+        }
+
+        $cookie = clone $this;
+        $cookie->raw = $raw;
+
+        return $cookie;
+    }
+
+    /**
+     * Creates a cookie copy with SameSite attribute.
+     *
+     * @return static
+     */
+    public function withSameSite(?string $sameSite): self
+    {
         if ('' === $sameSite) {
             $sameSite = null;
         } elseif (null !== $sameSite) {
@@ -129,7 +235,10 @@ class Cookie
             throw new \InvalidArgumentException('The "sameSite" parameter value is not valid.');
         }
 
-        $this->sameSite = $sameSite;
+        $cookie = clone $this;
+        $cookie->sameSite = $sameSite;
+
+        return $cookie;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35212
| License       | MIT
| Doc PR        | -

I was quite descriptive in the issue :-)

The main idea is to get the interface for changing a cookie to avoid every unneeded argument in the constructor.

Current:

```php
$cookie = Cookie::create(
    RegionSwitcher::REGION_COOKIE, $regionSlug, new DateTime('+1 year'), '/',
    $baseDomain, null, false
);
```

This PR:

```php
$cookie = Cookie::create('foo')
            ->withValue('bar')
            ->withExpiresTime(strtotime('Fri, 20-May-2011 15:25:52 GMT'))
            ->withDomain('.myfoodomain.com')
            ->withSecure(true);
```

Every `wither` returns a copy of current cookie with requested setting set. Cookie class remains immutable.