### PR TITLE
[symfony/contracts] Reference one main CHANGELOG in each contracts

### DIFF
--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -1,0 +1,19 @@
+CHANGELOG
+=========
+
+1.1.0
+-----
+
+ * added `HttpClient` namespace with contracts for implementing flexible HTTP clients
+ * added `EventDispatcherInterface` and `Event` in namespace `EventDispatcher`
+ * added `ServiceProviderInterface` in namespace `Service`
+
+1.0.0
+-----
+
+ * added `Service\ResetInterface` to provide a way to reset an object to its initial state
+ * added `Translation\TranslatorInterface` and `Translation\TranslatorTrait`
+ * added `Cache` contract to extend PSR-6 with tag invalidation, callback-based computation and stampede protection
+ * added `Service\ServiceSubscriberInterface` to declare the dependencies of a class that consumes a service locator
+ * added `Service\ServiceSubscriberTrait` to implement `Service\ServiceSubscriberInterface` using methods' return types
+ * added `Service\ServiceLocatorTrait` to help implement PSR-11 service locators

--- a/src/Symfony/Contracts/Cache/CHANGELOG.md
+++ b/src/Symfony/Contracts/Cache/CHANGELOG.md
@@ -1,7 +1,5 @@
 CHANGELOG
 =========
 
-1.0.0
------
-
- * added `Cache` contract to extend PSR-6 with tag invalidation, callback-based computation and stampede protection
+The changelog is maintained for all Symfony contracts at the following URL:
+https://github.com/symfony/contracts/blob/master/CHANGELOG.md

--- a/src/Symfony/Contracts/Deprecation/CHANGELOG.md
+++ b/src/Symfony/Contracts/Deprecation/CHANGELOG.md
@@ -1,7 +1,5 @@
 CHANGELOG
 =========
 
-1.2.0
------
-
- * added `trigger_deprecation` function
+The changelog is maintained for all Symfony contracts at the following URL:
+https://github.com/symfony/contracts/blob/master/CHANGELOG.md

--- a/src/Symfony/Contracts/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Contracts/EventDispatcher/CHANGELOG.md
@@ -1,7 +1,5 @@
 CHANGELOG
 =========
 
-1.1.0
------
-
- * added `EventDispatcherInterface` and `Event` in namespace `EventDispatcher`
+The changelog is maintained for all Symfony contracts at the following URL:
+https://github.com/symfony/contracts/blob/master/CHANGELOG.md

--- a/src/Symfony/Contracts/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Contracts/HttpClient/CHANGELOG.md
@@ -1,7 +1,5 @@
 CHANGELOG
 =========
 
-1.1.0
------
-
- * added `HttpClient` namespace with contracts for implementing flexible HTTP clients
+The changelog is maintained for all Symfony contracts at the following URL:
+https://github.com/symfony/contracts/blob/master/CHANGELOG.md

--- a/src/Symfony/Contracts/Service/CHANGELOG.md
+++ b/src/Symfony/Contracts/Service/CHANGELOG.md
@@ -1,15 +1,5 @@
 CHANGELOG
 =========
 
-1.1.0
------
-
- * added `ServiceProviderInterface` in namespace `Service`
-
-1.0.0
------
-
- * added `Service\ResetInterface` to provide a way to reset an object to its initial state
- * added `Service\ServiceSubscriberInterface` to declare the dependencies of a class that consumes a service locator
- * added `Service\ServiceSubscriberTrait` to implement `Service\ServiceSubscriberInterface` using methods' return types
- * added `Service\ServiceLocatorTrait` to help implement PSR-11 service locators
+The changelog is maintained for all Symfony contracts at the following URL:
+https://github.com/symfony/contracts/blob/master/CHANGELOG.md

--- a/src/Symfony/Contracts/Translation/CHANGELOG.md
+++ b/src/Symfony/Contracts/Translation/CHANGELOG.md
@@ -1,7 +1,5 @@
 CHANGELOG
 =========
 
-1.0.0
------
-
- * added `Translation\TranslatorInterface` and `Translation\TranslatorTrait`
+The changelog is maintained for all Symfony contracts at the following URL:
+https://github.com/symfony/contracts/blob/master/CHANGELOG.md


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Reverts #35663
This PR makes it easier to publish the changelog for the contracts: there is only one to reference. We also need a changelog for symfony/contracts and this PR fixes this concern.