### PR TITLE
[Routing] marked configurators traits as internal

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/LocalizedRouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/LocalizedRouteTrait.php
@@ -15,6 +15,8 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
+ * @internal
+ *
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Jules Pietri <jules@heahprod.com>
  */

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/PrefixTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/PrefixTrait.php
@@ -15,6 +15,8 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
+ * @internal
+ *
  * @author Nicolas Grekas <p@tchwork.com>
  */
 trait PrefixTrait


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/pull/30501#discussion_r376806342 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | not needed
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
