### PR TITLE
[HttpClient] Fix infinite loop on php 7.2 with mbstring.func_overload

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -455,7 +455,7 @@ trait HttpClientTrait
     {
         $result = '';
 
-        while (!\in_array($path, ['', '.', '..'], true)) {
+        while (!\in_array($path, [false, '', '.', '..'], true)) {
             if ('.' === $path[0] && (0 === strpos($path, $p = '../') || 0 === strpos($path, $p = './'))) {
                 $path = substr($path, \strlen($p));
             } elseif ('/.' === $path || 0 === strpos($path, '/./')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35114
| License       | MIT
| Doc PR        | 

On PHP 7.2 with mbstring.func_overload enabled substr() sometimes return
false instead of empty string. Since while loop in removeDotSegments()
does not check for false condition, it runs infinitely.