### PR TITLE
[Serializer] Use PropertyAccessor to access / mutate values in AbstractObjectNormalizer

### DIFF
--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+* Linking to PropertyInfo extractor to remove a lot of duplicate code
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -17,12 +17,16 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
-use Symfony\Component\Inflector\Inflector;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyReadInfo;
+use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyWriteInfo;
+use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
 
 /**
  * Default implementation of {@link PropertyAccessorInterface}.
@@ -36,17 +40,6 @@ class PropertyAccessor implements PropertyAccessorInterface
     private const VALUE = 0;
     private const REF = 1;
     private const IS_REF_CHAINED = 2;
-    private const ACCESS_HAS_PROPERTY = 0;
-    private const ACCESS_TYPE = 1;
-    private const ACCESS_NAME = 2;
-    private const ACCESS_REF = 3;
-    private const ACCESS_ADDER = 4;
-    private const ACCESS_REMOVER = 5;
-    private const ACCESS_TYPE_METHOD = 0;
-    private const ACCESS_TYPE_PROPERTY = 1;
-    private const ACCESS_TYPE_MAGIC = 2;
-    private const ACCESS_TYPE_ADDER_AND_REMOVER = 3;
-    private const ACCESS_TYPE_NOT_FOUND = 4;
     private const CACHE_PREFIX_READ = 'r';
     private const CACHE_PREFIX_WRITE = 'w';
     private const CACHE_PREFIX_PROPERTY_PATH = 'p';
@@ -64,6 +57,17 @@ class PropertyAccessor implements PropertyAccessorInterface
     private $cacheItemPool;
 
     private $propertyPathCache = [];
+
+    /**
+     * @var PropertyReadInfoExtractorInterface
+     */
+    private $readInfoExtractor;
+
+    /**
+     * @var PropertyWriteInfoExtractorInterface
+     */
+    private $writeInfoExtractor;
+
     private $readPropertyCache = [];
     private $writePropertyCache = [];
     private static $resultProto = [self::VALUE => null];
@@ -78,6 +82,13 @@ class PropertyAccessor implements PropertyAccessorInterface
         $this->ignoreInvalidIndices = !$throwExceptionOnInvalidIndex;
         $this->cacheItemPool = $cacheItemPool instanceof NullAdapter ? null : $cacheItemPool; // Replace the NullAdapter by the null value
         $this->ignoreInvalidProperty = !$throwExceptionOnInvalidPropertyPath;
+        $this->readInfoExtractor = $this->writeInfoExtractor = new ReflectionExtractor(
+            ['set'],
+            ['get', 'is', 'has', 'can'],
+            ['add', 'remove'],
+            false,
+            ReflectionExtractor::ALLOW_PUBLIC
+        );
     }
 
     /**
@@ -376,17 +387,22 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         $result = self::$resultProto;
         $object = $zval[self::VALUE];
-        $access = $this->getReadAccessInfo(\get_class($object), $property);
+        $class = \get_class($object);
+        $access = $this->getReadInfo($class, $property);
 
-        if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
-            $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]}();
-        } elseif (self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]) {
-            $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]};
-
-            if ($access[self::ACCESS_REF] && isset($zval[self::REF])) {
-                $result[self::REF] = &$object->{$access[self::ACCESS_NAME]};
+        if (null !== $access) {
+            if (PropertyReadInfo::TYPE_METHOD === $access->getType()) {
+                $result[self::VALUE] = $object->{$access->getName()}();
             }
-        } elseif (!$access[self::ACCESS_HAS_PROPERTY] && property_exists($object, $property)) {
+
+            if (PropertyReadInfo::TYPE_PROPERTY === $access->getType()) {
+                $result[self::VALUE] = $object->{$access->getName()};
+
+                if (isset($zval[self::REF]) && $access->canBeReference()) {
+                    $result[self::REF] = &$object->{$access->getName()};
+                }
+            }
+        } elseif ($object instanceof \stdClass && property_exists($object, $property)) {
             // Needed to support \stdClass instances. We need to explicitly
             // exclude $access[self::ACCESS_HAS_PROPERTY], otherwise if
             // a *protected* property was found on the class, property_exists()
@@ -397,11 +413,12 @@ class PropertyAccessor implements PropertyAccessorInterface
             if (isset($zval[self::REF])) {
                 $result[self::REF] = &$object->$property;
             }
-        } elseif (self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE]) {
-            // we call the getter and hope the __call do the job
-            $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]}();
         } elseif (!$ignoreInvalidProperty) {
-            throw new NoSuchPropertyException($access[self::ACCESS_NAME]);
+            throw new NoSuchPropertyException(sprintf(
+                'Can get a way to read the property "%s" in class "%s".',
+                $property,
+                $class
+            ));
         }
 
         // Objects are always passed around by reference
@@ -415,7 +432,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * Guesses how to read the property value.
      */
