### PR TITLE
[FrameworkBundle][HttpKernel] Add session usage reporting in stateless mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -66,7 +66,9 @@
             <argument type="service_locator">
                 <argument key="session" type="service" id="session" on-invalid="ignore" />
                 <argument key="initialized_session" type="service" id="session" on-invalid="ignore_uninitialized" />
+                <argument key="logger" type="service" id="logger" on-invalid="ignore" />
             </argument>
+            <argument>%kernel.debug%</argument>
         </service>
 
         <!-- for BC -->

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -504,7 +504,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('session.storage.native')->getArgument(1));
         $this->assertNull($container->getDefinition('session.storage.php_bridge')->getArgument(0));
 
-        $expected = ['session', 'initialized_session'];
+        $expected = ['session', 'initialized_session', 'logger'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
     }
 
@@ -1301,7 +1301,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('session_cookie_secure_auto');
 
-        $expected = ['session', 'initialized_session', 'session_storage', 'request_stack'];
+        $expected = ['session', 'initialized_session', 'logger', 'session_storage', 'request_stack'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
     }
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * allowed using public aliases to reference controllers
+ * added session usage reporting when the `_stateless` attribute of the request is set to `true`
 
 5.0.0
 -----

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -28,9 +28,9 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
  */
 class SessionListener extends AbstractSessionListener
 {
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, bool $debug = false)
     {
-        $this->container = $container;
+        parent::__construct($container, $debug);
     }
 
     protected function getSession(): ?SessionInterface

--- a/src/Symfony/Component/HttpKernel/Exception/UnexpectedSessionUsageException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnexpectedSessionUsageException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+class UnexpectedSessionUsageException extends \LogicException
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13344

https://github.com/orgs/symfony/projects/1#card-30506005

Provide a `stateless` attribute that forbid session usage.

## Implementations
**v1**
- ~~New session proxy that allows session to be marked as disabled~~
- ~~New default route attribute: `_stateless` (automatically set by `@Stateless`)~~
- ~~On kernel controller event, if `_stateless` is `true`, session is marked as disabled~~
- ~~Session listener is able to check if the session is disabled and prevent its creation~~

**v2**
- ~~New default route attribute: `_stateless` (automatically set by `@Stateless`)~~
- ~~On kernel response, check the session usage and if session was used when `_stateless` attribute is set to `true`: Either throw an exception (debug enabled) or log a warning (debug disabled)~~

**v3**
- New route default `_stateless` (automatically set by `stateless` route attribute)
- On kernel response, check the session usage and if session was used when `_stateless` attribute is set to `true`: Either throw an exception (debug enabled) or log a warning (debug disabled)