### PR TITLE
[Serializer] Add `name_converter` flag and use an array of name converters

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -23,3 +23,8 @@ Routing
 -------
 
  * Deprecated `RouteCollectionBuilder` in favor of `RoutingConfigurator`.
+
+Serializer
+----------
+
+ * Deprecated passing a name converter directly to the second argument of the constructor of `AbstractNormalizer`, pass an array of name converters instead.

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -72,7 +72,10 @@
 
         <service id="serializer.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer">
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
-            <argument type="service" id="serializer.name_converter.metadata_aware" />
+            <argument type="collection">
+                <argument type="service" id="serializer.name_converter.metadata_aware" />
+                <argument type="service" id="serializer.name_converter.camel_case_to_snake_case" />
+            </argument>
             <argument type="service" id="serializer.property_accessor" />
             <argument type="service" id="property_info" on-invalid="ignore" />
             <argument type="service" id="serializer.mapping.class_discriminator_resolver" on-invalid="ignore" />

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----
 
  * added support for scalar values denormalization
+ * changed the name converter constructor argument in normalizers to an array of name converters
+ * added `AbstractNormalizer::NAME_CONVERTER` constant to set the name converter to use in context
 
 5.0.0
 -----

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -19,7 +19,6 @@ use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
-use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Converts between objects and arrays using the PropertyAccess component.
@@ -34,7 +33,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
     private $objectClassResolver;
 
-    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = [])
+    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, /* array */ $nameConverter/*s*/ = [], PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = [])
     {
         if (!class_exists(PropertyAccess::class)) {
             throw new LogicException('The ObjectNormalizer class requires the "PropertyAccess" component. Install "symfony/property-access" to use it.');

--- a/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
@@ -44,7 +44,7 @@ class DeserializeNestedArrayOfObjectsTest extends TestCase
 }
 EOF;
         $serializer = new Serializer([
-            new ObjectNormalizer(null, null, null, new PhpDocExtractor()),
+            new ObjectNormalizer(null, [], null, new PhpDocExtractor()),
             new ArrayDenormalizer(),
         ], ['json' => new JsonEncoder()]);
         //WHEN

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -133,5 +134,14 @@ class AbstractNormalizerTest extends TestCase
         foreach ($dummy->getFoo() as $foo) {
             $this->assertInstanceOf(Dummy::class, $foo);
         }
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The 2nd constructor argument of the class "Symfony\Component\Serializer\Normalizer\AbstractNormalizer" should be an array of name converters, using a name converter directly or null is deprecated since Symfony 5.1.
+     */
+    public function testConstructNameConverter()
+    {
+        new AbstractNormalizerDummy($this->classMetadata, new CamelCaseToSnakeCaseNameConverter());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -136,7 +136,7 @@ class AbstractObjectNormalizerTest extends TestCase
                 null
             ));
 
-        $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
+        $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, [], $extractor);
         $arrayDenormalizer = new ArrayDenormalizerDummy();
         $serializer = new SerializerCollectionDummy([$arrayDenormalizer, $denormalizer]);
         $arrayDenormalizer->setSerializer($serializer);
@@ -183,7 +183,7 @@ class AbstractObjectNormalizerTest extends TestCase
                 null
             ));
 
-        $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
+        $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, [], $extractor);
         $arrayDenormalizer = new ArrayDenormalizerDummy();
         $serializer = new SerializerCollectionDummy([$arrayDenormalizer, $denormalizer]);
         $arrayDenormalizer->setSerializer($serializer);
@@ -219,7 +219,7 @@ class AbstractObjectNormalizerTest extends TestCase
         };
 
         $discriminatorResolver = new ClassDiscriminatorFromClassMetadata($loaderMock);
