### PR TITLE
[WIP] [Serializer] Added encoder that encodes and decodes data in HTML

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/HtmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/HtmlEncoder.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Encoder;
+
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Serializer\Exception\RuntimeException;
+
+/**
+ * Encodes HTML data.
+ *
+ * @author Andrzej Kupczyk <kontakt@andrzejkupczyk.pl>
+ */
+class HtmlEncoder implements EncoderInterface, DecoderInterface
+{
+    public const FORMAT = 'html';
+
+    /**
+     * @var \Symfony\Component\DomCrawler\Crawler
+     */
+    private $crawler;
+
+    /**
+     * @var array
+     */
+    private $defaultContext = ['default' => null, 'charset' => 'UTF-8'];
+
+    public function __construct(?Crawler $crawler = null, array $defaultContext = [])
+    {
+        if (!class_exists(Crawler::class)) {
+            throw new RuntimeException('The HtmlEncoder class requires the "DomCrawler" component. Install "symfony/dom-crawler" to use it.');
+        }
+
+        $this->crawler = $crawler ?: new Crawler();
+        $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
+    }
+
+    public function decode(string $data, string $format, array $context = [])
+    {
+        $context = array_merge($this->defaultContext, $context);
+
+        $this->crawler->clear();
+        $this->crawler->addHtmlContent($data, $context['charset']);
+
+        return $this->crawler;
+    }
+
+    public function supportsDecoding(string $format)
+    {
+        return self::FORMAT === $format;
+    }
+
+    public function encode($data, string $format, array $context = [])
+    {
+        $this->crawler->clear();
+        $this->crawler->addNodes($data);
+
+        $context = array_merge($this->defaultContext, $context);
+
+        return $this->crawler->html($context['default']);
+    }
+
+    public function supportsEncoding(string $format)
+    {
+        return self::FORMAT === $format;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

- [ ] gather feedback
- [ ] add unit tests
- [ ] update src/**/CHANGELOG.md files
- [ ] add docs PR

Somehow I did not manage to encode HTML using [built-in encoders](https://symfony.com/doc/current/components/serializer.html#built-in-encoders) :man_shrugging: 

This PR implements a new encoder that transforms arrays into HTML and vice versa.  
HtmlEncoder requires the [DomCrawler](https://symfony.com/doc/current/components/dom_crawler.html) component.