### PR TITLE
[Serializer] Fix cache in MetadataAwareNameConverter

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -47,7 +47,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return $this->normalizeFallback($propertyName, $class, $format, $context);
         }
 
-        if (!isset(self::$normalizeCache[$class][$propertyName])) {
+        if (!\array_key_exists($class, self::$normalizeCache) || !\array_key_exists($propertyName, self::$normalizeCache[$class])) {
             self::$normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class);
         }
 
@@ -64,7 +64,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         }
 
         $cacheKey = $this->getCacheKey($class, $context);
-        if (!isset(self::$denormalizeCache[$cacheKey][$propertyName])) {
+        if (!\array_key_exists($cacheKey, self::$denormalizeCache) || !\array_key_exists($propertyName, self::$denormalizeCache[$cacheKey])) {
             self::$denormalizeCache[$cacheKey][$propertyName] = $this->getCacheValueForDenormalization($propertyName, $class, $context);
         }
 
@@ -78,7 +78,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         }
 
         $attributesMetadata = $this->metadataFactory->getMetadataFor($class)->getAttributesMetadata();
-        if (!isset($attributesMetadata[$propertyName])) {
+        if (!\array_key_exists($propertyName, $attributesMetadata)) {
             return null;
         }
 
@@ -93,7 +93,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
     private function getCacheValueForDenormalization(string $propertyName, string $class, array $context): ?string
     {
         $cacheKey = $this->getCacheKey($class, $context);
-        if (!isset(self::$attributesMetadataCache[$cacheKey])) {
+        if (!\array_key_exists($cacheKey, self::$attributesMetadataCache)) {
             self::$attributesMetadataCache[$cacheKey] = $this->getCacheValueForAttributesMetadata($class, $context);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ref #35085
| License       | MIT
| Doc PR        | 

`isset` is used to test existence of values that is `null` by default, which result to always bypass the cache and force to do the calculation all the time.

This is a serious perf improvement in prod mode for an api.

![image](https://user-images.githubusercontent.com/84887/71933779-38c3ae80-31a3-11ea-8871-8e57cec87a89.png)


![image](https://user-images.githubusercontent.com/84887/71933675-074ae300-31a3-11ea-8e84-7adad3e6c96f.png)
