### PR TITLE
[Console] Moved estimated & remaining calculation logic to separate get method

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -191,9 +191,27 @@ final class ProgressBar
         return $this->percent;
     }
 
-    public function getBarOffset(): int
+    public function getBarOffset(): float
     {
         return floor($this->max ? $this->percent * $this->barWidth : (null === $this->redrawFreq ? min(5, $this->barWidth / 15) * $this->writeCount : $this->step) % $this->barWidth);
+    }
+
+    public function getEstimated(): float
+    {
+        if (!$this->step) {
+            return 0;
+        }
+
+        return round((time() - $this->startTime) / $this->step * $this->max);
+    }
+
+    public function getRemaining(): float
+    {
+        if (!$this->step) {
+            return 0;
+        }
+
+        return round((time() - $this->startTime) / $this->step * ($this->max - $this->step));
     }
 
     public function setBarWidth(int $size)
@@ -500,26 +518,14 @@ final class ProgressBar
                     throw new LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
                 }
 
-                if (!$bar->getProgress()) {
-                    $remaining = 0;
-                } else {
-                    $remaining = round((time() - $bar->getStartTime()) / $bar->getProgress() * ($bar->getMaxSteps() - $bar->getProgress()));
-                }
-
-                return Helper::formatTime($remaining);
+                return Helper::formatTime($bar->getRemaining());
             },
             'estimated' => function (self $bar) {
                 if (!$bar->getMaxSteps()) {
                     throw new LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
                 }
 
-                if (!$bar->getProgress()) {
-                    $estimated = 0;
-                } else {
-                    $estimated = round((time() - $bar->getStartTime()) / $bar->getProgress() * $bar->getMaxSteps());
-                }
-
-                return Helper::formatTime($estimated);
+                return Helper::formatTime($bar->getEstimated());
             },
             'memory' => function (self $bar) {
                 return Helper::formatMemory(memory_get_usage(true));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT

This way, we can use `getEstimated()`and `getRemaining()` to get easy access to the estimated / remaining number of seconds to be used in our placeholder definition set with `setPlaceholderFormatterDefinition` without having to redefine the calculation ourself.

Example before;

```php
ProgressBar::setPlaceholderFormatterDefinition(
    'eta',
    function (ProgressBar $progressBar) {
        $estimated = round((time() - $progressBar->getStartTime()) / ($progressBar->getProgress() ?: 0.1) * $progressBar->getMaxSteps());
        return date('H:i:s', strtotime('+' . $estimated . ' seconds'));
    }
);
```

Example after;

```php
ProgressBar::setPlaceholderFormatterDefinition(
    'eta',
    function (ProgressBar $progressBar) {
        return date('H:i:s', strtotime('+' . $this->getEstimated() . ' seconds'));
    }
);
```
