### PR TITLE
[Security] Replace 403 with 401 in `onAuthenticationFailure` method

### DIFF
--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
@@ -107,7 +107,7 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      * Called when authentication executed, but failed (e.g. wrong username password).
      *
      * This should return the Response sent back to the user, like a
-     * RedirectResponse to the login page or a 403 response.
+     * RedirectResponse to the login page or a 401 response.
      *
      * If you return null, the request will continue, but the user will
      * not be authenticated. This is probably not what you want to do.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This comment in `onAuthenticationFailure` was misleading since a 401 status code should probably be returned instead of a 403.