### PR TITLE
[DI][Routing] add wither to configure the path of PHP-DSL configurators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -124,7 +124,6 @@ trait MicroKernelTrait
             }
 
             // the user has opted into using the ContainerConfigurator
-            $defaultDefinition = (new Definition())->setAutowired(true)->setAutoconfigured(true);
             /* @var ContainerPhpFileLoader $kernelLoader */
             $kernelLoader = $loader->getResolver()->resolve($file);
             $kernelLoader->setCurrentDir(\dirname($file));
@@ -136,7 +135,7 @@ trait MicroKernelTrait
             };
 
             try {
-                $this->configureContainer(new ContainerConfigurator($container, $kernelLoader, $instanceof, $file, $file, $defaultDefinition), $loader);
+                $this->configureContainer(new ContainerConfigurator($container, $kernelLoader, $instanceof, $file, $file), $loader);
             } finally {
                 $instanceof = [];
                 $kernelLoader->registerAliasesForSinglyImplementedInterfaces();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
@@ -79,6 +79,7 @@ class FlexStyleMicroKernel extends Kernel
         $c->services()
             ->set('logger', NullLogger::class)
             ->set('stdClass', 'stdClass')
+                ->autowire()
                 ->factory([$this, 'createHalloween'])
                 ->arg('$halloween', '%halloween%');
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -27,7 +27,7 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "^4.4|^5.0",
         "symfony/finder": "^4.4|^5.0",
-        "symfony/routing": "^5.0"
+        "symfony/routing": "^5.1"
     },
     "require-dev": {
         "doctrine/annotations": "~1.7",

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -34,16 +34,14 @@ class ContainerConfigurator extends AbstractConfigurator
     private $path;
     private $file;
     private $anonymousCount = 0;
-    private $defaultDefinition;
 
-    public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path, string $file, Definition $defaultDefinition = null)
+    public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path, string $file)
     {
         $this->container = $container;
         $this->loader = $loader;
         $this->instanceof = &$instanceof;
         $this->path = $path;
         $this->file = $file;
-        $this->defaultDefinition = $defaultDefinition;
     }
 
     final public function extension(string $namespace, array $config)
@@ -69,7 +67,18 @@ class ContainerConfigurator extends AbstractConfigurator
 
     final public function services(): ServicesConfigurator
     {
-        return new ServicesConfigurator($this->container, $this->loader, $this->instanceof, $this->path, $this->anonymousCount, $this->defaultDefinition);
+        return new ServicesConfigurator($this->container, $this->loader, $this->instanceof, $this->path, $this->anonymousCount);
+    }
+
+    /**
+     * @return static
+     */
+    final public function withPath(string $path): self
+    {
+        $clone = clone $this;
+        $clone->path = $clone->file = $path;
+
+        return $clone;
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -32,19 +32,16 @@ class ServicesConfigurator extends AbstractConfigurator
     private $path;
     private $anonymousHash;
     private $anonymousCount;
-    private $defaultDefinition;
 
-    public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path = null, int &$anonymousCount = 0, Definition $defaultDefinition = null)
+    public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path = null, int &$anonymousCount = 0)
     {
-        $defaultDefinition = $defaultDefinition ?? new Definition();
-        $this->defaults = clone $defaultDefinition;
+        $this->defaults = new Definition();
         $this->container = $container;
         $this->loader = $loader;
         $this->instanceof = &$instanceof;
         $this->path = $path;
         $this->anonymousHash = ContainerBuilder::hash($path ?: mt_rand());
         $this->anonymousCount = &$anonymousCount;
-        $this->defaultDefinition = $defaultDefinition;
         $instanceof = [];
     }
 
@@ -53,7 +50,7 @@ class ServicesConfigurator extends AbstractConfigurator
      */
     final public function defaults(): DefaultsConfigurator
     {
-        return new DefaultsConfigurator($this, $this->defaults = clone $this->defaultDefinition, $this->path);
+        return new DefaultsConfigurator($this, $this->defaults = new Definition(), $this->path);
     }
 
     /**

--- a/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
@@ -57,4 +57,15 @@ class RoutingConfigurator
     {
         return new CollectionConfigurator($this->collection, $name);
     }
+
+    /**
+     * @return static
+     */
+    final public function withPath(string $path): self
+    {
+        $clone = clone $this;
+        $clone->path = $clone->file = $path;
+
+        return $clone;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This makes PHP-DSL configurators more flexible, by allowing to use them for a different path than they were initially created for.

Sidekick of https://github.com/symfony/recipes/pull/721