-    private function getReadAccessInfo(string $class, string $property): array
+    private function getReadInfo(string $class, string $property): ?PropertyReadInfo
     {
         $key = str_replace('\\', '.', $class).'..'.$property;
 
@@ -430,65 +447,17 @@ class PropertyAccessor implements PropertyAccessorInterface
             }
         }
 
-        $access = [];
-
-        $reflClass = new \ReflectionClass($class);
-        $access[self::ACCESS_HAS_PROPERTY] = $reflClass->hasProperty($property);
-        $camelProp = $this->camelize($property);
-        $getter = 'get'.$camelProp;
-        $getsetter = lcfirst($camelProp); // jQuery style, e.g. read: last(), write: last($item)
-        $isser = 'is'.$camelProp;
-        $hasser = 'has'.$camelProp;
-        $canAccessor = 'can'.$camelProp;
-
-        if ($reflClass->hasMethod($getter) && $reflClass->getMethod($getter)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $getter;
-        } elseif ($reflClass->hasMethod($getsetter) && $reflClass->getMethod($getsetter)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $getsetter;
-        } elseif ($reflClass->hasMethod($isser) && $reflClass->getMethod($isser)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $isser;
-        } elseif ($reflClass->hasMethod($hasser) && $reflClass->getMethod($hasser)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $hasser;
-        } elseif ($reflClass->hasMethod($canAccessor) && $reflClass->getMethod($canAccessor)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-            $access[self::ACCESS_NAME] = $canAccessor;
-        } elseif ($reflClass->hasMethod('__get') && $reflClass->getMethod('__get')->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
-            $access[self::ACCESS_NAME] = $property;
-            $access[self::ACCESS_REF] = false;
-        } elseif ($access[self::ACCESS_HAS_PROPERTY] && $reflClass->getProperty($property)->isPublic()) {
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
-            $access[self::ACCESS_NAME] = $property;
-            $access[self::ACCESS_REF] = true;
-        } elseif ($this->magicCall && $reflClass->hasMethod('__call') && $reflClass->getMethod('__call')->isPublic()) {
-            // we call the getter and hope the __call do the job
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
-            $access[self::ACCESS_NAME] = $getter;
-        } else {
-            $methods = [$getter, $getsetter, $isser, $hasser, '__get'];
-            if ($this->magicCall) {
-                $methods[] = '__call';
-            }
-
-            $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
-            $access[self::ACCESS_NAME] = sprintf(
-                'Neither the property "%s" nor one of the methods "%s()" '.
-                'exist and have public access in class "%s".',
-                $property,
-                implode('()", "', $methods),
-                $reflClass->name
-            );
-        }
+        $accessor = $this->readInfoExtractor->getReadInfo($class, $property, [
+            'enable_getter_setter_extraction' => true,
+            'enable_magic_call_extraction' => $this->magicCall,
+            'enable_constructor_extraction' => false,
+        ]);
 
         if (isset($item)) {
-            $this->cacheItemPool->save($item->set($access));
+            $this->cacheItemPool->save($item->set($accessor));
         }
 
-        return $this->readPropertyCache[$key] = $access;
+        return $this->readPropertyCache[$key] = $accessor;
     }
 
     /**
@@ -522,15 +491,22 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         $object = $zval[self::VALUE];
-        $access = $this->getWriteAccessInfo(\get_class($object), $property, $value);
+        $class = \get_class($object);
+        $mutator = $this->getWriteInfo($class, $property, $value);
 
-        if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
-            $object->{$access[self::ACCESS_NAME]}($value);
-        } elseif (self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]) {
-            $object->{$access[self::ACCESS_NAME]} = $value;
-        } elseif (self::ACCESS_TYPE_ADDER_AND_REMOVER === $access[self::ACCESS_TYPE]) {
-            $this->writeCollection($zval, $property, $value, $access[self::ACCESS_ADDER], $access[self::ACCESS_REMOVER]);
-        } elseif (!$access[self::ACCESS_HAS_PROPERTY] && property_exists($object, $property)) {
+        if (null !== $mutator) {
+            if (PropertyWriteInfo::TYPE_METHOD === $mutator->getType()) {
+                $object->{$mutator->getName()}($value);
+            }
+
+            if (PropertyWriteInfo::TYPE_PROPERTY === $mutator->getType()) {
+                $object->{$mutator->getName()} = $value;
+            }
+
+            if (PropertyWriteInfo::TYPE_ADDER_AND_REMOVER === $mutator->getType()) {
+                $this->writeCollection($zval, $property, $value, $mutator->getAdderInfo(), $mutator->getRemoverInfo());
+            }
+        } elseif ($object instanceof \stdClass && property_exists($object, $property)) {
             // Needed to support \stdClass instances. We need to explicitly
             // exclude $access[self::ACCESS_HAS_PROPERTY], otherwise if
             // a *protected* property was found on the class, property_exists()
@@ -538,19 +514,21 @@ class PropertyAccessor implements PropertyAccessorInterface
             // fatal error.
 
             $object->$property = $value;
-        } elseif (self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE]) {
-            $object->{$access[self::ACCESS_NAME]}($value);
-        } elseif (self::ACCESS_TYPE_NOT_FOUND === $access[self::ACCESS_TYPE]) {
-            throw new NoSuchPropertyException(sprintf('Could not determine access type for property "%s" in class "%s"%s', $property, \get_class($object), isset($access[self::ACCESS_NAME]) ? ': '.$access[self::ACCESS_NAME] : '.'));
         } else {
-            throw new NoSuchPropertyException($access[self::ACCESS_NAME]);
+            throw new NoSuchPropertyException(sprintf('Could not determine access type for property "%s" in class "%s".', $property, \get_class($object)));
         }
     }
 
     /**
      * Adjusts a collection-valued property by calling add*() and remove*() methods.
+     *
+     * @param array             $zval         The array containing the object to write to
+     * @param string            $property     The property to write
+     * @param iterable          $collection   The collection to write
+     * @param PropertyWriteInfo $addMethod    The add*() method
+     * @param PropertyWriteInfo $removeMethod The remove*() method
      */
