### PR TITLE
[Security] Fix RememberMe with null password

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -89,10 +89,10 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
     /**
      * Generates the cookie value.
      *
-     * @param string $class
-     * @param string $username The username
-     * @param int    $expires  The Unix timestamp when the cookie expires
-     * @param string $password The encoded password
+     * @param string      $class
+     * @param string      $username The username
+     * @param int         $expires  The Unix timestamp when the cookie expires
+     * @param string|null $password The encoded password
      *
      * @return string
      */
@@ -111,10 +111,10 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
     /**
      * Generates a hash for the cookie to ensure it is not being tampered with.
      *
-     * @param string $class
-     * @param string $username The username
-     * @param int    $expires  The Unix timestamp when the cookie expires
-     * @param string $password The encoded password
+     * @param string      $class
+     * @param string      $username The username
+     * @param int         $expires  The Unix timestamp when the cookie expires
+     * @param string|null $password The encoded password
      *
      * @return string
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | NA
| License       | MIT
| Doc PR        | NA

From `UserInterface` the method getPassword may return null, while generateCookieHash requires a string. 
This PR changes the signature of the methods to allows null password

Similar to #35335 for branch 3.4