### PR TITLE
[Translation][Debug] Add installation and minimal example to README

### DIFF
--- a/src/Symfony/Component/Debug/README.md
+++ b/src/Symfony/Component/Debug/README.md
@@ -3,10 +3,22 @@ Debug Component
 
 The Debug component provides tools to ease debugging PHP code.
 
+Getting Started
+---------------
+
+```
+$ composer install symfony/debug
+```
+
+```php
+use Symfony\Component\Debug\Debug;
+
+Debug::enable();
+```
+
 Resources
 ---------
 
-  * [Documentation](https://symfony.com/doc/current/components/debug.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)

--- a/src/Symfony/Component/Translation/README.md
+++ b/src/Symfony/Component/Translation/README.md
@@ -3,10 +3,28 @@ Translation Component
 
 The Translation component provides tools to internationalize your application.
 
+Getting Started
+---------------
+
+```
+$ composer require symfony/translation
+```
+
+```php
+use Symfony\Component\Translation\Translator;
+
+$translator = new Translator('fr_FR');
+$translator->addResource('array', [
+    'Hello World!' => 'Bonjour !',
+], 'fr_FR');
+
+echo $translator->trans('Hello World!'); // outputs « Bonjour ! »
+```
+
 Resources
 ---------
 
-  * [Documentation](https://symfony.com/doc/current/components/translation.html)
+  * [Documentation](https://symfony.com/doc/current/translation.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | -

At SymfonyCon, we decided to test out removing some component documentation from the official docs. These were duplicating quite some information of the main guides and were confusing people that used the components in the framework.

I think it's good to reintroduced the composer installation command and a very minimal example in the README's of the component. This doesn't require maintenance and can kickstart people to gain knowledge on how to use the component.

For now, we've (re)moved the Debug and Translation component docs, so that's why I've only modified those README's.

cc @symfony/team-symfony-docs 