### PR TITLE
[FrameworkBundle] fixed suggesting deprecated WebServerBundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/SuggestMissingPackageSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/SuggestMissingPackageSubscriber.php
@@ -39,8 +39,7 @@ final class SuggestMissingPackageSubscriber implements EventSubscriberInterface
             '_default' => ['MakerBundle', 'symfony/maker-bundle --dev'],
         ],
         'server' => [
-            'dump' => ['Debug Bundle', 'symfony/debug-bundle --dev'],
-            '_default' => ['WebServerBundle', 'symfony/web-server-bundle --dev'],
+            '_default' => ['Debug Bundle', 'symfony/debug-bundle --dev'],
         ],
     ];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -208,7 +208,7 @@ class ApplicationTest extends TestCase
 
     public function testSuggestingPackagesWithExactMatch()
     {
-        $result = $this->createEventForSuggestingPackages('server:dump', []);
+        $result = $this->createEventForSuggestingPackages('doctrine:fixtures', []);
         $this->assertRegExp('/You may be looking for a command provided by/', $result);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35495 
| License       | MIT
| Doc PR        | 

Removed suggestion to install `symfony/web-server-bundle` in console missing packages suggestions. The web server bundle was deprecated and no longer works with Symfony 5.x, .