### PR TITLE
[Translator][TwigBridge] allow using trans() with a list of messages to use as fallbacks

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * made the `trans()` filter accept a list of messages to use as fallbacks when translation is missing
+
 5.0.0
 -----
 

--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -89,12 +89,24 @@ final class TranslationExtension extends AbstractExtension
         return $this->translationNodeVisitor ?: $this->translationNodeVisitor = new TranslationNodeVisitor();
     }
 
-    public function trans(string $message, array $arguments = [], string $domain = null, string $locale = null, int $count = null): string
+    public function trans($message, array $arguments = [], string $domain = null, string $locale = null, int $count = null): string
     {
         if (null !== $count) {
             $arguments['%count%'] = $count;
         }
 
-        return $this->getTranslator()->trans($message, $arguments, $domain, $locale);
+        if ('' === $message || [] === $messages = (array) $message) {
+            return '';
+        }
+
+        $translator = $this->getTranslator();
+
+        foreach ($messages as $msg) {
+            if ($msg !== $message = $translator->trans($msg, $arguments, $domain, $locale)) {
+                break;
+            }
+        }
+
+        return $message;
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -113,6 +113,7 @@ class TranslationExtensionTest extends TestCase
             ['{{ hello|trans({ \'%name%\': \'Symfony\' }) }}', 'Hello Symfony', ['hello' => 'Hello %name%']],
             ['{% set vars = { \'%name%\': \'Symfony\' } %}{{ hello|trans(vars) }}', 'Hello Symfony', ['hello' => 'Hello %name%']],
             ['{{ "Hello"|trans({}, "messages", "fr") }}', 'Hello'],
+            ['{{ ["bar", "fallback"]|trans }}', 'fallback'],
 
             // trans filter with count
             ['{{ "{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples"|trans(count=count) }}', 'There is 5 apples', ['count' => 5]],

--- a/src/Symfony/Component/Translation/AltTranslator.php
+++ b/src/Symfony/Component/Translation/AltTranslator.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Accepts several messages and returns the first translated one in the list.
+ *
+ * A message is considered *not* translated when its translation is the same as its id.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class AltTranslator implements TranslatorInterface
+{
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|string[]|null $id
+     */
+    public function trans($id, array $parameters = [], string $domain = null, string $locale = null)
+    {
+        if ('' === $id || [] === $ids = (array) $id) {
+            return '';
+        }
+
+        foreach ($ids as $id) {
+            if ($id !== $message = $this->translator->trans($id, $parameters, $domain, $locale)) {
+                break;
+            }
+        }
+
+        return $message;
+    }
+}

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added support for `name` attribute on `unit` element from xliff2 to be used as a translation key instead of always the `source` element
+ * added `AltTranslator`, whose `trans()` method accepts a list of messages to use as fallbacks when translation is missing
 
 5.0.0
 -----

--- a/src/Symfony/Component/Translation/Tests/AltTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/AltTranslatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\AltTranslator;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Translator;
+
+class AltTranslatorTest extends TestCase
+{
+    public function testTrans()
+    {
+        $translator = new Translator('fr');
+        $translator->setFallbackLocales(['en']);
+
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['bar' => 'foobar'], 'en');
+
+        $translator = new AltTranslator($translator);
+
+        $this->assertSame('', $translator->trans(''));
+        $this->assertSame('', $translator->trans(null));
+        $this->assertSame('', $translator->trans([]));
+        $this->assertSame('foobar', $translator->trans('bar'));
+        $this->assertSame('foobar', $translator->trans(['bar']));
+        $this->assertSame('foobar', $translator->trans(['foo', 'bar']));
+        $this->assertSame('buz', $translator->trans(['foo', 'buz']));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #35466
| License       | MIT
| Doc PR        | -

Alternative of #35636

In Twig:
`{{ ["bar", "fallback"]|trans }}'`

In PHP:
```php
$translator = new AltTranslator($translator);
$translator->trans(['bar', 'fallback']);
```

A message is considered *not* translated when its translation is the same as its id.