### PR TITLE
sms endpoint is only available in ovh-eu

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -28,12 +28,6 @@ final class OvhCloudTransport extends AbstractTransport
 {
     private $endpoints = [
         'ovh-eu' => 'https://eu.api.ovh.com/1.0',
-        'ovh-ca' => 'https://ca.api.ovh.com/1.0',
-        'ovh-us' => 'https://api.us.ovhcloud.com/1.0',
-        'kimsufi-eu' => 'https://eu.api.kimsufi.com/1.0',
-        'kimsufi-ca' => 'https://ca.api.kimsufi.com/1.0',
-        'soyoustart-eu' => 'https://eu.api.soyoustart.com/1.0',
-        'soyoustart-ca' => 'https://ca.api.soyoustart.com/1.0',
     ];
 
     private $applicationKey;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | no ticket. <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT

`/sms` endpoint is only available for `ovh-eu` api.

Signed-off-by: Cyrille Bourgois <cyrille.bourgois@corp.ovh.com>