### PR TITLE
[DI] give precedence to env var loaders when a .env var is set to the empty string

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -523,11 +523,17 @@ CSV;
 
     public function testEnvLoader()
     {
+        $_ENV['FAKE_REALENV_VAR'] = 'abc';
+        $_ENV['FAKE_DOTENV_VAR'] = 'def';
+        $_ENV['FOO_ENV_LOADER'] = '';
+        $_ENV['SYMFONY_DOTENV_VARS'] = 'FAKE_DOTENV_VAR,FOO_ENV_LOADER';
+
         $loaders = function () {
             yield new class() implements EnvVarLoaderInterface {
                 public function loadEnvVars(): array
                 {
                     return [
+                        'FAKE_REALENV_VAR' => '345',
                         'FOO_ENV_LOADER' => '123',
                     ];
                 }
@@ -539,12 +545,19 @@ CSV;
                     return [
                         'FOO_ENV_LOADER' => '234',
                         'BAR_ENV_LOADER' => '456',
+                        'FAKE_DOTENV_VAR' => '567',
                     ];
                 }
             };
         };
 
         $processor = new EnvVarProcessor(new Container(), $loaders());
+
+        $result = $processor->getEnv('string', 'FAKE_REALENV_VAR', function () {});
+        $this->assertSame('abc', $result);
+
+        $result = $processor->getEnv('string', 'FAKE_DOTENV_VAR', function () {});
+        $this->assertSame('def', $result);
 
         $result = $processor->getEnv('string', 'FOO_ENV_LOADER', function () {});
         $this->assertSame('123', $result);
@@ -554,6 +567,8 @@ CSV;
 
         $result = $processor->getEnv('string', 'FOO_ENV_LOADER', function () {});
         $this->assertSame('123', $result); // check twice
+
+        unset($_ENV['FAKE_REALENV_VAR'], $_ENV['FAKE_DOTENV_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_ENV['FOO_ENV_LOADER']);
     }
 
     public function testCircularEnvLoader()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR allows defining empty vars in .env files and have them be overriden
by env vars loaders (typically secrets). Right now, empty .env vars have
higher precedence over env var loaders (non-empty .env vars still have
higher precedence.)

An alternative to #35564