### PR TITLE
[MonologBridge] Use composition instead of inheritance in monolog bridge

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -48,6 +48,12 @@ Mime
 
  * Deprecated `Address::fromString()`, use `Address::create()` instead
 
+Monolog
+-------
+
+ * The `$actionLevel` constructor argument of `Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy` has been deprecated and replaced by the `$inner` one which expects an ActivationStrategyInterface to decorate instead. `Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy` will become final in 6.0.
+ * The `$actionLevel` constructor argument of `Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy` has been deprecated and replaced by the `$inner` one which expects an ActivationStrategyInterface to decorate instead. `Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy` will become final in 6.0
+
 PropertyAccess
 --------------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -98,6 +98,12 @@ Mime
 
  * Removed `Address::fromString()`, use `Address::create()` instead
 
+Monolog
+-------
+
+ * The `$actionLevel` constructor argument of `Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy` has been replaced by the `$inner` one which expects an ActivationStrategyInterface to decorate instead. `Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy` is now final.
+ * The `$actionLevel` constructor argument of `Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy` has been replaced by the `$inner` one which expects an ActivationStrategyInterface to decorate instead. `Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy` is now final.
+
 OptionsResolver
 ---------------
 

--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -1,8 +1,15 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * The `$actionLevel` constructor argument of `Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy` has been deprecated and replaced by the `$inner` one which expects an ActivationStrategyInterface to decorate instead. `Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy` will become final in 6.0.
+ * The `$actionLevel` constructor argument of `Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy` has been deprecated and replaced by the `$inner` one which expects an ActivationStrategyInterface to decorate instead. `Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy` will become final in 6.0
+
 5.1.0
 -----
+
  * Added `MailerHandler`
 
 5.0.0

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Monolog\Tests\Handler\FingersCrossed;
 
+use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy;
@@ -22,18 +23,33 @@ class NotFoundActivationStrategyTest extends TestCase
 {
     /**
      * @dataProvider isActivatedProvider
+     *
+     * @group legacy
      */
-    public function testIsActivated($url, $record, $expected)
+    public function testIsActivatedLegacy(string $url, array $record, bool $expected): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(Request::create($url));
 
         $strategy = new NotFoundActivationStrategy($requestStack, ['^/foo', 'bar'], Logger::WARNING);
 
-        $this->assertEquals($expected, $strategy->isHandlerActivated($record));
+        self::assertEquals($expected, $strategy->isHandlerActivated($record));
     }
 
-    public function isActivatedProvider()
+    /**
+     * @dataProvider isActivatedProvider
+     */
+    public function testIsActivated(string $url, array $record, bool $expected): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create($url));
+
+        $strategy = new NotFoundActivationStrategy($requestStack, ['^/foo', 'bar'], new ErrorLevelActivationStrategy(Logger::WARNING));
+
+        self::assertEquals($expected, $strategy->isHandlerActivated($record));
+    }
+
+    public function isActivatedProvider(): array
     {
         return [
             ['/test',      ['level' => Logger::DEBUG], false],
@@ -48,7 +64,7 @@ class NotFoundActivationStrategyTest extends TestCase
         ];
     }
 
-    protected function getContextException($code)
+    protected function getContextException(int $code): array
     {
         return ['exception' => new HttpException($code)];
     }

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -19,7 +19,8 @@
         "php": ">=7.2.5",
         "monolog/monolog": "^1.25.1|^2",
         "symfony/service-contracts": "^1.1|^2",
-        "symfony/http-kernel": "^4.4|^5.0"
+        "symfony/http-kernel": "^4.4|^5.0",
+        "symfony/deprecation-contracts": "^2.1"
     },
     "require-dev": {
         "symfony/console": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

In order to allow better customization in monolog activation strategy, this PR introduce composition instead of inheritance for these 2 classes : 
- HttpCodeActivationStrategy
- NotFoundActivationStrategy
