### PR TITLE
[Translation] add support for default translation message when translation is missing

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * add support for default translation message when translation is missing
+
 5.0.0
 -----
 
@@ -16,7 +21,7 @@ CHANGELOG
 
  * added a new `TwigErrorRenderer` for `html` format, integrated with the `ErrorHandler` component
  * marked all classes extending twig as `@final`
- * deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
+ * deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the
    `DebugCommand::__construct()` method, swap the variables position.
  * the `LintCommand` lints all the templates stored in all configured Twig paths if none argument is provided
  * deprecated accepting STDIN implicitly when using the `lint:twig` command, use `lint:twig -` (append a dash) instead to make it explicit.
@@ -29,7 +34,7 @@ CHANGELOG
 
  * added the `form_parent()` function that allows to reliably retrieve the parent form in Twig templates
  * added the `workflow_transition_blockers()` function
- * deprecated the `$requestStack` and `$requestContext` arguments of the 
+ * deprecated the `$requestStack` and `$requestContext` arguments of the
    `HttpFoundationExtension`, pass a `Symfony\Component\HttpFoundation\UrlHelper`
    instance as the only argument instead
 

--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -89,12 +89,12 @@ final class TranslationExtension extends AbstractExtension
         return $this->translationNodeVisitor ?: $this->translationNodeVisitor = new TranslationNodeVisitor();
     }
 
-    public function trans(string $message, array $arguments = [], string $domain = null, string $locale = null, int $count = null): string
+    public function trans(string $message, array $arguments = [], string $domain = null, string $locale = null, int $count = null, ?string $default = null): string
     {
         if (null !== $count) {
             $arguments['%count%'] = $count;
         }
 
-        return $this->getTranslator()->trans($message, $arguments, $domain, $locale);
+        return $this->getTranslator()->trans($message, $arguments, $domain, $locale, $default);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
@@ -15,7 +15,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StubTranslator implements TranslatorInterface
 {
-    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
+    /**
+     * {@inheritdoc}
+     * @param string|null $default    A default message if the translation had not been found
+     */
+    public function trans($id, array $parameters = [], $domain = null, $locale = null/*, ?string $default = null*/): string
     {
         return '[trans]'.strtr($id, $parameters).'[/trans]';
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -114,6 +114,9 @@ class TranslationExtensionTest extends TestCase
             ['{% set vars = { \'%name%\': \'Symfony\' } %}{{ hello|trans(vars) }}', 'Hello Symfony', ['hello' => 'Hello %name%']],
             ['{{ "Hello"|trans({}, "messages", "fr") }}', 'Hello'],
 
+            ['{{ "bar"|trans }}', 'bar'],
+            ['{{ "bar"|trans(default="fallback") }}', 'fallback'],
+
             // trans filter with count
             ['{{ "{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples"|trans(count=count) }}', 'There is 5 apples', ['count' => 5]],
             ['{{ text|trans(count=5, arguments={\'%name%\': \'Symfony\'}) }}', 'There is 5 apples (Symfony)', ['text' => '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%)']],

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added support for `name` attribute on `unit` element from xliff2 to be used as a translation key instead of always the `source` element
+ * added support for default translation message when translation is missing
 
 5.0.0
 -----

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -46,10 +46,12 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
 
     /**
      * {@inheritdoc}
+     *
+     * @param string|null $default A default message if the translation had not been found
      */
-    public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null)
+    public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null/*, ?string $default = null*/)
     {
-        $trans = $this->translator->trans($id = (string) $id, $parameters, $domain, $locale);
+        $trans = $this->translator->trans($id = (string) $id, $parameters, $domain, $locale, \func_get_args()[4] ?? null);
         $this->collectMessage($locale, $domain, $id, $trans, $parameters);
 
         return $trans;

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -43,10 +43,12 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @param string|null $default A default message if the translation had not been found
      */
-    public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null)
+    public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null/*, ?string $default = null*/)
     {
-        $trans = $this->translator->trans($id = (string) $id, $parameters, $domain, $locale);
+        $trans = $this->translator->trans($id = (string) $id, $parameters, $domain, $locale, \func_get_args()[4] ?? null);
         $this->log($id, $domain, $locale);
 
         return $trans;

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -367,6 +367,40 @@ class TranslatorTest extends TestCase
         $this->assertEquals($expected, $translator->trans($id, $parameters, $domain, $locale));
     }
 
+    public function getTransWithDefaultTests()
+    {
+        //      $id         $locale      $expected
+        //            $default    $domain
+        yield ['foo', null, null, null, 'foo (messages EN)'];
+        yield ['foo', null, 'fr', null, 'foo (messages FR)'];
+        yield ['foo', null, 'es', null, 'foo (messages FR)'];
+        yield ['foo', null, null, 'domain2', 'foo (messages EN, domain2)'];
+        yield ['foo', null, null, 'domain3', 'foo'];
+        yield ['nope', null, null, null, 'nope'];
+
+        yield ['foo', 'bar', null, null, 'foo (messages EN)'];
+        yield ['foo', 'bar', 'fr', null, 'foo (messages FR)'];
+        yield ['foo', 'bar', 'es', null, 'bar'];
+        yield ['foo', 'bar', null, 'domain2', 'foo (messages EN, domain2)'];
+        yield ['foo', 'bar', null, 'domain3', 'bar'];
+        yield ['nope', 'bar', null, null, 'bar'];
+    }
+
+    /**
+     * @dataProvider getTransWithDefaultTests
+     */
+    public function testTransWithDefault(string $id, ?string $default, ?string $locale, ?string $domain, string $expected)
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['foo' => 'foo (messages EN)'], 'en');
+        $translator->addResource('array', ['foo' => 'foo (messages EN, domain2)'], 'en', 'domain2');
+        $translator->setFallbackLocales(['fr']);
+        $translator->addResource('array', ['foo' => 'foo (messages FR)'], 'fr');
+
+        $this->assertSame($expected, $translator->trans($id, [], $domain, $locale, $default));
+    }
+
     /**
      * @dataProvider getInvalidLocalesTests
      */

--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+1.2.0
+
+ * add support for default translation message when translation is missing
+
 1.1.0
 -----
 

--- a/src/Symfony/Contracts/Translation/TranslatorInterface.php
+++ b/src/Symfony/Contracts/Translation/TranslatorInterface.php
@@ -56,10 +56,12 @@ interface TranslatorInterface
      * @param array       $parameters An array of parameters for the message
      * @param string|null $domain     The domain for the message or null to use the default
      * @param string|null $locale     The locale or null to use the default
+     * @param string|null $locale     The locale or null to use the default
+     * @param string|null $default    A default message if the translation had not been found
      *
      * @return string The translated string
      *
      * @throws \InvalidArgumentException If the locale contains invalid characters
      */
-    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null);
+    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null/*, ?string $default = null*/);
 }

--- a/src/Symfony/Contracts/Translation/TranslatorTrait.php
+++ b/src/Symfony/Contracts/Translation/TranslatorTrait.php
@@ -40,6 +40,8 @@ trait TranslatorTrait
 
     /**
      * {@inheritdoc}
+     *
+     * @param string|null $default A default message if the translation had not been found
      */
     public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35466
| License       | MIT
| Doc PR        |