### PR TITLE
[DependencyInjection] Fix typo in test name

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1090,7 +1090,7 @@ class ContainerBuilderTest extends TestCase
         $container->set('a', new \stdClass());
     }
 
-    public function testThrowsExceptionWhenAddServiceOnACompiledContainer()
+    public function testNoExceptionWhenAddServiceOnACompiledContainer()
     {
         $container = new ContainerBuilder();
         $container->compile();


### PR DESCRIPTION
Rename testThrowsExceptionWhenAddServiceOnACompiledContainer to testNoExceptionWhenAddServiceOnACompiledContainer.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes (technically)
| New feature?  | no
| Deprecations? | no
| Tickets       | #35505
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->