### PR TITLE
[Mailer] Fix support for NullTransport when creating from DSN

### DIFF
--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -78,7 +78,7 @@ class Transport
 
         switch ($parsedDsn['host']) {
             case 'null':
-                if ('smtp' === $parsedDsn['scheme']) {
+                if ('null' === $parsedDsn['scheme']) {
                     return new Transport\NullTransport($dispatcher, $logger);
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | none
| License       | MIT
| Doc PR        | none

Although documentation describes null://null scheme as recommended for creating NullTransport, the current code supports only smtp://null for that.