### PR TITLE
[DependencyInjection] Handle ServiceClosureArgument for callable in container linting

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
@@ -216,6 +217,10 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
         }
 
         if ('callable' === $type && \is_array($value) && isset($value[0]) && ($value[0] instanceof Reference || $value[0] instanceof Definition)) {
+            return;
+        }
+
+        if (\in_array($type, ['callable', 'Closure'], true) && $value instanceof ServiceClosureArgument) {
             return;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CheckTypeDeclarationsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -692,6 +693,30 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $container
             ->register('foobar', BarMethodCall::class)
             ->addMethodCall('setCallable', [$closureDefinition]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingServiceClosureArgumentToCallable()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', BarMethodCall::class)
+            ->addMethodCall('setCallable', [new ServiceClosureArgument(new Reference('foo'))]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingServiceClosureArgumentToClosure()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', BarMethodCall::class)
+            ->addMethodCall('setClosure', [new ServiceClosureArgument(new Reference('foo'))]);
 
         (new CheckTypeDeclarationsPass(true))->process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
@@ -40,4 +40,8 @@ class BarMethodCall
     public function setCallable(callable $callable): void
     {
     }
+
+    public function setClosure(\Closure $closure): void
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (+)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | (none)
| License       | MIT

Making use of `ServiceClosureArgument` instances in service definitions was not accounted for in container linting when a service type-hints for `callable` in an argument - adding this check ensures that `ServiceClosureArgument` instances are recognised correctly as callables (once they are resolved).
