### PR TITLE
[Translation] Support name attribute on the xliff2 translator loader

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * added support for `name` attribute on `unit` element from xliff2 to be used as a translation key instead of always the `source` element
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -135,11 +135,12 @@ class XliffFileLoader implements LoaderInterface
 
         foreach ($xml->xpath('//xliff:unit') as $unit) {
             foreach ($unit->segment as $segment) {
-                $source = $segment->source;
+                $attributes = $unit->attributes();
+                $source = $attributes['name'] ?? $segment->source;
 
                 // If the xlf file has another encoding specified, try to convert it because
                 // simple_xml will always return utf-8 encoded values
-                $target = $this->utf8ToCharset((string) (isset($segment->target) ? $segment->target : $source), $encoding);
+                $target = $this->utf8ToCharset((string) ($segment->target ?? $segment->source), $encoding);
 
                 $catalogue->set((string) $source, $target, $domain);
 

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -314,4 +314,12 @@ class XliffFileLoaderTest extends TestCase
             $catalogue->getMetadata('test', 'domain1')
         );
     }
+
+    public function testLoadVersion2WithName()
+    {
+        $loader = new XliffFileLoader();
+        $catalogue = $loader->load(__DIR__.'/../fixtures/resources-2.0-name.xlf', 'en', 'domain1');
+
+        $this->assertEquals(['foo' => 'bar', 'bar' => 'baz', 'baz' => 'foo', 'qux' => 'qux source'], $catalogue->all('domain1'));
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources-2.0-name.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources-2.0-name.xlf
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US">
+    <file id="f1" original="Graphic Example.psd">
+        <unit id="1" name="foo">
+            <segment>
+                <source></source>
+                <target>bar</target>
+            </segment>
+        </unit>
+        <unit id="2" name="bar">
+            <segment>
+                <source>bar source</source>
+                <target>baz</target>
+            </segment>
+        </unit>
+        <unit id="3">
+            <segment>
+                <source>baz</source>
+                <target>foo</target>
+            </segment>
+        </unit>
+        <unit id="4" name="qux">
+            <segment>
+                <source>qux source</source>
+            </segment>
+        </unit>
+    </file>
+</xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Tickets       | Fix #32048 
| License       | MIT
| Doc PR        | not done yet

Support using the `name` attribute on the `unit` element in xliff 2.0 to use as the "translation key" rather than always relying on the `<source>` content, as was done on the xliff 1.2.