### PR TITLE
[PhpUnitBridge] When using phpenv + phpenv-composer plugin, composer executable is wrapped into a bash script

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -60,7 +60,7 @@ foreach ($defaultEnvs as $envName => $envValue) {
 $COMPOSER = file_exists($COMPOSER = $oldPwd.'/composer.phar')
     || ($COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer.phar`) : `which composer.phar 2> /dev/null`))
     || ($COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer`) : `which composer 2> /dev/null`))
-    ? $PHP.' '.escapeshellarg($COMPOSER)
+    ? (file_get_contents($COMPOSER, null, 0, 18) === '#!/usr/bin/env php' ? $PHP : '').' '.escapeshellarg($COMPOSER) // detect shell wrappers by looking at the shebang
     : 'composer';
 
 if (false === $SYMFONY_PHPUNIT_REMOVE = getenv('SYMFONY_PHPUNIT_REMOVE')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #34796
| License       | MIT
| Doc PR        | -

Locally using [phpenv](https://github.com/phpenv/phpenv) together [phpenv-composer](https://github.com/ngyuki/phpenv-composer) with for managing php versions and composer installations.

`which composer` is detecting wrapper instead of binary.
Before appending PHP executable to composer path need to validate that detected composer is not a wrapper otherwise PHP will simply return the content of a wrapper

