### PR TITLE
[PhpUnitBridge] Fix running skipped tests expecting only deprecations

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -222,6 +222,10 @@ class SymfonyTestsListenerTrait
                 }
             }
 
+            if (!$test->getTestResultObject()) {
+                return;
+            }
+
             $annotations = $Test::parseTestMethodAnnotations(\get_class($test), $test->getName(false));
 
             if (isset($annotations['class']['expectedDeprecation'])) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/OnlyExpectingDeprecationSkippedTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/OnlyExpectingDeprecationSkippedTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test is meant to be skipped.
+ *
+ * @requires extension ext-dummy
+ */
+final class OnlyExpectingDeprecationSkippedTest extends TestCase
+{
+    /**
+     * Do not remove this test in the next major versions.
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation unreachable
+     */
+    public function testExpectingOnlyDeprecations()
+    {
+        $this->fail('should never be ran.');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

If a test class has unsatisfied `@requires` and contains test methods expecting deprecation only, you get:

> Fatal error: Uncaught Error: Call to a member function beStrictAboutTestsThatDoNotTestAnything() on null in ./symfony/symfony-dev/vendor/symfony/phpunit-bridge/Legacy/SymfonyTestsListenerTrait.php:229

Spotted in #34925's build.