### PR TITLE
[FrameworkBundle] Set booted flag to false when test kernel is unset

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -45,6 +45,7 @@ abstract class KernelTestCase extends TestCase
     {
         static::ensureKernelShutdown();
         static::$kernel = null;
+        static::$booted = false;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When `KernelTestCase::$kernel` is set to `null` `KernelTestCase::$booted` is not reseted and recreating the client is not possible because it relies on `booted` flag
