### PR TITLE
Revert #34797 "Fixed translations file dumper behavior" and fix #34713

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
@@ -67,37 +67,36 @@ abstract class FileDumper implements DumperInterface
             throw new InvalidArgumentException('The file dumper needs a path option.');
         }
 
-        $hasMessageFormatter = class_exists(\MessageFormatter::class);
-
         // save a file for each domain
         foreach ($messages->getDomains() as $domain) {
-            if ($hasMessageFormatter) {
-                $defaultDomain = $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX;
-                $altDomain = $domain;
-            } else {
-                $defaultDomain = $domain;
-                $altDomain = $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX;
-            }
-            $defaultPath = $options['path'].'/'.$this->getRelativePath($defaultDomain, $messages->getLocale());
-            $altPath = $options['path'].'/'.$this->getRelativePath($altDomain, $messages->getLocale());
-
-            if (!file_exists($defaultPath) && file_exists($altPath)) {
-                [$defaultPath, $altPath] = [$altPath, $defaultPath];
-            }
-
-            if (!file_exists($defaultPath)) {
-                $directory = \dirname($defaultPath);
+            $fullpath = $options['path'].'/'.$this->getRelativePath($domain, $messages->getLocale());
+            if (!file_exists($fullpath)) {
+                $directory = \dirname($fullpath);
                 if (!file_exists($directory) && !@mkdir($directory, 0777, true)) {
                     throw new RuntimeException(sprintf('Unable to create directory "%s".', $directory));
                 }
             }
 
-            if (file_exists($altPath)) {
-                // clear alternative translation file
-                file_put_contents($altPath, $this->formatCatalogue(new MessageCatalogue($messages->getLocale()), $altDomain, $options));
+            $intlDomain = $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX;
+            $intlMessages = $messages->all($intlDomain);
+
+            if ($intlMessages) {
+                $intlPath = $options['path'].'/'.$this->getRelativePath($intlDomain, $messages->getLocale());
+                file_put_contents($intlPath, $this->formatCatalogue($messages, $intlDomain, $options));
+
+                $messages->replace([], $intlDomain);
+
+                try {
+                    if ($messages->all($domain)) {
+                        file_put_contents($fullpath, $this->formatCatalogue($messages, $domain, $options));
+                    }
+                    continue;
+                } finally {
+                    $messages->replace($intlMessages, $intlDomain);
+                }
             }
 
-            file_put_contents($defaultPath, $this->formatCatalogue($messages, $domain, $options));
+            file_put_contents($fullpath, $this->formatCatalogue($messages, $domain, $options));
         }
     }
 

--- a/src/Symfony/Component/Translation/Tests/Dumper/FileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/FileDumperTest.php
@@ -27,15 +27,11 @@ class FileDumperTest extends TestCase
         $dumper = new ConcreteFileDumper();
         $dumper->dump($catalogue, ['path' => $tempDir]);
 
-        $suffix = class_exists(\MessageFormatter::class) ? '+intl-icu' : '';
-        $this->assertFileExists($tempDir."/messages$suffix.en.concrete");
+        $this->assertFileExists($tempDir.'/messages.en.concrete');
 
-        @unlink($tempDir."/messages$suffix.en.concrete");
+        @unlink($tempDir.'/messages.en.concrete');
     }
 
-    /**
-     * @requires extension intl
-     */
     public function testDumpIntl()
     {
         $tempDir = sys_get_temp_dir();
@@ -46,11 +42,13 @@ class FileDumperTest extends TestCase
         $catalogue->add(['bar' => 'foo'], 'd2+intl-icu');
 
         $dumper = new ConcreteFileDumper();
+        @unlink($tempDir.'/d2.en.concrete');
         $dumper->dump($catalogue, ['path' => $tempDir]);
 
-        $this->assertFileNotExists($tempDir.'/d1.en.concrete');
+        $this->assertStringEqualsFile($tempDir.'/d1.en.concrete', 'foo=bar');
+        @unlink($tempDir.'/d1.en.concrete');
 
-        $this->assertStringEqualsFile($tempDir.'/d1+intl-icu.en.concrete', 'bar=foo&foo=bar');
+        $this->assertStringEqualsFile($tempDir.'/d1+intl-icu.en.concrete', 'bar=foo');
         @unlink($tempDir.'/d1+intl-icu.en.concrete');
 
         $this->assertFileNotExists($tempDir.'/d2.en.concrete');
@@ -62,8 +60,7 @@ class FileDumperTest extends TestCase
     {
         $tempDir = sys_get_temp_dir();
         $translationsDir = $tempDir.'/test/translations';
-        $suffix = class_exists(\MessageFormatter::class) ? '+intl-icu' : '';
-        $file = $translationsDir."/messages$suffix.en.concrete";
+        $file = $translationsDir.'/messages.en.concrete';
 
         $catalogue = new MessageCatalogue('en');
         $catalogue->add(['foo' => 'bar']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35264
| License       | MIT
| Doc PR        | -

Revert https://github.com/symfony/symfony/pull/34797

See also https://github.com/symfony/symfony/issues/35328

It's very likely that the new way will be completely different from this one that is being reverted. That's why I'm reverting rather than fixing it.