### PR TITLE
[4.3] Minor Travis configuration cosmetic patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -179,7 +179,7 @@ before_install:
       done
     - |
       # List all php extensions with versions
-    - php -r 'foreach (get_loaded_extensions() as $extension) echo $extension . " " . phpversion($extension) . PHP_EOL;'
+      php -r 'foreach (get_loaded_extensions() as $extension) echo $extension . " " . phpversion($extension) . PHP_EOL;'
 
     - |
       # Load fixtures


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 (Does not appear in previous versions)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no

The Travis configuration is organized in steps: each step begins with a comment followed by the commands to run.
The ` # List all PHP extensions with versions` is empty, its content has been put in the next section, without comment title. 

This patch fixes this minor issue