### PR TITLE
[FrameworkBundle] Deprecate *not* setting the "framework.router.utf8" option

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -10,6 +10,7 @@ FrameworkBundle
 ---------------
 
  * Deprecated passing a `RouteCollectionBuiler` to `MicroKernelTrait::configureRoutes()`, type-hint `RoutingConfigurator` instead
+ * Deprecated *not* setting the "framework.router.utf8" configuration option as it will default to `true` in Symfony 6.0
 
 HttpFoundation
 --------------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -10,6 +10,7 @@ FrameworkBundle
 ---------------
 
  * `MicroKernelTrait::configureRoutes()` is now always called with a `RoutingConfigurator`
+ * The "framework.router.utf8" configuration option defaults to `true`
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Added flex-compatible default implementations for `MicroKernelTrait::registerBundles()` and `getProjectDir()`
  * Deprecated passing a `RouteCollectionBuiler` to `MicroKernelTrait::configureRoutes()`, type-hint `RoutingConfigurator` instead
  * The `TemplateController` now accepts context argument
+ * Deprecated *not* setting the "framework.router.utf8" configuration option as it will default to `true` in Symfony 6.0
 
 5.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -481,7 +481,7 @@ class Configuration implements ConfigurationInterface
                             )
                             ->defaultTrue()
                         ->end()
-                        ->booleanNode('utf8')->defaultFalse()->end()
+                        ->booleanNode('utf8')->defaultNull()->end()
                         ->arrayNode('context')
                             ->info('router request context')
                             ->addDefaultsIfNotSet()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -838,6 +838,10 @@ class FrameworkExtension extends Extension
 
         $loader->load('routing.xml');
 
+        if (null === $config['utf8']) {
+            @trigger_error('Not setting the "framework.router.utf8" configuration option is deprecated since Symfony 5.1, it will default to "true" in Symfony 6.0.', E_USER_DEPRECATED);
+        }
+
         if ($config['utf8']) {
             $container->getDefinition('routing.loader')->replaceArgument(1, ['utf8' => true]);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -412,7 +412,7 @@ class ConfigurationTest extends TestCase
                 'http_port' => 80,
                 'https_port' => 443,
                 'strict_requirements' => true,
-                'utf8' => false,
+                'utf8' => null,
                 'context' => [
                     'host' => '%router.request_context.host%',
                     'scheme' => '%router.request_context.scheme%',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -23,6 +23,7 @@ $container->loadFromExtension('framework', [
     'router' => [
         'resource' => '%kernel.project_dir%/config/routing.xml',
         'type' => 'xml',
+        'utf8' => true,
     ],
     'session' => [
         'storage_id' => 'session.storage.native',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -14,7 +14,7 @@
         <framework:esi enabled="true" />
         <framework:ssi enabled="true" />
         <framework:profiler only-exceptions="true" enabled="false" />
-        <framework:router resource="%kernel.project_dir%/config/routing.xml" type="xml" />
+        <framework:router resource="%kernel.project_dir%/config/routing.xml" type="xml" utf8="true" />
         <framework:session gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-id="session.storage.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="false" use-cookies="true" save-path="/path/to/sessions" sid-length="22" sid-bits-per-character="4" />
         <framework:request>
             <framework:format name="csv">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -16,6 +16,7 @@ framework:
     router:
         resource:     '%kernel.project_dir%/config/routing.xml'
         type:         xml
+        utf8:         true
     session:
         storage_id:      session.storage.native
         handler_id:      session.handler.native_file

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -1,6 +1,6 @@
 framework:
     secret:        test
-    router:        { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml" }
+    router:        { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation:    { enabled: true, enable_annotations: true }
     csrf_protection: true
     form: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -91,6 +91,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
         $c->register('logger', NullLogger::class);
         $c->loadFromExtension('framework', [
             'secret' => '$ecret',
+            'router' => ['utf8' => true],
         ]);
 
         $c->setParameter('halloween', 'Have a great day!');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
@@ -81,5 +81,7 @@ class FlexStyleMicroKernel extends Kernel
             ->set('stdClass', 'stdClass')
                 ->factory([$this, 'createHalloween'])
                 ->arg('$halloween', '%halloween%');
+
+        $c->extension('framework', ['router' => ['utf8' => true]]);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -140,7 +140,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
         ];
 
         $ext = new FrameworkExtension();
-        $ext->load(['framework' => ['csrf_protection' => false, 'router' => ['resource' => 'dummy']]], $container);
+        $ext->load(['framework' => ['csrf_protection' => false, 'router' => ['resource' => 'dummy', 'utf8' => true]]], $container);
 
         $ext = new SecurityExtension();
         $ext->load($config, $container);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Anonymous/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Anonymous/config.yml
@@ -1,6 +1,6 @@
 framework:
     secret: test
-    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml" }
+    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation: { enabled: true, enable_annotations: true }
     csrf_protection: true
     form: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -1,6 +1,6 @@
 framework:
     secret: test
-    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml" }
+    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation: { enabled: true, enable_annotations: true }
     csrf_protection: true
     form: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/config.yml
@@ -1,6 +1,6 @@
 framework:
     secret: test
-    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml" }
+    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     test: ~
     default_locale: en
     profiler: false

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -1,6 +1,6 @@
 framework:
     secret: test
-    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml" }
+    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml", utf8: true }
     validation: { enabled: true, enable_annotations: true }
     assets: ~
     csrf_protection: true

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -43,6 +43,7 @@ class WebProfilerBundleKernel extends Kernel
             'secret' => 'foo-secret',
             'profiler' => ['only_exceptions' => false],
             'session' => ['storage_id' => 'session.storage.mock_file'],
+            'router' => ['utf8' => true],
         ]);
 
         $containerBuilder->loadFromExtension('web_profiler', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

The goal here is to get rid of the `config/packages/routing.yaml` file in Symfony 6.
This should have no practical impact as all new apps already define this setting for 2 years.