### PR TITLE
[Console] Fix SymfonyQuestionHelper tests sometimes failing on AppVeyor

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -145,13 +145,13 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
         );
 
         $this->assertOutputContains(<<<EOT
-qqq:
+ qqq:
   [foo   ] foo
   [żółw  ] bar
   [łabądź] baz
  > 
 EOT
-        , $output);
+        , $output, true);
     }
 
     public function testChoiceQuestionCustomPrompt()
@@ -168,9 +168,9 @@ EOT
         $this->assertOutputContains(<<<EOT
  qqq:
   [0] foo
- >ccc>
+ >ccc> 
 EOT
-        , $output);
+        , $output, true);
     }
 
     protected function getInputStream($input)
@@ -200,10 +200,15 @@ EOT
         return $mock;
     }
 
-    private function assertOutputContains($expected, StreamOutput $output)
+    private function assertOutputContains($expected, StreamOutput $output, $normalize = false)
     {
         rewind($output->getStream());
         $stream = stream_get_contents($output->getStream());
+
+        if ($normalize) {
+            $stream = str_replace(PHP_EOL, "\n", $stream);
+        }
+
         $this->assertStringContainsString($expected, $stream);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/35035
| License       | MIT
| Doc PR        | -

The test uses heredoc for the expected part. Expected line returns are `"\n"` because that's how they are written in the source code file.
However, on Windows, the console outputs `"\r\n"` (`PHP_EOL`) for new lines.
`"qqq:\r\n"` does not contain `"qqq:\n"`.

I'm still wondering why this test is not *always* failing...
