### PR TITLE
[HttpKernel] Sort the KernelEvents constants

### DIFF
--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -30,27 +30,6 @@ final class KernelEvents
     const REQUEST = 'kernel.request';
 
     /**
-     * The EXCEPTION event occurs when an uncaught exception appears.
-     *
-     * This event allows you to create a response for a thrown exception or
-     * to modify the thrown exception.
-     *
-     * @Event("Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent")
-     */
-    const EXCEPTION = 'kernel.exception';
-
-    /**
-     * The VIEW event occurs when the return value of a controller
-     * is not a Response instance.
-     *
-     * This event allows you to create a response for the return value of the
-     * controller.
-     *
-     * @Event("Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent")
-     */
-    const VIEW = 'kernel.view';
-
-    /**
      * The CONTROLLER event occurs once a controller was found for
      * handling a request.
      *
@@ -70,6 +49,17 @@ final class KernelEvents
      * @Event("Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent")
      */
     const CONTROLLER_ARGUMENTS = 'kernel.controller_arguments';
+
+    /**
+     * The VIEW event occurs when the return value of a controller
+     * is not a Response instance.
+     *
+     * This event allows you to create a response for the return value of the
+     * controller.
+     *
+     * @Event("Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent")
+     */
+    const VIEW = 'kernel.view';
 
     /**
      * The RESPONSE event occurs once a response was created for
@@ -100,4 +90,14 @@ final class KernelEvents
      * @Event("Symfony\Component\HttpKernel\Event\FinishRequestEvent")
      */
     const FINISH_REQUEST = 'kernel.finish_request';
+
+    /**
+     * The EXCEPTION event occurs when an uncaught exception appears.
+     *
+     * This event allows you to create a response for a thrown exception or
+     * to modify the thrown exception.
+     *
+     * @Event("Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent")
+     */
+    const EXCEPTION = 'kernel.exception';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

Hi,

When I need to visualize all the kernel events I often open the KernelEvents file. However, it is difficult to navigate through it because the constants are not in the same order compared to the framework execution life cycle.

This PR aims to sort this constants to match it. It's also the same order used in [this documentation page](https://symfony.com/doc/current/reference/events.html).

Thanks.