### PR TITLE
[FrameworkBundle] Add --show-arguments example to debug:container command help text

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -74,6 +74,10 @@ To get specific information about a service, specify its name:
 
   <info>php %command.full_name% validator</info>
 
+To get specific information about a service including all its arguments, use the <info>--show-arguments</info> flag:
+
+  <info>php %command.full_name% validator --show-arguments</info>
+
 To see available types that can be used for autowiring, use the <info>--types</info> flag:
 
   <info>php %command.full_name% --types</info>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

I like this option a lot and I think it deserves to be mentioned in the command help text :-) 