### PR TITLE
[FrameworkBundle] use framework.translator.enabled_locales to build routes' default "_locale" requirement

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -669,6 +669,7 @@ class Configuration implements ConfigurationInterface
                     ->{!class_exists(FullStack::class) && class_exists(Translator::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                     ->fixXmlConfig('fallback')
                     ->fixXmlConfig('path')
+                    ->fixXmlConfig('enabled_locale')
                     ->children()
                         ->arrayNode('fallbacks')
                             ->info('Defaults to the value of "default_locale".')
@@ -689,12 +690,6 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('enabled_locales')
                             ->prototype('scalar')
                             ->defaultValue([])
-                            ->beforeNormalization()
-                                ->always()
-                                ->then(function ($config) {
-                                    return array_unique((array) $config);
-                                })
-                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -354,7 +354,7 @@ class FrameworkExtension extends Extension
         $this->registerProfilerConfiguration($config['profiler'], $container, $loader);
         $this->registerWorkflowConfiguration($config['workflows'], $container, $loader);
         $this->registerDebugConfiguration($config['php_errors'], $container, $loader);
-        $this->registerRouterConfiguration($config['router'], $container, $loader);
+        $this->registerRouterConfiguration($config['router'], $container, $loader, $config['translator']['enabled_locales'] ?? []);
         $this->registerAnnotationsConfiguration($config['annotations'], $container, $loader);
         $this->registerPropertyAccessConfiguration($config['property_access'], $container, $loader);
         $this->registerSecretsConfiguration($config['secrets'], $container, $loader);
@@ -845,7 +845,7 @@ class FrameworkExtension extends Extension
         }
     }
 
-    private function registerRouterConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
+    private function registerRouterConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader, array $enabledLocales = [])
     {
         if (!$this->isConfigEnabled($container, $config)) {
             $container->removeDefinition('console.command.router_debug');
@@ -862,6 +862,11 @@ class FrameworkExtension extends Extension
 
         if ($config['utf8']) {
             $container->getDefinition('routing.loader')->replaceArgument(1, ['utf8' => true]);
+        }
+
+        if ($enabledLocales) {
+            $enabledLocales = implode('|', array_map('preg_quote', $enabledLocales));
+            $container->getDefinition('routing.loader')->replaceArgument(2, ['_locale' => $enabledLocales]);
         }
 
         $container->setParameter('router.resource', $config['resource']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -48,6 +48,7 @@
         <service id="routing.loader" class="Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader" public="true">
             <argument type="service" id="routing.resolver" />
             <argument type="collection" />
+            <argument type="collection" />
         </service>
 
         <service id="router.default" class="Symfony\Bundle\FrameworkBundle\Routing\Router">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -169,6 +169,7 @@
         <xsd:sequence>
             <xsd:element name="fallback" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="path" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="enabled-locale" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="fallback" type="xsd:string" />

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -29,10 +29,12 @@ class DelegatingLoader extends BaseDelegatingLoader
 {
     private $loading = false;
     private $defaultOptions;
+    private $defaultRequirements;
 
-    public function __construct(LoaderResolverInterface $resolver, array $defaultOptions = [])
+    public function __construct(LoaderResolverInterface $resolver, array $defaultOptions = [], array $defaultRequirements = [])
     {
         $this->defaultOptions = $defaultOptions;
+        $this->defaultRequirements = $defaultRequirements;
 
         parent::__construct($resolver);
     }
@@ -72,6 +74,9 @@ class DelegatingLoader extends BaseDelegatingLoader
         foreach ($collection->all() as $route) {
             if ($this->defaultOptions) {
                 $route->setOptions($route->getOptions() + $this->defaultOptions);
+            }
+            if ($this->defaultRequirements) {
+                $route->setRequirements($route->getRequirements() + $this->defaultRequirements);
             }
             if (!\is_string($controller = $route->getDefault('_controller'))) {
                 continue;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -50,6 +50,7 @@ $container->loadFromExtension('framework', [
         'fallback' => 'fr',
         'paths' => ['%kernel.project_dir%/Fixtures/translations'],
         'cache_dir' => '%kernel.cache_dir%/translations',
+        'enabled_locales' => ['fr', 'en']
     ],
     'validation' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -28,6 +28,8 @@
         <framework:assets version="v1" />
         <framework:translator enabled="true" fallback="fr" logging="true" cache-dir="%kernel.cache_dir%/translations">
             <framework:path>%kernel.project_dir%/Fixtures/translations</framework:path>
+            <framework:enabled-locale>fr</framework:enabled-locale>
+            <framework:enabled-locale>en</framework:enabled-locale>
         </framework:translator>
         <framework:validation enabled="true" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -41,6 +41,7 @@ framework:
         default_path: '%kernel.project_dir%/translations'
         cache_dir: '%kernel.cache_dir%/translations'
         paths: ['%kernel.project_dir%/Fixtures/translations']
+        enabled_locales: [fr, en]
     validation:
         enabled: true
     annotations:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -458,6 +458,8 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals($container->getParameter('kernel.project_dir').'/config/routing.xml', $container->getParameter('router.resource'), '->registerRouterConfiguration() sets routing resource');
         $this->assertEquals('%router.resource%', $arguments[1], '->registerRouterConfiguration() sets routing resource');
         $this->assertEquals('xml', $arguments[2]['resource_type'], '->registerRouterConfiguration() sets routing resource type');
+
+        $this->assertSame(['_locale' => 'fr|en'], $container->getDefinition('routing.loader')->getArgument(2));
     }
 
     public function testRouterRequiresResourceOption()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/DelegatingLoaderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/DelegatingLoaderTest.php
@@ -32,13 +32,13 @@ class DelegatingLoaderTest extends TestCase
 
         $routeCollection = new RouteCollection();
         $routeCollection->add('foo', new Route('/', [], [], ['utf8' => false]));
-        $routeCollection->add('bar', new Route('/', [], [], ['foo' => 123]));
+        $routeCollection->add('bar', new Route('/', [], ['_locale' => 'de'], ['foo' => 123]));
 
         $loader->expects($this->once())
             ->method('load')
             ->willReturn($routeCollection);
 
-        $delegatingLoader = new DelegatingLoader($loaderResolver, ['utf8' => true]);
+        $delegatingLoader = new DelegatingLoader($loaderResolver, ['utf8' => true], ['_locale' => 'fr|en']);
 
         $loadedRouteCollection = $delegatingLoader->load('foo');
         $this->assertCount(2, $loadedRouteCollection);
@@ -48,6 +48,7 @@ class DelegatingLoaderTest extends TestCase
             'utf8' => false,
         ];
         $this->assertSame($expected, $routeCollection->get('foo')->getOptions());
+        $this->assertSame(['_locale' => 'fr|en'], $routeCollection->get('foo')->getRequirements());
 
         $expected = [
             'compiler_class' => 'Symfony\Component\Routing\RouteCompiler',
@@ -55,5 +56,6 @@ class DelegatingLoaderTest extends TestCase
             'utf8' => true,
         ];
         $this->assertSame($expected, $routeCollection->get('bar')->getOptions());
+        $this->assertSame(['_locale' => 'de'], $routeCollection->get('bar')->getRequirements());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

No need to configure the same requirements for `_locale` in all routes any more thanks to the `framework.translator.enabled_locales` config option introduced in #32433.