### PR TITLE
[Filesystem] chown and chgrp should also accept int as owner and group

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -207,10 +207,11 @@ class Filesystem
      * Change the owner of an array of files or directories.
      *
      * @param string|iterable $files A filename, an array of files, or a \Traversable instance to change owner
+     * @param string|int      $user  A user name or number
      *
      * @throws IOException When the change fails
      */
-    public function chown($files, string $user, bool $recursive = false)
+    public function chown($files, $user, bool $recursive = false)
     {
         foreach ($this->toIterable($files) as $file) {
             if ($recursive && is_dir($file) && !is_link($file)) {
@@ -232,10 +233,11 @@ class Filesystem
      * Change the group of an array of files or directories.
      *
      * @param string|iterable $files A filename, an array of files, or a \Traversable instance to change group
+     * @param string|int      $group A group name or number
      *
      * @throws IOException When the change fails
      */
-    public function chgrp($files, string $group, bool $recursive = false)
+    public function chgrp($files, $group, bool $recursive = false)
     {
         foreach ($this->toIterable($files) as $file) {
             if ($recursive && is_dir($file) && !is_link($file)) {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -521,7 +521,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFilePermissions(753, $subdirectory);
     }
 
-    public function testChown()
+    public function testChownByName()
     {
         $this->markAsSkippedIfPosixIsMissing();
 
@@ -534,7 +534,20 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertSame($owner, $this->getFileOwner($dir));
     }
 
-    public function testChownRecursive()
+    public function testChownById()
+    {
+        $this->markAsSkippedIfPosixIsMissing();
+
+        $dir = $this->workspace.\DIRECTORY_SEPARATOR.'dir';
+        mkdir($dir);
+
+        $ownerId = $this->getFileOwnerId($dir);
+        $this->filesystem->chown($dir, $ownerId);
+
+        $this->assertSame($ownerId, $this->getFileOwnerId($dir));
+    }
+
+    public function testChownRecursiveByName()
     {
         $this->markAsSkippedIfPosixIsMissing();
 
@@ -547,6 +560,21 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chown($dir, $owner, true);
 
         $this->assertSame($owner, $this->getFileOwner($file));
+    }
+
+    public function testChownRecursiveById()
+    {
+        $this->markAsSkippedIfPosixIsMissing();
+
+        $dir = $this->workspace.\DIRECTORY_SEPARATOR.'dir';
+        mkdir($dir);
+        $file = $dir.\DIRECTORY_SEPARATOR.'file';
+        touch($file);
+
+        $ownerId = $this->getFileOwnerId($dir);
+        $this->filesystem->chown($dir, $ownerId, true);
+
+        $this->assertSame($ownerId, $this->getFileOwnerId($file));
     }
 
     public function testChownSymlink()
@@ -624,7 +652,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chown($dir, 'user'.time().mt_rand(1000, 9999));
     }
 
-    public function testChgrp()
+    public function testChgrpByName()
     {
         $this->markAsSkippedIfPosixIsMissing();
 
@@ -635,6 +663,19 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chgrp($dir, $group);
 
         $this->assertSame($group, $this->getFileGroup($dir));
+    }
+
+    public function testChgrpById()
+    {
+        $this->markAsSkippedIfPosixIsMissing();
+
+        $dir = $this->workspace.\DIRECTORY_SEPARATOR.'dir';
+        mkdir($dir);
+
+        $groupId = $this->getFileGroupId($dir);
+        $this->filesystem->chgrp($dir, $groupId);
+
+        $this->assertSame($groupId, $this->getFileGroupId($dir));
     }
 
     public function testChgrpRecursive()
@@ -652,7 +693,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertSame($group, $this->getFileGroup($file));
     }
 
-    public function testChgrpSymlink()
+    public function testChgrpSymlinkByName()
     {
         $this->markAsSkippedIfSymlinkIsMissing();
 
@@ -667,6 +708,23 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->chgrp($link, $group);
 
         $this->assertSame($group, $this->getFileGroup($link));
+    }
+
+    public function testChgrpSymlinkById()
+    {
+        $this->markAsSkippedIfSymlinkIsMissing();
+
+        $file = $this->workspace.\DIRECTORY_SEPARATOR.'file';
+        $link = $this->workspace.\DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
+
+        $this->filesystem->symlink($file, $link);
+
+        $groupId = $this->getFileGroupId($link);
+        $this->filesystem->chgrp($link, $groupId);
+
+        $this->assertSame($groupId, $this->getFileGroupId($link));
     }
 
     public function testChgrpLink()

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -105,21 +105,36 @@ class FilesystemTestCase extends TestCase
         );
     }
 
-    protected function getFileOwner($filepath)
+    protected function getFileOwnerId($filepath)
     {
         $this->markAsSkippedIfPosixIsMissing();
 
         $infos = stat($filepath);
 
-        return ($datas = posix_getpwuid($infos['uid'])) ? $datas['name'] : null;
+        return $infos['uid'];
+    }
+
+    protected function getFileOwner($filepath)
+    {
+        $this->markAsSkippedIfPosixIsMissing();
+
+        return ($datas = posix_getpwuid($this->getFileOwnerId($filepath))) ? $datas['name'] : null;
+    }
+
+    protected function getFileGroupId($filepath)
+    {
+        $this->markAsSkippedIfPosixIsMissing();
+
+        $infos = stat($filepath);
+
+        return $infos['gid'];
     }
 
     protected function getFileGroup($filepath)
     {
         $this->markAsSkippedIfPosixIsMissing();
 
-        $infos = stat($filepath);
-        if ($datas = posix_getgrgid($infos['gid'])) {
+        if ($datas = posix_getgrgid($this->getFileGroupId($filepath))) {
             return $datas['name'];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0 for bug fixes
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

Both [chown](https://www.php.net/manual/en/function.chown.php) and [chgrp](https://www.php.net/manual/en/function.chgrp.php) accept both `string` for username and `int` for user id.

The string typehint was only in the docblock till 4.4, so it was non-blocking.