### PR TITLE
[Cache] fix sharing cache between apps

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
@@ -87,7 +87,7 @@ class CachePoolPassTest extends TestCase
 
         $this->assertInstanceOf(Reference::class, $cachePool->getArgument(0));
         $this->assertSame('foobar', (string) $cachePool->getArgument(0));
-        $this->assertSame('tQNhcV-8xa', $cachePool->getArgument(1));
+        $this->assertSame('croSeNd5bG', $cachePool->getArgument(1));
         $this->assertSame(3, $cachePool->getArgument(2));
     }
 
@@ -108,7 +108,7 @@ class CachePoolPassTest extends TestCase
 
         $this->cachePoolPass->process($container);
 
-        $this->assertSame('+naTpPa4Sm', $cachePool->getArgument(1));
+        $this->assertSame('-Tv17ISg7e', $cachePool->getArgument(1));
     }
 
     public function testThrowsExceptionWhenCachePoolTagHasUnknownAttributes()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1457,11 +1457,11 @@ abstract class FrameworkExtensionTest extends TestCase
                 (new ChildDefinition('cache.adapter.array'))
                     ->replaceArgument(0, 12),
                 (new ChildDefinition('cache.adapter.filesystem'))
-                    ->replaceArgument(0, 'xctxZ1lyiH')
+                    ->replaceArgument(0, 'kByObfHfz6')
                     ->replaceArgument(1, 12),
                 (new ChildDefinition('cache.adapter.redis'))
                     ->replaceArgument(0, new Reference('.cache_connection.kYdiLgf'))
-                    ->replaceArgument(1, 'xctxZ1lyiH')
+                    ->replaceArgument(1, 'kByObfHfz6')
                     ->replaceArgument(2, 12),
             ],
             12,

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -52,8 +52,8 @@ class CachePoolPass implements CompilerPassInterface
             $seed = '.'.$container->getParameterBag()->resolveValue($container->getParameter('cache.prefix.seed'));
         } else {
             $seed = '_'.$container->getParameter('kernel.project_dir');
+            $seed .= '.'.$container->getParameter('kernel.container_class');
         }
-        $seed .= '.'.$container->getParameter('kernel.container_class');
 
         $allPools = [];
         $clearers = [];

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
@@ -135,7 +135,7 @@ class CachePoolPassTest extends TestCase
 
         $this->assertInstanceOf(Reference::class, $cachePool->getArgument(0));
         $this->assertSame('foobar', (string) $cachePool->getArgument(0));
-        $this->assertSame('tQNhcV-8xa', $cachePool->getArgument(1));
+        $this->assertSame('croSeNd5bG', $cachePool->getArgument(1));
         $this->assertSame(3, $cachePool->getArgument(2));
     }
 
@@ -156,7 +156,7 @@ class CachePoolPassTest extends TestCase
 
         $this->cachePoolPass->process($container);
 
-        $this->assertSame('+naTpPa4Sm', $cachePool->getArgument(1));
+        $this->assertSame('-Tv17ISg7e', $cachePool->getArgument(1));
     }
 
     public function testThrowsExceptionWhenCachePoolTagHasUnknownAttributes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        |

The configurable cache prefix seed (#20610) does not give full control over the cache prefix because the container class is added to the prefix in any case. This is a problem because the container class contains the app env name. We use different app environments for different deployment targets (dev and test). We want dev and test to use the same redis cache. But this is impossible to achieve because even setting the cache prefix seed does not accomplish this.