### PR TITLE
[SecurityBundle] fix ldap_bind service arguments

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -195,10 +195,10 @@
             <argument /> <!-- UserChecker -->
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- LDAP -->
-            <argument /> <!-- search dn -->
-            <argument /> <!-- search password -->
             <argument /> <!-- Base DN -->
             <argument>%security.authentication.hide_user_not_found%</argument>
+            <argument /> <!-- search dn -->
+            <argument /> <!-- search password -->
         </service>
 
         <service id="security.authentication.provider.simple" class="Symfony\Component\Security\Core\Authentication\Provider\SimpleAuthenticationProvider" abstract="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT

The 6th argument of `LdapBindAuthenticationProvider` was not correctly set in the service declaration `security_listeners.xml`. Thus, instead `'Invalid credentials.'` we had `'User "foo" not found.'`.
