### PR TITLE
[EventDispatcher] Add `DefaultPriorityInterface` to allow setting priority for autowired listener, without a need to register it as a service in configs.

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * Add `DefaultPriorityInterface` to allow setting priority for autowired listener, without a need to register it as a service.
  * The `LegacyEventDispatcherProxy` class has been deprecated.
 
 5.0.0

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
- * Add `DefaultPriorityInterface` to allow setting priority for autowired listener, without a need to register it as a service.
+ * Add `DefaultPriorityInterface` to allow setting priority for autowired listener, without a need to register it as a service in configs.
  * The `LegacyEventDispatcherProxy` class has been deprecated.
 
 5.0.0

--- a/src/Symfony/Component/EventDispatcher/DefaultPriorityInterface.php
+++ b/src/Symfony/Component/EventDispatcher/DefaultPriorityInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ * DefaultPriorityInterface.
+ *
+ * @author Artem Henvald <genvaldartem@gmail.com>
+ */
+interface DefaultPriorityInterface
+{
+    /**
+     * Returns the default priority for the listener.
+     */
+    public static function getDefaultPriority(): int;
+}

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -16,10 +16,10 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\DefaultPriorityInterface;
 use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\EventDispatcher\DefaultPriorityInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -70,7 +70,7 @@ class RegisterListenersPass implements CompilerPassInterface
                 $priority = 0;
                 if (isset($event['priority'])) {
                     $priority = $event['priority'];
-                } elseif (null !== ($class = $container->getDefinition($id)->getClass()) && \is_subclass_of($class, DefaultPriorityInterface::class)) {
+                } elseif (null !== ($class = $container->getDefinition($id)->getClass()) && is_subclass_of($class, DefaultPriorityInterface::class)) {
                     $priority = \call_user_func([$class, 'getDefaultPriority']);
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | Will add if pull request be approved

Thanks to the autowiring, we can easily add new services without a need to register them in configs.
We can create an EventListener class that has a method `__invoke` that receives the event of some class and thanks to the autowiring we don't need to register this listener as service in configs.
```yaml
services:
    _defaults:
        autowire: true

App\EventListener\:
    resource: '../../src/EventListener/'
    tags:
        - 'kernel.event_listener'
```
```php
namespace App\EventListener;

use Symfony\Component\HttpKernel\Event\RequestEvent;

final class FooListener
{
    public function __invoke(RequestEvent $event): void
    {
    }
}
```

By default all listeners have priority 0. But when we need to set a custom priority, we have to add a config for listener and set the priority there. (If listener implements `EventSubscriberInterface` then it is possible to set priority in `getSubscribedEvents` method. But I talk about listeners as closures)

```yaml
services:
    _defaults:
        autowire: true

App\EventListener\:
    resource: '../../src/EventListener/'
    tags:
        - 'kernel.event_listener'

App\EventListener\FooListener:
    class: App\EventListener\FooListener
    tags:
        - { name: kernel.event_listener, priority: 100 }
```

If you have a lot of listeners with custom priority you have to write configs for all of them. So you cannot use easily autowiring in this case.

I propose to add a `DefaultPriorityInterface` with a static method `getDefaultPriority` and set the default priority inside the class, so you don't have to put priority into config files. And your config files will be smaller and cleaner.

My request doesn't break BC, because you can still add `priority` as config parameter for listener.

So as a result config file with autowiring:
```yaml
services:
    _defaults:
        autowire: true

App\EventListener\:
    resource: '../../src/EventListener/'
    tags:
        - 'kernel.event_listener'
```

Listener with a custom priority:
```php
namespace App\EventListener;

use Symfony\Component\EventDispatcher\DefaultPriorityInterface;
use Symfony\Component\HttpKernel\Event\RequestEvent;

final class FooListener implements DefaultPriorityInterface
{
    public function __invoke(RequestEvent $event): void
    {
    }

    public static function getDefaultPriority(): int
    {
        return 100;
    }
}
```

In the case when listener implements `DefaultPriorityInterface` and has `priority` argument in config, the `priority` from config will be used. In this case it is **99**
```yaml
services:
    _defaults:
        autowire: true

App\EventListener\:
    resource: '../../src/EventListener/'
    tags:
        - 'kernel.event_listener'

App\EventListener\FooListener:
    class: App\EventListener\FooListener
    tags:
        - { name: kernel.event_listener, priority: 99 }
```

```php
namespace App\EventListener;

use Symfony\Component\EventDispatcher\DefaultPriorityInterface;
use Symfony\Component\HttpKernel\Event\RequestEvent;

final class FooListener implements DefaultPriorityInterface
{
    public function __invoke(RequestEvent $event): void
    {
    }

    public static function getDefaultPriority(): int
    {
        return 100;
    }
}
```