### PR TITLE
[VarDumper] fixed DateCaster not displaying additional fields

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -31,7 +31,11 @@ class DateCaster
             .($location ? ($d->format('I') ? "\nDST On" : "\nDST Off") : '')
         ;
 
-        $a = [];
+        unset(
+            $a[Caster::PREFIX_DYNAMIC.'date'],
+            $a[Caster::PREFIX_DYNAMIC.'timezone'],
+            $a[Caster::PREFIX_DYNAMIC.'timezone_type']
+        );
         $a[$prefix.'date'] = new ConstStub(self::formatDateTime($d, $location ? ' e (P)' : ' P'), $title);
 
         $stub->class .= $d->format(' @U');

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/DateTimeChild.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/DateTimeChild.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\VarDumper\Tests\Fixtures;
+
+class DateTimeChild extends \DateTime
+{
+    private $addedProperty = 'foo';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35699
| License       | MIT
| Doc PR        | ~

----

Here's the result with [Holiday](https://github.com/azuyalabs/yasumi/blob/develop/src/Yasumi/Holiday.php) class 

| before  | after
| ------- | -----
| ![before](https://user-images.githubusercontent.com/4425529/74445818-48f03d00-4e77-11ea-97e1-58d88ac52cba.png) | ![after](https://user-images.githubusercontent.com/4425529/74445825-4c83c400-4e77-11ea-8e8e-1fbbb1040438.png)
