### PR TITLE
[Translation] prefer intl domain when adding messages to catalogue

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -153,15 +153,21 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function add(array $messages, string $domain = 'messages')
     {
+        $intlDomain = $domain;
+        if (false === mb_strpos($intlDomain, self::INTL_DOMAIN_SUFFIX)) {
+            $intlDomain .= self::INTL_DOMAIN_SUFFIX;
+        }
+        if (!isset($this->messages[$intlDomain])) {
+            $this->messages[$intlDomain] = [];
+        }
         if (!isset($this->messages[$domain])) {
-            $this->messages[$domain] = $messages;
-        } elseif (isset($this->messages[$domain.self::INTL_DOMAIN_SUFFIX])) {
-            foreach ($messages as $id => $message) {
-                $this->messages[$domain.self::INTL_DOMAIN_SUFFIX][$id] = $message;
-            }
-        } else {
-            foreach ($messages as $id => $message) {
+            $this->messages[$domain] = [];
+        }
+        foreach ($messages as $id => $message) {
+            if (isset($this->messages[$domain][$id])) {
                 $this->messages[$domain][$id] = $message;
+            } else {
+                $this->messages[$intlDomain][$id] = $message;
             }
         }
     }

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -155,6 +155,10 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
     {
         if (!isset($this->messages[$domain])) {
             $this->messages[$domain] = $messages;
+        } elseif (isset($this->messages[$domain.self::INTL_DOMAIN_SUFFIX])) {
+            foreach ($messages as $id => $message) {
+                $this->messages[$domain.self::INTL_DOMAIN_SUFFIX][$id] = $message;
+            }
         } else {
             foreach ($messages as $id => $message) {
                 $this->messages[$domain][$id] = $message;

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -164,10 +164,10 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             $this->messages[$domain] = [];
         }
         foreach ($messages as $id => $message) {
-            if (isset($this->messages[$domain][$id])) {
-                $this->messages[$domain][$id] = $message;
-            } else {
+            if (isset($this->messages[$intlDomain][$id])) {
                 $this->messages[$intlDomain][$id] = $message;
+            } else {
+                $this->messages[$domain][$id] = $message;
             }
         }
     }

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -161,7 +161,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             $intlDomain .= self::INTL_DOMAIN_SUFFIX;
         }
         foreach ($messages as $id => $message) {
-            if (isset($this->messages[$intlDomain]) && array_key_exists($id, $this->messages[$intlDomain])) {
+            if (isset($this->messages[$intlDomain]) && \array_key_exists($id, $this->messages[$intlDomain])) {
                 $this->messages[$intlDomain][$id] = $message;
             } else {
                 $this->messages[$domain][$id] = $message;

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -153,15 +153,12 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function add(array $messages, string $domain = 'messages')
     {
+        if (!isset($this->messages[$domain])) {
+            $this->messages[$domain] = [];
+        }
         $intlDomain = $domain;
         if (false === mb_strpos($intlDomain, self::INTL_DOMAIN_SUFFIX)) {
             $intlDomain .= self::INTL_DOMAIN_SUFFIX;
-        }
-        if (!isset($this->messages[$intlDomain])) {
-            $this->messages[$intlDomain] = [];
-        }
-        if (!isset($this->messages[$domain])) {
-            $this->messages[$domain] = [];
         }
         foreach ($messages as $id => $message) {
             if (isset($this->messages[$intlDomain][$id])) {

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -161,7 +161,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             $intlDomain .= self::INTL_DOMAIN_SUFFIX;
         }
         foreach ($messages as $id => $message) {
-            if (isset($this->messages[$intlDomain][$id])) {
+            if (isset($this->messages[$intlDomain]) && array_key_exists($id, $this->messages[$intlDomain])) {
                 $this->messages[$intlDomain][$id] = $message;
             } else {
                 $this->messages[$domain][$id] = $message;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR ensures that when adding translations to a catalogue using the `add(array $messages, string $domain = 'messages')` method internally the intl icu domain is checked first.

Otherwise it could happen that existing messages in e.g. `messages+intl-icu` are not updated but the same keys are added to `messages`.
