### PR TITLE
[Yaml] fix PHP const mapping keys using the inline notation

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -504,6 +504,11 @@ class Inline
             $isKeyQuoted = \in_array($mapping[$i], ['"', "'"], true);
             $key = self::parseScalar($mapping, $flags, [':', ' '], $i, false, [], true);
 
+            if ('!php/const' === $key) {
+                $key .= self::parseScalar($mapping, $flags, [':', ' '], $i, false, [], true);
+                $key = self::evaluateScalar($key, $flags);
+            }
+
             if (':' !== $key && false === $i = strpos($mapping, ':', $i)) {
                 break;
             }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -58,6 +58,7 @@ class InlineTest extends TestCase
             ['!php/const PHP_INT_MAX', PHP_INT_MAX],
             ['[!php/const PHP_INT_MAX]', [PHP_INT_MAX]],
             ['{ foo: !php/const PHP_INT_MAX }', ['foo' => PHP_INT_MAX]],
+            ['{ !php/const PHP_INT_MAX: foo }', [PHP_INT_MAX => 'foo']],
             ['!php/const NULL', null],
         ];
     }
@@ -93,6 +94,7 @@ class InlineTest extends TestCase
             ['!php/const:PHP_INT_MAX', PHP_INT_MAX],
             ['[!php/const:PHP_INT_MAX]', [PHP_INT_MAX]],
             ['{ foo: !php/const:PHP_INT_MAX }', ['foo' => PHP_INT_MAX]],
+            ['{ !php/const:PHP_INT_MAX: foo }', [PHP_INT_MAX => 'foo']],
             ['!php/const:NULL', null],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35179
| License       | MIT
| Doc PR        | 