### PR TITLE
[FrameworkBundle][Cache] tag cache.app.taggable as a cache pool

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -18,6 +18,7 @@
 
         <service id="cache.app.taggable" class="Symfony\Component\Cache\Adapter\TagAwareAdapter">
             <argument type="service" id="cache.app" />
+            <tag name="cache.pool" />
         </service>
 
         <service id="cache.system" parent="cache.adapter.system" public="true">

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Cache\DependencyInjection;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -155,11 +156,12 @@ class CachePoolPass implements CompilerPassInterface
                     if ($tags[0][$attr]) {
                         $pool->addTag($this->kernelResetTag, ['method' => $tags[0][$attr]]);
                     }
-                } elseif ('namespace' !== $attr || ArrayAdapter::class !== $class) {
+                } elseif (('namespace' !== $attr || ArrayAdapter::class !== $class) && TagAwareAdapter::class !== $class && !is_subclass_of($class, TagAwareAdapter::class)) {
                     $pool->replaceArgument($i++, $tags[0][$attr]);
                 }
                 unset($tags[0][$attr]);
             }
+
             if (!empty($tags[0])) {
                 throw new InvalidArgumentException(sprintf('Invalid "%s" tag for service "%s": accepted attributes are "clearer", "provider", "name", "namespace", "default_lifetime" and "reset", found "%s".', $this->cachePoolTag, $id, implode('", "', array_keys($tags[0]))));
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34810
| License       | MIT
| Doc PR        | 

With this change the CacheCollectorPass will be able to decorate the
TagAwareAdapter and thus injects a traceable cache when a service
argument's type declaration asks for a TagAwareCacheInterface
implementation.