### PR TITLE
[3.4] Fixed PHPdoc return type of Response::getContent()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -407,7 +407,7 @@ class Response
     /**
      * Gets the current response content.
      *
-     * @return string|false
+     * @return string
      */
     public function getContent()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The constructor sets the content property and there is no other place where this is set to `false`. Furthermore, `Response::sendContent()` also assumes the property always contains a string. So I think the `false` in this PHPdoc is wrong.