### PR TITLE
[FrameworkBundle] Remove entities from class map as it is optional

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -325,7 +325,6 @@ class FrameworkExtension extends Extension
 
         $this->addAnnotatedClassesToCompile([
             '**\\Controller\\',
-            '**\\Entity\\',
 
             // Added explicitly so that we don't rely on the class map being dumped to make it work
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This is interesting situation as this is not really a bug fix and not really a new feature.
Not quite sure if it could break something..

But I am certain that this entity import to class map is in the wrong place.
This could be moved to `doctrine/doctrine-bundle` where it check for orm presence.

My issue comes with PHP 7.4 and class preloading. Project has no doctrine ORM (using ODM instead), but other vendors has entities and those entities are preloaded now. If those entities are missing some dependencies - preloading fails with exceptions. This was not an issue until PHP 7.4, but now I have to work around this forced entity preloading. Why should Framework bundle even care about entities at all?

My temporary solution to this:
```
class Kernel extends BaseKernel
{
    /**
     * {@inheritDoc}
     */
    public function setAnnotatedClassCache(array $annotatedClasses)
    {
        $filteredArray = array_filter(
            $annotatedClasses,
            function (string $class) {
                return !preg_match("#Entity#", $class);
            }
        );

        parent::setAnnotatedClassCache($filteredArray);
    }
}