### PR TITLE
[RFC][DX][OptionsResolver] Allow setting info message per option

### DIFF
--- a/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
@@ -108,7 +108,15 @@ abstract class Descriptor implements DescriptorInterface
 
     protected function getOptionDefinition(OptionsResolver $optionsResolver, string $option)
     {
-        $definition = [
+        $definition = [];
+
+        if ($info = $optionsResolver->getInfo($option)) {
+            $definition = [
+                'info' => $info,
+            ];
+        }
+
+        $definition += [
             'required' => $optionsResolver->isRequired($option),
             'deprecated' => $optionsResolver->isDeprecated($option),
         ];

--- a/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
@@ -73,6 +73,7 @@ class JsonDescriptor extends Descriptor
             }
         }
         $map += [
+            'info' => 'info',
             'required' => 'required',
             'default' => 'default',
             'allowed_types' => 'allowedTypes',

--- a/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
@@ -114,6 +114,7 @@ class TextDescriptor extends Descriptor
             ];
         }
         $map += [
+            'Info' => 'info',
             'Required' => 'required',
             'Default' => 'default',
             'Allowed types' => 'allowedTypes',

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -152,6 +152,8 @@ Symfony\Component\Form\Tests\Command\FooType (foo)
 ==================================================
 
  ---------------- -----------%s
+  Info             "Info"    %s
+ ---------------- -----------%s
   Required         true      %s
  ---------------- -----------%s
   Default          -         %s
@@ -209,5 +211,6 @@ class FooType extends AbstractType
         $resolver->setNormalizer('foo', function (Options $options, $value) {
             return (string) $value;
         });
+        $resolver->setInfo('foo', 'Info');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
@@ -3,6 +3,8 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (choice_translation_domain
 =================================================================================
 
  ---------------- -----------%s
+  Info             -         %s
+ ---------------- -----------%s
   Required         false     %s
  ---------------- -----------%s
   Default          true      %s

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/deprecated_option.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/deprecated_option.txt
@@ -6,6 +6,8 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (bar)
  --------------------- ----------------------------------- 
   Deprecation message   "The option "bar" is deprecated."  
  --------------------- ----------------------------------- 
+  Info                  -                                  
+ --------------------- ----------------------------------- 
   Required              false                              
  --------------------- ----------------------------------- 
   Default               -                                  

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
@@ -2,6 +2,8 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (empty_data)
 ====================================================================
 
  ---------------- ----------------------%s 
+  Info             -                    %s 
+ ---------------- ----------------------%s
   Required         false                %s 
  ---------------- ----------------------%s 
   Default          Value: null          %s 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
@@ -3,6 +3,8 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (foo)
 =============================================================
 
  ---------------- -----------%s
+  Info             -         %s
+ ---------------- -----------%s
   Required         true      %s
  ---------------- -----------%s
   Default          -         %s

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.2.5",
         "symfony/event-dispatcher": "^4.4|^5.0",
         "symfony/intl": "^4.4|^5.0",
-        "symfony/options-resolver": "^5.0",
+        "symfony/options-resolver": "^5.1",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/property-access": "^5.0",

--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added fluent configuration of options using `OptionResolver::define()`
+ * added `setInfo()` and `getInfo()` methods
 
 5.0.0
 -----

--- a/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
+++ b/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
@@ -124,4 +124,18 @@ final class OptionConfigurator
 
         return $this;
     }
+
+    /**
+     * Sets an info message for an option.
+     *
+     * @return $this
+     *
+     * @throws AccessException If called from a lazy option or normalizer
+     */
+    public function info(string $info): self
+    {
+        $this->resolver->setInfo($this->name, $info);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

This is a DX proposal that will help in debugging/errors to better understand the meaning of one defined option.

This is how you'd use it:
```php
$resolver = new OptionsResolver();
$resolver->setDefined('date');
$resolver->setAllowedTypes('date', \DateTime::class);
$resolver->setInfo('date', 'A future date'); // <-- NEW
// ...
```
This information may be useful for those options where their name cannot be intuitive enough, or their purpose is too complex. Here is an example (based on the example above):
```php
// ...
$resolver->setAllowedValues('date', static function ($value): bool {
    return $value >= new \DateTime('now');
});
```
So, if you introduce a date value that does not match the criteria, you will get this error message:

**Before:**
```
The option "date" with value DateTime is invalid.
```
Note that the allowed value is not printable in this case, hence the error message cannot be clear at all.

**After:**
```
The option "date" with value DateTime is invalid. Info: A future date.
```
Although a more accurate error message can be triggered within the `\Closure` if desired.

Also you'll see this info message on `debug:form` command (see tests), then you have in advance the informative description of any option.

What do you think?