### PR TITLE
[Form][LanguageType] Add whitelist option

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * The `view_timezone` option defaults to the `model_timezone` if no `reference_date` is configured.
  * Added default `inputmode` attribute to Search, Email and Tel form types.
+ * Added the `whitelist` option to `LanguageType` to filter the available choices.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -150,4 +150,21 @@ class LanguageTypeTest extends BaseTypeTest
     {
         parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
     }
+
+    public function testWhitelist()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'whitelist' => [
+                    'fr',
+                    'de',
+                ],
+            ])
+            ->createView()->vars['choices'];
+
+        $this->assertContainsEquals(new ChoiceView('fr', 'fr', 'French'), $choices);
+        $this->assertContainsEquals(new ChoiceView('de', 'de', 'German'), $choices);
+        $this->assertNotContainsEquals(new ChoiceView('en', 'en', 'English'), $choices);
+        $this->assertNotContainsEquals(new ChoiceView('es', 'es', 'Spanish'), $choices);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

From my experience, it's common to want a language choice input, but only on "available" (prefiltered) languages from the application. For example, I know my application content must only be available in 5 languages, so I want to display only those 5 options when contributing it.

Currently, I think there is no way to use the core `LanguageType` with only some defined choices. That means I have to create a custom `LanguageType` (whatever the implementation) and that I don't benefit from the core one **easily**. I can extend it but that requires additional logic /code.

I think that adding a `whitelist` option on all `Intl` related core form types would make sense. I'm only pushing the language one right now as a demo and to open the discussion. Maybe that actually adding this option to all core form types that have the `ChoiceType` as their parent and that somehow force the choices would make sense as well.