### PR TITLE
[FrameworkBundle] Cache ClassMetadataFactory by default

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -65,12 +65,14 @@
         {%- endif -%}
         {%- if preferred_choices|length > 0 -%}
             {% set options = preferred_choices %}
+            {% set render_preferred_choices = true %}
             {{- block('choice_widget_options') -}}
             {%- if choices|length > 0 and separator is not none -%}
                 <option disabled="disabled">{{ separator }}</option>
             {%- endif -%}
         {%- endif -%}
         {%- set options = choices -%}
+        {%- set render_preferred_choices = false -%}
         {{- block('choice_widget_options') -}}
     </select>
 {%- endblock choice_widget_collapsed -%}
@@ -83,7 +85,7 @@
                 {{- block('choice_widget_options') -}}
             </optgroup>
         {%- else -%}
-            <option value="{{ choice.value }}"{% if choice.attr %}{% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) }}</option>
+            <option value="{{ choice.value }}"{% if choice.attr %}{% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if not render_preferred_choices|default(false) and choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) }}</option>
         {%- endif -%}
     {% endfor %}
 {%- endblock choice_widget_options -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -160,12 +160,14 @@
         {%- endif %}
         {%- if preferred_choices|length > 0 -%}
             {% set options = preferred_choices %}
+            {% set render_preferred_choices = true %}
             {{- block('choice_widget_options') -}}
             {% if choices|length > 0 and separator is not none -%}
                 <option disabled="disabled">{{ separator }}</option>
             {%- endif %}
         {%- endif -%}
         {% set options = choices -%}
+        {%- set render_preferred_choices = false -%}
         {{- block('choice_widget_options') -}}
     </select>
 {%- endblock choice_widget_collapsed %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -531,6 +531,31 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    public function testSingleChoiceWithSelectedPreferred()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'preferred_choices' => ['&a'],
+            'multiple' => false,
+            'expanded' => false,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['separator' => '-- sep --', 'attr' => ['class' => 'my&class']],
+'/select
+    [@name="name"]
+    [@class="my&class form-control"]
+    [not(@required)]
+    [
+        ./option[@value="&a"][not(@selected)][.="[trans]Choice&A[/trans]"]
+        /following-sibling::option[@disabled="disabled"][not(@selected)][.="-- sep --"]
+        /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::option[@value="&b"][.="[trans]Choice&B[/trans]"]
+    ]
+    [count(./option)=4]
+'
+        );
+    }
+
     public function testSingleChoiceWithPreferredAndNoSeparator()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -102,11 +102,12 @@ final class ContainerLintCommand extends Command
             $refl->setAccessible(true);
             $refl->setValue($parameterBag, true);
 
-            $passConfig = $container->getCompilerPassConfig();
-            $passConfig->setRemovingPasses([]);
-            $passConfig->setAfterRemovingPasses([]);
-
-            $skippedIds = $kernelContainer->getRemovedIds();
+            $skippedIds = [];
+            foreach ($container->getServiceIds() as $serviceId) {
+                if (0 === strpos($serviceId, '.errored.')) {
+                    $skippedIds[$serviceId] = true;
+                }
+            }
         }
 
         $container->setParameter('container.build_hash', 'lint_container');

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -103,7 +103,12 @@ class CachePoolPass implements CompilerPassInterface
             if (ChainAdapter::class === $class) {
                 $adapters = [];
                 foreach ($adapter->getArgument(0) as $provider => $adapter) {
-                    $chainedPool = $adapter = new ChildDefinition($adapter);
+                    if ($adapter instanceof ChildDefinition) {
+                        $chainedPool = $adapter;
+                    } else {
+                        $chainedPool = $adapter = new ChildDefinition($adapter);
+                    }
+
                     $chainedTags = [\is_int($provider) ? [] : ['provider' => $provider]];
                     $chainedClass = '';
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
@@ -216,6 +217,10 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
         }
 
         if ('callable' === $type && \is_array($value) && isset($value[0]) && ($value[0] instanceof Reference || $value[0] instanceof Definition)) {
+            return;
+        }
+
+        if (\in_array($type, ['callable', 'Closure'], true) && $value instanceof ServiceClosureArgument) {
             return;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CheckTypeDeclarationsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -692,6 +693,30 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $container
             ->register('foobar', BarMethodCall::class)
             ->addMethodCall('setCallable', [$closureDefinition]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingServiceClosureArgumentToCallable()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', BarMethodCall::class)
+            ->addMethodCall('setCallable', [new ServiceClosureArgument(new Reference('foo'))]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingServiceClosureArgumentToClosure()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', BarMethodCall::class)
+            ->addMethodCall('setClosure', [new ServiceClosureArgument(new Reference('foo'))]);
 
         (new CheckTypeDeclarationsPass(true))->process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
@@ -40,4 +40,8 @@ class BarMethodCall
     public function setCallable(callable $callable): void
     {
     }
+
+    public function setClosure(\Closure $closure): void
+    {
+    }
 }

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Request;
@@ -68,9 +69,13 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
             throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\Psr18Client" as no PSR-17 factories have been provided. Try running "composer require nyholm/psr7".');
         }
 
-        $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
-        $this->responseFactory = $this->responseFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findResponseFactory();
-        $this->streamFactory = $this->streamFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
+        try {
+            $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
+            $this->responseFactory = $this->responseFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findResponseFactory();
+            $this->streamFactory = $this->streamFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
+        } catch (NotFoundException $e) {
+            throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\HttplugClient" as no PSR-17 factories have been found. Try running "composer require nyholm/psr7".', 0, $e);
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -556,7 +556,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                             }
                         }
 
-                        public function __destruct()
+                        public function release()
                         {
                             flock($this->lock, LOCK_UN);
                             fclose($this->lock);
@@ -634,7 +634,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         }
 
         $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
-        unset($cache);
+        $cache->release();
         $this->container = require $cachePath;
         $this->container->set('kernel', $this);
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -186,6 +186,20 @@ class ConnectionTest extends TestCase
         $redis->del('messenger-getnonblocking');
     }
 
