### PR TITLE
[Config][XmlReferenceDumper] Prevent potential \TypeError

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -91,7 +91,7 @@ class XmlReferenceDumper
                 }
 
                 if ($prototype instanceof PrototypedArrayNode) {
-                    $prototype->setName($key);
+                    $prototype->setName($key ?? '');
                     $children = [$key => $prototype];
                 } elseif ($prototype instanceof ArrayNode) {
                     $children = $prototype->getChildren();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/34841
| License       | MIT
| Doc PR        | -

`$key` can be null and `setName()` is now typed with `string`. Fallbacking on an empty string restores the behavior (and output) of < 5.0.

However, that shows that's a case we don't handle (yet) properly. But that's another task 😃