### PR TITLE
Fixes a runtime error when accessing the cache panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -108,9 +108,9 @@
                                     <div class="metric">
                                         <span class="value">
                                             {% if key == 'time' %}
-                                                {{ '%0.2f'|format(1000 * value.value) }} <span class="unit">ms</span>
+                                                {{ '%0.2f'|format(1000 * value) }} <span class="unit">ms</span>
                                             {% elseif key == 'hit_read_ratio' %}
-                                                {{ value.value ?? 0 }} <span class="unit">%</span>
+                                                {{ value ?? 0 }} <span class="unit">%</span>
                                             {% else %}
                                                 {{ value }}
                                             {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #35419 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixes a runtime error (_Impossible to access an attribute ("value") on a double variable..._) when accessing the cache panel on 4.4.3