-    private function writeCollection(array $zval, string $property, iterable $collection, string $addMethod, string $removeMethod)
+    private function writeCollection(array $zval, string $property, iterable $collection, PropertyWriteInfo $addMethod, PropertyWriteInfo $removeMethod)
     {
         // At this point the add and remove methods have been found
         $previousValue = $this->readProperty($zval, $property);
@@ -566,7 +544,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             foreach ($previousValue as $key => $item) {
                 if (!\in_array($item, $collection, true)) {
                     unset($previousValue[$key]);
-                    $zval[self::VALUE]->{$removeMethod}($item);
+                    $zval[self::VALUE]->{$removeMethod->getName()}($item);
                 }
             }
         } else {
@@ -575,17 +553,12 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         foreach ($collection as $item) {
             if (!$previousValue || !\in_array($item, $previousValue, true)) {
-                $zval[self::VALUE]->{$addMethod}($item);
+                $zval[self::VALUE]->{$addMethod->getName()}($item);
             }
         }
     }
 
-    /**
-     * Guesses how to write the property value.
-     *
-     * @param mixed $value
-     */
-    private function getWriteAccessInfo(string $class, string $property, $value): array
+    private function getWriteInfo(string $class, string $property, $value): ?PropertyWriteInfo
     {
         $useAdderAndRemover = \is_array($value) || $value instanceof \Traversable;
         $key = str_replace('\\', '.', $class).'..'.$property.'..'.(int) $useAdderAndRemover;
@@ -601,124 +574,18 @@ class PropertyAccessor implements PropertyAccessorInterface
             }
         }
 
