### PR TITLE
[Serializer] Allow to include the severity in ConstraintViolationList

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added support for scalar values denormalization
  * added support for `\stdClass` to `ObjectNormalizer`
  * added the ability to ignore properties using metadata (e.g. `@Symfony\Component\Serializer\Annotation\Ignore`)
+ * added an option to serialize constraint violations payloads (e.g. severity)
 
 5.0.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

The Validator component allow to attach severity and other data to a violation: https://symfony.com/doc/current/validation/severity.html
This feature allow to include all or some fields of this payload in serialized errors.

This feature is already supported in API Platform (https://api-platform.com/docs/core/validation/#error-levels-and-payload-serialization). Including this in Symfony will allow us to migrate from our own RFC7807 normalizer to the Symfony one.

Usage: see the test.