### PR TITLE
[Messenger] Fix bug when using single route with XML config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1193,6 +1193,10 @@ class Configuration implements ConfigurationInterface
                                     if (!\is_array($config)) {
                                         return [];
                                     }
+                                    // If XML config with only one routing attribute
+                                    if (2 === \count($config) && isset($config['message-class']) && isset($config['sender'])) {
+                                        $config = [0 => $config];
+                                    }
 
                                     $newConfig = [];
                                     foreach ($config as $k => $v) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_single.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing_single.php
@@ -1,0 +1,12 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'messenger' => [
+        'routing' => [
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage' => ['amqp'],
+        ],
+        'transports' => [
+            'amqp' => 'amqp://localhost/%2f/messages',
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_single.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing_single.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:messenger>
+            <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage">
+                <framework:sender service="amqp" />
+            </framework:routing>
+            <framework:transport name="amqp" dsn="amqp://localhost/%2f/messages" />
+        </framework:messenger>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_single.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing_single.yml
@@ -1,0 +1,7 @@
+framework:
+    messenger:
+        routing:
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage': [amqp]
+
+        transports:
+            amqp: 'amqp://localhost/%2f/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -740,6 +740,15 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals(new Reference('messenger.transport.audit'), $sendersLocator->getArgument(0)['messenger.transport.audit']->getValues()[0]);
     }
 
+    public function testMessengerRoutingSingle()
+    {
+        $container = $this->createContainerFromFile('messenger_routing_single');
+        $senderLocatorDefinition = $container->getDefinition('messenger.senders_locator');
+
+        $sendersMapping = $senderLocatorDefinition->getArgument(0);
+        $this->assertEquals(['amqp'], $sendersMapping[DummyMessage::class]);
+    }
+
     public function testMessengerTransportConfiguration()
     {
         $container = $this->createContainerFromFile('messenger_transport');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35500
| License       | MIT
| Doc PR        | 

When using just a single routing attribute with XML then the sky falls down. 

This small change make sure everything works as expected. 