### PR TITLE
[Cache] added calculateHitReadRatio method

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added max-items + LRU + max-lifetime capabilities to `ArrayCache`
  * added `CouchbaseBucketAdapter`
+ * added private method `calculateHitReadRatio` in `CacheDataCollector`
 
 5.0.0
 -----

--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -151,11 +151,8 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
                     ++$statistics[$name]['deletes'];
                 }
             }
-            if ($statistics[$name]['reads']) {
-                $statistics[$name]['hit_read_ratio'] = round(100 * $statistics[$name]['hits'] / $statistics[$name]['reads'], 2);
-            } else {
-                $statistics[$name]['hit_read_ratio'] = null;
-            }
+
+            $this->calculateHitReadRatio($statistics[$name]);
         }
 
         return $statistics;
@@ -178,12 +175,19 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
                 $totals[$key] += $statistics[$name][$key];
             }
         }
-        if ($totals['reads']) {
-            $totals['hit_read_ratio'] = round(100 * $totals['hits'] / $totals['reads'], 2);
-        } else {
-            $totals['hit_read_ratio'] = null;
-        }
+
+        $this->calculateHitReadRatio($totals);
 
         return $totals;
+    }
+
+    /**
+     * Set hits_read_ratio key on a given array by reference
+     *
+     * @param array $array Array containing 'hits' & 'reads' keys, passed by reference
+     */
+    private function calculateHitReadRatio(array &$array): void
+    {
+        $array['hit_read_ratio'] = $array['reads'] ? round(100 * $array['hits'] / $array['reads'], 2) : null;
     }
 }

--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -182,7 +182,7 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
     }
 
     /**
-     * Set hits_read_ratio key on a given array by reference
+     * Set hits_read_ratio key on a given array by reference.
      *
      * @param array $array Array containing 'hits' & 'reads' keys, passed by reference
      */


### PR DESCRIPTION
Create new reusable private method for calculating hit_read_ratio key

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13111

Setting the hit_read_ratio key is currently done in two places, so this PR aims to create a reusable private method which can set the key.