### PR TITLE
[Security\Http] Prevent canceled remember-me cookie from being accepted

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/ClearRememberMeTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/ClearRememberMeTest.php
@@ -33,7 +33,7 @@ class ClearRememberMeTest extends AbstractWebTestCase
         $this->assertNotNull($cookieJar->get('REMEMBERME'));
 
         $client->request('GET', '/foo');
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertRedirect($client->getResponse(), '/login');
         $this->assertNull($cookieJar->get('REMEMBERME'));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5.9|>=7.0.8",
         "ext-xml": "*",
         "symfony/config": "~3.4|~4.0",
-        "symfony/security": "~3.4.36|~4.3.9|^4.4.1",
+        "symfony/security": "~3.4.37|~4.3.10|^4.4.3",
         "symfony/dependency-injection": "^3.4.3|^4.0.3",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/polyfill-php70": "~1.0"

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -99,6 +99,10 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
      */
     final public function autoLogin(Request $request)
     {
+        if (($cookie = $request->attributes->get(self::COOKIE_ATTR_NAME)) && null === $cookie->getValue()) {
+            return null;
+        }
+
         if (null === $cookie = $request->cookies->get($this->options['name'])) {
             return null;
         }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -39,6 +39,17 @@ class AbstractRememberMeServicesTest extends TestCase
         $this->assertNull($service->autoLogin(new Request()));
     }
 
+    public function testAutoLoginReturnsNullAfterLoginFail()
+    {
+        $service = $this->getService(null, ['name' => 'foo', 'path' => null, 'domain' => null]);
+
+        $request = new Request();
+        $request->cookies->set('foo', 'foo');
+
+        $service->loginFail($request);
+        $this->assertNull($service->autoLogin($request));
+    }
+
     /**
      * @group legacy
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35198
| License       | MIT
| Doc PR        | -

`RememberMeServices::autoLogin()` only checks that the cookie exists in `$request->cookies` while `loginFail()` only alter `$request->attributes` (which allows child implementations to read the canceled cookie for e.g. removing a persistent one).
This makes `autoLogin()` checks for `request->attributes` first, which fixes the linked issue.

Failure expected on deps=high build.
