### PR TITLE
[Messenger] Added support for passing dbindex as a query parameter to the redis transport DSN

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 4.3.0
 -----
-
+ * Added support for passing dbindex as a query parameter to the redis transport DSN.
  * Added `NonSendableStampInterface` that a stamp can implement if
    it should not be sent to a transport. Transport serializers
    must now check for these stamps and not encode them.
@@ -32,11 +32,11 @@ CHANGELOG
  * Added `AmqpStamp` allowing to provide a routing key, flags and attributes on message publishing.
  * [BC BREAK] Removed publishing with a `routing_key` option from queue configuration, for
    AMQP. Use exchange `default_publish_routing_key` or `AmqpStamp` instead.
- * [BC BREAK] Changed the `queue` option in the AMQP transport DSN to be `queues[name]`. You can 
+ * [BC BREAK] Changed the `queue` option in the AMQP transport DSN to be `queues[name]`. You can
    therefore name the queue but also configure `binding_keys`, `flags` and `arguments`.
- * [BC BREAK] The methods `get`, `ack`, `nack` and `queue` of the AMQP `Connection` 
+ * [BC BREAK] The methods `get`, `ack`, `nack` and `queue` of the AMQP `Connection`
    have a new argument: the queue name.
- * Added optional parameter `prefetch_count` in connection configuration, 
+ * Added optional parameter `prefetch_count` in connection configuration,
    to setup channel prefetch count.
  * New classes: `RoutableMessageBus`, `AddBusNameStampMiddleware`
    and `BusNameStamp` were added, which allow you to add a bus identifier
@@ -89,7 +89,7 @@ CHANGELOG
    only. Pass the `auto_setup` connection option to control this.
  * Added a `SetupTransportsCommand` command to setup the transports
  * Added a Doctrine transport. For example, use the `doctrine://default` DSN (this uses the `default` Doctrine entity manager)
- * [BC BREAK] The `getConnectionConfiguration` method on Amqp's `Connection` has been removed. 
+ * [BC BREAK] The `getConnectionConfiguration` method on Amqp's `Connection` has been removed.
  * [BC BREAK] A `HandlerFailedException` exception will be thrown if one or more handler fails.
  * [BC BREAK] The `HandlersLocationInterface::getHandlers` method needs to return `HandlerDescriptor`
    instances instead of callables.
@@ -101,7 +101,7 @@ CHANGELOG
 4.2.0
 -----
 
- * Added `HandleTrait` leveraging a message bus instance to return a single 
+ * Added `HandleTrait` leveraging a message bus instance to return a single
    synchronous message handling result
  * Added `HandledStamp` & `SentStamp` stamps
  * All the changes below are BC BREAKS

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -113,6 +113,15 @@ class ConnectionTest extends TestCase
         Connection::fromDsn('redis://password@localhost/queue', [], $redis);
     }
 
+    public function testDbIndex()
+    {
+        $redis = new \Redis();
+
+        Connection::fromDsn('redis://password@localhost/queue?dbindex=2', [], $redis);
+
+        $this->assertSame(2, $redis->getDbNum());
+    }
+
     public function testFirstGetPendingMessagesThenNewMessages()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -115,11 +115,7 @@ class ConnectionTest extends TestCase
 
     public function testDbIndex()
     {
-        $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();
-
-        $redis->expects($this->exactly(1))->method('auth')
-            ->with('password')
-            ->willReturn(true);
+        $redis = new \Redis();
 
         Connection::fromDsn('redis://password@localhost/queue?dbindex=2', [], $redis);
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -115,7 +115,11 @@ class ConnectionTest extends TestCase
 
     public function testDbIndex()
     {
-        $redis = new \Redis();
+        $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('password')
+            ->willReturn(true);
 
         Connection::fromDsn('redis://password@localhost/queue?dbindex=2', [], $redis);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | yes (it's already present in 4.4 and 5.
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

 Added support for passing dbindex as a query parameter to the redis transport DSN.
It's already present in 4.4 and 5.
