### PR TITLE
[ErrorHandler] Never throw on warnings triggered by assert() and set assert.exception=1 in Debug::enable()

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Debug.php
+++ b/src/Symfony/Component/ErrorHandler/Debug.php
@@ -29,6 +29,11 @@ class Debug
             ini_set('display_errors', 1);
         }
 
+        ini_set('zend.assertions', 1);
+        ini_set('assert.active', 1);
+        ini_set('assert.warning', 0);
+        ini_set('assert.exception', 1);
+
         DebugClassLoader::enable();
 
         return ErrorHandler::register(new ErrorHandler(new BufferingLogger(), true));

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -413,6 +413,11 @@ class ErrorHandler
         $throw = $this->thrownErrors & $type & $level;
         $type &= $level | $this->screamedErrors;
 
+        // Never throw on warnings triggered by assert()
+        if (E_WARNING === $type && 'a' === $message[0] && 0 === strncmp($message, 'assert(): ', 10)) {
+            $throw = 0;
+        }
+
         if (!$type || (!$log && !$throw)) {
             return !$silenced && $type && $log;
         }

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -615,4 +615,39 @@ class ErrorHandlerTest extends TestCase
             }
         }
     }
+
+    public function testAssertQuietEval()
+    {
+        $ini = [
+            ini_set('zend.assertions', 1),
+            ini_set('assert.active', 1),
+            ini_set('assert.bail', 0),
+            ini_set('assert.warning', 1),
+            ini_set('assert.callback', null),
+            ini_set('assert.exception', 0),
+        ];
+
+        $logger = new BufferingLogger();
+        $handler = new ErrorHandler($logger);
+        $handler = ErrorHandler::register($handler);
+
+        try {
+            \assert(false);
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+
+            ini_set('zend.assertions', $ini[0]);
+            ini_set('assert.active', $ini[1]);
+            ini_set('assert.bail', $ini[2]);
+            ini_set('assert.warning', $ini[3]);
+            ini_set('assert.callback', $ini[4]);
+            ini_set('assert.exception', $ini[5]);
+        }
+
+        $logs = $logger->cleanLogs();
+
+        $this->assertSame('warning', $logs[0][0]);
+        $this->assertSame('Warning: assert(): assert(false) failed', $logs[0][1]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Because we don't use `assert()`, this is something we completely overlooked, but warnings triggered should not throw as there is already a dedicated exception mode when using `assert()`.

This turns this exception mode to 1 in debug mode and logs the assert() warnings in prod.