### PR TITLE
[Intl] Fix legacy API

### DIFF
--- a/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
@@ -42,15 +42,6 @@ class LanguageBundle extends LanguageDataProvider implements LanguageBundleInter
      */
     public function getLanguageName($language, $region = null, $displayLocale = null)
     {
-        // Some languages are translated together with their region,
-        // i.e. "en_GB" is translated as "British English"
-        if (null !== $region) {
-            try {
-                return $this->getName($language.'_'.$region, $displayLocale);
-            } catch (MissingResourceException $e) {
-            }
-        }
-
         try {
             return $this->getName($language, $displayLocale);
         } catch (MissingResourceException $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35309
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The legacy API can crash as of 4.4, due  #33148 where we split some indices which affects both the old and new API.

in 4.4 e.g. `[Names][en_US]` doesnt exist anymore, hence the $region variable became useless (we force fake a fallback now).

The data is still available in `[LocalizedNames][en_US]`, but let's be pragmatic for now and fix the BC break at least.