### PR TITLE
[HttpFoundation] Add Psr6SessionHandler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * added `Request::preferSafeContent()` and `Response::setContentSafe()` to handle "safe" HTTP preference
    according to [RFC 8674](https://tools.ietf.org/html/rfc8674)
  * made the Mime component an optional dependency
+ * added `Psr6SessionHandler`
 
 5.0.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/Psr6SessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/Psr6SessionHandler.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Session handler that supports a PSR6 cache implementation.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Psr6SessionHandler implements \SessionHandlerInterface
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @var int Time to live in seconds
+     */
+    private $ttl;
+
+    /**
+     * @var string Key prefix for shared environments.
+     */
+    private $prefix;
+
+    /**
+     * List of available options:
+     *  * prefix: The prefix to use for the cache keys in order to avoid collision
+     *  * ttl: The time to live in seconds.
+     *
+     * @param CacheItemPoolInterface $cache   A Cache instance
+     * @param array                  $options An associative array of cache options
+     */
+    public function __construct(CacheItemPoolInterface $cache, array $options = array())
+    {
+        $this->cache = $cache;
+
+        $this->ttl = isset($options['ttl']) ? (int) $options['ttl'] : 86400;
+        $this->prefix = isset($options['prefix']) ? $options['prefix'] : 'sfPsr6sess_';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function open($savePath, $sessionName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($sessionId)
+    {
+        $item = $this->getCacheItem($sessionId);
+        if ($item->isHit()) {
+            return $item->get();
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($sessionId, $data)
+    {
+        $item = $this->getCacheItem($sessionId);
+        $item->set($data)
+            ->expiresAfter($this->ttl);
+
+        return $this->cache->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($sessionId)
+    {
+        return $this->cache->deleteItem($this->prefix.$sessionId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function gc($lifetime)
+    {
+        // not required here because cache will auto expire the records anyhow.
+        return true;
+    }
+
+    /**
+     * @param string $sessionId
+     *
+     * @return \Psr\Cache\CacheItemInterface
+     */
+    private function getCacheItem($sessionId)
+    {
+        return $this->cache->getItem($this->prefix.$sessionId);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\Psr6SessionHandler;
+
+/**
+ * @author Aaron Scherer <aequasi@gmail.com>
+ */
+class Psr6SessionHandlerTest extends TestCase
+{
+    const TTL = 100;
+    const PREFIX = 'pre';
+
+    /**
+     * @var Psr6SessionHandler
+     */
+    private $handler;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|CacheItemPoolInterface
+     */
+    private $psr6;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->psr6 = $this->getMockBuilder(Cache::class)
+            ->setMethods(array('getItem', 'deleteItem', 'save'))
+            ->getMock();
+        $this->handler = new Psr6SessionHandler($this->psr6, array('prefix' => self::PREFIX, 'ttl' => self::TTL));
+    }
+
+    public function testOpen()
+    {
+        $this->assertTrue($this->handler->open('foo', 'bar'));
+    }
+
+    public function testClose()
+    {
+        $this->assertTrue($this->handler->close());
+    }
+
+    public function testGc()
+    {
+        $this->assertTrue($this->handler->gc(4711));
+    }
+
+    public function testReadMiss()
+    {
+        $item = $this->getItemMock();
+        $item->expects($this->once())
+            ->method('isHit')
+            ->willReturn(false);
+        $this->psr6->expects($this->once())
+            ->method('getItem')
+            ->willReturn($item);
+
+        $this->assertEquals('', $this->handler->read('foo'));
+    }
+
+    public function testReadHit()
+    {
+        $item = $this->getItemMock();
+        $item->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item->expects($this->once())
+            ->method('get')
+            ->willReturn('bar');
+        $this->psr6->expects($this->once())
+            ->method('getItem')
+            ->willReturn($item);
+
+        $this->assertEquals('bar', $this->handler->read('foo'));
+    }
+
+    public function testWrite()
+    {
+        $item = $this->getItemMock();
+
+        $item->expects($this->once())
+            ->method('set')
+            ->with('session value')
+            ->willReturnSelf();
+        $item->expects($this->once())
+            ->method('expiresAfter')
+            ->with(self::TTL)
+            ->willReturnSelf();
+
+        $this->psr6->expects($this->once())
+            ->method('getItem')
+            ->with(self::PREFIX.'foo')
+            ->willReturn($item);
+
+        $this->psr6->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $this->assertTrue($this->handler->write('foo', 'session value'));
+    }
+
+    public function testDestroy()
+    {
+        $this->psr6->expects($this->once())
+            ->method('deleteItem')
+            ->with(self::PREFIX.'foo')
+            ->willReturn(true);
+
+        $this->assertTrue($this->handler->destroy('foo'));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getItemMock()
+    {
+        return $this->getMockBuilder(CacheItemInterface::class)
+            ->setMethods(array('isHit', 'getKey', 'get', 'set', 'expiresAt', 'expiresAfter'))
+            ->getMock();
+    }
+}
+
+class Cache implements CacheItemPoolInterface
+{
+    public function getItem($key)
+    {
+    }
+
+    public function getItems(array $keys = array())
+    {
+    }
+
+    public function hasItem($key)
+    {
+    }
+
+    public function clear()
+    {
+    }
+
+    public function deleteItem($key)
+    {
+    }
+
+    public function deleteItems(array $keys)
+    {
+    }
+
+    public function save(CacheItemInterface $item)
+    {
+    }
+
+    public function saveDeferred(CacheItemInterface $item)
+    {
+    }
+
+    public function commit()
+    {
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -30,18 +31,18 @@ class Psr6SessionHandlerTest extends TestCase
     private $handler;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|CacheItemPoolInterface
+     * @var MockObject|CacheItemPoolInterface
      */
     private $psr6;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->psr6 = $this->getMockBuilder(Cache::class)
-            ->setMethods(array('getItem', 'deleteItem', 'save'))
+            ->setMethods(['getItem', 'deleteItem', 'save'])
             ->getMock();
-        $this->handler = new Psr6SessionHandler($this->psr6, array('prefix' => self::PREFIX, 'ttl' => self::TTL));
+        $this->handler = new Psr6SessionHandler($this->psr6, ['prefix' => self::PREFIX, 'ttl' => self::TTL]);
     }
 
     public function testOpen()
@@ -125,12 +126,12 @@ class Psr6SessionHandlerTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     private function getItemMock()
     {
         return $this->getMockBuilder(CacheItemInterface::class)
-            ->setMethods(array('isHit', 'getKey', 'get', 'set', 'expiresAt', 'expiresAfter'))
+            ->setMethods(['isHit', 'getKey', 'get', 'set', 'expiresAt', 'expiresAfter'])
             ->getMock();
     }
 }
@@ -141,7 +142,7 @@ class Cache implements CacheItemPoolInterface
     {
     }
 
-    public function getItems(array $keys = array())
+    public function getItems(array $keys = [])
     {
     }
 

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "predis/predis": "~1.0",
+        "psr/cache": "~1.0",
         "symfony/mime": "^4.4|^5.0",
         "symfony/expression-language": "^4.4|^5.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/orgs/symfony/projects/1#card-30499487
| License       | MIT
| Doc PR        | TODO

Add a PSR6 based session handler
By using this handler we can benefit from the cache `SodiumMarshaller` implemented in https://github.com/symfony/symfony/pull/35019, to encrypt/decrypt session data

Here is an example of how this can be used:

```yaml
# services.yaml
services:
    # ...
    Symfony\Component\HttpFoundation\Session\Storage\Handler\Psr6SessionHandler:
        arguments:
            $cache: '@cache.app'
```

```yaml
# packages/framework.yaml
framework:
    # ...
    session:
        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\Psr6SessionHandler
```

# Task list
- [ ] Add unit test
- [ ] Add doc

/cc @nicolas-grekas 