### PR TITLE
Remove deprecated endpoint

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -34,7 +34,6 @@ final class OvhCloudTransport extends AbstractTransport
         'kimsufi-ca' => 'https://ca.api.kimsufi.com/1.0',
         'soyoustart-eu' => 'https://eu.api.soyoustart.com/1.0',
         'soyoustart-ca' => 'https://ca.api.soyoustart.com/1.0',
-        'runabove-ca' => 'https://api.runabove.com/1.0',
     ];
 
     private $applicationKey;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (deprecated endpoint)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no ticket.
| License       | MIT

runabove has been closed.

previous attempt made on the read-only repository: https://github.com/symfony/ovh-cloud-notifier/pull/1

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>