### PR TITLE
[Lock] Don't allow mysqli to be used as it doesn't work

### DIFF
--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -307,6 +307,7 @@ class PdoStore implements StoreInterface
         } else {
             switch ($this->driver = $con->getDriver()->getName()) {
                 case 'mysqli':
+                    throw new NotSupportedException(sprintf('The store "%s" does not support the mysqli driver, use pdo_mysql instead.', \get_class($this)));
                 case 'pdo_mysql':
                 case 'drizzle_pdo_mysql':
                     $this->driver = 'mysql';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Mysqli doesn't support named parameters, so if you pass a doctrine connection using `mysqli` then you get the following error:
`You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ':id, :token, UNIX_TIMESTAMP() + 300)'`
This PR ensures a clear error is provided and suggests to use `pdo_mysql` instead