### PR TITLE
[Validator][GroupSequences][Form] filter out excess violations while validating form field constraints with sequence of groups

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Tests\Extension\Core\Type\TextTypeTest;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validation;
@@ -72,6 +73,132 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
         $form->submit(['field' => 'wrong']);
 
         $this->assertCount(1, $form->getErrors(true));
+    }
+
+    /**
+     * @dataProvider provideGroupsSequenceAndResultData
+     */
+    public function testGroupSequenceWithConstraintsOptionMatrix(
+        array $groups,
+        array $sequence,
+        $errorCount,
+        array $propertyPaths
+    ) {
+        $form = Forms::createFormFactoryBuilder()
+            ->addExtension(new ValidatorExtension(Validation::createValidator()))
+            ->getFormFactory()
+            ->create(FormTypeTest::TESTED_TYPE, null, ([
+                'validation_groups' => new GroupSequence($sequence),
+            ]));
+
+        $data = [];
+        foreach ($groups as $fieldName => $fieldGroups) {
+            $form = $form->add(
+                $fieldName, TextTypeTest::
+                TESTED_TYPE,
+                [
+                    'constraints' => [new NotBlank(['groups' => $fieldGroups])],
+                ]);
+
+            $data[$fieldName] = '';
+        }
+
+        $form->submit($data);
+
+        $errors = $form->getErrors(true);
+        $this->assertCount($errorCount, $form->getErrors(true));
+
+        foreach ($errors as $i => $error) {
+            $this->assertEquals('children['.$propertyPaths[$i].'].data', $error->getCause()->getPropertyPath());
+        }
+    }
+
+    public function provideGroupsSequenceAndResultData()
+    {
+        return [
+            // two fields (sequence of groups and group order):
+            [
+                'groups' => [
+                    'field1' => ['First'],
+                    'field2' => ['Second'],
+                ],
+                'sequence' => ['First'],
+                'errors' => 1,
+                'propertyPaths' => ['field1'],
+            ],
+            [
+                'groups' => [
+                    'field1' => ['First'],
+                    'field2' => ['Second'],
+                ],
+                'sequence' => ['Second'],
+                'errors' => 1,
+                'propertyPaths' => ['field2'],
+            ],
+            [
+                'groups' => [
+                    'field1' => ['First'],
+                    'field2' => ['Second'],
+                ],
+                'sequence' => ['First', 'Second'],
+                'errors' => 1,
+                'propertyPaths' => ['field1'],
+            ],
+            [
+                'groups' => [
+                    'field1' => ['First'],
+                    'field2' => ['Second'],
+                ],
+                'sequence' => ['Second', 'First'],
+                'errors' => 1,
+                'propertyPaths' => ['field2'],
+            ],
+
+            // two fields (field with sequence of groups)
+            [
+                'groups' => [
+                    'field1' => ['First'],
+                    'field2' => ['Second', 'First'],
+                ],
+                'sequence' => ['First'],
+                'errors' => 2,
+                'propertyPaths' => ['field1', 'field2'],
+            ],
+
+            // three fields (sequence with multigroup)
+            [
+                'groups' => [
+                    'field1' => ['First'],
+                    'field2' => ['Second'],
+                    'field3' => ['Third'],
+                ],
+                'sequence' => [['First', 'Second'], 'Third'],
+                'errors' => 2,
+                'propertyPaths' => ['field1', 'field2'],
+            ],
+            [
+                'groups' => [
+                    'field1' => ['First'],
+                    'field2' => ['Second'],
+                    'field3' => ['Third'],
+                ],
+                'sequence' => ['First', ['Second', 'Third']],
+                'errors' => 1,
+                'propertyPaths' => ['field1'],
+            ],
+
+            // three fields (field with sequence of groups)
+            [
+                'groups' => [
+                    'field1' => ['First'],
+                    'field2' => ['Second'],
+                    'field3' => ['Third', 'Second'],
+                ],
+                'sequence' => [['First', 'Second'], 'Third'],
+                'errors' => 3,
+                'propertyPaths' => ['field1', 'field2', 'field3'],
+            ],
+        ];
     }
 
     protected function createForm(array $options = [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #9939
| License       | MIT
| Doc PR        | 

Because all form fields are validated independently by design, sequence of groups of constraints somehow need to be restored after each validation to remove all excesses violations that must be omitted by the sequence rules.

Tests for some cases were added.

Any comments are welcome.