### PR TITLE
Fail on empty password verification (without warning on any implementation)

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -76,6 +76,9 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
      */
     public function isPasswordValid($encoded, $raw, $salt): bool
     {
+        if ('' === $raw) {
+            return false;
+        }
         if (\strlen($raw) > self::MAX_PASSWORD_LENGTH) {
             return false;
         }

--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -76,6 +76,9 @@ final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSalti
      */
     public function isPasswordValid($encoded, $raw, $salt): bool
     {
+        if ('' === $raw) {
+            return false;
+        }
         if (\strlen($raw) > self::MAX_PASSWORD_LENGTH) {
             return false;
         }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/NativePasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/NativePasswordEncoderTest.php
@@ -53,6 +53,7 @@ class NativePasswordEncoderTest extends TestCase
         $result = $encoder->encodePassword('password', null);
         $this->assertTrue($encoder->isPasswordValid($result, 'password', null));
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));
+        $this->assertFalse($encoder->isPasswordValid($result, '', null));
     }
 
     public function testNonArgonValidation()

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
@@ -29,6 +29,7 @@ class SodiumPasswordEncoderTest extends TestCase
         $result = $encoder->encodePassword('password', null);
         $this->assertTrue($encoder->isPasswordValid($result, 'password', null));
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));
+        $this->assertFalse($encoder->isPasswordValid($result, '', null));
     }
 
     public function testBCryptValidation()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | sort of
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When using the sodium extension, an empty $raw string will issue a warning during validation, but the standard `password_verify()` does not. This PR aims to provide identical behavior independent of the underlying implementation. Two assumptions were made (please doublecheck if they are correct):
- Empty password is never valid.
- Empty password is not that severe that anybody needs to be informed using a warning or exception.
