### PR TITLE
[Workflow] Added a way to not fire the announce event

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Added context to `TransitionException` and its child classes whenever they are thrown in `Workflow::apply()`
  * Added `Registry::has()` to check if a workflow exists
+ * Added support for `$context[Workflow::DISABLE_ANNOUNCE_EVENT] = true` when calling `workflow->apply()` to not fire the announce event
 
 5.0.0
 -----

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -426,6 +426,30 @@ class WorkflowTest extends TestCase
         $this->assertSame($eventNameExpected, $eventDispatcher->dispatchedEvents);
     }
 
+    public function provideApplyWithEventDispatcherForAnnounceTests()
+    {
+        yield [false, [Workflow::DISABLE_ANNOUNCE_EVENT => true]];
+        yield [true, [Workflow::DISABLE_ANNOUNCE_EVENT => false]];
+        yield [true, []];
+    }
+
+    /** @dataProvider provideApplyWithEventDispatcherForAnnounceTests */
+    public function testApplyWithEventDispatcherForAnnounce(bool $fired, array $context)
+    {
+        $definition = $this->createComplexWorkflowDefinition();
+        $subject = new Subject();
+        $eventDispatcher = new EventDispatcherMock();
+        $workflow = new Workflow($definition, new MethodMarkingStore(), $eventDispatcher, 'workflow_name');
+
+        $workflow->apply($subject, 't1', $context);
+
+        if ($fired) {
+            $this->assertContains('workflow.workflow_name.announce', $eventDispatcher->dispatchedEvents);
+        } else {
+            $this->assertNotContains('workflow.workflow_name.announce', $eventDispatcher->dispatchedEvents);
+        }
+    }
+
     public function testApplyDoesNotTriggerExtraGuardWithEventDispatcher()
     {
         $transitions[] = new Transition('a-b', 'a', 'b');

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -33,6 +33,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class Workflow implements WorkflowInterface
 {
+    public const DISABLE_ANNOUNCE_EVENT = 'workflow_disable_announce_event';
+
     private $definition;
     private $markingStore;
     private $dispatcher;
@@ -207,7 +209,9 @@ class Workflow implements WorkflowInterface
 
             $this->completed($subject, $transition, $marking);
 
-            $this->announce($subject, $transition, $marking);
+            if (!($context[self::DISABLE_ANNOUNCE_EVENT] ?? false)) {
+                $this->announce($subject, $transition, $marking);
+            }
         }
 
         return $marking;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35286
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/12942