### PR TITLE
[ErrorHandler] Make assert() silent when assert.quiet_eval=1

### DIFF
--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * made `assert()` silent when `assert.quiet_eval=1`
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -615,4 +615,41 @@ class ErrorHandlerTest extends TestCase
             }
         }
     }
+
+    public function testAssertQuietEval()
+    {
+        $ini = [
+            ini_set('zend.assertions', 1),
+            ini_set('assert.active', 1),
+            ini_set('assert.bail', 0),
+            ini_set('assert.warning', 1),
+            ini_set('assert.callback', null),
+            ini_set('assert.quiet_eval', 1),
+            ini_set('assert.exception', 0),
+        ];
+
+        $logger = new BufferingLogger();
+        $handler = new ErrorHandler($logger);
+        $handler = ErrorHandler::register($handler);
+
+        try {
+            \assert(false);
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+
+            ini_set('zend.assertions', $ini[0]);
+            ini_set('assert.active', $ini[1]);
+            ini_set('assert.bail', $ini[2]);
+            ini_set('assert.warning', $ini[3]);
+            ini_set('assert.callback', $ini[4]);
+            ini_set('assert.quiet_eval', $ini[5]);
+            ini_set('assert.exception', $ini[6]);
+        }
+
+        $logs = $logger->cleanLogs();
+
+        $this->assertSame('debug', $logs[0][0]);
+        $this->assertSame('Warning: assert(): assert(false) failed', $logs[0][1]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Working around https://bugs.php.net/75769
/cc @nikic FYI :)