### PR TITLE
[FrameworkBundle][ContainerLintCommand] Only skip .errored. services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -102,11 +102,12 @@ final class ContainerLintCommand extends Command
             $refl->setAccessible(true);
             $refl->setValue($parameterBag, true);
 
-            $passConfig = $container->getCompilerPassConfig();
-            $passConfig->setRemovingPasses([]);
-            $passConfig->setAfterRemovingPasses([]);
-
-            $skippedIds = $kernelContainer->getRemovedIds();
+            $skippedIds = [];
+            foreach ($container->getServiceIds() as $serviceId) {
+                if (0 === strpos($serviceId, '.errored.')) {
+                    $skippedIds[$serviceId] = true;
+                }
+            }
         }
 
         $container->setParameter('container.build_hash', 'lint_container');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR partially reverts https://github.com/symfony/symfony/pull/34935 that was a kind of a mistake. Skipping all removed ids cannot work because all private services are in the "removed" ids. So the command ends up not validating much.

To still fix the original issue https://github.com/symfony/symfony/issues/34858 we need to skip errored services. However, definition errors are not dumped / read (see https://github.com/symfony/symfony/pull/34928). So instead, even if it's bad, we can maybe rely on the name for this particular error since it's hardcoded 😕 At least it fixes this case in a simple way 😕
