### PR TITLE
Fix HTTP client config handling

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1402,7 +1402,7 @@ class Configuration implements ConfigurationInterface
                                             if (!\is_array($config)) {
                                                 return [];
                                             }
-                                            if (!isset($config['host'])) {
+                                            if (!isset($config['host'], $config['value']) || \count($config) > 2) {
                                                 return $config;
                                             }
 
@@ -1511,7 +1511,7 @@ class Configuration implements ConfigurationInterface
                                                 if (!\is_array($config)) {
                                                     return [];
                                                 }
-                                                if (!isset($config['key'])) {
+                                                if (!isset($config['key'], $config['value']) || \count($config) > 2) {
                                                     return $config;
                                                 }
 
@@ -1541,7 +1541,7 @@ class Configuration implements ConfigurationInterface
                                                 if (!\is_array($config)) {
                                                     return [];
                                                 }
-                                                if (!isset($config['host'])) {
+                                                if (!isset($config['host'], $config['value']) || \count($config) > 2) {
                                                     return $config;
                                                 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_xml_key.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_xml_key.php
@@ -1,0 +1,22 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'http_client' => [
+        'default_options' => [
+            'resolve' => [
+                'host' => '127.0.0.1',
+            ],
+        ],
+        'scoped_clients' => [
+            'foo' => [
+                'base_uri' => 'http://example.com',
+                'query' => [
+                    'key' => 'foo',
+                ],
+                'resolve' => [
+                    'host' => '127.0.0.1',
+                ],
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_xml_key.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_xml_key.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:http-client>
+            <framework:default-options>
+                <framework:resolve host="host">127.0.0.1</framework:resolve>
+            </framework:default-options>
+            <framework:scoped-client name="foo" base-uri="http://example.com">
+                <framework:query key="key">foo</framework:query>
+                <framework:resolve host="host">127.0.0.1</framework:resolve>
+            </framework:scoped-client>
+        </framework:http-client>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_xml_key.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_xml_key.yml
@@ -1,0 +1,12 @@
+framework:
+    http_client:
+        default_options:
+            resolve:
+                host: 127.0.0.1
+        scoped_clients:
+            foo:
+                base_uri: http://example.com
+                query:
+                    key: foo
+                resolve:
+                    host: 127.0.0.1

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1559,6 +1559,21 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame($expected, $container->getDefinition('foo')->getArgument(2));
     }
 
+    public function testHttpClientWithQueryParameterKey()
+    {
+        $container = $this->createContainerFromFile('http_client_xml_key');
+
+        $expected = [
+            'key' => 'foo',
+        ];
+        $this->assertSame($expected, $container->getDefinition('foo')->getArgument(2)['query']);
+
+        $expected = [
+            'host' => '127.0.0.1',
+        ];
+        $this->assertSame($expected, $container->getDefinition('foo')->getArgument(2)['resolve']);
+    }
+
     public function testHttpClientFullDefaultOptions()
     {
         $container = $this->createContainerFromFile('http_client_full_default_options');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Defining a `key` parameter in the `query` option of a scoped HTTP client triggers an error:
```
Undefined index: value
```
This PR fixes this issue but an edge case still remains with YAML and PHP config. If one wants to define parameters `key=foo`, `value=bar` and nothing else, the query will actually be `foo=bar` instead of `key=foo&value=bar`. Not sure how to fix this case without breaking the tests I added here.