### PR TITLE
[FrameworkBundle] Use MailerAssertionsTrait in KernelTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -55,6 +55,7 @@ CHANGELOG
  * Made `framework.session.handler_id` accept a DSN
  * Marked the `RouterDataCollector` class as `@final`.
  * [BC Break] The `framework.messenger.buses.<name>.middleware` config key is not deeply merged anymore.
+ * Moved `MailerAssertionsTrait` in `KernelTestCase`
 
 4.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -23,6 +23,8 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 abstract class KernelTestCase extends TestCase
 {
+    use MailerAssertionsTrait;
+
     protected static $class;
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
@@ -118,10 +118,6 @@ trait MailerAssertionsTrait
 
     private static function getMessageMailerEvents(): MessageEvents
     {
-        if (!self::getClient()->getRequest()) {
-            static::fail('Unable to make email assertions. Did you forget to make an HTTP request?');
-        }
-
         if (!$logger = self::$container->get('mailer.logger_message_listener')) {
             static::fail('A client must have Mailer enabled to make email assertions. Did you forget to require symfony/mailer?');
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -22,7 +22,6 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 abstract class WebTestCase extends KernelTestCase
 {
     use WebTestAssertionsTrait;
-    use MailerAssertionsTrait;
 
     protected function tearDown(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4+
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35510 
| License       | MIT
| Doc PR        |

Since 4.4, we have new PHPUnit constraints for the mailer component, but these are only available with `WebTestCase` and not `KernelTestCase`. I think this would be useful to access these constraints from both TestCase.

I don't know if I should move these [tests](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php) or add new ones only for `KernelTestCase`?
