### PR TITLE
[Validator] Add option "allowNull" on Type constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added the `Hostname` constraint and validator
+ * added option `allowNull` to Type constraint
 
 5.0.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/Type.php
+++ b/src/Symfony/Component/Validator/Constraints/Type.php
@@ -29,6 +29,7 @@ class Type extends Constraint
 
     public $message = 'This value should be of type {{ type }}.';
     public $type;
+    public $allowNull = true;
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -29,11 +29,19 @@ class TypeValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Type::class);
         }
 
+        $types = (array) $constraint->type;
+
         if (null === $value) {
+            if (!$constraint->allowNull) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', 'null')
+                    ->setParameter('{{ type }}', implode('|', $types))
+                    ->setCode(Type::INVALID_TYPE_ERROR)
+                    ->addViolation();
+            }
+
             return;
         }
-
-        $types = (array) $constraint->type;
 
         foreach ($types as $type) {
             $type = strtolower($type);

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -33,6 +33,28 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testNullIsValidIfAllowNullTrue()
+    {
+        $constraint = new Type(['type' => 'integer', 'allowNull' => true]);
+
+        $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testNullIsNotValidIfAllowNullFalse()
+    {
+        $constraint = new Type(['type' => 'integer', 'allowNull' => false]);
+
+        $this->validator->validate(null, $constraint);
+
+        $this->buildViolation($constraint->message)
+            ->setParameter('{{ value }}', 'null')
+            ->setParameter('{{ type }}', 'integer')
+            ->setCode(Type::INVALID_TYPE_ERROR)
+            ->assertRaised();
+    }
+
     public function testEmptyIsValidIfString()
     {
         $constraint = new Type(['type' => 'string']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | On the way

This PR lets you opt-in to more strict validation of the type. 

```php
/**
 * @Assert\Type("string")
 */
private $foo;
```

After validation `$foo` can be null or string. 

This PR adds the feature to write: 
```php
/**
 * @Assert\Type("string", allowNull = false)
 */
private $foo;
```

Using "allowNull" is consistent with [NotBlank's constraint](https://symfony.com/blog/new-in-symfony-4-3-improved-the-notblank-validator).