### PR TITLE
[Serializer] Add support for stdClass

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -262,7 +262,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             array_unshift($attributes, $mapping->getTypeProperty());
         }
 
-        if ($context['cache_key']) {
+        if ($context['cache_key'] && \stdClass::class !== $class) {
             $this->attributesCache[$key] = $attributes;
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -62,6 +62,10 @@ class ObjectNormalizer extends AbstractObjectNormalizer
      */
     protected function extractAttributes(object $object, string $format = null, array $context = [])
     {
+        if (\stdClass::class === \get_class($object)) {
+            return array_keys((array) $object);
+        }
+
         // If not using groups, detect manually
         $attributes = [];
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -696,6 +696,20 @@ class ObjectNormalizerTest extends TestCase
             $normalizer->normalize($obj, 'any')
         );
     }
+
+    public function testNormalizeStdClass()
+    {
+        $o1 = new \stdClass();
+        $o1->foo = 'f';
+        $o1->bar = 'b';
+
+        $this->assertSame(['foo' => 'f', 'bar' => 'b'], $this->normalizer->normalize($o1));
+
+        $o2 = new \stdClass();
+        $o2->baz = 'baz';
+
+        $this->assertSame(['baz' => 'baz'], $this->normalizer->normalize($o2));
+    }
 }
 
 class ProxyObjectDummy extends ObjectDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #33047, #33894
| License       | MIT
| Doc PR        | n/a

Add support for `stdClass`. Alternative to #33894.