### PR TITLE
[HttpFoundation] Changed visibility of emulateSameSite

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -52,7 +52,7 @@ class NativeSessionStorage implements SessionStorageInterface
     /**
      * @var string|null
      */
-    private $emulateSameSite;
+    protected $emulateSameSite;
 
     /**
      * Depending on how you want the storage driver to behave you probably


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35460 
| License       | MIT
| Doc PR        | 

Changed `private` to `protected` for easier usage in subclasses.
Further details are described in #35460.
