### PR TITLE
[Serializer] Serialization versioning

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -934,6 +934,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->scalarNode('default_version')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1598,6 +1598,12 @@ class FrameworkExtension extends Extension
             $defaultContext += ['max_depth_handler' => new Reference($config['max_depth_handler'])];
             $container->getDefinition('serializer.normalizer.object')->replaceArgument(6, $defaultContext);
         }
+
+        if (isset($config['default_version']) && $config['default_version']) {
+            $defaultContext = $container->getDefinition('serializer.normalizer.object')->getArgument(6);
+            $defaultContext += ['version' => $config['default_version']];
+            $container->getDefinition('serializer.normalizer.object')->replaceArgument(6, $defaultContext);
+        }
     }
 
     private function registerPropertyInfoConfiguration(ContainerBuilder $container, PhpFileLoader $loader)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -251,7 +251,7 @@
         <xsd:attribute name="name-converter" type="xsd:string" />
         <xsd:attribute name="circular-reference-handler" type="xsd:string" />
         <xsd:attribute name="max-depth-handler" type="xsd:string" />
-        <xsd:attribute name="default_version" type="xsd:string" />
+        <xsd:attribute name="default-version" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="property_info">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -251,6 +251,7 @@
         <xsd:attribute name="name-converter" type="xsd:string" />
         <xsd:attribute name="circular-reference-handler" type="xsd:string" />
         <xsd:attribute name="max-depth-handler" type="xsd:string" />
+        <xsd:attribute name="default_version" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="property_info">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -67,6 +67,7 @@ $container->loadFromExtension('framework', [
         'name_converter' => 'serializer.name_converter.camel_case_to_snake_case',
         'circular_reference_handler' => 'my.circular.reference.handler',
         'max_depth_handler' => 'my.max.depth.handler',
+        'default_version' => '1.0.0',
     ],
     'property_info' => true,
     'ide' => 'file%%link%%format',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -33,7 +33,7 @@
         </framework:translator>
         <framework:validation enabled="true" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />
-        <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" circular-reference-handler="my.circular.reference.handler" max-depth-handler="my.max.depth.handler" default_version="1.0.0" />
+        <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" circular-reference-handler="my.circular.reference.handler" max-depth-handler="my.max.depth.handler" default-version="1.0.0" />
         <framework:property-info />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -33,7 +33,7 @@
         </framework:translator>
         <framework:validation enabled="true" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />
-        <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" circular-reference-handler="my.circular.reference.handler" max-depth-handler="my.max.depth.handler" />
+        <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" circular-reference-handler="my.circular.reference.handler" max-depth-handler="my.max.depth.handler" default_version="1.0.0" />
         <framework:property-info />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -55,6 +55,7 @@ framework:
          name_converter:             serializer.name_converter.camel_case_to_snake_case
          circular_reference_handler: my.circular.reference.handler
          max_depth_handler:          my.max.depth.handler
+         default_version:            1.0.0
     property_info: ~
     ide: file%%link%%format
     request:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1108,6 +1108,8 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertArrayHasKey('circular_reference_handler', $container->getDefinition('serializer.normalizer.object')->getArgument(6));
         $this->assertArrayHasKey('max_depth_handler', $container->getDefinition('serializer.normalizer.object')->getArgument(6));
         $this->assertEquals($container->getDefinition('serializer.normalizer.object')->getArgument(6)['max_depth_handler'], new Reference('my.max.depth.handler'));
+        $this->assertArrayHasKey('version', $container->getDefinition('serializer.normalizer.object')->getArgument(6));
+        $this->assertEquals($container->getDefinition('serializer.normalizer.object')->getArgument(6)['version'], '1.0.0');
     }
 
     public function testRegisterSerializerExtractor()

--- a/src/Symfony/Component/Serializer/Annotation/Since.php
+++ b/src/Symfony/Component/Serializer/Annotation/Since.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @Since().
+ *
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Arnaud Tarroux <ta.arnaud@gmail.com>
+ */
+class Since
+{
+    /**
+     * @var string
+     */
+    private $version;
+
+    public function __construct(array $data)
+    {
+        if (!isset($data['value'])) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', \get_class($this)));
+        }
+
+        if (!\is_string($data['value']) || empty($data['value'])) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', \get_class($this)));
+        }
+
+        $this->version = $data['value'];
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+}

