### PR TITLE
[Messenger][AMQP] Set the delayed queue as lazy

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -376,6 +376,7 @@ class Connection
             // after being released from to DLX, make sure the original routing key will be used
             // we must use an empty string instead of null for the argument to be picked up
             'x-dead-letter-routing-key' => $routingKey ?? '',
+            'x-queue-mode' => 'lazy',
         ]);
 
         return $queue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

> Since RabbitMQ 3.6.0, the broker has the concept of Lazy Queues - queues that move their contents to disk as early as practically possible, and only load them in RAM when requested by consumers, therefore the lazy denomination.
>
> One of the main goals of lazy queues is to be able to support very long queues (many millions of messages). Queues can become very long for various reasons:
>
> * consumers are offline / have crashed / are down for maintenance
> * there is a sudden message ingress spike, producers are outpacing consumers
> * consumers are slower than normal
>
> By default, queues keep an in-memory cache of messages that is filled up as messages are published into RabbitMQ. The idea of this cache is to be able to deliver messages to consumers as fast as possible. Note that persistent messages can be written to disk as they enter the broker and kept in RAM at the same time.

From: https://www.rabbitmq.com/lazy-queues.html

It's typically the case of delay queue

---

**WARNING**: This is a BC Break.

An exception similar to the following will happen if the delayed queue
already exist:

```
AMQPQueueException {#664
  #message: "Server channel error: 406, message: PRECONDITION_FAILED - inequivalent arg 'x-queue-mode' for queue 'test.load' in vhost 'joli_redirection': received 'lazy' but current is 'default'"
```

I don't know how to fix that:

1. We could try to create the queue as lazy and if it does not work, as normal.
2. We could add an option in the config, and it's up to the user to do what it should be done

Note: It's possible to change the type at runtime