### PR TITLE
[Yaml] Deprecate using the object and const tag without a value

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -40,3 +40,8 @@ Routing
 -------
 
  * Deprecated `RouteCollectionBuilder` in favor of `RoutingConfigurator`.
+
+Yaml
+----
+
+ * Deprecated using the `!php/object` and `!php/const` tags without a value.

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added `yaml-lint` binary.
+ * Deprecated using the `!php/object` and `!php/const` tags without a value.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -590,6 +590,8 @@ class Inline
                     case 0 === strpos($scalar, '!php/object'):
                         if (self::$objectSupport) {
                             if (!isset($scalar[12])) {
+                                @trigger_error('Using the !php/object tag without a value is deprecated since Symfony 5.1.', E_USER_DEPRECATED);
+
                                 return false;
                             }
 
@@ -604,6 +606,8 @@ class Inline
                     case 0 === strpos($scalar, '!php/const'):
                         if (self::$constantSupport) {
                             if (!isset($scalar[11])) {
+                                @trigger_error('Using the !php/const tag without a value is deprecated since Symfony 5.1.', E_USER_DEPRECATED);
+
                                 return '';
                             }
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -740,6 +740,10 @@ class InlineTest extends TestCase
 
     /**
      * @dataProvider phpObjectTagWithEmptyValueProvider
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation Using the !php/object tag without a value is deprecated since Symfony 5.1.
      */
     public function testPhpObjectWithEmptyValue($expected, $value)
     {
@@ -760,6 +764,10 @@ class InlineTest extends TestCase
 
     /**
      * @dataProvider phpConstTagWithEmptyValueProvider
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation Using the !php/const tag without a value is deprecated since Symfony 5.1.
      */
     public function testPhpConstTagWithEmptyValue($expected, $value)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/pull/35332#discussion_r366757204
| License       | MIT
| Doc PR        | -

WIP because it needs 3.4 merged up into master + https://github.com/symfony/symfony/pull/35332.