### PR TITLE
Fixes typo in error message.

### DIFF
--- a/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
+++ b/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
@@ -37,7 +37,7 @@ class TwigErrorRenderer implements ErrorRendererInterface
     public function __construct(Environment $twig, HtmlErrorRenderer $fallbackErrorRenderer = null, $debug = false)
     {
         if (!\is_bool($debug) && !\is_callable($debug)) {
-            throw new \TypeError(sprintf('Argument 2 passed to %s() must be a boolean or a callable, %s given.', __METHOD__, \is_object($debug) ? \get_class($debug) : \gettype($debug)));
+            throw new \TypeError(sprintf('Argument 3 passed to %s() must be a boolean or a callable, %s given.', __METHOD__, \is_object($debug) ? \get_class($debug) : \gettype($debug)));
         }
 
         $this->twig = $twig;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

Fixes a minor typo where the error message refers to the wrong argument.