### PR TITLE
[Mailer] add ability to disable the TLS peer verification via DSN

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -36,6 +36,7 @@ CHANGELOG
  * Added `Symfony\Component\Mailer\Test\TransportFactoryTestCase` to ease testing custom transport factories.
  * Added `SentMessage::getDebug()` and `TransportExceptionInterface::getDebug` to help debugging
  * Made `MessageEvent` final
+ * add DSN parameter `verify_peer` to disable TLS peer verification for SMTP transport
 
 4.3.0
 -----

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -6,6 +6,7 @@ use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
 use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 
 class EsmtpTransportFactoryTest extends TransportFactoryTestCase
@@ -65,6 +66,19 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
 
         yield [
             new Dsn('smtps', 'example.com', '', '', 465),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        /** @var SocketStream $stream */
+        $stream = $transport->getStream();
+        $streamOptions = $stream->getStreamOptions();
+        $streamOptions['ssl']['verify_peer'] = false;
+        $streamOptions['ssl']['verify_peer_name'] = false;
+        $stream->setStreamOptions($streamOptions);
+
+        yield [
+            new Dsn('smtps', 'example.com', '', '', 465, ['verify_peer' => false]),
             $transport,
         ];
     }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mailer\Transport\Smtp;
 
 use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
 /**
@@ -27,6 +28,17 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
         $host = $dsn->getHost();
 
         $transport = new EsmtpTransport($host, $port, $tls, $this->dispatcher, $this->logger);
+
+        if (!$dsn->getOption('verify_peer', true)) {
+            /** @var SocketStream $stream */
+            $stream = $transport->getStream();
+            $streamOptions = $stream->getStreamOptions();
+
+            $streamOptions['ssl']['verify_peer'] = false;
+            $streamOptions['ssl']['verify_peer_name'] = false;
+
+            $stream->setStreamOptions($streamOptions);
+        }
 
         if ($user = $dsn->getUser()) {
             $transport->setUsername($user);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix
| License       | MIT
| Doc PR        | symfony/symfony-docs/pull/12997

Add the ability to disable the peer TLS verification with the DNS when using `EsmtpTransport` like this :

```
MAILER_DSN=smtp://foo@default?verify_peer=false
```

By default the verification is enabled