### PR TITLE
[Validator] do not merge constraints within interfaces

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Fixtures/AbstractPropertyGetter.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/AbstractPropertyGetter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+abstract class AbstractPropertyGetter implements PropertyGetterInterface
+{
+    private $property;
+
+    public function getProperty()
+    {
+        return $this->property;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ChildGetterInterface.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ChildGetterInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+interface ChildGetterInterface extends PropertyGetterInterface
+{
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/PropertyGetter.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/PropertyGetter.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+/**
+ * This class has two paths to PropertyGetterInterface:
+ *   PropertyGetterInterface <- AbstractPropertyGetter <- PropertyGetter
+ *   PropertyGetterInterface <- ChildGetterInterface <- PropertyGetter
+ */
+class PropertyGetter extends AbstractPropertyGetter implements ChildGetterInterface
+{
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/PropertyGetterInterface.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/PropertyGetterInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+interface PropertyGetterInterface
+{
+    public function getProperty();
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #22538
| License       | MIT
| Doc PR        | 

This fix disables merge constraints within interfaces.

There is no reason to merge constraints from one interface to another because each class merges the constraints of all its interfaces. Only one check is needed is to eliminate all interfaces that comes from parent class to avoid duplication.

