### PR TITLE
[DependencyInjection] Enable expressions for aliases

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -11,10 +11,20 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\ExpressionLanguage;
 use Symfony\Component\DependencyInjection\Reference;
+use function class_exists;
+use function sprintf;
+use function stripcslashes;
+use function substr;
+use function substr_replace;
 
 /**
  * Replaces aliases with actual service definitions, effectively removing these
@@ -25,6 +35,8 @@ use Symfony\Component\DependencyInjection\Reference;
 class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
 {
     private $replacements;
+    private $expressionLanguageInstance;
+    private $inExpressionUsage = false;
 
     /**
      * Process the Container to replace aliases with service definitions.
@@ -53,6 +65,20 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
             // Process new target
             $seenAliasTargets[$targetId] = true;
             try {
+                if (strpos($targetId, '=') === 0) {
+                    $service = trim($targetId, '=');
+
+                    $result = $this
+                        ->getExpressionLanguage()
+                        ->evaluate($service, ['this' => 'container', 'container' => $container]);
+
+                    $container->setAlias($targetId, \get_class($result))
+                        ->setPublic($target->isPublic())
+                        ->setPrivate($target->isPrivate());
+
+                    continue;
+                }
+
                 $definition = $container->getDefinition($targetId);
             } catch (ServiceNotFoundException $e) {
                 if ('' !== $e->getId() && '@' === $e->getId()[0]) {
@@ -90,5 +116,32 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
         }
 
         return parent::processValue($value, $isRoot);
+    }
+
+    private function getExpressionLanguage(ContainerInterface $container): ExpressionLanguage
+    {
+        if (null === $this->expressionLanguageInstance) {
+            if (!class_exists(ExpressionLanguage::class)) {
+                throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+            }
+
+            $providers = $container->getExpressionLanguageProviders();
+            $this->expressionLanguageInstance = new ExpressionLanguage(null, $providers, function (string $arg): string {
+                if ('""' === substr_replace($arg, '', 1, -1)) {
+                    $id = stripcslashes(substr($arg, 1, -1));
+                    $this->inExpressionUsage = true;
+                    $arg = $this->processValue(new Reference($id));
+                    $this->inExpressionUsage = false;
+                    if (!$arg instanceof Reference) {
+                        throw new RuntimeException(sprintf('"%s::processValue()" must return a Reference when processing an expression, %s returned for service("%s").', \get_class($this), \is_object($arg) ? \get_class($arg) : \gettype($arg), $id));
+                    }
+                    $arg = sprintf('"%s"', $arg);
+                }
+
+                return sprintf('$this->get(%s)', $arg);
+            });
+        }
+
+        return $this->expressionLanguageInstance;
     }
 }


### PR DESCRIPTION
It may be useful to have expression enabled for aliases. It turns out
that on the development process, it sometimes is too much to have
factories that don't create anything, but just decide which object to
return.

TODO:
- [ ] It is missing tests
- [ ] Need to know if that is valuable for the community

| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/roadmap):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
