### PR TITLE
[Mime] don’t include name token in content-type for TextPart

### DIFF
--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -131,9 +131,6 @@ class TextPart extends AbstractPart
         if ($this->charset) {
             $headers->setHeaderParameter('Content-Type', 'charset', $this->charset);
         }
-        if ($this->name) {
-            $headers->setHeaderParameter('Content-Type', 'name', $this->name);
-        }
         $headers->setHeaderBody('Text', 'Content-Transfer-Encoding', $this->encoding);
 
         if (!$headers->has('Content-Disposition') && null !== $this->disposition) {

--- a/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
@@ -65,7 +65,7 @@ class DataPartTest extends TestCase
 
         $p = new DataPart('content', 'photo.jpg', 'text/html');
         $this->assertEquals(new Headers(
-            new ParameterizedHeader('Content-Type', 'text/html', ['name' => 'photo.jpg']),
+            new ParameterizedHeader('Content-Type', 'text/html'),
             new UnstructuredHeader('Content-Transfer-Encoding', 'base64'),
             new ParameterizedHeader('Content-Disposition', 'attachment', ['name' => 'photo.jpg', 'filename' => 'photo.jpg'])
         ), $p->getPreparedHeaders());
@@ -76,7 +76,7 @@ class DataPartTest extends TestCase
         $p = new DataPart('content', 'photo.jpg', 'text/html');
         $p->asInline();
         $this->assertEquals(new Headers(
-            new ParameterizedHeader('Content-Type', 'text/html', ['name' => 'photo.jpg']),
+            new ParameterizedHeader('Content-Type', 'text/html'),
             new UnstructuredHeader('Content-Transfer-Encoding', 'base64'),
             new ParameterizedHeader('Content-Disposition', 'inline', ['name' => 'photo.jpg', 'filename' => 'photo.jpg'])
         ), $p->getPreparedHeaders());
@@ -88,7 +88,7 @@ class DataPartTest extends TestCase
         $p->asInline();
         $cid = $p->getContentId();
         $this->assertEquals(new Headers(
-            new ParameterizedHeader('Content-Type', 'text/html', ['name' => 'photo.jpg']),
+            new ParameterizedHeader('Content-Type', 'text/html'),
             new UnstructuredHeader('Content-Transfer-Encoding', 'base64'),
             new ParameterizedHeader('Content-Disposition', 'inline', ['name' => 'photo.jpg', 'filename' => 'photo.jpg']),
             new IdentificationHeader('Content-ID', $cid)
@@ -105,7 +105,7 @@ class DataPartTest extends TestCase
         $this->assertEquals('image', $p->getMediaType());
         $this->assertEquals('gif', $p->getMediaSubType());
         $this->assertEquals(new Headers(
-            new ParameterizedHeader('Content-Type', 'image/gif', ['name' => 'test.gif']),
+            new ParameterizedHeader('Content-Type', 'image/gif'),
             new UnstructuredHeader('Content-Transfer-Encoding', 'base64'),
             new ParameterizedHeader('Content-Disposition', 'attachment', ['name' => 'test.gif', 'filename' => 'test.gif'])
         ), $p->getPreparedHeaders());
@@ -121,7 +121,7 @@ class DataPartTest extends TestCase
         $this->assertEquals('image', $p->getMediaType());
         $this->assertEquals('jpeg', $p->getMediaSubType());
         $this->assertEquals(new Headers(
-            new ParameterizedHeader('Content-Type', 'image/jpeg', ['name' => 'photo.gif']),
+            new ParameterizedHeader('Content-Type', 'image/jpeg'),
             new UnstructuredHeader('Content-Transfer-Encoding', 'base64'),
             new ParameterizedHeader('Content-Disposition', 'attachment', ['name' => 'photo.gif', 'filename' => 'photo.gif'])
         ), $p->getPreparedHeaders());

--- a/src/Symfony/Component/Mime/Tests/Part/MessagePartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/MessagePartTest.php
@@ -34,7 +34,7 @@ class MessagePartTest extends TestCase
     {
         $p = new MessagePart((new Email())->from('fabien@symfony.com')->text('content')->subject('Subject'));
         $this->assertEquals(new Headers(
-            new ParameterizedHeader('Content-Type', 'message/rfc822', ['name' => 'Subject.eml']),
+            new ParameterizedHeader('Content-Type', 'message/rfc822'),
             new UnstructuredHeader('Content-Transfer-Encoding', 'base64'),
             new ParameterizedHeader('Content-Disposition', 'attachment', ['name' => 'Subject.eml', 'filename' => 'Subject.eml'])
         ), $p->getPreparedHeaders());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35443 
| License       | MIT

I went through rfc7578 and rfc7233  and couldn't really find anything about this. The only reference to a `name` in the `content-type` was in rfc2046 for `message/external-body`. More details in #35443