### PR TITLE
[Filesystem][FilesystemCommonTrait] Use a dedicated directory when there are no namespace

### DIFF
--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -35,6 +35,8 @@ trait FilesystemCommonTrait
                 throw new InvalidArgumentException(sprintf('Namespace contains "%s" but only characters in [-+_.A-Za-z0-9] are allowed.', $match[0]));
             }
             $directory .= \DIRECTORY_SEPARATOR.$namespace;
+        } else {
+            $directory .= \DIRECTORY_SEPARATOR.'@';
         }
         if (!file_exists($directory)) {
             @mkdir($directory, 0777, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR fixes the following edge case:
- you use a namespaced filesystem adapter with root dir `/foo` and namespace `a`: all files are written in `/foo/a` (eg: it will write `/foo/a/I/W/file`)
- you use another filesystem adapter with the same root dir but without namespace and you clear it.
- it will fail because it will try to delete the `/foo/a/I` directory (see https://github.com/symfony/symfony/pull/33921 new `scanHashDir()` method - `a` is a possible dir value (see `getFile()`) so we look for it).

The simple solution (suggested by @nicolas-grekas) is to put the "empty namespace" in a dedicated directory.

Bonus: that will fix the tests that currently always fail on AppVeyor. The file in the namespace `a` is a leftover from a previous test. Without this patch, I have the same fail on my Mac. I did not look why it currently passes on travis.