### PR TITLE
[Messenger] Add middleware to stop all workers on exception

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -56,6 +56,13 @@
             <argument type="service" id="debug.stopwatch" />
         </service>
 
+        <service id="messenger.middleware.stop_worker_on_exceptions" class="Symfony\Component\Messenger\Middleware\StopWorkerOnExceptionMiddleware" abstract="true" public="false">
+            <argument type="collection" />
+            <call method="setRestartSignalCachePool">
+                <argument type="service" id="cache.messenger.restart_workers_signal" />
+            </call>
+        </service>
+
         <!-- Discovery -->
         <service id="messenger.receiver_locator">
             <tag name="container.service_locator" />

--- a/src/Symfony/Component/Messenger/Middleware/StopWorkerOnExceptionMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/StopWorkerOnExceptionMiddleware.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+
+/**
+ * Stop all workers when an exceptions is thrown.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class StopWorkerOnExceptionMiddleware
+{
+    private $exceptions;
+    private $restartSignalCachePool;
+
+    /**
+     *
+     * @param array $exceptions of fully qualified class names of exceptions
+     */
+    public function __construct(array $exceptions)
+    {
+        $this->exceptions = array_values($exceptions);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } catch (HandlerFailedException $e) {
+            if (count($this->exceptions) === 0) {
+                throw $e;
+            }
+
+            if (count($this->exceptions) === 1 && $this->exceptions[0] === '*') {
+                $this->stopWorkers();
+                throw $e;
+            }
+
+            foreach ($e->getNestedExceptions() as $exception) {
+                if (in_array(get_class($exception), $this->exceptions)) {
+                    $this->stopWorkers();
+                    break;
+                }
+            }
+
+            throw $e;
+        }
+    }
+
+    private function stopWorkers(): void
+    {
+        $cacheItem = $this->restartSignalCachePool->getItem(StopWorkerOnRestartSignalListener::RESTART_REQUESTED_TIMESTAMP_KEY);
+        $cacheItem->set(microtime(true));
+        $this->restartSignalCachePool->save($cacheItem);
+    }
+
+    public function setRestartSignalCachePool(CacheItemPoolInterface $restartSignalCachePool): void
+    {
+        if ($this->restartSignalCachePool !== null) {
+            throw new \RuntimeException('Cannot update restartSignalCachePool dependency');
+        }
+
+        $this->restartSignalCachePool = $restartSignalCachePool;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #34414
| License       | MIT
| Doc PR        | will come

This is an alternative to #35453. It will fix #34414 and fix #35360.

```yaml
framework:
    messenger:
        buses:
            command_bus:
                middleware:
                    - stop_worker_on_exceptions: [['App\Exception\Foo', 'Doctrine\ORM\ORMException']]
```

If any of these exceptions is thrown when handling a message in "command_bus" we will stop all workers. 

You may also be more defensive: 
```yaml
framework:
    messenger:
        buses:
            command_bus:
                middleware:
                    - stop_worker_on_exceptions: [['*']]
```

-------------

This will avoid situation where you have 100 messages on the queue, and when handling message 5 it causes an exception that closes the EntityManager. As a result the other 95 messages will also fail because "The EntityManager is closed."

-------------

Drawback of this approach. This will stop ALL workers, even workers in other threads. It will also stop all workers even if the message was handled synchronously. 

-------------

This is a draft PR, which means that Im not done with the implementation. I want some feedback before I add tests, documentation and possibly trying to fix some of the drawbacks. 