### PR TITLE
[Validator] fix access to uninitialized property when getting value

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -48,7 +48,13 @@ class PropertyMetadata extends MemberMetadata
      */
     public function getPropertyValue($object)
     {
-        return $this->getReflectionMember($object)->getValue($object);
+        $reflProperty = $this->getReflectionMember($object);
+
+        if (\PHP_VERSION_ID >= 70400 && !$reflProperty->isInitialized($object)) {
+            return null;
+        }
+
+        return $reflProperty->getValue($object);
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Entity_74.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Entity_74.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class Entity_74
+{
+    public int $uninitialized;
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
@@ -14,10 +14,12 @@ namespace Symfony\Component\Validator\Tests\Mapping;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Mapping\PropertyMetadata;
 use Symfony\Component\Validator\Tests\Fixtures\Entity;
+use Symfony\Component\Validator\Tests\Fixtures\Entity_74;
 
 class PropertyMetadataTest extends TestCase
 {
     const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
+    const CLASSNAME_74 = 'Symfony\Component\Validator\Tests\Fixtures\Entity_74';
     const PARENTCLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
 
     public function testInvalidPropertyName()
@@ -52,5 +54,16 @@ class PropertyMetadataTest extends TestCase
 
         $this->expectException('Symfony\Component\Validator\Exception\ValidatorException');
         $metadata->getPropertyValue($entity);
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testGetPropertyValueFromUninitializedProperty()
+    {
+        $entity = new Entity_74();
+        $metadata = new PropertyMetadata(self::CLASSNAME_74, 'uninitialized');
+
+        $this->assertNull($metadata->getPropertyValue($entity));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35454
| License       | MIT
| Doc PR        | 

In PHP 7.4, the type-hinted property is [uninitialized](https://wiki.php.net/rfc/typed_properties_v2#uninitialized_and_unset_properties) by default. So it needs to be checked before use.