### PR TITLE
[Expression Language] Add support for callable properties

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Added support for callable properties
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -82,8 +82,18 @@ class GetAttrNode extends Node
                 if (!\is_object($obj)) {
                     throw new \RuntimeException('Unable to get a property on a non-object.');
                 }
-                if (!\is_callable($toCall = [$obj, $this->nodes['attribute']->attributes['value']])) {
-                    throw new \RuntimeException(sprintf('Unable to call method "%s" of object "%s".', $this->nodes['attribute']->attributes['value'], \get_class($obj)));
+
+                $toCall = [$obj, $this->nodes['attribute']->attributes['value']];
+                if (!\is_callable($toCall)) {
+                    $property = $this->nodes['attribute']->attributes['value'];
+
+                    if (property_exists($obj, $property)) {
+                        $toCall = $obj->$property;
+                    }
+                }
+
+                if (!\is_callable($toCall)) {
+                    throw new \RuntimeException(sprintf('Unable to call method or callable property "%s" on object "%s".', $this->nodes['attribute']->attributes['value'], \get_class($obj)));
                 }
 
                 return $toCall(...array_values($this->nodes['arguments']->evaluate($functions, $values)));

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -220,7 +220,7 @@ class ExpressionLanguageTest extends TestCase
     public function testCallBadCallable()
     {
         $this->expectException('RuntimeException');
-        $this->expectExceptionMessageRegExp('/Unable to call method "\w+" of object "\w+"./');
+        $this->expectExceptionMessageRegExp('/Unable to call method or callable property "\w+" on object "\w+"./');
         $el = new ExpressionLanguage();
         $el->evaluate('foo.myfunction()', ['foo' => new \stdClass()]);
     }
@@ -256,4 +256,25 @@ class ExpressionLanguageTest extends TestCase
             ],
         ];
     }
+
+    public function testCallableProperties()
+    {
+        $el = new ExpressionLanguage();
+        $obj = new ObjectWithCallableProperty();
+        $obj->prop = static function ($value) {
+            return $value * 2;
+        };
+
+        $this->assertEquals(4, $el->evaluate(
+            'obj.prop(2)',
+            [
+                'obj' => $obj,
+            ]
+        ));
+    }
+}
+
+class ObjectWithCallableProperty
+{
+    public $prop;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Given the following expression `obj.prop(2)`, Expression Language will always assume that `prop` will be a method on `obj`. 

But what if it's a `callable` property? 

This PR will fall back to a property, when the method is not found, and checks if the property is callable.
