### PR TITLE
[FrameworkBundle] added new parameter router.request_context.url

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RequestContextPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RequestContextPass.php
@@ -15,13 +15,12 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Add support of url property for routing generator
+ * Add support of url property for routing generator.
  *
  * @author Danil Pyatnitsev <danil@pyatnitsev.ru>
  */
 class RequestContextPass implements CompilerPassInterface
 {
-
     public function process(ContainerBuilder $container)
     {
         if (false === $container->hasParameter('router.request_context.url')) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RequestContextPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RequestContextPass.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Add support of url property for routing generator
+ *
+ * @author Danil Pyatnitsev <danil@pyatnitsev.ru>
+ */
+class RequestContextPass implements CompilerPassInterface
+{
+
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasParameter('router.request_context.url')) {
+            return;
+        }
+
+        $url = $container->getParameter('router.request_context.url');
+        $urlComponents = parse_url($url);
+
+        if (isset($urlComponents['scheme'])) {
+            $container->setParameter('router.request_context.scheme', $urlComponents['scheme']);
+        }
+        if (isset($urlComponents['host'])) {
+            $container->setParameter('router.request_context.host', $urlComponents['host']);
+        }
+        if (isset($urlComponents['port'])) {
+            $name = (isset($urlComponents['scheme']) && 'https' === $urlComponents['scheme']) ? 'https' : 'http';
+            $container->setParameter("request_listener.{$name}_port", $urlComponents['port']);
+        }
+        if (isset($urlComponents['path'])) {
+            $container->setParameter("router.request_context.base_url", $urlComponents['path']);
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RequestContextPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RequestContextPass.php
@@ -41,7 +41,7 @@ class RequestContextPass implements CompilerPassInterface
             $container->setParameter("request_listener.{$name}_port", $urlComponents['port']);
         }
         if (isset($urlComponents['path'])) {
-            $container->setParameter("router.request_context.base_url", $urlComponents['path']);
+            $container->setParameter('router.request_context.base_url', $urlComponents['path']);
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -489,6 +489,7 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('host')->defaultValue('%router.request_context.host%')->end()
                                 ->scalarNode('scheme')->defaultValue('%router.request_context.scheme%')->end()
                                 ->scalarNode('base_url')->defaultValue('%router.request_context.base_url%')->end()
+                                ->scalarNode('url')->defaultValue('%router.request_context.url%')->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilder
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggingTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RequestContextPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerRealRefPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerWeakRefPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\UnusedTagsPass;
@@ -130,6 +131,7 @@ class FrameworkBundle extends Bundle
         $this->addCompilerPassIfExists($container, AddAutoMappingConfigurationPass::class);
         $container->addCompilerPass(new RegisterReverseContainerPass(true));
         $container->addCompilerPass(new RegisterReverseContainerPass(false), PassConfig::TYPE_AFTER_REMOVING);
+        $container->addCompilerPass(new RequestContextPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -8,6 +8,7 @@
         <parameter key="router.request_context.host">localhost</parameter>
         <parameter key="router.request_context.scheme">http</parameter>
         <parameter key="router.request_context.base_url"></parameter>
+        <parameter key="router.request_context.url"></parameter>
     </parameters>
 
     <services>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RequestContextPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RequestContextPassTest.php
@@ -1,9 +1,12 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Danil Pyatnitsev
- * Date: 03.02.2020
- * Time: 22:12
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
@@ -40,7 +43,7 @@ class RequestContextPassTest extends TestCase
 
         $this->assertEquals('foo.example.com', $container->getParameter('router.request_context.host'));
         $this->assertEquals('https', $container->getParameter('router.request_context.scheme'));
-        $this->assertEquals(false, $container->hasParameter('router.request_context.base_url'));
+        $this->assertFalse(false, $container->hasParameter('router.request_context.base_url'));
         $this->assertEquals('8080', $container->getParameter('request_listener.https_port'));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RequestContextPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RequestContextPassTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Danil Pyatnitsev
+ * Date: 03.02.2020
+ * Time: 22:12
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RequestContextPass;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RequestContextPassTest extends TestCase
+{
+    public function testRouterRequestContextUrlParseTest()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('router.request_context.url', 'https://foo.example.com:8080/bar');
+        $container->addCompilerPass(new RequestContextPass());
+
+        $container->register('router', '\stdClass')->setPublic(true);
+        $container->compile();
+
+        $this->assertEquals('foo.example.com', $container->getParameter('router.request_context.host'));
+        $this->assertEquals('https', $container->getParameter('router.request_context.scheme'));
+        $this->assertEquals('/bar', $container->getParameter('router.request_context.base_url'));
+        $this->assertEquals('8080', $container->getParameter('request_listener.https_port'));
+    }
+
+    public function testRouterRequestContextUrlParseWithoutBaseUrlTest()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('router.request_context.url', 'https://foo.example.com:8080');
+        $container->addCompilerPass(new RequestContextPass());
+
+        $container->register('router', '\stdClass')->setPublic(true);
+        $container->compile();
+
+        $this->assertEquals('foo.example.com', $container->getParameter('router.request_context.host'));
+        $this->assertEquals('https', $container->getParameter('router.request_context.scheme'));
+        $this->assertEquals(false, $container->hasParameter('router.request_context.base_url'));
+        $this->assertEquals('8080', $container->getParameter('request_listener.https_port'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -417,6 +417,7 @@ class ConfigurationTest extends TestCase
                     'host' => '%router.request_context.host%',
                     'scheme' => '%router.request_context.scheme%',
                     'base_url' => '%router.request_context.base_url%',
+                    'url' => '%router.request_context.url%'
                 ],
             ],
             'session' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -417,7 +417,7 @@ class ConfigurationTest extends TestCase
                     'host' => '%router.request_context.host%',
                     'scheme' => '%router.request_context.scheme%',
                     'base_url' => '%router.request_context.base_url%',
-                    'url' => '%router.request_context.url%'
+                    'url' => '%router.request_context.url%',
                 ],
             ],
             'session' => [


### PR DESCRIPTION
The router.request_context.url can be used instead of router.request_context / router.request_context.host etc to define url in console commands

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35121
| License       | MIT
| Doc PR        | will be created after review