### PR TITLE
Avoid `stale-if-error` in FrameworkBundle's HttpCache if kernel.debug = true

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -37,7 +37,14 @@ abstract class HttpCache extends BaseHttpCache
         $this->kernel = $kernel;
         $this->cacheDir = $cacheDir;
 
-        parent::__construct($kernel, $this->createStore(), $this->createSurrogate(), array_merge(['debug' => $kernel->isDebug()], $this->getOptions()));
+        $isDebug = $kernel->isDebug();
+        $options = ['debug' => $isDebug];
+
+        if ($isDebug) {
+            $options['stale_if_error'] = 0;
+        }
+
+        parent::__construct($kernel, $this->createStore(), $this->createSurrogate(), array_merge($options, $this->getOptions()));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #24248 (maybe?)
| License       | MIT
| Doc PR        | 

When working with the `HttpCache` in development, error messages may not become visible if a `public` response has been successfully generated for the same URL before.

This is because the `HttpCache` from the `HttpKernel` component by default sets `stale_if_error` to 60 seconds.

At least when using the `HttpCache` subclass from the `FrameworkBundle`, we know about the `kernel.debug` setting and its intention to support local development. In that case, we could set the *default* `stale-if-error` value to 0.
