### PR TITLE
Check if the event is from the contract in legacy dispatcher

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -150,8 +150,8 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
             $event = $eventName ?? new Event();
             $eventName = $swap;
 
-            if (!$event instanceof Event) {
-                throw new \TypeError(sprintf('Argument 1 passed to "%s::dispatch()" must be an instance of %s, %s given.', EventDispatcherInterface::class, Event::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+            if (!$event instanceof Event && !$event instanceof ContractsEvent) {
+                throw new \TypeError(sprintf('Argument 1 passed to "%s::dispatch()" must be an instance of either %s or %s, %s given.', EventDispatcherInterface::class, Event::class, ContractsEvent::class, \is_object($event) ? \get_class($event) : \gettype($event)));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

This adds in the condition of the traceable event dispatcher, when called in the legacy way (`$dispatcher->dispatch(string, EventContract)`) that it doesn't fail the check if an `Event` from the contract in passed instead of the one from the component.

I wondered if it was not done because the "legacy call" should or should not support the contract ?