### PR TITLE
[Security] Fix user role restriction.

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -276,7 +276,7 @@ abstract class AbstractToken implements TokenInterface
             $userRoles[] = 'ROLE_PREVIOUS_ADMIN';
         }
 
-        if (\count($userRoles) !== \count($this->getRoleNames()) || \count($userRoles) !== \count(array_intersect($userRoles, $this->getRoleNames()))) {
+        if (\count($userRoles) !== \count($this->getRoleNames()) && \count($this->getRoleNames()) !== \count(array_intersect($this->getRoleNames(), $userRoles))) {
             return true;
         }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -276,7 +276,7 @@ abstract class AbstractToken implements TokenInterface
             $userRoles[] = 'ROLE_PREVIOUS_ADMIN';
         }
 
-        if (\count($userRoles) !== \count($this->getRoleNames()) && \count($this->getRoleNames()) !== \count(array_intersect($this->getRoleNames(), $userRoles))) {
+        if (\count($this->getRoleNames()) !== \count(array_intersect($this->getRoleNames(), $userRoles))) {
             return true;
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
@@ -72,5 +72,53 @@ class SwitchUserTokenTest extends TestCase
         $token = new SwitchUserToken($impersonated, 'bar', 'provider-key', ['ROLE_USER', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
         $token->setUser($impersonated);
         $this->assertTrue($token->isAuthenticated());
+
+        $impersonator = new class() implements UserInterface {
+            public function getUsername()
+            {
+                return 'impersonator';
+            }
+
+            public function getPassword()
+            {
+                return null;
+            }
+
+            public function eraseCredentials()
+            {
+            }
+
+            public function getRoles()
+            {
+                return ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'];
+            }
+
+            public function getSalt()
+            {
+                return null;
+            }
+        };
+
+        $originalToken = new UsernamePasswordToken($impersonator, 'foo', 'provider-key', ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
+
+        $token = new SwitchUserToken($impersonator, 'foo', 'provider-key', ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
+        $token->setUser($impersonator);
+        $this->assertTrue($token->isAuthenticated());
+
+        $token = new SwitchUserToken($impersonator, 'foo', 'provider-key', ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
+        $token->setUser($impersonator);
+        $this->assertTrue($token->isAuthenticated());
+
+        $token = new SwitchUserToken($impersonator, 'foo', 'provider-key', ['ROLE_ADMIN', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
+        $token->setUser($impersonator);
+        $this->assertTrue($token->isAuthenticated());
+
+        $token = new SwitchUserToken($impersonator, 'foo', 'provider-key', ['ROLE_TEST', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
+        $token->setUser($impersonator);
+        $this->assertFalse($token->isAuthenticated());
+
+        $token = new SwitchUserToken($impersonator, 'foo', 'provider-key', ['ROLE_USER', 'ROLE_TEST', 'ROLE_PREVIOUS_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'], $originalToken);
+        $token->setUser($impersonator);
+        $this->assertFalse($token->isAuthenticated());
     }
 }

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -145,8 +145,8 @@ final class User implements UserInterface, EquatableInterface
 
         $currentRoles = array_map('strval', (array) $this->getRoles());
         $newRoles = array_map('strval', (array) $user->getRoles());
-        $rolesChanged = \count($currentRoles) !== \count($newRoles) || \count($currentRoles) !== \count(array_intersect($currentRoles, $newRoles));
-        if ($rolesChanged) {
+
+        if (\count($newRoles) !== \count(array_intersect($newRoles, $currentRoles))) {
             return false;
         }
 


### PR DESCRIPTION
It was impossible to restrict user roles on the fly without deauthentication.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35509
| License       | MIT
| Doc PR        |

Allowed to restrict current user roles without changing roles for user object.


