### PR TITLE
Sort the KernelEvents constants to match the lifecycle of the framework

### DIFF
--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -40,17 +40,6 @@ final class KernelEvents
     const EXCEPTION = 'kernel.exception';
 
     /**
-     * The VIEW event occurs when the return value of a controller
-     * is not a Response instance.
-     *
-     * This event allows you to create a response for the return value of the
-     * controller.
-     *
-     * @Event("Symfony\Component\HttpKernel\Event\ViewEvent")
-     */
-    const VIEW = 'kernel.view';
-
-    /**
      * The CONTROLLER event occurs once a controller was found for
      * handling a request.
      *
@@ -72,6 +61,17 @@ final class KernelEvents
     const CONTROLLER_ARGUMENTS = 'kernel.controller_arguments';
 
     /**
+     * The VIEW event occurs when the return value of a controller
+     * is not a Response instance.
+     *
+     * This event allows you to create a response for the return value of the
+     * controller.
+     *
+     * @Event("Symfony\Component\HttpKernel\Event\ViewEvent")
+     */
+    const VIEW = 'kernel.view';
+
+    /**
      * The RESPONSE event occurs once a response was created for
      * replying to a request.
      *
@@ -83,15 +83,6 @@ final class KernelEvents
     const RESPONSE = 'kernel.response';
 
     /**
-     * The TERMINATE event occurs once a response was sent.
-     *
-     * This event allows you to run expensive post-response jobs.
-     *
-     * @Event("Symfony\Component\HttpKernel\Event\TerminateEvent")
-     */
-    const TERMINATE = 'kernel.terminate';
-
-    /**
      * The FINISH_REQUEST event occurs when a response was generated for a request.
      *
      * This event allows you to reset the global and environmental state of
@@ -100,4 +91,13 @@ final class KernelEvents
      * @Event("Symfony\Component\HttpKernel\Event\FinishRequestEvent")
      */
     const FINISH_REQUEST = 'kernel.finish_request';
+
+    /**
+     * The TERMINATE event occurs once a response was sent.
+     *
+     * This event allows you to run expensive post-response jobs.
+     *
+     * @Event("Symfony\Component\HttpKernel\Event\TerminateEvent")
+     */
+    const TERMINATE = 'kernel.terminate';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR is the same as #35248 but on the correct branch this time!

> Hi,
> 
> When I need to visualize all the kernel events I often open the KernelEvents file. However, it is difficult to navigate through it because the constants are not in the same order compared to the framework execution life cycle.
> 
> This PR aims to sort this constants to match it. It's also the same order used in [this documentation page](https://symfony.com/doc/current/reference/events.html).
> 
> Thanks.
