### PR TITLE
[FrameworkBundle] TemplateController should accept extra arguments to be sent to the template

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Added a new `mailer.message_bus` option to configure or disable the message bus to use to send mails.
  * Added flex-compatible default implementations for `MicroKernelTrait::registerBundles()` and `getProjectDir()`
  * Deprecated passing a `RouteCollectionBuiler` to `MicroKernelTrait::configureRoutes()`, type-hint `RoutingConfigurator` instead
+ * The `TemplateController` now accepts context argument
 
 5.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -33,18 +33,19 @@ class TemplateController
     /**
      * Renders a template.
      *
-     * @param string    $template  The template name
-     * @param int|null  $maxAge    Max age for client caching
-     * @param int|null  $sharedAge Max age for shared (proxy) caching
-     * @param bool|null $private   Whether or not caching should apply for client caches only
+     * @param string     $template  The template name
+     * @param int|null   $maxAge    Max age for client caching
+     * @param int|null   $sharedAge Max age for shared (proxy) caching
+     * @param bool|null  $private   Whether or not caching should apply for client caches only
+     * @param array      $context   The context (arguments) of the template
      */
-    public function templateAction(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null): Response
+    public function templateAction(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null, array $context = []): Response
     {
         if (null === $this->twig) {
             throw new \LogicException('You can not use the TemplateController if the Twig Bundle is not available.');
         }
 
-        $response = new Response($this->twig->render($template));
+        $response = new Response($this->twig->render($template, $context));
 
         if ($maxAge) {
             $response->setMaxAge($maxAge);
@@ -63,8 +64,8 @@ class TemplateController
         return $response;
     }
 
-    public function __invoke(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null): Response
+    public function __invoke(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null, array $context = []): Response
     {
-        return $this->templateAction($template, $maxAge, $sharedAge, $private);
+        return $this->templateAction($template, $maxAge, $sharedAge, $private, $context);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -38,5 +40,23 @@ class TemplateControllerTest extends TestCase
 
         $controller->templateAction('mytemplate')->getContent();
         $controller('mytemplate')->getContent();
+    }
+
+    public function testContext()
+    {
+        $templateName = 'template_controller.html.twig';
+        $context = [
+            'param' => 'hello world',
+        ];
+        $expected = '<h1>'.$context['param'].'</h1>';
+
+        $loader = new ArrayLoader();
+        $loader->setTemplate($templateName, '<h1>{{param}}</h1>');
+
+        $twig = new Environment($loader);
+        $controller = new TemplateController($twig);
+
+        $this->assertEquals($expected, $controller->templateAction($templateName, null, null, null, $context)->getContent());
+        $this->assertEquals($expected, $controller($templateName, null, null, null, $context)->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

In the official documentation (symfony.com/doc/master/templates.html#rendering-a-template-directly-from-a-route) it says that TemplateController should accept extra arguments. In fact it's not available for instance.
So i added the context argument as an array. Because of deprecation of templating, only the twig instance will apply the context argument.

It will need to be implemented in branch 5.

The following issue has been created in documentation project : https://github.com/symfony/symfony-docs/issues/12897