### PR TITLE
[Console] Handle zero row count in appendRow() for Table

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -601,7 +601,9 @@ class Table
             ++$numberOfRows; // Add row for header separator
         }
 
-        ++$numberOfRows; // Add row for footer separator
+        if (\count($this->rows) > 0) {
+            ++$numberOfRows; // Add row for footer separator
+        }
 
         return $numberOfRows;
     }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -951,6 +951,38 @@ TABLE;
         $table->appendRow(['9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25']);
     }
 
+    public function testSectionOutputHandlesZeroRowsAfterRender()
+    {
+        $sections = [];
+        $stream = $this->getOutputStream(true);
+        $output = new ConsoleSectionOutput($stream->getStream(), $sections, $stream->getVerbosity(), $stream->isDecorated(), new OutputFormatter());
+        $output->writeln('My Table');
+        $table = new Table($output);
+        $table
+            ->setHeaders(['ISBN', 'Title', 'Author', 'Price'])
+            ->setRows([]);
+
+        $table->render();
+
+        $table->appendRow(['9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25']);
+
+        $expected =
+            <<<TABLE
+My Table
++------+-------+--------+-------+
+|\033[32m ISBN \033[39m|\033[32m Title \033[39m|\033[32m Author \033[39m|\033[32m Price \033[39m|
++------+-------+--------+-------+
+\x1b[3A\x1b[0J+---------------+----------------------+-----------------+--------+
+|\033[32m ISBN          \033[39m|\033[32m Title                \033[39m|\033[32m Author          \033[39m|\033[32m Price  \033[39m|
++---------------+----------------------+-----------------+--------+
+| 9971-5-0210-0 | A Tale of Two Cities | Charles Dickens | 139.25 |
++---------------+----------------------+-----------------+--------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
     public function testIsNotDefinedStyleException()
     {
         $this->expectException('Symfony\Component\Console\Exception\InvalidArgumentException');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

When a `Table` is created and rendered with no rows (headers only) and subsequently rows are added using `appendRow()`, the first call to `appendRow()` clears back one line too far., thus removing the last run 

This is caused by `calculateRowCount()` not accounting for the fact that the footer separator is also the header separator when no rows are present.

This PR works around the issue by checking to ensure that at least 1 row exists before including the footer separator in the row count.

## Example

Command:
```php
<?php

namespace App\Command;

class TableTestCommand extends Command
{
    // ...

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $output->writeln('My table');

        $table = new Table($output->section());
        $table->setHeaders(['Column', 'Another column']);
        $table->render();
        
        $table->appendRow(['Value', 'Another Value']);
        $table->appendRow(['Value', 'Another Value']);
    }
}
```

Before fix:
```
+--------+----------------+
| Column | Another column |
+--------+----------------+
| Value  | Another Value  |
| Value  | Another Value  |
+--------+----------------+
```

After fix:
```
My table
+--------+----------------+
| Column | Another column |
+--------+----------------+
| Value  | Another Value  |
| Value  | Another Value  |
+--------+----------------+
```