### PR TITLE
Add missing autoload calls

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -282,3 +282,5 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
         $this->choiceLoaders = [];
     }
 }
+
+interface_exists(ObjectManager::class);

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -97,3 +97,5 @@ class EntityType extends DoctrineType
         return [$parameter->getName(), $parameter->getType(), $parameter->getValue()];
     }
 }
+
+interface_exists(ObjectManager::class);

--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -153,3 +153,6 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
         return $this->getObjectManager()->getClassMetadata($this->classOrAlias);
     }
 }
+
+interface_exists(ObjectManager::class);
+interface_exists(ObjectRepository::class);


### PR DESCRIPTION
Until either php 7.4 or doctrine/persistence 2 is required, these will
be needed to make sure php recognises signatures using the old names as
compatible with signatures using the new names.
This is necessary for types defined outside Symfony that extend types
from Symfony and still use the old names in signatures of methods they
override.

Fixes https://github.com/doctrine/DoctrineMongoDBBundle/issues/616

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/doctrine/DoctrineMongoDBBundle/issues/616
| License       | MIT
| Doc PR        | n/a
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
This topic is fairly complicated, more details at https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf