### PR TITLE
[Contracts] Split the global CHANGELOG in dedicated CHANGELOG per contract

### DIFF
--- a/src/Symfony/Contracts/Cache/CHANGELOG.md
+++ b/src/Symfony/Contracts/Cache/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+1.0.0
+-----
+
+ * added `Cache` contract to extend PSR-6 with tag invalidation, callback-based computation and stampede protection

--- a/src/Symfony/Contracts/Deprecation/CHANGELOG.md
+++ b/src/Symfony/Contracts/Deprecation/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+1.2.0
+-----
+
+ * added `trigger_deprecation` function

--- a/src/Symfony/Contracts/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Contracts/EventDispatcher/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+1.1.0
+-----
+
+ * added `EventDispatcherInterface` and `Event` in namespace `EventDispatcher`

--- a/src/Symfony/Contracts/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Contracts/HttpClient/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+1.1.0
+-----
+
+ * added `HttpClient` namespace with contracts for implementing flexible HTTP clients

--- a/src/Symfony/Contracts/Service/CHANGELOG.md
+++ b/src/Symfony/Contracts/Service/CHANGELOG.md
@@ -4,16 +4,12 @@ CHANGELOG
 1.1.0
 -----
 
- * added `HttpClient` namespace with contracts for implementing flexible HTTP clients
- * added `EventDispatcherInterface` and `Event` in namespace `EventDispatcher`
  * added `ServiceProviderInterface` in namespace `Service`
 
 1.0.0
 -----
 
  * added `Service\ResetInterface` to provide a way to reset an object to its initial state
- * added `Translation\TranslatorInterface` and `Translation\TranslatorTrait`
- * added `Cache` contract to extend PSR-6 with tag invalidation, callback-based computation and stampede protection
  * added `Service\ServiceSubscriberInterface` to declare the dependencies of a class that consumes a service locator
  * added `Service\ServiceSubscriberTrait` to implement `Service\ServiceSubscriberInterface` using methods' return types
  * added `Service\ServiceLocatorTrait` to help implement PSR-11 service locators

--- a/src/Symfony/Contracts/Translation/CHANGELOG.md
+++ b/src/Symfony/Contracts/Translation/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+1.0.0
+-----
+
+ * added `Translation\TranslatorInterface` and `Translation\TranslatorTrait`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

This is more in sync with what we do with other components + bundles.
And when we contribute to a contact, it's easier to find the file (because with the substree, we don't get the global package)
