### PR TITLE
[Translator] fix TranslatorInterface::setLocale() typehint  TranslatorInterface

### DIFF
--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -59,7 +59,7 @@ interface TranslatorInterface extends LocaleAwareInterface
      *
      * @throws InvalidArgumentException If the locale contains invalid characters
      */
-    public function setLocale($locale);
+    public function setLocale(string $locale);
 
     /**
      * Returns the current locale.


### PR DESCRIPTION
fixes Declaration of Symfony\Component\Translation\TranslatorInterface::setLocale($locale) must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::setLocale(string $locale) error on PHP 7.1.x
