### PR TITLE
fix links to releases page (formerly known as "roadmap")

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 Replace this notice by a short README for your feature/bugfix. This will help people
 understand your PR and can be used as a start for the documentation.
 
-Additionally (see https://symfony.com/roadmap):
+Additionally (see https://symfony.com/releases):
  - Always add tests and ensure they pass.
  - Never break backward compatibility (see https://symfony.com/bc).
  - Bug fixes must be submitted against the lowest maintained branch where they apply

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -202,7 +202,7 @@
                     <td class="font-normal">{{ collector.symfonyeom }}</td>
                     <td class="font-normal">{{ collector.symfonyeol }}</td>
                     <td class="font-normal">
-                        <a href="https://symfony.com/roadmap?version={{ collector.symfonyminorversion }}#checker">View roadmap</a>
+                        <a href="https://symfony.com/releases?version={{ collector.symfonyminorversion }}#checker">View roadmap</a>
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

Current releases page is https://symfony.com/releases
Formerly it was https://symfony.com/roadmap and there's a nice redirect to new URL.
Anyway, I think that pointing to the right new URL would be better
