### PR TITLE
Removed duplicated variable

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -131,7 +131,6 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
 
         $event = new ControllerEvent($this, $controller, $request, $type);
         $this->dispatcher->dispatch($event, KernelEvents::CONTROLLER);
-        $controller = $event->getController();
 
         // controller arguments
         $arguments = $this->argumentResolver->getArguments($request, $controller);


### PR DESCRIPTION
Removed duplicated variable.
There is already a `$controller = $event->getController();` few lines below.
