### PR TITLE
[String] Allow to keep the last word when truncating a text

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -620,7 +620,7 @@ abstract class AbstractString implements \JsonSerializable
     /**
      * @return static
      */
-    public function truncate(int $length, string $ellipsis = ''): self
+    public function truncate(int $length, string $ellipsis = '', bool $cut = true): self
     {
         $stringLength = $this->length();
 
@@ -632,6 +632,10 @@ abstract class AbstractString implements \JsonSerializable
 
         if ($length < $ellipsisLength) {
             $ellipsisLength = 0;
+        }
+
+        if (!$cut) {
+            $length = $ellipsisLength + ($this->indexOf([' ', "\r", "\n", "\t"], ($length ?: 1) - 1) ?? $stringLength);
         }
 
         $str = $this->slice(0, $length - $ellipsisLength);

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -7,9 +7,10 @@ CHANGELOG
  * added the `AbstractString::reverse()` method
  * made `AbstractString::width()` follow POSIX.1-2001
  * added `LazyString` which provides memoizing stringable objects
- * The component is not marked as `@experimental` anymore.
- * Added the `s()` helper method to get either an `UnicodeString` or `ByteString` instance,
-   depending of the input string UTF-8 compliancy.
+ * The component is not marked as `@experimental` anymore
+ * added the `s()` helper method to get either an `UnicodeString` or `ByteString` instance,
+   depending of the input string UTF-8 compliancy
+ * added `$cut` parameter to `Symfony\Component\String\AbstractString::truncate()`
 
 5.0.0
 -----

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1405,9 +1405,9 @@ abstract class AbstractAsciiTestCase extends TestCase
     /**
      * @dataProvider provideTruncate
      */
-    public function testTruncate(string $expected, string $origin, int $length, string $ellipsis)
+    public function testTruncate(string $expected, string $origin, int $length, string $ellipsis, bool $cut = true)
     {
-        $instance = static::createFromString($origin)->truncate($length, $ellipsis);
+        $instance = static::createFromString($origin)->truncate($length, $ellipsis, $cut);
 
         $this->assertEquals(static::createFromString($expected), $instance);
     }
@@ -1417,12 +1417,17 @@ abstract class AbstractAsciiTestCase extends TestCase
         return [
             ['', '', 3, ''],
             ['', 'foo', 0, '...'],
+            ['foo', 'foo', 0, '...', false],
             ['fo', 'foobar', 2, ''],
             ['foobar', 'foobar', 10, ''],
+            ['foobar', 'foobar', 10, '...', false],
             ['foo', 'foo', 3, '...'],
             ['fo', 'foobar', 2, '...'],
             ['...', 'foobar', 3, '...'],
             ['fo...', 'foobar', 5, '...'],
+            ['foobar...', 'foobar foo', 6, '...', false],
+            ['foobar...', 'foobar foo', 7, '...', false],
+            ['foobar foo...', 'foobar foo a', 10, '...', false],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35567
| License       | MIT
| Doc PR        | -

The [truncate filter from twig/extensions](https://github.com/twigphp/Twig-extensions/blob/master/src/TextExtension.php#L36) has a `preserve` parameter to preserve whole words. 

Since `twig/extensions` is deprecated and its alternative for `truncate` filter is the use of `u` filter, this PR adds preverse word functionality.