### PR TITLE
Release v4.3.11

### DIFF
--- a/CHANGELOG-4.3.md
+++ b/CHANGELOG-4.3.md
@@ -7,6 +7,15 @@ in 4.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.3.0...v4.3.1
 
+* 4.3.11 (2020-01-31)
+
+ * bug #35530 [HttpClient] Fix regex bearer (noniagriconomie)
+ * bug #35532 [Validator] fix access to uninitialized property when getting value (greedyivan)
+ * bug #35305 [HttpKernel] Fix stale-if-error behavior, add tests (mpdude)
+ * bug #34808 [PhpUnitBridge] Properly handle phpunit arguments for configuration file (biozshock)
+ * bug #35480 [Messenger] Check for all serialization exceptions during message dec… (Patrick Berenschot)
+ * bug #35428 [Cache] fix checking for igbinary availability (nicolas-grekas)
+
 * 4.3.10 (2020-01-21)
 
  * bug #35364 [Yaml] Throw on unquoted exclamation mark (fancyweb)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.3.11-DEV';
+    const VERSION = '4.3.11';
     const VERSION_ID = 40311;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 3;
     const RELEASE_VERSION = 11;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2020';
     const END_OF_LIFE = '07/2020';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.3.10...v4.3.11)

 * bug #35530 [HttpClient] Fix regex bearer (@noniagriconomie)
 * bug #35532 [Validator] fix access to uninitialized property when getting value (@greedyivan)
 * bug #35305 [HttpKernel] Fix stale-if-error behavior, add tests (@mpdude)
 * bug #34808 [PhpUnitBridge] Properly handle phpunit arguments for configuration file (@biozshock)
 * bug #35480 [Messenger] Check for all serialization exceptions during message dec… (@Patrick Berenschot)
 * bug #35428 [Cache] fix checking for igbinary availability (@nicolas-grekas)
