### PR TITLE
[VarDumper] [HtmlDumper] regex has to be a string

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -164,8 +164,8 @@ class HtmlDumper extends CliDumper
 Sfdump = window.Sfdump || (function (doc) {
 
 var refStyle = doc.createElement('style'),
-    rxEsc = /([.*+?^${}()|\[\]\/\\])/g,
-    idRx = /\bsf-dump-\d+-ref[012]\w+\b/,
+    rxEsc = '/([.*+?^${}()|\[\]\/\\])/g',
+    idRx = '/\bsf-dump-\d+-ref[012]\w+\b/',
     keyHint = 0 <= navigator.platform.toUpperCase().indexOf('MAC') ? 'Cmd' : 'Ctrl',
     addEventListener = function (e, n, cb) {
         e.addEventListener(n, cb, false);
@@ -600,7 +600,7 @@ return function (root, x) {
                     */
                     return;
                 }
-    
+
                 e.preventDefault();
                 search.className = search.className.replace(/\bsf-dump-search-hidden\b/, '');
                 searchInput.focus();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | didnt found smth
| License       | MIT
| Doc PR        | just a fix


Error in Browser
```
Uncaught SyntaxError: Invalid regular expression: /([.*+?^${}()|\[\]\/\])/g, idRx = /\bsf-dump-\d+-ref[012]\w+\b/: Range out of order in character class

Uncaught ReferenceError: Sfdump is not defined

Uncaught ReferenceError: Sfdump is not defined
```

Because the regex has to be a string in JS.

