### PR TITLE
Late Static Bindings for SetUpTearDownTrait

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV5.php
@@ -21,7 +21,7 @@ trait SetUpTearDownTraitForV5
      */
     public static function setUpBeforeClass()
     {
-        self::doSetUpBeforeClass();
+        static::doSetUpBeforeClass();
     }
 
     /**
@@ -29,7 +29,7 @@ trait SetUpTearDownTraitForV5
      */
     public static function tearDownAfterClass()
     {
-        self::doTearDownAfterClass();
+        static::doTearDownAfterClass();
     }
 
     /**
@@ -37,7 +37,7 @@ trait SetUpTearDownTraitForV5
      */
     protected function setUp()
     {
-        self::doSetUp();
+        static::doSetUp();
     }
 
     /**
@@ -45,7 +45,7 @@ trait SetUpTearDownTraitForV5
      */
     protected function tearDown()
     {
-        self::doTearDown();
+        static::doTearDown();
     }
 
     private static function doSetUpBeforeClass()

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV8.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV8.php
@@ -18,22 +18,22 @@ trait SetUpTearDownTraitForV8
 {
     public static function setUpBeforeClass(): void
     {
-        self::doSetUpBeforeClass();
+        static::doSetUpBeforeClass();
     }
 
     public static function tearDownAfterClass(): void
     {
-        self::doTearDownAfterClass();
+        static::doTearDownAfterClass();
     }
 
     protected function setUp(): void
     {
-        self::doSetUp();
+        static::doSetUp();
     }
 
     protected function tearDown(): void
     {
-        self::doTearDown();
+        static::doTearDown();
     }
 
     private static function doSetUpBeforeClass(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In one of the project I have my own TestCase class and what to use phpunit-bridge, but noticed that 
`doSetUp` and others aren't called on final class due to missing LSB

https://www.php.net/manual/en/language.oop5.late-static-bindings.php#language.oop5.late-static-bindings.usage