### PR TITLE
[Finder] Adjust regex to work with negative lookup by converting ! symbol

### DIFF
--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -46,7 +46,6 @@ class Glob
         $escaping = false;
         $inCurlies = 0;
         $inNegative = 0;
-        $negativeForCurlies = [];
         $regex = '';
         $sizeGlob = \strlen($glob);
         for ($i = 0; $i < $sizeGlob; ++$i) {
@@ -86,6 +85,9 @@ class Glob
                 if (!$escaping) {
                     ++$inNegative;
                     if ('{' === $glob[$i + 1]) {
+                        if (!isset($negativeForCurlies)) {
+                            $negativeForCurlies = [];
+                        }
                         $negativeForCurlies[$inNegative] = 0;
                     }
 

--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -105,7 +105,7 @@ class Glob
                     --$inCurlies;
                     if ($inNegative && isset($negativeForCurlies[$inNegative])) {
                         --$negativeForCurlies[$inNegative];
-                        if (0 === $negativeForCurlies[$inNegative])  {
+                        if (0 === $negativeForCurlies[$inNegative]) {
                             $regex .= ')';
                             unset($negativeForCurlies[$inNegative]);
                             --$inNegative;

--- a/src/Symfony/Component/Finder/Tests/GlobTest.php
+++ b/src/Symfony/Component/Finder/Tests/GlobTest.php
@@ -92,4 +92,14 @@ class GlobTest extends TestCase
 
         $this->assertSame(['one/.dot', 'one/a', 'one/b', 'one/b/c.neon', 'one/b/d.neon'], $match);
     }
+
+    public function testGlobToRegexNegativeLookup()
+    {
+        $this->assertEquals('#^(?=[^\.])(?!(a|b))$#', Glob::toRegex('!{a,b}'));
+        $this->assertEquals('#^(?=[^\.])(?!c)har/(?=[^\.])(a|b)$#', Glob::toRegex('!char/{a,b}'));
+        $this->assertEquals('#^(?=[^\.])(?!(Service))$#', Glob::toRegex('!{Service}'));
+        $this->assertEquals('#^(?=[^\.])(?!(a|(?!(a|b))|b|c))(?!(d|e|f))x$#', Glob::toRegex('!{a,!{a,b},b,c}!{d,e,f}x'));
+        $this->assertEquals('#^(?=[^\.])(?!!)!((?!a)|(?!b))$#', Glob::toRegex('!\\!\\!{!a,!b}'));
+        $this->assertEquals('#^(?=[^\.])(?!((?!((?!(a|b))|c))))$#', Glob::toRegex('!{!{!{a,b},c}}'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Adding ! symbol to be converted to regex negative lookahead (see https://www.regular-expressions.info/lookaround.html for description)

Examples:
 -   **!{a,b}** to **#^(?=[^.])(?!(a|b))$#**
 -   **!{Service}** to **#^(?=[^.])(?!(Service))$#**
 -   **!{!{!{a,b},c}}** to **#^(?=[^.])(?!((?!((?!(a|b))|c))))$#** 

An example of a tool where such syntax can be applied: https://globster.xyz/

Syntax of the extended glob matching feature (extglob). Matches anything except one of the given pattern

@nicolas-grekas @stof 

