### PR TITLE
[HttpKernel] allow using public aliases to reference controllers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -141,7 +141,7 @@ trait MicroKernelTrait
                 AbstractConfigurator::$valuePreProcessor = $valuePreProcessor;
             }
 
-            $container->setAlias(static::class, 'kernel');
+            $container->setAlias(static::class, 'kernel')->setPublic(true);
         });
     }
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * allowed using public aliases to reference controllers
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -53,6 +53,13 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
         $parameterBag = $container->getParameterBag();
         $controllers = [];
 
+        $publicAliases = [];
+        foreach ($container->getAliases() as $id => $alias) {
+            if ($alias->isPublic()) {
+                $publicAliases[(string) $alias][] = $id;
+            }
+        }
+
         foreach ($container->findTaggedServiceIds($this->controllerTag, true) as $id => $tags) {
             $def = $container->getDefinition($id);
             $def->setPublic(true);
@@ -182,6 +189,10 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                 // register the maps as a per-method service-locators
                 if ($args) {
                     $controllers[$id.'::'.$r->name] = ServiceLocatorTagPass::register($container, $args);
+
+                    foreach ($publicAliases[$id] ?? [] as $alias) {
+                        $controllers[$alias.'::'.$r->name] = clone $controllers[$id.'::'.$r->name];
+                    }
                 }
             }
         }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
@@ -43,6 +43,11 @@ class RemoveEmptyControllerArgumentLocatorsPass implements CompilerPassInterface
                 // any methods listed for call-at-instantiation cannot be actions
                 $reason = false;
                 list($id, $action) = explode('::', $controller);
+
+                if ($container->hasAlias($id)) {
+                    continue;
+                }
+
                 $controllerDef = $container->getDefinition($id);
                 foreach ($controllerDef->getMethodCalls() as list($method)) {
                     if (0 === strcasecmp($action, $method)) {

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -379,6 +379,23 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $this->assertInstanceOf(Reference::class, $locatorArgument);
     }
+
+    public function testAlias()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service')->addArgument([]);
+
+        $container->register('foo', RegisterTestController::class)
+            ->addTag('controller.service_arguments');
+
+        $container->setAlias(RegisterTestController::class, 'foo')->setPublic(true);
+
+        $pass = new RegisterControllerArgumentLocatorsPass();
+        $pass->process($container);
+
+        $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
+        $this->assertSame([RegisterTestController::class.'::fooAction', 'foo::fooAction'], array_keys($locator));
+    }
 }
 
 class RegisterTestController


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR allows referencing a controller with an alias when needed. The use case I'm targetting is using `@Route` annotations on methods of the `App\Kernel` and have them work. This PR allows it.

Sidekick of https://github.com/symfony/recipes/pull/735