### PR TITLE
[Messenger] Add TLS option to Redis transport's DSN

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 -----
 
  * Introduced the Redis bridge.
+ * Added TLS option in the DSN. Example: `redis://127.0.0.1?tls=1`

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Messenger\Bridge\Redis\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\Connection;
+use Symfony\Component\Messenger\Exception\TransportException;
 
 /**
  * @requires extension redis >= 4.3.0
@@ -71,6 +71,28 @@ class ConnectionTest extends TestCase
             Connection::fromDsn('redis://localhost', ['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1', 'auto_setup' => false, 'serializer' => 2]),
             Connection::fromDsn('redis://localhost/queue/group1/consumer1?serializer=2&auto_setup=0')
         );
+    }
+
+    public function testFromDsnWithTls()
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->once())
+            ->method('connect')
+            ->with('tls://127.0.0.1', 6379)
+            ->willReturn(null);
+
+        Connection::fromDsn('redis://127.0.0.1?tls=1', [], $redis);
+    }
+
+    public function testFromDsnWithTlsOption()
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->once())
+            ->method('connect')
+            ->with('tls://127.0.0.1', 6379)
+            ->willReturn(null);
+
+        Connection::fromDsn('redis://127.0.0.1', ['tls' => true], $redis);
     }
 
     public function testFromDsnWithQueryOptions()

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -104,6 +104,12 @@ class Connection
             unset($redisOptions['dbindex']);
         }
 
+        $tls = false;
+        if (\array_key_exists('tls', $redisOptions)) {
+            $tls = filter_var($redisOptions['tls'], FILTER_VALIDATE_BOOLEAN);
+            unset($redisOptions['tls']);
+        }
+
         $configuration = [
             'stream' => $redisOptions['stream'] ?? null,
             'group' => $redisOptions['group'] ?? null,
@@ -125,6 +131,9 @@ class Connection
             $configuration['stream'] = $pathParts[1] ?? $configuration['stream'];
             $configuration['group'] = $pathParts[2] ?? $configuration['group'];
             $configuration['consumer'] = $pathParts[3] ?? $configuration['consumer'];
+            if ($tls) {
+                $connectionCredentials['host'] = 'tls://'.$connectionCredentials['host'];
+            }
         } else {
             $connectionCredentials = [
                 'host' => $parsedUrl['path'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #33025
| License       | MIT
| Doc PR        | 

As suggested by @matas-valuzis, this will enable TLS support for Redis transport. 

Configure it with the following DSN

```
redis://127.0.0.1?tls=1
```

The implementation just prefix the host with `tls://` as described here: https://github.com/phpredis/phpredis#connect-open

It is already possible to use TLS with the Redis transport, but there are not support in the DSN until now. 