### PR TITLE
[Security] Fix RememberMe with null password

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -91,12 +91,12 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
     /**
      * Generates the cookie value.
      *
-     * @param int    $expires  The Unix timestamp when the cookie expires
-     * @param string $password The encoded password
+     * @param int         $expires  The Unix timestamp when the cookie expires
+     * @param string|null $password The encoded password
      *
      * @return string
      */
-    protected function generateCookieValue(string $class, string $username, int $expires, string $password)
+    protected function generateCookieValue(string $class, string $username, int $expires, ?string $password)
     {
         // $username is encoded because it might contain COOKIE_DELIMITER,
         // we assume other values don't
@@ -111,12 +111,12 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
     /**
      * Generates a hash for the cookie to ensure it is not being tampered with.
      *
-     * @param int    $expires  The Unix timestamp when the cookie expires
-     * @param string $password The encoded password
+     * @param int         $expires  The Unix timestamp when the cookie expires
+     * @param string|null $password The encoded password
      *
      * @return string
      */
-    protected function generateCookieHash(string $class, string $username, int $expires, string $password)
+    protected function generateCookieHash(string $class, string $username, int $expires, ?string $password)
     {
         return hash_hmac('sha256', $class.self::COOKIE_DELIMITER.$username.self::COOKIE_DELIMITER.$expires.self::COOKIE_DELIMITER.$password, $this->getSecret());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | NA
| License       | MIT
| Doc PR        | NA

From `UserInterface` the method getPassword may return null, while generateCookieHash requires a string. 
This PR changes the signature of the methods to allows null password