### PR TITLE
[Messenger] Check for all serialization exceptions during message dec…

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -207,7 +207,40 @@ class SerializerTest extends TestCase
         $encoded = $serializer->encode($envelope);
         $this->assertStringNotContainsString('DummySymfonySerializerNonSendableStamp', print_r($encoded['headers'], true));
     }
+
+    public function testDecodingFailedConstructorDeserialization()
+    {
+        $serializer = new Serializer();
+
+        $this->expectException(MessageDecodingFailedException::class);
+
+        $serializer->decode([
+            'body' => '{}',
+            'headers' => ['type' => DummySymfonySerializerInvalidConstructor::class],
+        ]);
+    }
+
+    public function testDecodingStampFailedDeserialization()
+    {
+        $serializer = new Serializer();
+
+        $this->expectException(MessageDecodingFailedException::class);
+
+        $serializer->decode([
+            'body' => '{"message":"hello"}',
+            'headers' => [
+                'type' => DummyMessage::class,
+                'X-Message-Stamp-'.SerializerStamp::class => '[{}]',
+            ],
+        ]);
+    }
 }
 class DummySymfonySerializerNonSendableStamp implements NonSendableStampInterface
 {
+}
+class DummySymfonySerializerInvalidConstructor
+{
+    public function __construct(string $missingArgument)
+    {
+    }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -19,7 +19,7 @@ use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
-use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
@@ -81,7 +81,7 @@ class Serializer implements SerializerInterface
 
         try {
             $message = $this->serializer->deserialize($encodedEnvelope['body'], $encodedEnvelope['headers']['type'], $this->format, $context);
-        } catch (UnexpectedValueException $e) {
+        } catch (ExceptionInterface $e) {
             throw new MessageDecodingFailedException(sprintf('Could not decode message: %s.', $e->getMessage()), $e->getCode(), $e);
         }
 
@@ -119,7 +119,7 @@ class Serializer implements SerializerInterface
 
             try {
                 $stamps[] = $this->serializer->deserialize($value, substr($name, \strlen(self::STAMP_HEADER_PREFIX)).'[]', $this->format, $this->context);
-            } catch (UnexpectedValueException $e) {
+            } catch (ExceptionInterface $e) {
                 throw new MessageDecodingFailedException(sprintf('Could not decode stamp: %s.', $e->getMessage()), $e->getCode(), $e);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35446 
| License       | MIT

Makes it so that the Messenger Serializer throws a `MessageDecodingFailedException` for any serializer exception.