### PR TITLE
[HttpClient] fix exception in case of PSR17 discovery failure

### DIFF
--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Request;
@@ -68,9 +69,13 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
             throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\Psr18Client" as no PSR-17 factories have been provided. Try running "composer require nyholm/psr7".');
         }
 
-        $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
-        $this->responseFactory = $this->responseFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findResponseFactory();
-        $this->streamFactory = $this->streamFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
+        try {
+            $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
+            $this->responseFactory = $this->responseFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findResponseFactory();
+            $this->streamFactory = $this->streamFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
+        } catch (NotFoundException $e) {
+            throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\HttplugClient" as no PSR-17 factories have been found. Try running "composer require nyholm/psr7".', 0, $e);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

On symfony.com, we need to use HTTPlug for 3rd party libs. When `nyholm/psr7` is not installed, we currently see an exception saying `No HTTPlug clients found.` from `HttpClientDiscovery`.

This fixes the message by correctly suggesting `nyholm/psr7` instead, since there *is* an HTTPlug client: `HttplugClient` from our HttpClient component.

It's quite unfortunate that `guzzle/psr7` provides no PSR17 factory yet, because that would have solved some part of this deps mess. /cc @Nyholm @sagikazarmark FYI
Note that https://packagist.org/providers/psr/http-factory-implementation lists `guzzle/psr7` but this is a wrong solution: no tagged release of it is PSR17-compatible, which means installing it doesn't solve the issue.