### PR TITLE
[Notifier] Prevent Notifier installation for symfony/framework-bundle < 5.0.0

### DIFF
--- a/src/Symfony/Component/Notifier/composer.json
+++ b/src/Symfony/Component/Notifier/composer.json
@@ -19,7 +19,8 @@
         "php": "^7.2.5"
     },
     "conflict": {
-        "symfony/http-kernel": "<4.4"
+        "symfony/http-kernel": "<4.4",
+        "symfony/framework-bundle": "<5.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\": "" },


### PR DESCRIPTION
Prevent Notifier installation for symfony/framework-bundle < 5.0.0

| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The notifier component is currently incompatible with `symfony/framework-bundle:
<5.0` when using Flex. This PR prevents installing the notifier component when using `symfony/framework-bundle` less . than `5.0.0`