### PR TITLE
[Messenger] Add missing documentation link in README

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DisallowRobotsIndexingListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DisallowRobotsIndexingListenerTest.php
@@ -24,8 +24,9 @@ class DisallowRobotsIndexingListenerTest extends TestCase
     /**
      * @dataProvider provideResponses
      */
-    public function testInvoke(?string $expected, Response $response): void
+    public function testInvoke(?string $expected, array $responseArgs)
     {
+        $response = new Response(...$responseArgs);
         $listener = new DisallowRobotsIndexingListener();
 
         $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $this->createMock(Request::class), KernelInterface::MASTER_REQUEST, $response);
@@ -37,11 +38,11 @@ class DisallowRobotsIndexingListenerTest extends TestCase
 
     public function provideResponses(): iterable
     {
-        yield 'No header' => ['noindex', new Response()];
+        yield 'No header' => ['noindex', []];
 
         yield 'Header already set' => [
             'something else',
-            new Response('', 204, ['X-Robots-Tag' => 'something else']),
+            ['', 204, ['X-Robots-Tag' => 'something else']],
         ];
     }
 }

--- a/src/Symfony/Component/Messenger/README.md
+++ b/src/Symfony/Component/Messenger/README.md
@@ -12,6 +12,7 @@ are not covered by Symfony's
 Resources
 ---------
 
+  * [Documentation](https://symfony.com/doc/current/components/messenger.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (lower was experimental)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -