### PR TITLE
[Validator] Leverage `Countable::count()` in constraint violations

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -70,7 +70,7 @@ class FormValidator extends ConstraintValidator
                 foreach ($groups as $group) {
                     if (\in_array($group, $formConstraint->groups)) {
                         $validator->atPath('data')->validate($form->getData(), $formConstraint, $group);
-                        if (\count($this->context->getViolations()) > 0) {
+                        if ($this->context->getViolations()->count() > 0) {
                             break;
                         }
                     }

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -34,11 +34,11 @@ class ImageValidator extends FileValidator
             throw new UnexpectedTypeException($constraint, Image::class);
         }
 
-        $violations = \count($this->context->getViolations());
+        $violations = $this->context->getViolations()->count();
 
         parent::validate($value, $constraint);
 
-        $failed = \count($this->context->getViolations()) !== $violations;
+        $failed = $this->context->getViolations()->count() !== $violations;
 
         if ($failed || null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -198,7 +198,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
 
     protected function assertNoViolation()
     {
-        $this->assertSame(0, $violationsCount = \count($this->context->getViolations()), sprintf('0 violation expected. Got %u.', $violationsCount));
+        $this->assertCount(0, $this->context->getViolations(), sprintf('0 violation expected. Got %u.', $this->context->getViolations()->count()));
     }
 
     /**
@@ -320,7 +320,7 @@ class ConstraintViolationAssertion
 
         $violations = iterator_to_array($this->context->getViolations());
 
-        Assert::assertSame($expectedCount = \count($expected), $violationsCount = \count($violations), sprintf('%u violation(s) expected. Got %u.', $expectedCount, $violationsCount));
+        Assert::assertCount($expectedCount = \count($expected), $this->context->getViolations(), sprintf('%u violation(s) expected. Got %u.', $expectedCount, $this->context->getViolations()->count()));
 
         reset($violations);
 

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -668,7 +668,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      */
     private function stepThroughGroupSequence($value, $object, ?string $cacheKey, ?MetadataInterface $metadata, string $propertyPath, int $traversalStrategy, GroupSequence $groupSequence, ?string $cascadedGroup, ExecutionContextInterface $context)
     {
-        $violationCount = \count($context->getViolations());
+        $violationCount = $context->getViolations()->count();
         $cascadedGroups = $cascadedGroup ? [$cascadedGroup] : null;
 
         foreach ($groupSequence->groups as $groupInSequence) {
@@ -700,7 +700,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             }
 
             // Abort sequence validation if a violation was generated
-            if (\count($context->getViolations()) > $violationCount) {
+            if ($context->getViolations()->count() > $violationCount) {
                 break;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Leverage `ConstraintViolationListInterface::count()` (inherited from `Countable`) in constraint violations.