### PR TITLE
[Cache] Don't allow mysqli to be used as it doesn't work

### DIFF
--- a/src/Symfony/Component/Cache/Traits/PdoTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PdoTrait.php
@@ -395,6 +395,7 @@ trait PdoTrait
             } else {
                 switch ($this->driver = $this->conn->getDriver()->getName()) {
                     case 'mysqli':
+                        throw new \LogicException(sprintf('The adapter "%s" does not support the mysqli driver, use pdo_mysql instead.', \get_class($this)));
                     case 'pdo_mysql':
                     case 'drizzle_pdo_mysql':
                         $this->driver = 'mysql';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

As discussed in #35375 Mysqli doesn't support named parameters, so if you pass a doctrine connection using `mysqli` then you get errors for any queries using named parameters.
This PR ensures a clear error is provided and suggests to use `pdo_mysql` instead