### PR TITLE
[HttpKernel] Check if lock can be released

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -634,7 +634,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         }
 
         $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
-        $cache->release();
+        if (method_exists($cache, 'release')) {
+            $cache->release();
+        }
+
         $this->container = require $cachePath;
         $this->container->set('kernel', $this);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35421
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

[HttpKernel] Make sure the `$cache->release()` method exists before executing it
