### PR TITLE
[Process] throw when PhpProcess::fromShellCommandLine() is used

### DIFF
--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Process;
 
+use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\RuntimeException;
 
 /**
@@ -47,6 +48,14 @@ class PhpProcess extends Process
         }
 
         parent::__construct($php, $cwd, $env, $script, $timeout);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromShellCommandline(string $command, string $cwd = null, array $env = null, $input = null, ?float $timeout = 60)
+    {
+        throw new LogicException(sprintf('The "%s()" method cannot be called when using "%s".', __METHOD__, self::class));
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/PhpProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpProcessTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Process\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\PhpProcess;
 
@@ -59,5 +60,15 @@ PHP;
         $process = new PhpProcess($script, null, null, 60, $php);
         $process->run();
         $this->assertEquals($expected, $process->getOutput());
+    }
+
+    public function testProcessCannotBeCreatedUsingFromShellCommandLine()
+    {
+        static::expectException(LogicException::class);
+        static::expectExceptionMessage('The "Symfony\Component\Process\PhpProcess::fromShellCommandline()" method cannot be called when using "Symfony\Component\Process\PhpProcess".');
+        PhpProcess::fromShellCommandline(<<<PHP
+<?php echo 'Hello World!';
+PHP
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #35637
| License       | MIT
| Doc PR        | None

Close #35638 

Final PR (rebased and tests added)