### PR TITLE
[Routing] Use env() in route condition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -115,5 +115,9 @@
         <service id="Symfony\Bundle\FrameworkBundle\Controller\TemplateController" public="true">
             <argument type="service" id="twig" on-invalid="ignore" />
         </service>
+
+        <service id="Symfony\Component\Routing\Matcher\ExpressionLanguageProvider" public="false">
+            <tag name="routing.expression_language_provider" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * deprecated `RouteCollectionBuilder` in favor of `RoutingConfigurator`.
  * added "priority" option to annotated routes
  * added argument `$priority` to `RouteCollection::add()`
+ * added `ExpressionLanguageProvider` that provides `env` function.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Routing/Matcher/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/Routing/Matcher/ExpressionLanguageProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * Defines some ExpressionLanguage functions.
+ *
+ * @author Ahmed TAILOULOUTE <ahmed.tailouloute@gmail.com>
+ */
+class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new ExpressionFunction(
+                'env',
+                static function ($str, $default = 'null') {
+                    return sprintf('($_SERVER[%s] ?? %s)', $str, $default);
+                },
+                static function ($arguments, $str, $default = null) {
+                    return $_SERVER[$str] ?? $default;
+                }
+            ),
+        ];
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Matcher/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/ExpressionLanguageTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Matcher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Routing\Matcher\ExpressionLanguageProvider;
+
+class ExpressionLanguageTest extends TestCase
+{
+    public function setUp()
+    {
+        $_SERVER['test__APP_ENV'] = 'test';
+        $_SERVER['test__PHP_VERSION'] = '7.2';
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testEnv(string $expression, $expected): void
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $expressionLanguage->registerProvider(new ExpressionLanguageProvider());
+
+        $this->assertEquals($expected, $expressionLanguage->evaluate($expression));
+    }
+
+    public function provider(): array
+    {
+        return [
+            ['env("test__APP_ENV")', 'test'],
+            ['env("test__PHP_VERSION")', '7.2'],
+            ['env("test__unknown_env_variable")', null],
+            ['env("test__unknown_env_variable", "default")', 'default'],
+        ];
+    }
+
+    public function tearDown()
+    {
+        unset($_SERVER['test__APP_ENV'], $_SERVER['test__PHP_VERSION']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TODO

Added an `ExpressionLanguageProvider` in the Routing component, that provides the `env` function which could be used in route conditions

An example of the feature

```php
/**
 * @Route("/only-for-dev", condition="env('APP_ENV') === 'dev'")
 */
public function __invoke()
{
   echo "This will be executed only when APP_ENV = dev";
}
```

With a default value:
```php
/**
 * @Route("/only-for-dev", condition="env('APP_ENV', 'dev') === 'dev'")
 */
```