### PR TITLE
[Mailer] Fix broken mandrill http send for recipients with names

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/MandrillTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Http/MandrillTransport.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Mailchimp\Http;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\SmtpEnvelope;
+use Symfony\Component\Mailer\Transport\Http\AbstractHttpTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Kevin Verschaeve
+ *
+ * @experimental in 4.3
+ */
+class MandrillTransport extends AbstractHttpTransport
+{
+    private const ENDPOINT = 'https://mandrillapp.com/api/1.0/messages/send-raw.json';
+    private $key;
+
+    public function __construct(string $key, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    {
+        $this->key = $key;
+
+        parent::__construct($client, $dispatcher, $logger);
+    }
+
+    protected function doSend(SentMessage $message): void
+    {
+        $envelope = $message->getEnvelope();
+        $response = $this->client->request('POST', self::ENDPOINT, [
+            'json' => [
+                'key' => $this->key,
+                'to' => $this->getRecipients($envelope),
+                'from_email' => $envelope->getSender()->getAddress(),
+                'raw_message' => $message->toString(),
+            ],
+        ]);
+
+        if (200 !== $response->getStatusCode()) {
+            $result = $response->toArray(false);
+            if ('error' === ($result['status'] ?? false)) {
+                throw new TransportException(sprintf('Unable to send an email: %s (code %s).', $result['message'], $result['code']));
+            }
+
+            throw new TransportException(sprintf('Unable to send an email (code %s).', $result['code']));
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getRecipients(SmtpEnvelope $envelope): array
+    {
+        return array_map(function (Address $recipient): string {
+            return $recipient->getAddress();
+        }, $envelope->getRecipients());
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
@@ -12,9 +12,11 @@
 namespace Symfony\Component\Mailer\Bridge\Mailchimp\Transport;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractHttpTransport;
+use Symfony\Component\Mime\Address;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -45,7 +47,7 @@ class MandrillHttpTransport extends AbstractHttpTransport
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/1.0/messages/send-raw.json', [
             'json' => [
                 'key' => $this->key,
-                'to' => $this->stringifyAddresses($envelope->getRecipients()),
+                'to' => $this->getRecipients($envelope->getRecipients()),
                 'from_email' => $envelope->getSender()->toString(),
                 'raw_message' => $message->toString(),
             ],
@@ -68,5 +70,15 @@ class MandrillHttpTransport extends AbstractHttpTransport
     private function getEndpoint(): ?string
     {
         return ($this->host ?: self::HOST).($this->port ? ':'.$this->port : '');
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getRecipients(Envelope $envelope): array
+    {
+        return array_map(function (Address $recipient): string {
+            return $recipient->getAddress();
+        }, $envelope->getRecipients());
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

As specified in https://mandrillapp.com/api/docs/messages.JSON.html#method=send-raw, Mandrill API expects array of email addresses for `to` parameter.