-        $access = [];
-
-        $reflClass = new \ReflectionClass($class);
-        $access[self::ACCESS_HAS_PROPERTY] = $reflClass->hasProperty($property);
-        $camelized = $this->camelize($property);
-        $singulars = (array) Inflector::singularize($camelized);
-        $errors = [];
-
-        if ($useAdderAndRemover) {
-            foreach ($this->findAdderAndRemover($reflClass, $singulars) as $methods) {
-                if (3 === \count($methods)) {
-                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_ADDER_AND_REMOVER;
-                    $access[self::ACCESS_ADDER] = $methods[self::ACCESS_ADDER];
-                    $access[self::ACCESS_REMOVER] = $methods[self::ACCESS_REMOVER];
-                    break;
-                }
-
-                if (isset($methods[self::ACCESS_ADDER])) {
-                    $errors[] = sprintf('The add method "%s" in class "%s" was found, but the corresponding remove method "%s" was not found', $methods['methods'][self::ACCESS_ADDER], $reflClass->name, $methods['methods'][self::ACCESS_REMOVER]);
-                }
-
-                if (isset($methods[self::ACCESS_REMOVER])) {
-                    $errors[] = sprintf('The remove method "%s" in class "%s" was found, but the corresponding add method "%s" was not found', $methods['methods'][self::ACCESS_REMOVER], $reflClass->name, $methods['methods'][self::ACCESS_ADDER]);
-                }
-            }
-        }
-
-        if (!isset($access[self::ACCESS_TYPE])) {
-            $setter = 'set'.$camelized;
-            $getsetter = lcfirst($camelized); // jQuery style, e.g. read: last(), write: last($item)
-
-            if ($this->isMethodAccessible($reflClass, $setter, 1)) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-                $access[self::ACCESS_NAME] = $setter;
-            } elseif ($this->isMethodAccessible($reflClass, $getsetter, 1)) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
-                $access[self::ACCESS_NAME] = $getsetter;
-            } elseif ($this->isMethodAccessible($reflClass, '__set', 2)) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
-                $access[self::ACCESS_NAME] = $property;
-            } elseif ($access[self::ACCESS_HAS_PROPERTY] && $reflClass->getProperty($property)->isPublic()) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_PROPERTY;
-                $access[self::ACCESS_NAME] = $property;
-            } elseif ($this->magicCall && $this->isMethodAccessible($reflClass, '__call', 2)) {
-                // we call the getter and hope the __call do the job
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
-                $access[self::ACCESS_NAME] = $setter;
-            } else {
-                foreach ($this->findAdderAndRemover($reflClass, $singulars) as $methods) {
-                    if (3 === \count($methods)) {
-                        $errors[] = sprintf(
-                            'The property "%s" in class "%s" can be defined with the methods "%s()" but '.
-                            'the new value must be an array or an instance of \Traversable, '.
-                            '"%s" given.',
-                            $property,
-                            $reflClass->name,
-                            implode('()", "', [$methods[self::ACCESS_ADDER], $methods[self::ACCESS_REMOVER]]),
-                            \is_object($value) ? \get_class($value) : \gettype($value)
-                        );
-                    }
-                }
-
-                if (!isset($access[self::ACCESS_NAME])) {
-                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
-
-                    $triedMethods = [
-                        $setter => 1,
-                        $getsetter => 1,
-                        '__set' => 2,
-                        '__call' => 2,
-                    ];
-
-                    foreach ($singulars as $singular) {
-                        $triedMethods['add'.$singular] = 1;
-                        $triedMethods['remove'.$singular] = 1;
-                    }
-
-                    foreach ($triedMethods as $methodName => $parameters) {
-                        if (!$reflClass->hasMethod($methodName)) {
-                            continue;
-                        }
-
-                        $method = $reflClass->getMethod($methodName);
-
-                        if (!$method->isPublic()) {
-                            $errors[] = sprintf('The method "%s" in class "%s" was found but does not have public access', $methodName, $reflClass->name);
-                            continue;
-                        }
-
-                        if ($method->getNumberOfRequiredParameters() > $parameters || $method->getNumberOfParameters() < $parameters) {
-                            $errors[] = sprintf('The method "%s" in class "%s" requires %d arguments, but should accept only %d', $methodName, $reflClass->name, $method->getNumberOfRequiredParameters(), $parameters);
-                        }
-                    }
-
-                    if (\count($errors)) {
-                        $access[self::ACCESS_NAME] = implode('. ', $errors).'.';
-                    } else {
-                        $access[self::ACCESS_NAME] = sprintf(
-                            'Neither the property "%s" nor one of the methods %s"%s()", "%s()", '.
-                            '"__set()" or "__call()" exist and have public access in class "%s".',
-                            $property,
-                            implode('', array_map(function ($singular) {
-                                return '"add'.$singular.'()"/"remove'.$singular.'()", ';
-                            }, $singulars)),
-                            $setter,
-                            $getsetter,
-                            $reflClass->name
-                        );
-                    }
-                }
-            }
-        }
+        $mutator = $this->writeInfoExtractor->getWriteInfo($class, $property, [
+            'enable_getter_setter_extraction' => true,
+            'enable_magic_call_extraction' => $this->magicCall,
+            'enable_constructor_extraction' => false,
+            'enable_adder_remover_extraction' => $useAdderAndRemover,
+        ]);
 
         if (isset($item)) {
-            $this->cacheItemPool->save($item->set($access));
+            $this->cacheItemPool->save($item->set($mutator));
         }
 
