### PR TITLE
[FrameworkBundle] Adding better output to secrets:decrypt-to-local command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
@@ -69,10 +69,23 @@ EOF
 
         $secrets = $this->vault->list(true);
 
+        $io->comment(sprintf('%d secret%s found in the vault.', \count($secrets), 1 !== \count($secrets) ? 's' : ''));
+
+        $skipped = 0;
         if (!$input->getOption('force')) {
             foreach ($this->localVault->list() as $k => $v) {
-                unset($secrets[$k]);
+                if (isset($secrets[$k])) {
+                    ++$skipped;
+                    unset($secrets[$k]);
+                }
             }
+        }
+
+        if ($skipped > 0) {
+            $io->warning([
+                sprintf('%d secret%s already overridden in the local vault and will be skipped.', $skipped, 1 !== $skipped ? 's are' : ' is'),
+                'Use the --force flag to override these.',
+            ]);
         }
 
         foreach ($secrets as $k => $v) {
@@ -83,6 +96,7 @@ EOF
             }
 
             $this->localVault->seal($k, $v);
+            $io->note($this->localVault->getLastMessage());
         }
 
         return 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | not needed

Hi!

The `secrets:decrypt-to-local` doesn't give any output. This adds some basic details:

<img width="1280" alt="Screen Shot 2020-01-09 at 11 53 54 AM" src="https://user-images.githubusercontent.com/121003/72087704-ebe0f480-32d6-11ea-950c-c698abde783d.png">

(note the `-vvv` wasn't necessary in the command to show the output). And the `<info>`part is fixed.

Cheers!
