### PR TITLE
[ErrorHandler] silence warning when zend.assertions=-1

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Debug.php
+++ b/src/Symfony/Component/ErrorHandler/Debug.php
@@ -29,7 +29,7 @@ class Debug
             ini_set('display_errors', 1);
         }
 
-        ini_set('zend.assertions', 1);
+        @ini_set('zend.assertions', 1);
         ini_set('assert.active', 1);
         ini_set('assert.warning', 0);
         ini_set('assert.exception', 1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Reported at https://github.com/symfony/orm-pack/commit/1000287d032aaae70e74cdfb5c512cfb02c9abeb#commitcomment-37276894