### PR TITLE
[Yaml] Fix parsing !tagged_iterator

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -823,7 +823,7 @@ class Inline
         $nextOffset += strspn($value, ' ', $nextOffset);
 
         // Is followed by a scalar
-        if ((!isset($value[$nextOffset]) || !\in_array($value[$nextOffset], ['[', '{'], true)) && 'tagged' !== $tag) {
+        if ((!isset($value[$nextOffset]) || !\in_array($value[$nextOffset], ['[', '{'], true)) && 'tagged' !== $tag && 'tagged_iterator' !== $tag) {
             // Manage non-whitelisted scalars in {@link self::evaluateScalar()}
             return null;
         }

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -720,7 +720,7 @@ class Parser
             if ('' !== $matches['tag']) {
                 if ('!!binary' === $matches['tag']) {
                     return Inline::evaluateBinaryScalar($data);
-                } elseif ('tagged' === $matches['tag']) {
+                } elseif ('tagged' === $matches['tag'] || 'tagged_iterator' === $matches['tag']) {
                     return new TaggedValue(substr($matches['tag'], 1), $data);
                 } elseif ('!' !== $matches['tag']) {
                     @trigger_error($this->getDeprecationMessage(sprintf('Using the custom tag "%s" for the value "%s" is deprecated since Symfony 3.3. It will be replaced by an instance of %s in 4.0.', $matches['tag'], $data, TaggedValue::class)), E_USER_DEPRECATED);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Replacing `!tagged` with `!tagged_iterator` on 4.4 does not currently work with symfony/yaml at 3.4 because the tag is parsed as a string.

@nicolas-grekas I wonder how this was not caught by tests. DI tests on 4.4 should run with symfony/yaml 3.4 on deps=low isn'it?

Also do we need to bump symfony/yaml dependency on DI to 3.4.next?