### PR TITLE
[HttpFoundation] Make dependency on Mime component optional

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
    `__construct()` instead)
  * added `Request::preferSafeContent()` and `Response::setContentSafe()` to handle "safe" HTTP preference
    according to [RFC 8674](https://tools.ietf.org/html/rfc8674)
+ * made the Mime component an optional dependency
 
 5.0.0
 -----

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -54,6 +54,10 @@ class File extends \SplFileInfo
      */
     public function guessExtension()
     {
+        if (!class_exists(MimeTypes::class)) {
+            throw new \LogicException('You cannot guess the extension as the Mime component is not installed. Try running "composer require symfony/mime".');
+        }
+
         return MimeTypes::getDefault()->getExtensions($this->getMimeType())[0] ?? null;
     }
 

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -133,6 +133,10 @@ class UploadedFile extends File
      */
     public function guessClientExtension()
     {
+        if (!class_exists(MimeTypes::class)) {
+            throw new \LogicException('You cannot guess the extension as the Mime component is not installed. Try running "composer require symfony/mime".');
+        }
+
         return MimeTypes::getDefault()->getExtensions($this->getClientMimeType())[0] ?? null;
     }
 

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -17,12 +17,15 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "symfony/mime": "^4.4|^5.0",
         "symfony/polyfill-mbstring": "~1.1"
     },
     "require-dev": {
         "predis/predis": "~1.0",
+        "symfony/mime": "^4.4|^5.0",
         "symfony/expression-language": "^4.4|^5.0"
+    },
+    "suggest" : {
+        "symfony/mime": "To use the file extension guesser"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpFoundation\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

Make the Mime component dependency optional

/cc @nicolas-grekas 