--- a/src/Symfony/Component/Serializer/Annotation/Since.php
+++ b/src/Symfony/Component/Serializer/Annotation/Since.php
@@ -31,11 +31,11 @@ class Since
     public function __construct(array $data)
     {
         if (!isset($data['value'])) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', \get_class($this)));
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', static::class));
         }
 
         if (!\is_string($data['value']) || empty($data['value'])) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', \get_class($this)));
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', static::class));
         }
 
         $this->version = $data['value'];

--- a/src/Symfony/Component/Serializer/Annotation/Until.php
+++ b/src/Symfony/Component/Serializer/Annotation/Until.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @Until().
+ *
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Arnaud Tarroux <ta.arnaud@gmail.com>
+ */
+class Until
+{
+    /**
+     * @var string
+     */
+    private $version;
+
+    public function __construct(array $data)
+    {
+        if (!isset($data['value'])) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', \get_class($this)));
+        }
+
+        if (!\is_string($data['value']) || empty($data['value'])) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', \get_class($this)));
+        }
+
+        $this->version = $data['value'];
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+}

--- a/src/Symfony/Component/Serializer/Annotation/Until.php
+++ b/src/Symfony/Component/Serializer/Annotation/Until.php
@@ -31,11 +31,11 @@ class Until
     public function __construct(array $data)
     {
         if (!isset($data['value'])) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', \get_class($this)));
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', static::class));
         }
 
         if (!\is_string($data['value']) || empty($data['value'])) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', \get_class($this)));
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', static::class));
         }
 
         $this->version = $data['value'];

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -59,6 +59,24 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public $ignore = false;
 