-        $normalizer = new AbstractObjectNormalizerDummy($factory, null, new PhpDocExtractor(), $discriminatorResolver);
+        $normalizer = new AbstractObjectNormalizerDummy($factory, [], new PhpDocExtractor(), $discriminatorResolver);
         $serializer = new Serializer([$normalizer]);
         $normalizer->setSerializer($serializer);
         $normalizedData = $normalizer->denormalize(['foo' => 'foo', 'baz' => 'baz', 'quux' => ['value' => 'quux'], 'type' => 'second'], AbstractDummy::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/JsonSerializableNormalizerTest.php
@@ -41,7 +41,7 @@ class JsonSerializableNormalizerTest extends TestCase
     private function createNormalizer(array $defaultContext = [])
     {
         $this->serializer = $this->getMockBuilder(JsonSerializerNormalizer::class)->getMock();
-        $this->normalizer = new JsonSerializableNormalizer(null, null, $defaultContext);
+        $this->normalizer = new JsonSerializableNormalizer(null, [], $defaultContext);
         $this->normalizer->setSerializer($this->serializer);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -406,7 +406,7 @@ class SerializerTest extends TestCase
         };
 
         $discriminatorResolver = new ClassDiscriminatorFromClassMetadata($loaderMock);
-        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new PhpDocExtractor(), $discriminatorResolver)], ['json' => new JsonEncoder()]);
+        $serializer = new Serializer([new ObjectNormalizer(null, [], null, new PhpDocExtractor(), $discriminatorResolver)], ['json' => new JsonEncoder()]);
 
         $jsonData = '{"type":"first","quux":{"value":"quux"},"bar":"bar-value","foo":"foo-value"}';
 
@@ -573,7 +573,7 @@ class SerializerTest extends TestCase
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
 
-        return new Serializer([new ObjectNormalizer($classMetadataFactory, null, null, new ReflectionExtractor(), new ClassDiscriminatorFromClassMetadata($classMetadataFactory))], ['json' => new JsonEncoder()]);
+        return new Serializer([new ObjectNormalizer($classMetadataFactory, [], null, new ReflectionExtractor(), new ClassDiscriminatorFromClassMetadata($classMetadataFactory))], ['json' => new JsonEncoder()]);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | To do

The aim of this PR is to bring the possibility to modify the name converter to use at runtime.

Imagine you use the classical serializer for your (de)normalization needs (if you use some DTOs for instance). You also need to call an API using snake case and you want to use the serializer too.

In the current state, you need to do something like this:

```yaml
services:
    app.serializer.normalizer.object.snake_case:
        class: Symfony\Component\Serializer\Normalizer\ObjectNormalizer
        autoconfigure: false
        arguments:
            $nameConverter: '@serializer.name_converter.camel_case_to_snake_case'

    app.serializer.denormalizer.array.snake_case:
        class: Symfony\Component\Serializer\Normalizer\ArrayDenormalizer
        autoconfigure: false

    app.serializer.normalizer.datetime.snake_case:
        class: Symfony\Component\Serializer\Normalizer\DateTimeNormalizer
        autoconfigure: false

    app.serializer.encoder.json.snake_case:
        class: Symfony\Component\Serializer\Encoder\JsonEncoder
        autoconfigure: false

    app.serializer.snake_case:
        class: Symfony\Component\Serializer\Serializer
        autoconfigure: false
        arguments:
            - ['@app.serializer.normalizer.datetime.snake_case', '@app.serializer.normalizer.object.snake_case', '@app.serializer.denormalizer.array.snake_case']
            - ['@app.serializer.encoder.json.snake_case']
```

You have to reconfigure all the (de)normalizers because if you use the ones from Symfony in the declaration of your snake case serializer, they can use the snake case serializer instead of the classical one when you (de)normalize your data (mainly because of this: https://github.com/symfony/symfony/blob/af4035d4ecf98df3d9dec9ac9eaadd6ca6d00873/src/Symfony/Component/Serializer/Serializer.php#L77-L87).

With this PR, you can just use the classical serializer with a flag given to the context:

```php
$data = $this->normalizer->normalize($object, null, [
    AbstractNormalizer::NAME_CONVERTER => CamelCaseToSnakeCaseNameConverter::class,
]);
```
