### PR TITLE
[BrowserKit] added all() method to History class

### DIFF
--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * Added `History::all()` to retrieve requests in history
+
 4.3.0
 -----
 
@@ -14,7 +19,7 @@ CHANGELOG
 4.2.0
 -----
 
- * The method `Client::submit()` will have a new `$serverParameters` argument 
+ * The method `Client::submit()` will have a new `$serverParameters` argument
    in version 5.0, not defining it is deprecated
  * Added ability to read the "samesite" attribute of cookies using `Cookie::getSameSite()`
 

--- a/src/Symfony/Component/BrowserKit/History.php
+++ b/src/Symfony/Component/BrowserKit/History.php
@@ -97,4 +97,16 @@ class History
 
         return clone $this->stack[$this->position];
     }
+
+    /**
+     * Returns all the requests in history.
+     *
+     * @return Request[]
+     */
+    public function all(): array
+    {
+        return array_map(function (Request $request) {
+            return clone $request;
+        }, $this->stack);
+    }
 }

--- a/src/Symfony/Component/BrowserKit/Tests/HistoryTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HistoryTest.php
@@ -99,4 +99,17 @@ class HistoryTest extends TestCase
 
         $this->assertSame('http://www.example1.com/', $history->current()->getUri(), '->forward() returns the next request in the history');
     }
+
+    public function testAll()
+    {
+        $history = new History();
+        $history->add(new Request('http://www.example.com/', 'get'));
+        $history->add(new Request('http://www.example1.com/', 'get'));
+
+        $requests = $history->all();
+
+        $this->assertCount(2, $requests, '->all() returns the same amount of requests');
+        $this->assertSame('http://www.example.com/', $requests[0]->getUri(), '->all() returns first request');
+        $this->assertSame('http://www.example1.com/', $requests[1]->getUri(), '->all() returns second request');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35476
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Simple PR that adds `all` method to `History` class to retrieve all requests in the history. Should I add Doc PR now or after review?