+    /**
+     * @var string|null
+     *
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getSince()} instead.
+     */
+    public $since;
+
+    /**
+     * @var string|null
+     *
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getUntil()} instead.
+     */
+    public $until;
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -163,12 +181,44 @@ class AttributeMetadata implements AttributeMetadataInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function setSince(string $version)
+    {
+        $this->since = $version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSince(): ?string
+    {
+        return $this->since;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUntil(string $version)
+    {
+        $this->until = $version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUntil(): ?string
+    {
+        return $this->until;
+    }
+
+    /**
      * Returns the names of the properties that should be serialized.
      *
      * @return string[]
      */
     public function __sleep()
     {
-        return ['name', 'groups', 'maxDepth', 'serializedName', 'ignore'];
+        return ['name', 'groups', 'maxDepth', 'serializedName', 'ignore', 'since', 'until'];
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -75,4 +75,24 @@ interface AttributeMetadataInterface
      * Merges an {@see AttributeMetadataInterface} with in the current one.
      */
     public function merge(self $attributeMetadata);
+
+    /**
+     * Sets the version number from which the attribute must be serialized.
+     */
+    public function setSince(string $version);
+
+    /**
+     * Gets the version number from which the attribute must be serialized.
+     */
+    public function getSince(): ?string;
+
+    /**
+     * Sets the version number after which the attribute must not be serialized.
+     */
+    public function setUntil(string $version);
+
+    /**
+     * Gets the version number after which the attribute must not be serialized.
+     */
+    public function getUntil(): ?string;
 }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -17,6 +17,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Annotation\MaxDepth;
 use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Annotation\Since;
+use Symfony\Component\Serializer\Annotation\Until;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
@@ -74,6 +76,10 @@ class AnnotationLoader implements LoaderInterface
                         $attributesMetadata[$property->name]->setSerializedName($annotation->getSerializedName());
                     } elseif ($annotation instanceof Ignore) {
                         $attributesMetadata[$property->name]->setIgnore(true);
+                    } elseif ($annotation instanceof Since) {
+                        $attributesMetadata[$property->name]->setSince($annotation->getVersion());
+                    } elseif ($annotation instanceof Until) {
+                        $attributesMetadata[$property->name]->setUntil($annotation->getVersion());
                     }
 
                     $loaded = true;
@@ -121,6 +127,18 @@ class AnnotationLoader implements LoaderInterface
                     $attributeMetadata->setSerializedName($annotation->getSerializedName());
                 } elseif ($annotation instanceof Ignore) {
                     $attributeMetadata->setIgnore(true);
+                } elseif ($annotation instanceof Since) {
+                    if (!$accessorOrMutator) {
+                        throw new MappingException(sprintf('Since on "%s::%s" cannot be added. Since can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
+                    }
+
+                    $attributeMetadata->setSince($annotation->getVersion());
+                } elseif ($annotation instanceof Until) {
+                    if (!$accessorOrMutator) {
+                        throw new MappingException(sprintf('Until on "%s::%s" cannot be added. Until can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
+                    }
+
+                    $attributeMetadata->setUntil($annotation->getVersion());
                 }
 
                 $loaded = true;

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -74,6 +74,14 @@ class XmlFileLoader extends FileLoader
                 if (isset($attribute['ignore'])) {
                     $attributeMetadata->setIgnore((bool) $attribute['ignore']);
                 }
+
+                if (isset($attribute['since'])) {
+                    $attributeMetadata->setSince((string) $attribute['since']);
+                }
+
+                if (isset($attribute['until'])) {
+                    $attributeMetadata->setUntil((string) $attribute['until']);
+                }
             }
 
             if (isset($xml->{'discriminator-map'})) {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -101,6 +101,14 @@ class YamlFileLoader extends FileLoader
 
                     $attributeMetadata->setIgnore($data['ignore']);
                 }
+
+                if (isset($data['since'])) {
+                    $attributeMetadata->setSince((string) $data['since']);
+                }
+
+                if (isset($data['until'])) {
+                    $attributeMetadata->setUntil((string) $data['until']);
+                }
             }
         }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
@@ -79,6 +79,20 @@
             </xsd:simpleType>
         </xsd:attribute>
         <xsd:attribute name="ignore" type="xsd:boolean" />
+        <xsd:attribute name="since">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1" />
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+        <xsd:attribute name="until">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1" />
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
     </xsd:complexType>
 
 </xsd:schema>

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -450,6 +450,9 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         return $parentContext;
     }
 
+    /**
+     * @internal
+     */
     protected function attributeAllowedWithVersion(array $context, ?string $sinceVersion, ?string $untilVersion)
     {
         if (!isset($context['version'])) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Composer\Semver\Comparator;
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -455,11 +456,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             return true;
         }
 
-        if (null !== $sinceVersion && version_compare($sinceVersion, $context['version'], '>')) {
+        if (null !== $sinceVersion && Comparator::lessThan($context['version'], $sinceVersion)) {
             return false;
         }
 
-        if (null !== $untilVersion && version_compare($untilVersion, $context['version'], '<')) {
+        if (null !== $untilVersion && Comparator::greaterThanOrEqualTo($context['version'], $untilVersion)) {
             return false;
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -454,15 +454,16 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      */
     private function attributeAllowedWithVersion(array $context, ?string $sinceVersion, ?string $untilVersion)
     {
-        if (!isset($context['version'])) {
+        if (!isset($context['version']) && !isset($this->defaultContext['version'])) {
             return true;
         }
 
-        if (null !== $sinceVersion && version_compare($context['version'], $sinceVersion, '<')) {
+        $version = $context['version'] ?? $this->defaultContext['version'];
+        if (null !== $sinceVersion && version_compare($version, $sinceVersion, '<')) {
             return false;
         }
 
-        if (null !== $untilVersion && version_compare($context['version'], $untilVersion, '>=')) {
+        if (null !== $untilVersion && version_compare($version, $untilVersion, '>=')) {
             return false;
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -452,7 +452,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     /**
      * @internal
      */
-    protected function attributeAllowedWithVersion(array $context, ?string $sinceVersion, ?string $untilVersion)
+    private function attributeAllowedWithVersion(array $context, ?string $sinceVersion, ?string $untilVersion)
     {
         if (!isset($context['version'])) {
             return true;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -251,7 +251,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             if (
                 !$ignore &&
                 (false === $groups || array_intersect(array_merge($attributeMetadata->getGroups(), ['*']), $groups)) &&
-                $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)
+                $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context) &&
+                $this->attributeAllowedWithVersion($context, $attributeMetadata->getSince(), $attributeMetadata->getUntil())
             ) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;
             }
@@ -446,5 +447,22 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         }
 
         return $parentContext;
+    }
+
+    protected function attributeAllowedWithVersion(array $context, ?string $sinceVersion, ?string $untilVersion)
+    {
+        if (!isset($context['version'])) {
+            return true;
+        }
+
+        if (null !== $sinceVersion && version_compare($sinceVersion, $context['version'], '>')) {
+            return false;
+        }
+
+        if (null !== $untilVersion && version_compare($untilVersion, $context['version'], '<')) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-use Composer\Semver\Comparator;
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -459,11 +458,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             return true;
         }
 
-        if (null !== $sinceVersion && Comparator::lessThan($context['version'], $sinceVersion)) {
+        if (null !== $sinceVersion && version_compare($context['version'], $sinceVersion, '<')) {
             return false;
         }
 
-        if (null !== $untilVersion && Comparator::greaterThanOrEqualTo($context['version'], $untilVersion)) {
+        if (null !== $untilVersion && version_compare($context['version'], $untilVersion, '>=')) {
             return false;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Annotation/SinceTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/SinceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Annotation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Annotation\Since;
+
+/**
+ * @author Arnaud Tarroux <ta.arnaud@gmail.com>
+ */
+class SinceTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\Since" should be set.
+     */
+    public function testNotSetVersionParameter()
+    {
+        new Since([]);
+    }
+
+    public function provideInvalidValues()
+    {
+        return [
+            [''],
+            [0],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidValues
+     *
+     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\Since" must be a non-empty string.
+     */
+    public function testNotAStringVersionParameter($value)
+    {
+        new Since(['value' => $value]);
+    }
+
+    public function testVersionParameters()
+    {
+        $since = new Since(['value' => '1.1.2']);
+        $this->assertEquals('1.1.2', $since->getVersion());
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Annotation/SinceTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/SinceTest.php
@@ -13,18 +13,19 @@ namespace Symfony\Component\Serializer\Tests\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Annotation\Since;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**
  * @author Arnaud Tarroux <ta.arnaud@gmail.com>
  */
 class SinceTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\Since" should be set.
-     */
     public function testNotSetVersionParameter()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Parameter of annotation "Symfony\Component\Serializer\Annotation\Since" should be set.'
+        );
         new Since([]);
     }
 
@@ -38,12 +39,13 @@ class SinceTest extends TestCase
 
     /**
      * @dataProvider provideInvalidValues
-     *
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\Since" must be a non-empty string.
      */
     public function testNotAStringVersionParameter($value)
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Parameter of annotation "Symfony\Component\Serializer\Annotation\Since" must be a non-empty string.'
+        );
         new Since(['value' => $value]);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Annotation/SinceTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/SinceTest.php
@@ -52,6 +52,6 @@ class SinceTest extends TestCase
     public function testVersionParameters()
     {
         $since = new Since(['value' => '1.1.2']);
-        $this->assertEquals('1.1.2', $since->getVersion());
+        $this->assertSame('1.1.2', $since->getVersion());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Annotation/UntilTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/UntilTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Annotation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Annotation\Until;
+
+/**
+ * @author Arnaud Tarroux <ta.arnaud@gmail.com>
+ */
+class UntilTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\Until" should be set.
+     */
+    public function testNotSetVersionParameter()
+    {
+        new Until([]);
+    }
+
+    public function provideInvalidValues()
+    {
+        return [
+            [''],
+            [0],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidValues
+     *
+     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\Until" must be a non-empty string.
+     */
+    public function testNotAStringVersionParameter($value)
+    {
+        new Until(['value' => $value]);
+    }
+
+    public function testVersionParameters()
+    {
+        $since = new Until(['value' => '1.1.2']);
+        $this->assertEquals('1.1.2', $since->getVersion());
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Annotation/UntilTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/UntilTest.php
@@ -52,6 +52,6 @@ class UntilTest extends TestCase
     public function testVersionParameters()
     {
         $since = new Until(['value' => '1.1.2']);
-        $this->assertEquals('1.1.2', $since->getVersion());
+        $this->assertSame('1.1.2', $since->getVersion());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Annotation/UntilTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/UntilTest.php
@@ -13,18 +13,19 @@ namespace Symfony\Component\Serializer\Tests\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Annotation\Until;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**
  * @author Arnaud Tarroux <ta.arnaud@gmail.com>
  */
 class UntilTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\Until" should be set.
-     */
     public function testNotSetVersionParameter()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Parameter of annotation "Symfony\Component\Serializer\Annotation\Until" should be set.'
+        );
         new Until([]);
     }
 
@@ -38,12 +39,13 @@ class UntilTest extends TestCase
 
     /**
      * @dataProvider provideInvalidValues
-     *
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\Until" must be a non-empty string.
      */
     public function testNotAStringVersionParameter($value)
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Parameter of annotation "Symfony\Component\Serializer\Annotation\Until" must be a non-empty string.'
+        );
         new Until(['value' => $value]);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/VersioningDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/VersioningDummy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Since;
+use Symfony\Component\Serializer\Annotation\Until;
+
+class VersioningDummy
+{
+    /**
+     * @Since("1.0.0")
+     * @Until("1.1.9")
+     */
+    public $foo;
+
+    public $bar;
+
+    /**
+     * @Since("0.9.0")
+     */
+    public $username;
+
+    /**
+     * @Since("1.1.2")
+     */
+    public function getBar()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @Until("1.3.0")
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -39,4 +39,8 @@
         <attribute name="ignored2" ignore="true" />
     </class>
 
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\VersionDummy">
+        <attribute name="foo" since="1.2.0" until="1.9.1" />
+    </class>
+
 </serializer>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -30,3 +30,9 @@
       ignore: true
     ignored2:
       ignore: true
+
+'Symfony\Component\Serializer\Tests\Fixtures\VersionDummy':
+  attributes:
+    foo:
+      since: '1.0.0'
+      until: '1.1.9'

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -20,8 +20,8 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild;
-use Symfony\Component\Serializer\Tests\Fixtures\IgnoreDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyThirdChild;
+use Symfony\Component\Serializer\Tests\Fixtures\IgnoreDummy;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
 
 /**

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -118,4 +118,17 @@ class AnnotationLoaderTest extends TestCase
         $this->assertTrue($attributesMetadata['ignored1']->isIgnored());
         $this->assertTrue($attributesMetadata['ignored2']->isIgnored());
     }
+
+    public function testLoadVersion()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\VersioningDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+
+        $this->assertEquals('1.0.0', $attributesMetadata['foo']->getSince());
+        $this->assertEquals('1.1.2', $attributesMetadata['bar']->getSince());
+        $this->assertEquals('1.1.9', $attributesMetadata['foo']->getUntil());
+        $this->assertEquals('1.3.0', $attributesMetadata['username']->getUntil());
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -126,9 +126,9 @@ class AnnotationLoaderTest extends TestCase
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
 
-        $this->assertEquals('1.0.0', $attributesMetadata['foo']->getSince());
-        $this->assertEquals('1.1.2', $attributesMetadata['bar']->getSince());
-        $this->assertEquals('1.1.9', $attributesMetadata['foo']->getUntil());
-        $this->assertEquals('1.3.0', $attributesMetadata['username']->getUntil());
+        $this->assertSame('1.0.0', $attributesMetadata['foo']->getSince());
+        $this->assertSame('1.1.2', $attributesMetadata['bar']->getSince());
+        $this->assertSame('1.1.9', $attributesMetadata['foo']->getUntil());
+        $this->assertSame('1.3.0', $attributesMetadata['username']->getUntil());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -111,7 +111,7 @@ class XmlFileLoaderTest extends TestCase
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
 
-        $this->assertEquals('1.2.0', $attributesMetadata['foo']->getSince());
-        $this->assertEquals('1.9.1', $attributesMetadata['foo']->getUntil());
+        $this->assertSame('1.2.0', $attributesMetadata['foo']->getSince());
+        $this->assertSame('1.9.1', $attributesMetadata['foo']->getUntil());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -103,4 +103,15 @@ class XmlFileLoaderTest extends TestCase
         $this->assertTrue($attributesMetadata['ignored1']->isIgnored());
         $this->assertTrue($attributesMetadata['ignored2']->isIgnored());
     }
+
+    public function testVersion()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\VersionDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+
+        $this->assertEquals('1.2.0', $attributesMetadata['foo']->getSince());
+        $this->assertEquals('1.9.1', $attributesMetadata['foo']->getUntil());
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -133,7 +133,7 @@ class YamlFileLoaderTest extends TestCase
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
 
-        $this->assertEquals('1.0.0', $attributesMetadata['foo']->getSince());
-        $this->assertEquals('1.1.9', $attributesMetadata['foo']->getUntil());
+        $this->assertSame('1.0.0', $attributesMetadata['foo']->getSince());
+        $this->assertSame('1.1.9', $attributesMetadata['foo']->getUntil());
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -125,4 +125,15 @@ class YamlFileLoaderTest extends TestCase
 
         (new YamlFileLoader(__DIR__.'/../../Fixtures/invalid-ignore.yml'))->loadClassMetadata(new ClassMetadata(IgnoreDummy::class));
     }
+
+    public function testVersion()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\VersionDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+
+        $this->assertEquals('1.0.0', $attributesMetadata['foo']->getSince());
+        $this->assertEquals('1.1.9', $attributesMetadata['foo']->getUntil());
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -216,16 +216,16 @@ class AbstractNormalizerTest extends TestCase
         $result = $this->normalizer->getAllowedAttributes('c', [
             AbstractNormalizer::GROUPS => ['test'], 'version' => '1.8.0',
         ], true);
-        $this->assertEquals(['a', 'b', 'c'], $result);
+        $this->assertSame(['a', 'b', 'c'], $result);
 
         $result = $this->normalizer->getAllowedAttributes('c', [
             AbstractNormalizer::GROUPS => ['test'], 'version' => '1.7.0',
         ], true);
-        $this->assertEquals(['b'], $result);
+        $this->assertSame(['b'], $result);
 
         $result = $this->normalizer->getAllowedAttributes('c', [
             AbstractNormalizer::GROUPS => ['test'], 'version' => '2.3.0',
         ], true);
-        $this->assertEquals(['a'], $result);
+        $this->assertSame(['a'], $result);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -190,4 +190,42 @@ class AbstractNormalizerTest extends TestCase
 
         $this->assertSame([], $normalizer->normalize($dummy));
     }
+
+    public function testObjectWithVersioning()
+    {
+        $classMetadata = new ClassMetadata('c');
+
+        $a = new AttributeMetadata('a');
+        $a->setSince('1.8.0');
+        $a->addGroup('test');
+        $classMetadata->addAttributeMetadata($a);
+
+        $b = new AttributeMetadata('b');
+        $b->setUntil('2.1.0');
+        $b->addGroup('test');
+        $classMetadata->addAttributeMetadata($b);
+
+        $c = new AttributeMetadata('c');
+        $c->setSince('1.8.0');
+        $c->setUntil('2.0.0');
+        $c->addGroup('test');
+        $classMetadata->addAttributeMetadata($c);
+
+        $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [
+            AbstractNormalizer::GROUPS => ['test'], 'version' => '1.8.0',
+        ], true);
+        $this->assertEquals(['a', 'b', 'c'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [
+            AbstractNormalizer::GROUPS => ['test'], 'version' => '1.7.0',
+        ], true);
+        $this->assertEquals(['b'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [
+            AbstractNormalizer::GROUPS => ['test'], 'version' => '2.3.0',
+        ], true);
+        $this->assertEquals(['a'], $result);
+    }
 }

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-php80": "^1.15",
-        "composer/semver": "^1.0@dev"
+        "composer/semver": "^3.0"
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/polyfill-ctype": "~1.8",
-        "symfony/polyfill-php80": "^1.15"
+        "symfony/polyfill-php80": "^1.15",
+        "composer/semver": "^1.0@dev"
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -18,8 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/polyfill-ctype": "~1.8",
-        "symfony/polyfill-php80": "^1.15",
-        "composer/semver": "^3.0"
+        "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #30848
| License       | MIT
| Doc PR        | n/a

Add Serialization versioning.

- Added `@Since` annotation
- Added `@Until` annotation
- Added support of `since` and `until` to the `xml` and `yaml` mapping
- Added `version` context option
- Added the possibility to configure the `serializer.default_version` in the framework config
