### PR TITLE
[HttpKernel] Set previous exception when rethrown from controller resolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -85,7 +85,7 @@ class ControllerResolver implements ControllerResolverInterface
         try {
             $callable = $this->createController($controller);
         } catch (\InvalidArgumentException $e) {
-            throw new \InvalidArgumentException(sprintf('The controller for URI "%s" is not callable. %s', $request->getPathInfo(), $e->getMessage()));
+            throw new \InvalidArgumentException(sprintf('The controller for URI "%s" is not callable. %s', $request->getPathInfo(), $e->getMessage()), 0, $e);
         }
 
         if (!\is_callable($callable)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

If an `\InvalidArgumentException` is catched by ControllerResolver a new one is thrown. The old exception is not added as `previous` on the new one so it is not visible on the exception page. This pull request adds old exception as previous on the new one, so it is also visible on the exception page.

Thank you.