+    public function testJsonError()
+    {
+        $redis = new \Redis();
+
+        $connection = Connection::fromDsn('redis://localhost/json-error', [], $redis);
+
+        try {
+            $connection->add("\xB1\x31", []);
+        } catch (TransportException $e) {
+        }
+
+        $this->assertSame('Malformed UTF-8 characters, possibly incorrectly encoded', $e->getMessage());
+    }
+
     public function testMaxEntries()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -248,6 +248,10 @@ class Connection
                     'uniqid' => uniqid('', true),
                 ]);
 
+                if (false === $message) {
+                    throw new TransportException(json_last_error_msg());
+                }
+
                 $score = (int) ($this->getCurrentTimeInMilliseconds() + $delayInMs);
                 $added = $this->connection->zadd($this->queue, ['NX'], $score, $message);
             } else {
@@ -255,6 +259,10 @@ class Connection
                     'body' => $body,
                     'headers' => $headers,
                 ]);
+
+                if (false === $message) {
+                    throw new TransportException(json_last_error_msg());
+                }
 
                 if ($this->maxEntries) {
                     $added = $this->connection->xadd($this->stream, '*', ['message' => $message], $this->maxEntries, true);

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -47,7 +47,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return $this->normalizeFallback($propertyName, $class, $format, $context);
         }
 
-        if (!isset(self::$normalizeCache[$class][$propertyName])) {
+        if (!array_key_exists($propertyName, self::$normalizeCache[$class])) {
             self::$normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class);
         }
 
@@ -64,7 +64,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         }
 
         $cacheKey = $this->getCacheKey($class, $context);
-        if (!isset(self::$denormalizeCache[$cacheKey][$propertyName])) {
+        if (!array_key_exists($propertyName, self::$denormalizeCache[$class])) {
             self::$denormalizeCache[$cacheKey][$propertyName] = $this->getCacheValueForDenormalization($propertyName, $class, $context);
         }
 
@@ -78,7 +78,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         }
 
         $attributesMetadata = $this->metadataFactory->getMetadataFor($class)->getAttributesMetadata();
-        if (!isset($attributesMetadata[$propertyName])) {
+        if (!array_key_exists($propertyName, $attributesMetadata)) {
             return null;
         }
 
@@ -93,7 +93,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
     private function getCacheValueForDenormalization(string $propertyName, string $class, array $context): ?string
     {
         $cacheKey = $this->getCacheKey($class, $context);
-        if (!isset(self::$attributesMetadataCache[$cacheKey])) {
+        if (!array_key_exists($cacheKey, self::$attributesMetadataCache)) {
             self::$attributesMetadataCache[$cacheKey] = $this->getCacheValueForAttributesMetadata($class, $context);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no (performance)
| New feature?  | performance...
| Deprecations? | no
| Tickets       | #35096
| License       | MIT
| Doc PR        | 

Cf #35096, validator and serialization yaml/xml files are parsed at each requests. But they are already tracked by a `DirectoryResource` in 
https://github.com/symfony/symfony/blob/bd9dc7c573f537c5a751fc3543774cab9ad4770b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1246

So it only needs a real cache purge on validator / serializer sytem cache, and I use the [CachePoolClearerCacheWarmer](https://github.com/api-platform/core/blob/master/src/Bridge/Symfony/Bundle/CacheWarmer/CachePoolClearerCacheWarmer.php) from APIP that already does similar things.

Handling that sort of cache in Symfony fixes a lot of others performance issue.