### PR TITLE
[WebProfilerBundle][HttpClient] Added profiler links in the Web Profiler -> Http Client panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -54,6 +54,18 @@
                         {% else %}
                             <h4>Requests</h4>
                             {% for trace in client.traces %}
+                                {% set profiler_token = '' %}
+                                {% set profiler_link = '' %}
+                                {% if trace.info.response_headers is defined %}
+                                    {% for header in trace.info.response_headers %}
+                                        {% if header matches '/^x-debug-token: .*$/i' %}
+                                            {% set profiler_token = (header.getValue | slice('x-debug-token: ' | length)) %}
+                                        {% endif %}
+                                        {% if header matches '/^x-debug-token-link: .*$/i' %}
+                                            {% set profiler_link = (header.getValue | slice('x-debug-token-link: ' | length)) %}
+                                        {% endif %}
+                                    {% endfor %}
+                                {% endif %}
                                 <table>
                                     <thead>
                                     <tr>
@@ -66,6 +78,11 @@
                                                 {{ profiler_dump(trace.options, maxDepth=1) }}
                                             {% endif %}
                                         </th>
+                                        {% if profiler_token and profiler_link %}
+                                            <th>
+                                                Profile
+                                            </th>
+                                        {% endif %}
                                     </tr>
                                     </thead>
                                     <tbody>
@@ -85,6 +102,11 @@
                                         <td>
                                             {{ profiler_dump(trace.info, maxDepth=1) }}
                                         </td>
+                                        {% if profiler_token and profiler_link %}
+                                            <td>
+                                                <span><a href="{{ profiler_link }}" target="_blank">{{ profiler_token }}</a></span>
+                                            </td>
+                                        {% endif %}
                                     </tr>
                                     </tbody>
                                 </table>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | [#33311](https://github.com/symfony/symfony/issues/33311)
| License       | MIT
| Doc PR        | -

As per @Neirda24's idea in this [comment](https://github.com/symfony/symfony/issues/33311#issuecomment-524612722), I parsed the response headers collected by the TraceableHttpClient and created profiler links in the HttpClient Web Profiler panel for all the requests having the 'X-Debug-Token' header.

![profiler](https://user-images.githubusercontent.com/26301369/72686050-19a91300-3af9-11ea-998b-db063a3aa358.PNG)
