### PR TITLE
[FrameworkBundle][Routing] added XML and YAML loaders to handle template and redirect controllers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,7 +6,8 @@ CHANGELOG
 
  * Added link to source for controllers registered as named services
  * Added link to source on controller on `router:match`/`debug:router` (when `framework.ide` is configured)
- * Added `Routing\Loader` and `Routing\Loader\Configurator` namespaces to ease defining routes with default controllers
+ * Added XML and YAML routing loaders to ease defining routes with redirect and template controllers
+ * Added the `Routing\Loader\Configurator` namespace to ease defining routes with redirect and template controllers
  * Added the `framework.router.context` configuration node to configure the `RequestContext`
  * Made `MicroKernelTrait::configureContainer()` compatible with `ContainerConfigurator`
  * Added a new `mailer.message_bus` option to configure or disable the message bus to use to send mails.

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -15,12 +15,12 @@
 
         <service id="routing.resolver" class="Symfony\Component\Config\Loader\LoaderResolver" />
 
-        <service id="routing.loader.xml" class="Symfony\Component\Routing\Loader\XmlFileLoader">
+        <service id="routing.loader.xml" class="Symfony\Bundle\FrameworkBundle\Routing\Loader\XmlFileLoader">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
         </service>
 
-        <service id="routing.loader.yml" class="Symfony\Component\Routing\Loader\YamlFileLoader">
+        <service id="routing.loader.yml" class="Symfony\Bundle\FrameworkBundle\Routing\Loader\YamlFileLoader">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/framework-routing-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/framework-routing-1.0.xsd
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<xsd:schema xmlns="http://symfony.com/schema/routing"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://symfony.com/schema/routing"
+            elementFormDefault="qualified">
+
+  <xsd:redefine schemaLocation="https://symfony.com/schema/routing/routing-1.0.xsd">
+    <xsd:complexType name="routes">
+      <xsd:complexContent>
+        <xsd:extension base="routes">
+          <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="template-route" type="template-route" />
+            <xsd:element name="redirect-route" type="redirect-route" />
+            <xsd:element name="url-redirect-route" type="url-redirect-route" />
+            <xsd:element name="gone-route" type="gone-route" />
+          </xsd:choice>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:redefine>
+
+  <xsd:group name="base-configs">
+    <xsd:choice>
+      <xsd:element name="path" type="localized-path" />
+      <xsd:element name="requirement" type="element" />
+      <xsd:element name="option" type="element" />
+      <xsd:element name="condition" type="xsd:string" />
+    </xsd:choice>
+  </xsd:group>
+
+  <xsd:complexType name="base-route" abstract="true">
+    <xsd:attribute name="id" type="xsd:string" use="required" />
+    <xsd:attribute name="path" type="xsd:string" />
+    <xsd:attribute name="host" type="xsd:string" />
+    <xsd:attribute name="methods" type="xsd:string" />
+    <xsd:attribute name="locale" type="xsd:string" />
+    <xsd:attribute name="format" type="xsd:string" />
+    <xsd:attribute name="utf8" type="xsd:boolean" />
+  </xsd:complexType>
+
+  <xsd:complexType name="template-route">
+    <xsd:complexContent>
+      <xsd:extension base="base-route">
+        <xsd:sequence>
+          <xsd:element name="context" type="map" minOccurs="0" maxOccurs="1" />
+          <xsd:group ref="base-configs" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="template" type="xsd:string" use="required" />
+        <xsd:attribute name="max-age" type="xsd:int" />
+        <xsd:attribute name="shared-max-age" type="xsd:int" />
+        <xsd:attribute name="private" type="xsd:boolean" />
+        <xsd:attribute name="schemes" type="xsd:string" />
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="redirect-route">
+    <xsd:complexContent>
+      <xsd:extension base="base-route">
+        <xsd:sequence>
+          <xsd:group ref="base-configs" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="redirect-to-route" type="xsd:string" use="required"/>
+        <xsd:attribute name="permanent" type="xsd:boolean" />
+        <xsd:attribute name="ignore-attributes" type="xsd:string" />
+        <xsd:attribute name="keep-request-method" type="xsd:boolean" />
+        <xsd:attribute name="keep-query-params" type="xsd:boolean" />
+        <xsd:attribute name="schemes" type="xsd:string" />
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="url-redirect-route">
+    <xsd:complexContent>
+      <xsd:extension base="base-route">
+        <xsd:sequence>
+          <xsd:group ref="base-configs" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="redirect-to-url" type="xsd:string" use="required" />
+        <xsd:attribute name="permanent" type="xsd:boolean" />
+        <xsd:attribute name="scheme" type="xsd:string" />
+        <xsd:attribute name="http-port" type="xsd:int" />
+        <xsd:attribute name="https-port" type="xsd:int" />
+        <xsd:attribute name="keep-request-method" type="xsd:boolean" />
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="gone-route">
+    <xsd:complexContent>
+      <xsd:extension base="base-route">
+        <xsd:sequence>
+          <xsd:group ref="base-configs" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="permanent" type="xsd:boolean" />
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Loader/XmlFileLoader.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Routing\Loader;
+
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+use Symfony\Component\Config\Util\Exception\InvalidXmlException;
+use Symfony\Component\Config\Util\Exception\XmlParsingException;
+use Symfony\Component\Config\Util\XmlUtils;
+use Symfony\Component\Routing\Loader\XmlFileLoader as BaseXmlFileLoader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class XmlFileLoader extends BaseXmlFileLoader
+{
+    public const SCHEME_PATH = __DIR__.'/../../Resources/config/schema/framework-routing-1.0.xsd';
+
+    private const REDEFINED_SCHEME_URI = 'https://symfony.com/schema/routing/routing-1.0.xsd';
+    private const SCHEME_URI = 'https://symfony.com/schema/routing/framework-routing-1.0.xsd';
+    private const SCHEMA_LOCATIONS = [
+        self::REDEFINED_SCHEME_URI => parent::SCHEME_PATH,
+        self::SCHEME_URI => self::SCHEME_PATH,
+    ];
+
+    /** @var \DOMDocument */
+    private $document;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadFile(string $file)
+    {
+        if ('' === trim($content = @file_get_contents($file))) {
+            throw new \InvalidArgumentException(sprintf('File "%s" does not contain valid XML, it is empty.', $file));
+        }
+
+        foreach (self::SCHEMA_LOCATIONS as $uri => $path) {
+            if (false !== strpos($content, $uri)) {
+                $content = str_replace($uri, self::getRealSchemePath($path), $content);
+            }
+        }
+
+        try {
+            return $this->document = XmlUtils::parse($content, function (\DOMDocument $document) {
+                return @$document->schemaValidateSource(str_replace(
+                    self::REDEFINED_SCHEME_URI,
+                    self::getRealSchemePath(parent::SCHEME_PATH),
+                    file_get_contents(self::SCHEME_PATH)
+                ));
+            });
+        } catch (InvalidXmlException $e) {
+            throw new XmlParsingException(sprintf('The XML file "%s" is not valid.', $file), 0, $e->getPrevious());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseNode(RouteCollection $collection, \DOMElement $node, $path, $file)
+    {
+        switch ($node->localName) {
+            case 'template-route':
+            case 'redirect-route':
+            case 'url-redirect-route':
+            case 'gone-route':
+                if (self::NAMESPACE_URI !== $node->namespaceURI) {
+                    return;
+                }
+
+                $this->parseRoute($collection, $node, $path);
+
+                return;
+        }
+
+        parent::parseNode($collection, $node, $path, $file);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseRoute(RouteCollection $collection, \DOMElement $node, $path)
+    {
+        $templateContext = [];
+
+        if ('template-route' === $node->localName) {
+            /** @var \DOMElement $context */
+            foreach ($node->getElementsByTagNameNS(self::NAMESPACE_URI, 'context') as $context) {
+                $node->removeChild($context);
+                $map = $this->document->createElementNS(self::NAMESPACE_URI, 'map');
+
+                // extract context vars into a map
+                foreach ($context->childNodes as $n) {
+                    if (!$n instanceof \DOMElement) {
+                        continue;
+                    }
+
+                    $map->appendChild($n);
+                }
+
+                $default = $this->document->createElementNS(self::NAMESPACE_URI, 'default');
+                $default->setAttribute('key', 'context');
+                $default->appendChild($map);
+
+                $templateContext = $this->parseDefaultsConfig($default, $path);
+            }
+        }
+
+        parent::parseRoute($collection, $node, $path);
+
+        if ($route = $collection->get($id = $node->getAttribute(('id')))) {
+            $this->parseConfig($node, $route, $templateContext);
+
+            return;
+        }
+
+        foreach ($node->getElementsByTagNameNS(self::NAMESPACE_URI, 'path') as $n) {
+            $route = $collection->get($id.'.'.$n->getAttribute('locale'));
+
+            $this->parseConfig($node, $route, $templateContext);
+        }
+    }
+
+    private function parseConfig(\DOMElement $node, Route $route, array $templateContext): void
+    {
+        switch ($node->localName) {
+            case 'template-route':
+                $route
+                    ->setDefault('_controller', TemplateController::class)
+                    ->setDefault('template', $node->getAttribute('template'))
+                    ->setDefault('context', $templateContext)
+                    ->setDefault('maxAge', (int) $node->getAttribute('max-age') ?: null)
+                    ->setDefault('sharedAge', (int) $node->getAttribute('shared-max-age') ?: null)
+                    ->setDefault('private', $node->hasAttribute('private') ? XmlUtils::phpize($node->getAttribute('private')) : null)
+                ;
+                break;
+            case 'redirect-route':
+                $route
+                    ->setDefault('_controller', RedirectController::class.'::redirectAction')
+                    ->setDefault('route', $node->getAttribute('redirect-to-route'))
+                    ->setDefault('permanent', self::getBooleanAttribute($node, 'permanent'))
+                    ->setDefault('keepRequestMethod', self::getBooleanAttribute($node, 'keep-request-method'))
+                    ->setDefault('keepQueryParams', self::getBooleanAttribute($node, 'keep-query-params'))
+                ;
+
+                if (\is_string($ignoreAttributes = XmlUtils::phpize($node->getAttribute('ignore-attributes')))) {
+                    $ignoreAttributes = array_map('trim', explode(',', $ignoreAttributes));
+                }
+
+                $route->setDefault('ignoreAttributes', $ignoreAttributes);
+                break;
+            case 'url-redirect-route':
+                $route
+                    ->setDefault('_controller', RedirectController::class.'::urlRedirectAction')
+                    ->setDefault('path', $node->getAttribute('redirect-to-url'))
+                    ->setDefault('permanent', self::getBooleanAttribute($node, 'permanent'))
+                    ->setDefault('scheme', $node->getAttribute('scheme'))
+                    ->setDefault('keepRequestMethod', self::getBooleanAttribute($node, 'keep-request-method'))
+                ;
+                if ($node->hasAttribute('http-port')) {
+                    $route->setDefault('httpPort', (int) $node->getAttribute('http-port') ?: null);
+                } elseif ($node->hasAttribute('https-port')) {
+                    $route->setDefault('httpsPort', (int) $node->getAttribute('https-port') ?: null);
+                }
+                break;
+            case 'gone-route':
+                $route
+                    ->setDefault('_controller', RedirectController::class.'::redirectAction')
+                    ->setDefault('route', '')
+                ;
+                if ($node->hasAttribute('permanent')) {
+                    $route->setDefault('permanent', self::getBooleanAttribute($node, 'permanent'));
+                }
+                break;
+        }
+    }
+
+    private static function getRealSchemePath(string $schemePath): string
+    {
+        return 'file:///'.str_replace('\\', '/', realpath($schemePath));
+    }
+
+    private static function getBooleanAttribute(\DOMElement $node, string $attribute): bool
+    {
+        return $node->hasAttribute($attribute) ? XmlUtils::phpize($node->getAttribute($attribute)) : false;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Loader/YamlFileLoader.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Routing\Loader;
+
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+use Symfony\Component\Routing\Loader\YamlFileLoader as BaseYamlFileLoader;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class YamlFileLoader extends BaseYamlFileLoader
+{
+    private static $availableKeys = [
+        'template' => ['context', 'max_age', 'shared_max_age', 'private'],
+        'redirect_to_route' => ['permanent', 'ignore_attributes', 'keep_request_method', 'keep_query_params'],
+        'redirect_to_url' => ['permanent', 'scheme', 'http_port', 'https_port', 'keep_request_method'],
+        'gone' => ['permanent'],
+    ];
+
+    protected function validate($config, $name, $path)
+    {
+        if (\count($types = array_intersect_key($config, self::$availableKeys)) > 1) {
+            throw new \InvalidArgumentException(sprintf('The routing file "%s" must not specify only one route type among "%s" keys for "%s".', str_replace('/', \DIRECTORY_SEPARATOR, $path), implode('", "', array_keys($types)), $name));
+        }
+
+        foreach (self::$availableKeys as $routeType => $availableKeys) {
+            if (!isset($config[$routeType])) {
+                continue;
+            }
+
+            if (isset($config['controller'])) {
+                throw new \InvalidArgumentException(sprintf('The routing file "%s" must not specify both the "controller" and the "%s" keys for "%s".', str_replace('/', \DIRECTORY_SEPARATOR, $path), $routeType, $name));
+            }
+
+            // keys would be invalid for parent::validate(), but we use them below
+            unset($config[$routeType]);
+            foreach ($availableKeys as $key) {
+                unset($config[$key]);
+            }
+        }
+
+        parent::validate($config, $name, $path);
+    }
+
+    protected function parseRoute(RouteCollection $collection, $name, array $config, $path)
+    {
+        if (isset($config['template'])) {
+            $config['defaults'] = array_merge($config['defaults'] ?? [], [
+                '_controller' => TemplateController::class,
+                'template' => $config['template'],
+                'context' => $config['context'] ?? [],
+                'maxAge' => $config['max_age'] ?? null,
+                'sharedAge' => $config['shared_max_age'] ?? null,
+                'private' => $config['private'] ?? null,
+            ]);
+        } elseif (isset($config['redirect_to_route'])) {
+            $config['defaults'] = array_merge($config['defaults'] ?? [], [
+                '_controller' => RedirectController::class.'::redirectAction',
+                'route' => $config['redirect_to_route'],
+                'permanent' => $config['permanent'] ?? false,
+                'ignoreAttributes' => $config['ignore_attributes'] ?? false,
+                'keepRequestMethod' => $config['keep_request_method'] ?? false,
+                'keepQueryParams' => $config['keep_query_params'] ?? false,
+            ]);
+        } elseif (isset($config['redirect_to_url'])) {
+            $config['defaults'] = array_merge($config['defaults'] ?? [], [
+                '_controller' => RedirectController::class.'::urlRedirectAction',
+                'path' => $config['redirect_to_url'],
+                'permanent' => $config['permanent'] ?? false,
+                'scheme' => $config['scheme'] ?? null,
+                'keepRequestMethod' => $config['keep_request_method'] ?? false,
+            ]);
+
+            if (\array_key_exists('http_port', $config)) {
+                $config['defaults']['httpPort'] = (int) $config['http_port'] ?: null;
+            } elseif (\array_key_exists('http_port', $config)) {
+                $config['defaults']['httpsPort'] = (int) $config['https_port'] ?: null;
+            }
+        } elseif (isset($config['gone'])) {
+            $config['defaults'] = array_merge($config['defaults'] ?? [], [
+                '_controller' => RedirectController::class.'::redirectAction',
+                'route' => '',
+            ]);
+
+            if (isset($config['permanent'])) {
+                $config['defaults']['permanent'] = $config['permanent'];
+            }
+        }
+
+        parent::parseRoute($collection, $name, $config, $path);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/config/routing/routes.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/config/routing/routes.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/framework-routing-1.0.xsd">
+
+    <route id="classic_route" path="/classic" />
+
+    <template-route id="template_route"
+           path="/static"
+           template="static.html.twig"
+           max-age="300"
+           shared-max-age="100"
+           private="true"
+           methods="GET">
+        <context>
+            <string key="foo">bar</string>
+        </context>
+        <option key="utf8">true</option>
+        <condition>abc</condition>
+    </template-route>
+
+    <redirect-route id="redirect_route"
+           path="/redirect"
+           redirect-to-route="target_route"
+           permanent="true"
+           ignore-attributes="attr, ibutes"
+           keep-request-method="true"
+           keep-query-params="true"
+           schemes="http"
+           host="legacy">
+        <option key="utf8">true</option>
+    </redirect-route>
+
+    <url-redirect-route id="url_redirect_route"
+           path="/redirect-url"
+           redirect-to-url="/url-target"
+           permanent="true"
+           scheme="http"
+           http-port="1"
+           keep-request-method="true"
+           host="legacy">
+        <option key="utf8">true</option>
+    </url-redirect-route>
+
+    <gone-route id="not_a_route" path="/not-a-path" host="legacy">
+        <option key="utf8">true</option>
+    </gone-route>
+
+    <gone-route id="gone_route" path="/gone-path" permanent="true">
+        <option key="utf8">true</option>
+    </gone-route>
+
+</routes>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/config/routing/routes.yaml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/config/routing/routes.yaml
@@ -1,0 +1,47 @@
+classic_route:
+    path: /classic
+
+template_route:
+    path: /static
+    template: static.html.twig
+    context:
+        foo: bar
+    max_age: 300
+    shared_max_age: 100
+    private: true
+    methods: GET
+    options: { utf8: true }
+    condition: abc
+
+redirect_route:
+    path: /redirect
+    redirect_to_route: target_route
+    permanent: true
+    ignore_attributes: ['attr', 'ibutes']
+    keep_request_method: true
+    keep_query_params: true
+    schemes: http
+    host: legacy
+    options: { utf8: true }
+
+url_redirect_route:
+    path: /redirect-url
+    redirect_to_url: /url-target
+    permanent: true
+    scheme: http
+    http_port: 1
+    keep_request_method: true
+    host: legacy
+    options: { utf8: true }
+
+not_a_route:
+    path: /not-a-path
+    gone: true
+    host: legacy
+    options: { utf8: true }
+
+gone_route:
+    path: /gone-path
+    gone: true
+    permanent: true
+    options: { utf8: true }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/config/routing/template_and_redirect.yaml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/config/routing/template_and_redirect.yaml
@@ -1,0 +1,4 @@
+invalid_route:
+    path: '/path'
+    template: 'template.html.twig'
+    redirect_to_route: 'target_route'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/config/routing/with_controller_attribute.yaml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/config/routing/with_controller_attribute.yaml
@@ -1,0 +1,4 @@
+invalid_route:
+    path: '/path'
+    template: 'template.html.twig'
+    controller: 'SomeControllerClass'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/Loader/XmlFileLoaderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Routing\Loader;
+
+use Symfony\Bundle\FrameworkBundle\Routing\Loader\XmlFileLoader;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class XmlFileLoaderTest extends AbstractLoaderTest
+{
+    protected function getLoader(): LoaderInterface
+    {
+        return new XmlFileLoader($this->getLocator());
+    }
+
+    protected function getType(): string
+    {
+        return 'xml';
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/Loader/YamlFileLoaderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Routing\Loader;
+
+use Symfony\Bundle\FrameworkBundle\Routing\Loader\YamlFileLoader;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class YamlFileLoaderTest extends AbstractLoaderTest
+{
+    protected function getLoader(): LoaderInterface
+    {
+        return new YamlFileLoader($this->getLocator());
+    }
+
+    protected function getType(): string
+    {
+        return 'yaml';
+    }
+
+    /**
+     * @dataProvider getPathsToInvalidFiles
+     */
+    public function testLoadThrowsExceptionWithInvalidFile(string $filePath, string $exception)
+    {
+        $loader = $this->getLoader();
+
+        $message = sprintf($exception, __DIR__.'/../../Fixtures/Resources/config/routing/'.$filePath);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(str_replace('/', \DIRECTORY_SEPARATOR, $message));
+
+        $loader->load($filePath);
+    }
+
+    public function getPathsToInvalidFiles()
+    {
+        yield 'defining controller' => ['with_controller_attribute.yaml', 'The routing file "%s" must not specify both the "controller" and the "template" keys for "invalid_route".'];
+        yield 'defining template and redirect' => ['template_and_redirect.yaml', 'The routing file "%s" must not specify only one route type among "template", "redirect_to_route" keys for "invalid_route".'];
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -30,7 +30,7 @@ class XmlFileLoader extends FileLoader
     use PrefixTrait;
 
     const NAMESPACE_URI = 'http://symfony.com/schema/routing';
-    const SCHEME_PATH = '/schema/routing/routing-1.0.xsd';
+    const SCHEME_PATH = __DIR__.'/schema/routing/routing-1.0.xsd';
 
     /**
      * Loads an XML file.
@@ -229,7 +229,7 @@ class XmlFileLoader extends FileLoader
      */
     protected function loadFile(string $file)
     {
-        return XmlUtils::loadFile($file, __DIR__.static::SCHEME_PATH);
+        return XmlUtils::loadFile($file, static::SCHEME_PATH);
     }
 
     /**
@@ -303,7 +303,7 @@ class XmlFileLoader extends FileLoader
             if (isset($defaults['_stateless'])) {
                 $name = $node->hasAttribute('id') ? sprintf('"%s"', $node->getAttribute('id')) : sprintf('the "%s" tag', $node->tagName);
 
-                throw new \InvalidArgumentException(sprintf('The routing file "%s" must not specify both the "stateless" attribute and the defaults key "_stateless" for %s.', $path, $name));
+                throw new \InvalidArgumentException(sprintf('The routing file "%s" must not specify both the "stateless" attribute and the defaults key "_stateless" for "%s".', $path, $name));
             }
 
             $defaults['_stateless'] = XmlUtils::phpize($stateless);
@@ -317,7 +317,7 @@ class XmlFileLoader extends FileLoader
      *
      * @return array|bool|float|int|string|null The parsed value of the "default" element
      */
-    private function parseDefaultsConfig(\DOMElement $element, string $path)
+    final protected function parseDefaultsConfig(\DOMElement $element, string $path)
     {
         if ($this->isElementValueNull($element)) {
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #24640
| License       | MIT
| Doc PR        | symfony/symfony-docs#11120

Split from #30501 to add support in XML and YAML formats.

I've also improved the XML support for context with the `TemplateController` introduced in #35257.
