### PR TITLE
[Console][QuestionHelper] Use String width() to properly move the cursor backwards

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Terminal;
+use Symfony\Component\String\UnicodeString;
 
 /**
  * The QuestionHelper class provides helpers to interact with the user.
@@ -278,9 +279,10 @@ class QuestionHelper extends Helper
             } elseif ("\177" === $c) { // Backspace Character
                 if (0 === $numMatches && 0 !== $i) {
                     --$i;
-                    $fullChoice = self::substr($fullChoice, 0, $i);
                     // Move cursor backwards
-                    $output->write("\033[1D");
+                    $output->write(sprintf("\033[%dD", class_exists(UnicodeString::class) ? (new UnicodeString(self::substr($fullChoice, -1)))->width(false) : 1));
+
+                    $fullChoice = self::substr($fullChoice, 0, $i);
                 }
 
                 if (0 === $i) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As a bug fix on 3.4 if the String component is installed. On 5.0, we can add a test with symfony/string as a dev dependency.
