### PR TITLE
[HttpClient] fix getting response content after its destructor throwed an HttpExceptionInterface

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Chunk\InformationalChunk;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\CurlClientState;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -113,7 +114,7 @@ final class CurlResponse implements ResponseInterface
         $this->initializer = static function (self $response) {
             $waitFor = curl_getinfo($ch = $response->handle, CURLINFO_PRIVATE);
 
-            return 'H' === $waitFor[0] || 'D' === $waitFor[0];
+            return 'H' === $waitFor[0];
         };
 
         // Schedule the request in a non-blocking way
@@ -174,17 +175,15 @@ final class CurlResponse implements ResponseInterface
                 return; // Unused pushed response
             }
 
-            $waitFor = curl_getinfo($this->handle, CURLINFO_PRIVATE);
-
-            if ('C' === $waitFor[0] || '_' === $waitFor[0]) {
-                $this->close();
-            } elseif ('H' === $waitFor[0]) {
-                $waitFor[0] = 'D'; // D = destruct
-                curl_setopt($this->handle, CURLOPT_PRIVATE, $waitFor);
+            $e = null;
+            $this->doDestruct();
+        } catch (HttpExceptionInterface $e) {
+            throw $e;
+        } finally {
+            if (null !== $e) {
+                throw $e;
             }
 
-            $this->doDestruct();
-        } finally {
             $this->close();
 
             if (!$this->multi->openHandles) {
@@ -304,7 +303,7 @@ final class CurlResponse implements ResponseInterface
     {
         $waitFor = @curl_getinfo($ch, CURLINFO_PRIVATE) ?: '_0';
 
-        if ('H' !== $waitFor[0] && 'D' !== $waitFor[0]) {
+        if ('H' !== $waitFor[0]) {
             return \strlen($data); // Ignore HTTP trailers
         }
 
@@ -370,7 +369,7 @@ final class CurlResponse implements ResponseInterface
             // Headers and redirects completed, time to get the response's content
             $multi->handlesActivity[$id][] = new FirstChunk();
 
-            if ('D' === $waitFor[0] || 'HEAD' === $info['http_method'] || \in_array($statusCode, [204, 304], true)) {
+            if ('HEAD' === $info['http_method'] || \in_array($statusCode, [204, 304], true)) {
                 $waitFor = '_0'; // no content expected
                 $multi->handlesActivity[$id][] = null;
                 $multi->handlesActivity[$id][] = null;

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\NativeClientState;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -84,11 +85,16 @@ final class NativeResponse implements ResponseInterface
 
     public function __destruct()
     {
-        $this->shouldBuffer = null;
-
         try {
+            $e = null;
             $this->doDestruct();
+        } catch (HttpExceptionInterface $e) {
+            throw $e;
         } finally {
+            if (null !== $e) {
+                throw $e;
+            }
+
             $this->close();
 
             // Clear the DNS cache when all requests completed

--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -294,6 +294,8 @@ trait ResponseTrait
      */
     private function doDestruct()
     {
+        $this->shouldBuffer = true;
+
         if ($this->initializer && null === $this->info['error']) {
             self::initialize($this);
             $this->checkStatusCode();

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -782,6 +782,18 @@ abstract class HttpClientTestCase extends TestCase
         $this->assertLessThan(4, $duration);
     }
 
+    public function testGetContentAfterDestruct()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        try {
+            $client->request('GET', 'http://localhost:8057/404');
+            $this->fail(ClientExceptionInterface::class.' expected');
+        } catch (ClientExceptionInterface $e) {
+            $this->assertSame('GET', $e->getResponse()->toArray(false)['REQUEST_METHOD']);
+        }
+    }
+
     public function testProxy()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted by @B-Galati in https://github.com/symfony/symfony/pull/35659#issuecomment-584508876