### PR TITLE
[EventDispatcher] fix empty prio

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -94,7 +94,7 @@ class EventDispatcher implements EventDispatcherInterface
     public function getListenerPriority(string $eventName, $listener)
     {
         if (empty($this->listeners[$eventName])) {
-            return null;
+            return 0;
         }
 
         if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure && 2 >= \count($listener)) {
@@ -114,7 +114,7 @@ class EventDispatcher implements EventDispatcherInterface
             }
         }
 
-        return null;
+        return 0;
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -62,7 +62,7 @@ interface EventDispatcherInterface extends ContractsEventDispatcherInterface
      *
      * @param callable $listener The listener
      *
-     * @return int|null The event listener priority
+     * @return int The event listener priority, defaults to 0
      */
     public function getListenerPriority(string $eventName, $listener);
 

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -123,8 +123,8 @@ class EventDispatcherTest extends TestCase
 
         $this->assertSame(-10, $this->dispatcher->getListenerPriority('pre.foo', $listener1));
         $this->assertSame(0, $this->dispatcher->getListenerPriority('pre.foo', $listener2));
-        $this->assertNull($this->dispatcher->getListenerPriority('pre.bar', $listener2));
-        $this->assertNull($this->dispatcher->getListenerPriority('pre.foo', function () {}));
+        $this->assertEquals($this->dispatcher->getListenerPriority('pre.bar', $listener2), 0);
+        $this->assertEquals($this->dispatcher->getListenerPriority('pre.foo', function () {}), 0);
     }
 
     public function testDispatch()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35259
| License       | MIT


returns `0`  instead of `null`  as it is typ hinted on other places anyway, and leads to exceptions sometimes.