### PR TITLE
[HttpClient][WDT] Add missing response content

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -131,8 +131,9 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             }
 
             $debugInfo = array_diff_key($info, $baseInfo);
-            $info = array_diff_key($info, $debugInfo) + ['debug_info' => $debugInfo];
-            unset($traces[$i]['info']); // break PHP reference used by TraceableHttpClient
+            $responseContent = $trace['response_content'] ?? null;
+            $info = array_diff_key($info, $debugInfo) + ['response_content' => $responseContent, 'debug_info' => $debugInfo];
+            unset($traces[$i]['info'], $traces[$i]['response_content']); // break PHP reference used by TraceableHttpClient
             $traces[$i]['info'] = $this->cloneVar($info);
             $traces[$i]['options'] = $this->cloneVar($trace['options']);
         }

--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -131,7 +131,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             }
 
             $debugInfo = array_diff_key($info, $baseInfo);
-            $responseContent = $trace['response_content'] ?? null;
+            $responseContent = isset($trace['response_content']) ? $trace['response_content'] : null;
             $info = array_diff_key($info, $debugInfo) + ['response_content' => $responseContent, 'debug_info' => $debugInfo];
             unset($traces[$i]['info'], $traces[$i]['response_content']); // break PHP reference used by TraceableHttpClient
             $traces[$i]['info'] = $this->cloneVar($info);

--- a/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
@@ -36,7 +36,7 @@ class TraceableHttpClientTest extends TestCase
                     return true;
                 })
             )
-            ->willReturn(MockResponse::fromRequest('GET', '/foo/bar', ['options1' => 'foo'], new MockResponse()))
+            ->willReturn(MockResponse::fromRequest('GET', '/foo/bar', ['options1' => 'foo'], new MockResponse('{"foo": "bar"}')))
         ;
         $sut = new TraceableHttpClient($httpClient);
         $sut->request('GET', '/foo/bar', ['options1' => 'foo']);
@@ -47,6 +47,7 @@ class TraceableHttpClientTest extends TestCase
             'url' => '/foo/bar',
             'options' => ['options1' => 'foo'],
             'info' => [],
+            'response_content' => ['foo' => 'bar']
         ], $actualTracedRequest);
     }
 
@@ -58,6 +59,7 @@ class TraceableHttpClientTest extends TestCase
         $actualTracedRequest = $tracedRequests[0];
         $this->assertSame('GET', $actualTracedRequest['info']['http_method']);
         $this->assertSame('http://localhost:8057/', $actualTracedRequest['info']['url']);
+        $this->assertNull($actualTracedRequest['response_content']);
     }
 
     public function testItExecutesOnProgressOption()

--- a/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
@@ -47,7 +47,7 @@ class TraceableHttpClientTest extends TestCase
             'url' => '/foo/bar',
             'options' => ['options1' => 'foo'],
             'info' => [],
-            'response_content' => ['foo' => 'bar']
+            'response_content' => ['foo' => 'bar'],
         ], $actualTracedRequest);
     }
 

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -41,7 +41,7 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface
             'url' => $url,
             'options' => $options,
             'info' => &$traceInfo,
-            'response_content' => &$responseContent
+            'response_content' => &$responseContent,
         ];
         $onProgress = $options['on_progress'] ?? null;
 

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -35,11 +35,13 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
         $traceInfo = [];
+        $responseContent = null;
         $this->tracedRequests[] = [
             'method' => $method,
             'url' => $url,
             'options' => $options,
             'info' => &$traceInfo,
+            'response_content' => &$responseContent
         ];
         $onProgress = $options['on_progress'] ?? null;
 
@@ -51,7 +53,15 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface
             }
         };
 
-        return $this->client->request($method, $url, $options);
+        $response = $this->client->request($method, $url, $options);
+
+        // Try to convert response to array if possible
+        try {
+            $responseContent = $response->toArray(false);
+        } catch (\Throwable $e) {
+        }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/33015
| License       | MIT
| Doc PR        | -

DataCollector for HttpClient was added in https://github.com/symfony/symfony/pull/33015 but missing important (IMHO) thing during profiling a request to endpoint.

The PR add information about content do we get.