### PR TITLE
[Workflow] Make many internal services as hidden

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -632,7 +632,7 @@ class FrameworkExtension extends Extension
                 if ('workflow' === $type) {
                     $transitionDefinition = new Definition(Workflow\Transition::class, [$transition['name'], $transition['from'], $transition['to']]);
                     $transitionDefinition->setPublic(false);
-                    $transitionId = sprintf('%s.transition.%s', $workflowId, $transitionCounter++);
+                    $transitionId = sprintf('.%s.transition.%s', $workflowId, $transitionCounter++);
                     $container->setDefinition($transitionId, $transitionDefinition);
                     $transitions[] = new Reference($transitionId);
                     if (isset($transition['guard'])) {
@@ -654,7 +654,7 @@ class FrameworkExtension extends Extension
                         foreach ($transition['to'] as $to) {
                             $transitionDefinition = new Definition(Workflow\Transition::class, [$transition['name'], $from, $to]);
                             $transitionDefinition->setPublic(false);
-                            $transitionId = sprintf('%s.transition.%s', $workflowId, $transitionCounter++);
+                            $transitionId = sprintf('.%s.transition.%s', $workflowId, $transitionCounter++);
                             $container->setDefinition($transitionId, $transitionDefinition);
                             $transitions[] = new Reference($transitionId);
                             if (isset($transition['guard'])) {
@@ -750,7 +750,7 @@ class FrameworkExtension extends Extension
                 $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.transition', $name), 'method' => 'onTransition']);
                 $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.enter', $name), 'method' => 'onEnter']);
                 $listener->addArgument(new Reference('logger'));
-                $container->setDefinition(sprintf('%s.listener.audit_trail', $workflowId), $listener);
+                $container->setDefinition(sprintf('.%s.listener.audit_trail', $workflowId), $listener);
             }
 
             // Add Guard Listener
@@ -779,7 +779,7 @@ class FrameworkExtension extends Extension
                     $guard->addTag('kernel.event_listener', ['event' => $eventName, 'method' => 'onTransition']);
                 }
 
-                $container->setDefinition(sprintf('%s.listener.guard', $workflowId), $guard);
+                $container->setDefinition(sprintf('.%s.listener.guard', $workflowId), $guard);
                 $container->setParameter('workflow.has_guard_listeners', true);
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -264,7 +264,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $params = $transitionsMetadataCall[1];
         $this->assertCount(2, $params);
         $this->assertInstanceOf(Reference::class, $params[0]);
-        $this->assertSame('state_machine.pull_request.transition.0', (string) $params[0]);
+        $this->assertSame('.state_machine.pull_request.transition.0', (string) $params[0]);
 
         $serviceMarkingStoreWorkflowDefinition = $container->getDefinition('workflow.service_marking_store_workflow');
         /** @var Reference $markingStoreRef */
@@ -311,7 +311,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertCount(5, $transitions);
 
-        $this->assertSame('workflow.article.transition.0', (string) $transitions[0]);
+        $this->assertSame('.workflow.article.transition.0', (string) $transitions[0]);
         $this->assertSame([
             'request_review',
             [
@@ -322,7 +322,7 @@ abstract class FrameworkExtensionTest extends TestCase
             ],
         ], $container->getDefinition($transitions[0])->getArguments());
 
-        $this->assertSame('workflow.article.transition.1', (string) $transitions[1]);
+        $this->assertSame('.workflow.article.transition.1', (string) $transitions[1]);
         $this->assertSame([
             'journalist_approval',
             [
@@ -333,7 +333,7 @@ abstract class FrameworkExtensionTest extends TestCase
             ],
         ], $container->getDefinition($transitions[1])->getArguments());
 
-        $this->assertSame('workflow.article.transition.2', (string) $transitions[2]);
+        $this->assertSame('.workflow.article.transition.2', (string) $transitions[2]);
         $this->assertSame([
             'spellchecker_approval',
             [
@@ -344,7 +344,7 @@ abstract class FrameworkExtensionTest extends TestCase
             ],
         ], $container->getDefinition($transitions[2])->getArguments());
 
-        $this->assertSame('workflow.article.transition.3', (string) $transitions[3]);
+        $this->assertSame('.workflow.article.transition.3', (string) $transitions[3]);
         $this->assertSame([
             'publish',
             [
@@ -356,7 +356,7 @@ abstract class FrameworkExtensionTest extends TestCase
             ],
         ], $container->getDefinition($transitions[3])->getArguments());
 
-        $this->assertSame('workflow.article.transition.4', (string) $transitions[4]);
+        $this->assertSame('.workflow.article.transition.4', (string) $transitions[4]);
         $this->assertSame([
             'publish',
             [
@@ -372,10 +372,10 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('workflow_with_guard_expression');
 
-        $this->assertTrue($container->hasDefinition('workflow.article.listener.guard'), 'Workflow guard listener is registered as a service');
+        $this->assertTrue($container->hasDefinition('.workflow.article.listener.guard'), 'Workflow guard listener is registered as a service');
         $this->assertTrue($container->hasParameter('workflow.has_guard_listeners'), 'Workflow guard listeners parameter exists');
         $this->assertTrue(true === $container->getParameter('workflow.has_guard_listeners'), 'Workflow guard listeners parameter is enabled');
-        $guardDefinition = $container->getDefinition('workflow.article.listener.guard');
+        $guardDefinition = $container->getDefinition('.workflow.article.listener.guard');
         $this->assertSame([
             [
                 'event' => 'workflow.article.guard.publish',
@@ -385,9 +385,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $guardsConfiguration = $guardDefinition->getArgument(0);
         $this->assertTrue(1 === \count($guardsConfiguration), 'Workflow guard configuration contains one element per transition name');
         $transitionGuardExpressions = $guardsConfiguration['workflow.article.guard.publish'];
-        $this->assertSame('workflow.article.transition.3', (string) $transitionGuardExpressions[0]->getArgument(0));
+        $this->assertSame('.workflow.article.transition.3', (string) $transitionGuardExpressions[0]->getArgument(0));
         $this->assertSame('!!true', $transitionGuardExpressions[0]->getArgument(1));
-        $this->assertSame('workflow.article.transition.4', (string) $transitionGuardExpressions[1]->getArgument(0));
+        $this->assertSame('.workflow.article.transition.4', (string) $transitionGuardExpressions[1]->getArgument(0));
         $this->assertSame('!!false', $transitionGuardExpressions[1]->getArgument(1));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35197
| License       | MIT
| Doc PR        | 

I "removed":

* transitions
* auto-generated guard listener  (when enable via the configuration)
* auto-generated audit trail listener (when enable via the configuration)

I kept
* the registry
* the workflow (of course)
* its definition: I know people are using it
* `workflow.twig_extension` the twig extension because all others twig extensions are not hidden - but could IMHO
* the default marking store 
* the command to dump the workflow (SVG)
* The local expression language
* abstract workflow definition for the workflow and state machine