-        return $this->writePropertyCache[$key] = $access;
+        return $this->writePropertyCache[$key] = $mutator;
     }
 
     /**
@@ -732,79 +599,15 @@ class PropertyAccessor implements PropertyAccessorInterface
             return false;
         }
 
-        $access = $this->getWriteAccessInfo(\get_class($object), $property, []);
+        $mutatorForArray = $this->getWriteInfo(\get_class($object), $property, []);
 
-        $isWritable = self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]
-            || self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]
-            || self::ACCESS_TYPE_ADDER_AND_REMOVER === $access[self::ACCESS_TYPE]
-            || (!$access[self::ACCESS_HAS_PROPERTY] && property_exists($object, $property))
-            || self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE];
-
-        if ($isWritable) {
+        if (null !== $mutatorForArray || ($object instanceof \stdClass && property_exists($object, $property))) {
             return true;
         }
 
-        $access = $this->getWriteAccessInfo(\get_class($object), $property, '');
+        $mutator = $this->getWriteInfo(\get_class($object), $property, '');
 
-        return self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]
-            || self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]
-            || self::ACCESS_TYPE_ADDER_AND_REMOVER === $access[self::ACCESS_TYPE]
-            || (!$access[self::ACCESS_HAS_PROPERTY] && property_exists($object, $property))
-            || self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE];
-    }
-
-    /**
-     * Camelizes a given string.
-     */
-    private function camelize(string $string): string
-    {
-        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
-    }
-
-    /**
-     * Searches for add and remove methods.
-     */
-    private function findAdderAndRemover(\ReflectionClass $reflClass, array $singulars): iterable
-    {
-        foreach ($singulars as $singular) {
-            $addMethod = 'add'.$singular;
-            $removeMethod = 'remove'.$singular;
-            $result = ['methods' => [self::ACCESS_ADDER => $addMethod, self::ACCESS_REMOVER => $removeMethod]];
-
-            $addMethodFound = $this->isMethodAccessible($reflClass, $addMethod, 1);
-
-            if ($addMethodFound) {
-                $result[self::ACCESS_ADDER] = $addMethod;
-            }
-
-            $removeMethodFound = $this->isMethodAccessible($reflClass, $removeMethod, 1);
-
-            if ($removeMethodFound) {
-                $result[self::ACCESS_REMOVER] = $removeMethod;
-            }
-
-            yield $result;
-        }
-
-        return null;
-    }
-
-    /**
-     * Returns whether a method is public and has the number of required parameters.
-     */
-    private function isMethodAccessible(\ReflectionClass $class, string $methodName, int $parameters): bool
-    {
-        if ($class->hasMethod($methodName)) {
-            $method = $class->getMethod($methodName);
-
-            if ($method->isPublic()
-                && $method->getNumberOfRequiredParameters() <= $parameters
-                && $method->getNumberOfParameters() >= $parameters) {
-                return true;
-            }
-        }
-
-        return false;
+        return null !== $mutator || ($object instanceof \stdClass && property_exists($object, $property));
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
@@ -21,6 +21,7 @@ use Psr\Cache\CacheItemPoolInterface;
 class PropertyAccessorBuilder
 {
     private $magicCall = false;
+    private $staticCall = true;
     private $throwExceptionOnInvalidIndex = false;
     private $throwExceptionOnInvalidPropertyPath = true;
 
@@ -59,6 +60,20 @@ class PropertyAccessorBuilder
     public function isMagicCallEnabled()
     {
         return $this->magicCall;
+    }
+
+    public function enableStaticCall(): self
+    {
+        $this->staticCall = true;
+
+        return $this;
+    }
+
+    public function disableStaticCall(): self
+    {
+        $this->staticCall = false;
+
+        return $this;
     }
 
     /**
@@ -164,6 +179,6 @@ class PropertyAccessorBuilder
      */
     public function getPropertyAccessor()
     {
-        return new PropertyAccessor($this->magicCall, $this->throwExceptionOnInvalidIndex, $this->cacheItemPool, $this->throwExceptionOnInvalidPropertyPath);
+        return new PropertyAccessor($this->magicCall, $this->throwExceptionOnInvalidIndex, $this->cacheItemPool, $this->throwExceptionOnInvalidPropertyPath, null, null, $this->staticCall);
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -188,7 +188,7 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
     public function testSetValueFailsIfAdderAndRemoverExistButValueIsNotTraversable()
     {
         $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
-        $this->expectExceptionMessageRegExp('/Could not determine access type for property "axes" in class "Symfony\\\\Component\\\\PropertyAccess\\\\Tests\\\\PropertyAccessorCollectionTest_Car[^"]*": The property "axes" in class "Symfony\\\\Component\\\\PropertyAccess\\\\Tests\\\\PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis\(\)", "removeAxis\(\)" but the new value must be an array or an instance of \\\\Traversable, "string" given./');
+        $this->expectExceptionMessageRegExp('/The property "axes" in class "Symfony\\\Component\\\PropertyAccess\\\Tests\\\PropertyAccessorCollectionTest_Car" can be defined with the methods "addAxis\(\)", "removeAxis\(\)" but the new value must be an array or an instance of \\\Traversable\./');
         $car = new PropertyAccessorCollectionTest_Car();
 
         $this->propertyAccessor->setValue($car, 'axes', 'Not an array or Traversable');

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -760,7 +760,7 @@ class PropertyAccessorTest extends TestCase
     public function testAdderAndRemoveNeedsTheExactParametersDefined()
     {
         $this->expectException('Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException');
-        $this->expectExceptionMessageRegExp('/.*The method "addFoo" in class "Symfony\\\Component\\\PropertyAccess\\\Tests\\\Fixtures\\\TestAdderRemoverInvalidArgumentLength" requires 0 arguments, but should accept only 1\. The method "removeFoo" in class "Symfony\\\Component\\\PropertyAccess\\\Tests\\\Fixtures\\\TestAdderRemoverInvalidArgumentLength" requires 2 arguments, but should accept only 1\./');
+        $this->expectExceptionMessageRegExp('/.*The method "addFoo" in class "Symfony\\\Component\\\PropertyAccess\\\Tests\\\Fixtures\\\TestAdderRemoverInvalidArgumentLength" requires 0 arguments, but should accept only 1\./');
         $object = new TestAdderRemoverInvalidArgumentLength();
         $this->propertyAccessor->setValue($object, 'foo', [1, 2]);
     }

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "symfony/inflector": "^4.4|^5.0"
+        "symfony/inflector": "^4.4|^5.0",
+        "symfony/property-info": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/cache": "^4.4|^5.0"

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2.5",
         "symfony/inflector": "^4.4|^5.0",
-        "symfony/property-info": "^4.4|^5.0"
+        "symfony/property-info": "^5.1"
     },
     "require-dev": {
         "symfony/cache": "^4.4|^5.0"

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+* Add support for extracting accessor and mutator via PHP Reflection
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
@@ -37,8 +37,13 @@ final class PropertyReadInfo
 
     private $byRef;
 
-    private function __construct()
+    public function __construct(string $type, string $name, string $visibility, bool $static, bool $byRef)
     {
+        $this->type = $type;
+        $this->name = $name;
+        $this->visibility = $visibility;
+        $this->static = $static;
+        $this->byRef = $byRef;
     }
 
     /**
@@ -73,29 +78,5 @@ final class PropertyReadInfo
     public function canBeReference(): bool
     {
         return $this->byRef;
-    }
-
-    public static function forProperty(string $propertyName, string $visibility, bool $static, bool $byRef): self
-    {
-        $accessor = new self();
-        $accessor->type = self::TYPE_PROPERTY;
-        $accessor->name = $propertyName;
-        $accessor->visibility = $visibility;
-        $accessor->static = $static;
-        $accessor->byRef = $byRef;
-
-        return $accessor;
-    }
-
-    public static function forMethod(string $methodName, string $visibility, bool $static): self
-    {
-        $accessor = new self();
-        $accessor->type = self::TYPE_METHOD;
-        $accessor->name = $methodName;
-        $accessor->visibility = $visibility;
-        $accessor->static = $static;
-        $accessor->byRef = false;
-
-        return $accessor;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo;
+
+/**
+ * The property read info tells how a property can be read.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ *
+ * @internal
+ */
+final class PropertyReadInfo
+{
+    public const TYPE_METHOD = 'method';
+    public const TYPE_PROPERTY = 'property';
+
+    public const VISIBILITY_PUBLIC = 'public';
+    public const VISIBILITY_PROTECTED = 'protected';
+    public const VISIBILITY_PRIVATE = 'private';
+
+    private $type;
+
+    private $name;
+
+    private $visibility;
+
+    private $static;
+
+    private $byRef;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Get type of access.
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get name of the access, which can be a method name or a property name, depending on the type.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getVisibility(): string
+    {
+        return $this->visibility;
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->static;
+    }
+
+    /**
+     * Whether this accessor can be accessed by reference.
+     */
+    public function canBeReference(): bool
+    {
+        return $this->byRef;
+    }
+
+    public static function forProperty(string $propertyName, string $visibility, bool $static, bool $byRef): self
+    {
+        $accessor = new self();
+        $accessor->type = self::TYPE_PROPERTY;
+        $accessor->name = $propertyName;
+        $accessor->visibility = $visibility;
+        $accessor->static = $static;
+        $accessor->byRef = $byRef;
+
+        return $accessor;
+    }
+
+    public static function forMethod(string $methodName, string $visibility, bool $static): self
+    {
+        $accessor = new self();
+        $accessor->type = self::TYPE_METHOD;
+        $accessor->name = $methodName;
+        $accessor->visibility = $visibility;
+        $accessor->static = $static;
+        $accessor->byRef = false;
+
+        return $accessor;
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/PropertyReadInfoExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyReadInfoExtractorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo;
+
+/**
+ * Extract read information for the property of a class.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ *
+ * @internal
+ */
+interface PropertyReadInfoExtractorInterface
+{
+    /**
+     * Get read information object for a given property of a class.
+     *
+     * @internal
+     */
+    public function getReadInfo(string $class, string $property, array $context = []): ?PropertyReadInfo;
+}

--- a/src/Symfony/Component/PropertyInfo/PropertyReadInfoExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyReadInfoExtractorInterface.php
@@ -15,15 +15,11 @@ namespace Symfony\Component\PropertyInfo;
  * Extract read information for the property of a class.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
- *
- * @internal
  */
 interface PropertyReadInfoExtractorInterface
 {
     /**
      * Get read information object for a given property of a class.
-     *
-     * @internal
      */
     public function getReadInfo(string $class, string $property, array $context = []): ?PropertyReadInfo;
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyWriteInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyWriteInfo.php
@@ -20,6 +20,7 @@ namespace Symfony\Component\PropertyInfo;
  */
 final class PropertyWriteInfo
 {
+    public const TYPE_NONE = 'none';
     public const TYPE_METHOD = 'method';
     public const TYPE_PROPERTY = 'property';
     public const TYPE_ADDER_AND_REMOVER = 'adder_and_remover';
@@ -35,9 +36,14 @@ final class PropertyWriteInfo
     private $static;
     private $adderInfo;
     private $removerInfo;
+    private $errors = [];
 
-    private function __construct()
+    public function __construct(string $type = self::TYPE_NONE, string $name = null, string $visibility = null, bool $static = null)
     {
+        $this->type = $type;
+        $this->name = $name;
+        $this->visibility = $visibility;
+        $this->static = $static;
     }
 
     public function getType(): string
@@ -54,6 +60,11 @@ final class PropertyWriteInfo
         return $this->name;
     }
 
+    public function setAdderInfo(self $adderInfo): void
+    {
+        $this->adderInfo = $adderInfo;
+    }
+
     public function getAdderInfo(): self
     {
         if (null === $this->adderInfo) {
@@ -61,6 +72,11 @@ final class PropertyWriteInfo
         }
 
         return $this->adderInfo;
+    }
+
+    public function setRemoverInfo(self $removerInfo): void
+    {
+        $this->removerInfo = $removerInfo;
     }
 
     public function getRemoverInfo(): self
@@ -90,44 +106,18 @@ final class PropertyWriteInfo
         return $this->static;
     }
 
-    public static function forMethod(string $methodName, string $visibility, bool $static): self
+    public function setErrors(array $errors): void
     {
-        $mutator = new self();
-        $mutator->type = self::TYPE_METHOD;
-        $mutator->name = $methodName;
-        $mutator->visibility = $visibility;
-        $mutator->static = $static;
-
-        return $mutator;
+        $this->errors = $errors;
     }
 
-    public static function forProperty(string $propertyName, string $visibility, bool $static): self
+    public function getErrors(): array
     {
-        $mutator = new self();
-        $mutator->type = self::TYPE_PROPERTY;
-        $mutator->name = $propertyName;
-        $mutator->visibility = $visibility;
-        $mutator->static = $static;
-
-        return $mutator;
+        return $this->errors;
     }
 
-    public static function forAdderAndRemover(self $adder, self $remover): self
+    public function hasErrors(): bool
     {
-        $mutator = new self();
-        $mutator->type = self::TYPE_ADDER_AND_REMOVER;
-        $mutator->adderInfo = $adder;
-        $mutator->removerInfo = $remover;
-
-        return $mutator;
-    }
-
-    public static function forConstructor(string $propertyName): self
-    {
-        $mutator = new self();
-        $mutator->type = self::TYPE_CONSTRUCTOR;
-        $mutator->name = $propertyName;
-
-        return $mutator;
+        return (bool) \count($this->errors);
     }
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyWriteInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyWriteInfo.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo;
+
+/**
+ * The write mutator defines how a property can be written.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ *
+ * @internal
+ */
+final class PropertyWriteInfo
+{
+    public const TYPE_METHOD = 'method';
+    public const TYPE_PROPERTY = 'property';
+    public const TYPE_ADDER_AND_REMOVER = 'adder_and_remover';
+    public const TYPE_CONSTRUCTOR = 'constructor';
+
+    public const VISIBILITY_PUBLIC = 'public';
+    public const VISIBILITY_PROTECTED = 'protected';
+    public const VISIBILITY_PRIVATE = 'private';
+
+    private $type;
+    private $name;
+    private $visibility;
+    private $static;
+    private $adderInfo;
+    private $removerInfo;
+
+    private function __construct()
+    {
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getName(): string
+    {
+        if (null === $this->name) {
+            throw new \LogicException("Calling getName() when having a mutator of type {$this->type} is not tolerated");
+        }
+
+        return $this->name;
+    }
+
+    public function getAdderInfo(): self
+    {
+        if (null === $this->adderInfo) {
+            throw new \LogicException("Calling getAdderInfo() when having a mutator of type {$this->type} is not tolerated");
+        }
+
+        return $this->adderInfo;
+    }
+
+    public function getRemoverInfo(): self
+    {
+        if (null === $this->removerInfo) {
+            throw new \LogicException("Calling getRemoverInfo() when having a mutator of type {$this->type} is not tolerated");
+        }
+
+        return $this->removerInfo;
+    }
+
+    public function getVisibility(): string
+    {
+        if (null === $this->visibility) {
+            throw new \LogicException("Calling getVisibility() when having a mutator of type {$this->type} is not tolerated");
+        }
+
+        return $this->visibility;
+    }
+
+    public function isStatic(): bool
+    {
+        if (null === $this->static) {
+            throw new \LogicException("Calling isStatic() when having a mutator of type {$this->type} is not tolerated");
+        }
+
+        return $this->static;
+    }
+
+    public static function forMethod(string $methodName, string $visibility, bool $static): self
+    {
+        $mutator = new self();
+        $mutator->type = self::TYPE_METHOD;
+        $mutator->name = $methodName;
+        $mutator->visibility = $visibility;
+        $mutator->static = $static;
+
+        return $mutator;
+    }
+
+    public static function forProperty(string $propertyName, string $visibility, bool $static): self
+    {
+        $mutator = new self();
+        $mutator->type = self::TYPE_PROPERTY;
+        $mutator->name = $propertyName;
+        $mutator->visibility = $visibility;
+        $mutator->static = $static;
+
+        return $mutator;
+    }
+
+    public static function forAdderAndRemover(self $adder, self $remover): self
+    {
+        $mutator = new self();
+        $mutator->type = self::TYPE_ADDER_AND_REMOVER;
+        $mutator->adderInfo = $adder;
+        $mutator->removerInfo = $remover;
+
+        return $mutator;
+    }
+
+    public static function forConstructor(string $propertyName): self
+    {
+        $mutator = new self();
+        $mutator->type = self::TYPE_CONSTRUCTOR;
+        $mutator->name = $propertyName;
+
+        return $mutator;
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/PropertyWriteInfoExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyWriteInfoExtractorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo;
+
+/**
+ * Extract write information for the property of a class.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ *
+ * @internal
+ */
+interface PropertyWriteInfoExtractorInterface
+{
+    /**
+     * Get write information object for a given property of a class.
+     *
+     * @internal
+     */
+    public function getWriteInfo(string $class, string $property, array $context = []): ?PropertyWriteInfo;
+}

--- a/src/Symfony/Component/PropertyInfo/PropertyWriteInfoExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyWriteInfoExtractorInterface.php
@@ -15,15 +15,11 @@ namespace Symfony\Component\PropertyInfo;
  * Extract write information for the property of a class.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
- *
- * @internal
  */
 interface PropertyWriteInfoExtractorInterface
 {
     /**
      * Get write information object for a given property of a class.
-     *
-     * @internal
      */
     public function getWriteInfo(string $class, string $property, array $context = []): ?PropertyWriteInfo;
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -378,9 +378,9 @@ class ReflectionExtractorTest extends TestCase
         $bazMutator = $this->extractor->getWriteInfo(Dummy::class, 'baz');
 
         $this->assertNull($barAcessor);
-        $this->assertNull($barMutator);
+        $this->assertEquals(PropertyWriteInfo::TYPE_NONE, $barMutator->getType());
         $this->assertNull($bazAcessor);
-        $this->assertNull($bazMutator);
+        $this->assertEquals(PropertyWriteInfo::TYPE_NONE, $bazMutator->getType());
     }
 
     /**
@@ -439,7 +439,7 @@ class ReflectionExtractorTest extends TestCase
         ]);
 
         if (!$found) {
-            $this->assertNull($writeMutator);
+            $this->assertEquals(PropertyWriteInfo::TYPE_NONE, $writeMutator->getType());
 
             return;
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php71Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php71Dummy.php
@@ -35,6 +35,10 @@ class Php71Dummy
     public function addBaz(string $baz)
     {
     }
+
+    public function removeBaz(string $baz)
+    {
+    }
 }
 
 class Php71DummyExtended extends Php71Dummy

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -117,46 +117,4 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
         return $attributes;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = [])
-    {
-        $ucfirsted = ucfirst($attribute);
-
-        $getter = 'get'.$ucfirsted;
-        if (\is_callable([$object, $getter])) {
-            return $object->$getter();
-        }
-
-        $isser = 'is'.$ucfirsted;
-        if (\is_callable([$object, $isser])) {
-            return $object->$isser();
-        }
-
-        $haser = 'has'.$ucfirsted;
-        if (\is_callable([$object, $haser])) {
-            return $object->$haser();
-        }
-
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = [])
-    {
-        $setter = 'set'.ucfirst($attribute);
-        $key = \get_class($object).':'.$setter;
-
-        if (!isset(self::$setterAccessibleCache[$key])) {
-            self::$setterAccessibleCache[$key] = \is_callable([$object, $setter]) && !(new \ReflectionMethod($object, $setter))->isStatic();
-        }
-
-        if (self::$setterAccessibleCache[$key]) {
-            $object->$setter($value);
-        }
-    }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -127,48 +127,6 @@ class PropertyNormalizer extends AbstractObjectNormalizer
     }
 
     /**
-     * {@inheritdoc}
-     */
-    protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = [])
-    {
-        try {
-            $reflectionProperty = $this->getReflectionProperty($object, $attribute);
-        } catch (\ReflectionException $reflectionException) {
-            return null;
-        }
-
-        // Override visibility
-        if (!$reflectionProperty->isPublic()) {
-            $reflectionProperty->setAccessible(true);
-        }
-
-        return $reflectionProperty->getValue($object);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setAttributeValue(object $object, string $attribute, $value, string $format = null, array $context = [])
-    {
-        try {
-            $reflectionProperty = $this->getReflectionProperty($object, $attribute);
-        } catch (\ReflectionException $reflectionException) {
-            return;
-        }
-
-        if ($reflectionProperty->isStatic()) {
-            return;
-        }
-
-        // Override visibility
-        if (!$reflectionProperty->isPublic()) {
-            $reflectionProperty->setAccessible(true);
-        }
-
-        $reflectionProperty->setValue($object, $value);
-    }
-
-    /**
      * @param string|object $classOrObject
      *
      * @throws \ReflectionException


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR follows #30704 and will replace attribute access and mutation by PropertyAccessor in order to dispatch responsabilities between components (Serializer should not manage property access).

Since related PR is not yet merged, please review only the last commit.