### PR TITLE
[Validator] Add RgbColor constraint and validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/RgbColor.php
+++ b/src/Symfony/Component/Validator/Constraints/RgbColor.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class RgbColor extends Constraint
+{
+    public const INVALID_FORMAT_ERROR = '5720b8cb-fb2a-430e-94e9-2d33b4cd1fa9';
+
+    protected static $errorNames = [
+        self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',
+    ];
+
+    public $message = 'This is not a valid RGB color.';
+    public $allowAlpha = true;
+    public $alphaPrecision = 2;
+    public $lowerCaseOnly = false;
+
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+        
+        if (!is_int($this->alphaPrecision) || 1 > $this->alphaPrecision) {
+            throw new InvalidArgumentException(sprintf('The "alphaPrecision" option must be a positive integer ("%s" given)', $this->alphaPrecision));
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/RgbColor.php
+++ b/src/Symfony/Component/Validator/Constraints/RgbColor.php
@@ -36,8 +36,8 @@ class RgbColor extends Constraint
     public function __construct($options = null)
     {
         parent::__construct($options);
-        
-        if (!is_int($this->alphaPrecision) || 1 > $this->alphaPrecision) {
+
+        if (!\is_int($this->alphaPrecision) || 1 > $this->alphaPrecision) {
             throw new InvalidArgumentException(sprintf('The "alphaPrecision" option must be a positive integer ("%s" given)', $this->alphaPrecision));
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/RgbColorValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RgbColorValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+/**
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class RgbColorValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof RgbColor) {
+            throw new UnexpectedTypeException($constraint, RgbColor::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!\is_string($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        $value = (string) $value;
+        
+        $pattern = sprintf('/^rgb%s\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})%s\)$/%s', $constraint->allowAlpha ? 'a?' : '', $constraint->allowAlpha ? '(,\s*[0-1]{0,1}(?:\.\d{1,'.$constraint->alphaPrecision.'})?)?' : '', $constraint->lowerCaseOnly ? '' : 'i');
+
+        if (!preg_match($pattern, $value, $matches) || !$this->areRangesValid($matches)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(RgbColor::INVALID_FORMAT_ERROR)
+                ->addViolation();
+        }
+    }
+    
+    private function areRangesValid(array $matches): bool
+    {
+        for ($i = 1; $i < 4; $i++) {
+            if (0 > $matches[$i] || 255 < $matches[$i]) {
+                return false;
+            }
+        }
+        
+        if ($alpha = trim($matches[4] ?? null, ',')) {
+            if (0 > $alpha || 1 < $alpha) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/RgbColorValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RgbColorValidator.php
@@ -39,7 +39,7 @@ class RgbColorValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
-        
+
         $pattern = sprintf('/^rgb%s\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})%s\)$/%s', $constraint->allowAlpha ? 'a?' : '', $constraint->allowAlpha ? '(,\s*[0-1]{0,1}(?:\.\d{1,'.$constraint->alphaPrecision.'})?)?' : '', $constraint->lowerCaseOnly ? '' : 'i');
 
         if (!preg_match($pattern, $value, $matches) || !$this->areRangesValid($matches)) {
@@ -49,21 +49,21 @@ class RgbColorValidator extends ConstraintValidator
                 ->addViolation();
         }
     }
-    
+
     private function areRangesValid(array $matches): bool
     {
-        for ($i = 1; $i < 4; $i++) {
+        for ($i = 1; $i < 4; ++$i) {
             if (0 > $matches[$i] || 255 < $matches[$i]) {
                 return false;
             }
         }
-        
+
         if ($alpha = trim($matches[4] ?? null, ',')) {
             if (0 > $alpha || 1 < $alpha) {
                 return false;
             }
         }
-        
+
         return true;
     }
 }

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -370,6 +370,10 @@
                 <source>This value is not a valid hostname.</source>
                 <target>This value is not a valid hostname.</target>
             </trans-unit>
+            <trans-unit id="96">
+                <source>This is not a valid RGB color.</source>
+                <target>This is not a valid RGB color.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -334,6 +334,10 @@
                 <source>This value should be between {{ min }} and {{ max }}.</source>
                 <target>Ta wartość powinna być pomiędzy {{ min }} a {{ max }}.</target>
             </trans-unit>
+            <trans-unit id="96">
+                <source>This is not a valid RGB color.</source>
+                <target>To nie jest poprawny kolor RGB.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/RgbColorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RgbColorValidatorTest.php
@@ -30,7 +30,7 @@ class RgbColorValidatorTest extends ConstraintValidatorTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "alphaPrecision" option must be a positive integer ("foo" given)');
-        
+
         new RgbColor(['alphaPrecision' => 'foo']);
     }
 
@@ -142,7 +142,7 @@ class RgbColorValidatorTest extends ConstraintValidatorTestCase
     public function testValidRgbColorsWithAllowAlphaFalse($color)
     {
         $this->validator->validate($color, new RgbColor(['allowAlpha' => false]));
-        
+
         $this->assertNoViolation();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/RgbColorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RgbColorValidatorTest.php
@@ -1,0 +1,292 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\RgbColor;
+use Symfony\Component\Validator\Constraints\RgbColorValidator;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class RgbColorValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new RgbColorValidator();
+    }
+
+    public function testInvalidArgument()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "alphaPrecision" option must be a positive integer ("foo" given)');
+        
+        new RgbColor(['alphaPrecision' => 'foo']);
+    }
+
+    public function testUnexpectedType()
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "Symfony\Component\Validator\Constraints\RgbColor", "Symfony\Component\Validator\Constraints\Email" given');
+
+        $this->validator->validate(null, new Email());
+    }
+
+    public function testUnexpectedValue()
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Expected argument of type "string", "stdClass" given');
+
+        $this->validator->validate(new \stdClass(), new RgbColor());
+    }
+
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new RgbColor());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->validator->validate('', new RgbColor());
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getValidRgbColorsWithDefaultOptions
+     */
+    public function testValidRgbColorsWithDefaultOptions($color)
+    {
+        $this->validator->validate($color, new RgbColor());
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidRgbColorsWithDefaultOptions()
+    {
+        return [
+            ['rgb(0,0,0)'],
+            ['rgb(255,255,255)'],
+            ['RGB(0,0,0)'],
+            ['RgB(0,0,0)'],
+            ['rgb(0, 0, 0)'],
+            ['rgb(0,    0,   0)'],
+            ['rgba(0,0,0,0.2)'],
+            ['rgba(0,0,0,.75)'],
+            ['rgba(0,0,0,1)'],
+            [new class() {
+                public function __toString()
+                {
+                    return 'rgb(0,0,0)';
+                }
+            }],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidRgbColorsWithDefaultOptions
+     */
+    public function testInvalidRgbColorsWithDefaultOptions($color)
+    {
+        $this->validator->validate($color, new RgbColor(['message' => 'foo']));
+
+        $this->buildViolation('foo')
+            ->setParameter('{{ value }}', '"'.(string) $color.'"')
+            ->setCode(RgbColor::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidRgbColorsWithDefaultOptions()
+    {
+        return [
+            ['rgb(a,0,0)'],
+            ['rgb(0,a,0)'],
+            ['rgb(0,0,a)'],
+            ['rgb(0,0,0'],
+            ['rgb0,0,0)'],
+            ['rgb0,0,0'],
+            [' rgb(0,0,0)'],
+            ['rgb (0,0,0)'],
+            ['rgbb(0,0,0)'],
+            ['rgba(0,0,0,1.2)'],
+            ['rgba(0,0,0,0.751)'],
+            ['rgba(0,0,0,.)'],
+            ['rgba(0,0,0,3)'],
+            ['rgb(-1,0,0)'],
+            ['rgb(0,256,0)'],
+            ['rgb(0,0,256)'],
+            [new class() {
+                public function __toString()
+                {
+                    return 'rgb(0,0,0) ';
+                }
+            }],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidRgbColorsWithAllowAlphaFalse
+     */
+    public function testValidRgbColorsWithAllowAlphaFalse($color)
+    {
+        $this->validator->validate($color, new RgbColor(['allowAlpha' => false]));
+        
+        $this->assertNoViolation();
+    }
+
+    public function getValidRgbColorsWithAllowAlphaFalse()
+    {
+        return [
+            ['rgb(0,0,0)'],
+            ['rgb(255,255,255)'],
+            ['RGB(0,0,0)'],
+            ['RgB(0,0,0)'],
+            ['rgb(0, 0, 0)'],
+            ['rgb(0,    0,   0)'],
+            [new class() {
+                public function __toString()
+                {
+                    return 'rgb(0,0,0)';
+                }
+            }],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidRgbColorsWithAllowAlphaFalse
+     */
+    public function testInvalidRgbColorsWithAllowAlphaFalse($color)
+    {
+        $this->validator->validate($color, new RgbColor(['allowAlpha' => false, 'message' => 'foo']));
+
+        $this->buildViolation('foo')
+            ->setParameter('{{ value }}', '"'.(string) $color.'"')
+            ->setCode(RgbColor::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidRgbColorsWithAllowAlphaFalse()
+    {
+        return [
+            ['rgba(0,0,0,0.2)'],
+            ['rgba(0,0,0,.75)'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidRgbColorsWithLowerCaseOnly
+     */
+    public function testValidRgbColorsWithLowerCaseOnly($color)
+    {
+        $this->validator->validate($color, new RgbColor(['lowerCaseOnly' => true]));
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidRgbColorsWithLowerCaseOnly()
+    {
+        return [
+            ['rgb(0,0,0)'],
+            ['rgb(255,255,255)'],
+            ['rgb(0, 0, 0)'],
+            ['rgb(0,    0,   0)'],
+            ['rgba(0,0,0,0.2)'],
+            ['rgba(0,0,0,.75)'],
+            ['rgba(0,0,0,1)'],
+            [new class() {
+                public function __toString()
+                {
+                    return 'rgb(0,0,0)';
+                }
+            }],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidRgbColorsWithLowerCaseOnly
+     */
+    public function testInvalidRgbColorsWithLowerCaseOnly($color)
+    {
+        $this->validator->validate($color, new RgbColor(['lowerCaseOnly' => true, 'message' => 'foo']));
+
+        $this->buildViolation('foo')
+            ->setParameter('{{ value }}', '"'.(string) $color.'"')
+            ->setCode(RgbColor::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidRgbColorsWithLowerCaseOnly()
+    {
+        return [
+            ['RGB(0,0,0)'],
+            ['RgB(0,0,0)'],
+            ['rgbA(0,0,0,1)'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidRgbColorsWithLowerAlphaPrecision
+     */
+    public function testValidRgbColorsWithLowerAlphaPrecision($color)
+    {
+        $this->validator->validate($color, new RgbColor(['alphaPrecision' => 1]));
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidRgbColorsWithLowerAlphaPrecision()
+    {
+        return [
+            ['rgb(0,0,0)'],
+            ['rgb(255,255,255)'],
+            ['RGB(0,0,0)'],
+            ['RgB(0,0,0)'],
+            ['rgb(0, 0, 0)'],
+            ['rgb(0,    0,   0)'],
+            ['rgba(0,0,0,0.2)'],
+            ['rgba(0,0,0,.7)'],
+            ['RGBA(0,0,0,1.0)'],
+            ['rgba(0,0,0,1)'],
+            [new class() {
+                public function __toString()
+                {
+                    return 'rgb(0,0,0)';
+                }
+            }],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidRgbColorsWithLowerAlphaPrecision
+     */
+    public function testInvalidRgbColorsWithLowerAlphaPrecision($color)
+    {
+        $this->validator->validate($color, new RgbColor(['alphaPrecision' => 1, 'message' => 'foo']));
+
+        $this->buildViolation('foo')
+            ->setParameter('{{ value }}', '"'.(string) $color.'"')
+            ->setCode(RgbColor::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidRgbColorsWithLowerAlphaPrecision()
+    {
+        return [
+            ['rgba(0,0,0,.75)'],
+            ['rgba(0,0,0,0.75)'],
+            ['rgba(0,0,0,1.00)'],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | TODO

Following the idea for the HexColor constraint (#35626), I hereby propose the RgbColor constraint, which validates against rgb() and rgba() functions.