### PR TITLE
[Mailer] Fix MandrillHttpTransport::getRecipients()'s call

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillHttpTransportTest.php
@@ -57,7 +57,7 @@ class MandrillHttpTransportTest extends TestCase
             $body = json_decode($options['body'], true);
             $message = $body['raw_message'];
             $this->assertSame('KEY', $body['key']);
-            $this->assertSame('Saif Eddin <saif.gmati@symfony.com>', $body['to'][0]);
+            $this->assertSame('saif.gmati@symfony.com', $body['to'][0]);
             $this->assertSame('Fabien <fabpot@symfony.com>', $body['from_email']);
 
             $this->assertStringContainsString('Subject: Hello!', $message);

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
@@ -47,7 +47,7 @@ class MandrillHttpTransport extends AbstractHttpTransport
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/1.0/messages/send-raw.json', [
             'json' => [
                 'key' => $this->key,
-                'to' => $this->getRecipients($envelope->getRecipients()),
+                'to' => $this->getRecipients($envelope),
                 'from_email' => $envelope->getSender()->toString(),
                 'raw_message' => $message->toString(),
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Should make the CI green.