### PR TITLE
[String] add missing encoding when calling mb_ord()

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -172,7 +172,17 @@ abstract class AbstractUnicodeString extends AbstractString
     {
         $str = $this->slice($offset, 1);
 
-        return '' === $str->string ? [] : array_map('mb_ord', preg_split('//u', $str->string, -1, PREG_SPLIT_NO_EMPTY));
+        if ('' === $str->string) {
+            return [];
+        }
+
+        $codePoints = [];
+
+        foreach (preg_split('//u', $str->string, -1, PREG_SPLIT_NO_EMPTY) as $c) {
+            $codePoints[] = mb_ord($c, 'UTF-8');
+        }
+
+        return $codePoints;
     }
 
     public function folded(bool $compat = true): parent

--- a/src/Symfony/Component/String/CodePointString.php
+++ b/src/Symfony/Component/String/CodePointString.php
@@ -79,7 +79,7 @@ class CodePointString extends AbstractUnicodeString
     {
         $str = $offset ? $this->slice($offset, 1) : $this;
 
-        return '' === $str->string ? [] : [mb_ord($str->string)];
+        return '' === $str->string ? [] : [mb_ord($str->string, 'UTF-8')];
     }
 
     public function endsWith($suffix): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -