### PR TITLE
[HttpClient] Correctly remove trace level options for HttpCache

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -55,6 +55,8 @@ class CachingHttpClient implements HttpClientInterface
         unset($defaultOptions['allow_revalidate']);
         unset($defaultOptions['stale_while_revalidate']);
         unset($defaultOptions['stale_if_error']);
+        unset($defaultOptions['trace_level']);
+        unset($defaultOptions['trace_header']);
 
         if ($defaultOptions) {
             [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, $this->defaultOptions);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `HttpCache` component allows to [configure a trace level](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L46). Due to the behavior of `CachingHttpClient`, options that are meant for the `HttpCache` must be unset before preparing the request. Currently these options can't be set, because `HttpClient` errors with invalid configuration options.
