### PR TITLE
[Yaml] Support Binary int notation

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added `yaml-lint` binary.
+ * Added support for binary int notation.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -634,9 +634,18 @@ class Inline
                         return '0' == $scalar[1] ? -octdec(substr($scalar, 1)) : (($raw === (string) $cast) ? $cast : $raw);
                     case is_numeric($scalar):
                     case Parser::preg_match(self::getHexRegex(), $scalar):
+                    case Parser::preg_match(self::getBinRegex(), $scalar):
                         $scalar = str_replace('_', '', $scalar);
 
-                        return '0x' === $scalar[0].$scalar[1] ? hexdec($scalar) : (float) $scalar;
+                        if ('0x' === $scalar[0].$scalar[1]) {
+                            return hexdec($scalar);
+                        }
+
+                        if ('0b' === $scalar[0].$scalar[1]) {
+                            return bindec($scalar);
+                        }
+
+                        return (float) $scalar;
                     case '.inf' === $scalarLower:
                     case '.nan' === $scalarLower:
                         return -log(0);
@@ -749,5 +758,13 @@ EOF;
     private static function getHexRegex(): string
     {
         return '~^0x[0-9a-f_]++$~i';
+    }
+
+    /**
+     * Gets a regex that matches a YAML number in binary notation.
+     */
+    private static function getBinRegex(): string
+    {
+        return '~^0b[01]++$~i';
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -736,4 +736,9 @@ class InlineTest extends TestCase
             'negative octal number' => [-28, '-034'],
         ];
     }
+
+    public function testParseBinaryInt()
+    {
+        self::assertSame(0b010, Inline::parse('0b010'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix #35357
| License       | MIT
| Doc PR        | Not yet written

As said in #35357, in the yaml spec 1.1, which is superseeded by the 1.2 spec, there is a support for the binary int notation. This PR adds its support.