### PR TITLE
[RFC] Add problem details class for HTTP API Problem spec rfc7807

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
@@ -70,6 +70,6 @@ class JsonLoginTest extends AbstractWebTestCase
 
         $this->assertSame(400, $response->getStatusCode());
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
-        $this->assertSame(['type' => 'https://tools.ietf.org/html/rfc2616#section-10', 'title' => 'An error occurred', 'status' => 400, 'detail' => 'Bad Request'], json_decode($response->getContent(), true));
+        $this->assertSame(['type' => 'https://tools.ietf.org/html/rfc2616#section-10', 'title' => 'Bad Request', 'status' => 400], json_decode($response->getContent(), true));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
-        "symfony/http-kernel": "^5.0",
+        "symfony/http-kernel": "^5.1",
         "symfony/security-core": "^4.4|^5.0",
         "symfony/security-csrf": "^4.4|^5.0",
         "symfony/security-guard": "^4.4|^5.0",
@@ -35,9 +35,9 @@
         "symfony/dom-crawler": "^4.4|^5.0",
         "symfony/expression-language": "^4.4|^5.0",
         "symfony/form": "^4.4|^5.0",
-        "symfony/framework-bundle": "^4.4|^5.0",
+        "symfony/framework-bundle": "^4.4.1|^5.0.1",
         "symfony/process": "^4.4|^5.0",
-        "symfony/serializer": "^4.4|^5.0",
+        "symfony/serializer": "^5.1",
         "symfony/translation": "^4.4|^5.0",
         "symfony/twig-bundle": "^4.4|^5.0",
         "symfony/twig-bridge": "^4.4|^5.0",
@@ -50,7 +50,9 @@
         "symfony/console": "<4.4",
         "symfony/framework-bundle": "<4.4",
         "symfony/ldap": "<4.4",
-        "symfony/twig-bundle": "<4.4"
+        "symfony/twig-bundle": "<4.4",
+        "symfony/serializer": "<5.1",
+        "symfony/error-handler": "<5.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\SecurityBundle\\": "" },

--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\ErrorHandler\Exception;
 use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\ProblemHttpException;
 
 /**
  * FlattenException wraps a PHP Error or Exception to be able to serialize it.
@@ -30,6 +31,10 @@ class FlattenException
     private $trace;
     private $traceAsString;
     private $class;
+    private $type;
+    private $title;
+    private $instance;
+    private $extensions = [];
     private $statusCode;
     private $statusText;
     private $headers;
@@ -83,6 +88,13 @@ class FlattenException
 
         if ($previous instanceof \Throwable) {
             $e->setPrevious(static::createFromThrowable($previous));
+        }
+
+        if ($exception instanceof ProblemHttpException) {
+            $e->setType($exception->getType());
+            $e->setTitle($exception->getTitle());
+            $e->setInstance($exception->getInstance());
+            $e->setExtensions($exception->getExtensions());
         }
 
         return $e;
@@ -206,6 +218,66 @@ class FlattenException
         }
 
         $this->message = $message;
+
+        return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setType(?string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getInstance(): ?string
+    {
+        return $this->instance;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setInstance(?string $instance): self
+    {
+        $this->instance = $instance;
+
+        return $this;
+    }
+
+    public function getExtensions(): array
+    {
+        return $this->extensions;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setExtensions(array $extensions): self
+    {
+        $this->extensions = $extensions;
 
         return $this;
     }

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/SerializerErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/SerializerErrorRendererTest.php
@@ -34,6 +34,6 @@ class SerializerErrorRendererTest extends TestCase
             function () { return 'json'; }
         );
 
-        $this->assertSame('{"type":"https:\/\/tools.ietf.org\/html\/rfc2616#section-10","title":"An error occurred","status":500,"detail":"Internal Server Error"}', $errorRenderer->render($exception)->getAsString());
+        $this->assertSame('{"type":"https:\/\/tools.ietf.org\/html\/rfc2616#section-10","title":"Internal Server Error","status":500}', $errorRenderer->render($exception)->getAsString());
     }
 }

--- a/src/Symfony/Component/ErrorHandler/composer.json
+++ b/src/Symfony/Component/ErrorHandler/composer.json
@@ -21,8 +21,11 @@
         "symfony/var-dumper": "^4.4|^5.0"
     },
     "require-dev": {
-        "symfony/http-kernel": "^4.4|^5.0",
-        "symfony/serializer": "^4.4|^5.0"
+        "symfony/http-kernel": "^5.1",
+        "symfony/serializer": "^5.1"
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<4.4.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\ErrorHandler\\": "" },

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,13 +6,14 @@ CHANGELOG
 
  * allowed using public aliases to reference controllers
  * added session usage reporting when the `_stateless` attribute of the request is set to `true`
+ * added `ProblemHttpException` class
 
 5.0.0
 -----
 
  * removed support for getting the container from a non-booted kernel
- * removed the first and second constructor argument of `ConfigDataCollector` 
- * removed `ConfigDataCollector::getApplicationName()` 
+ * removed the first and second constructor argument of `ConfigDataCollector`
+ * removed `ConfigDataCollector::getApplicationName()`
  * removed `ConfigDataCollector::getApplicationVersion()`
  * removed support for `Symfony\Component\Templating\EngineInterface` in `HIncludeFragmentRenderer`, use a `Twig\Environment` only
  * removed `TranslatorListener` in favor of `LocaleAwareListener`
@@ -24,7 +25,7 @@ CHANGELOG
  * removed `GetResponseForControllerResultEvent`, use `ViewEvent` instead
  * removed `GetResponseForExceptionEvent`, use `ExceptionEvent` instead
  * removed `PostResponseEvent`, use `TerminateEvent` instead
- * removed `SaveSessionListener` in favor of `AbstractSessionListener` 
+ * removed `SaveSessionListener` in favor of `AbstractSessionListener`
  * removed `Client`, use `HttpKernelBrowser` instead
  * added method `getProjectDir()` to `KernelInterface`
  * removed methods `serialize` and `unserialize` from `DataCollector`, store the serialized state in the data property instead

--- a/src/Symfony/Component/HttpKernel/Exception/ProblemHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ProblemHttpException.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * The problem details class for HTTP API Problem spec (RFC 7807).
+ *
+ * @see https://tools.ietf.org/html/rfc7807
+ *
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+class ProblemHttpException extends HttpException
+{
+    private $type;
+    private $title;
+    private $instance;
+    private $extensions = [];
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets the reference of the problem type.
+     *
+     * @param string $type A URI reference that identifies the problem type
+     *
+     * @return $this
+     */
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Sets the summary of the problem.
+     *
+     * @param string $title A short, human-readable summary of the problem type.
+     *                      It should not change from occurrence to occurrence of the
+     *                      problem, except for purposes of localization
+     *
+     * @return $this
+     */
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getInstance(): ?string
+    {
+        return $this->instance;
+    }
+
+    /**
+     * Sets the reference of the specific problem.
+     *
+     * @param string $instance A URI reference that identifies the specific occurrence
+     *                         of the problem
+     *
+     * @return $this
+     */
+    public function setInstance(string $instance): self
+    {
+        $this->instance = $instance;
+
+        return $this;
+    }
+
+    public function getExtensions(): array
+    {
+        return $this->extensions;
+    }
+
+    /**
+     * Sets additional members to the problem details.
+     *
+     * @param array $extensions A list of key-value pairs
+     *
+     * @return $this
+     */
+    public function setExtensions(array $extensions): self
+    {
+        $this->extensions = $extensions;
+
+        return $this;
+    }
+
+    public function setHeaders(array $headers): self
+    {
+        parent::setHeaders($headers);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ProblemNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ProblemNormalizerTest.php
@@ -38,9 +38,8 @@ class ProblemNormalizerTest extends TestCase
     {
         $expected = [
             'type' => 'https://tools.ietf.org/html/rfc2616#section-10',
-            'title' => 'An error occurred',
+            'title' => 'Internal Server Error',
             'status' => 500,
-            'detail' => 'Internal Server Error',
         ];
 
         $this->assertSame($expected, $this->normalizer->normalize(FlattenException::createFromThrowable(new \RuntimeException('Error'))));

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -26,7 +26,7 @@
         "symfony/cache": "^4.4|^5.0",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
-        "symfony/error-handler": "^4.4|^5.0",
+        "symfony/error-handler": "^5.1",
         "symfony/http-foundation": "^4.4|^5.0",
         "symfony/mime": "^4.4|^5.0",
         "symfony/property-access": "^4.4|^5.0",
@@ -39,7 +39,9 @@
         "symfony/dependency-injection": "<4.4",
         "symfony/property-access": "<4.4",
         "symfony/property-info": "<4.4",
-        "symfony/yaml": "<4.4"
+        "symfony/yaml": "<4.4",
+        "symfony/error-handler": "<5.1",
+        "symfony/security-bundle": "<5.1"
     },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

Based on [RFC 7807](https://tools.ietf.org/html/rfc7807), this PR defines a "problem detail" exception class as a way to carry machine-readable details of errors in a HTTP response to avoid the need to define new error responses for HTTP APIs.

HTTP status codes are sometimes not sufficient to convey enough information about an error to be helpful.  While humans behind Web browsers can be informed about the nature of the problem with an HTML response body, non-human consumers of so-called "HTTP APIs" are usually not.

This PR defines a simple exception class to suit this purpose. It's designed to be reused by HTTP APIs, which can identify distinct "problem types" specific to their needs.

Thus, API clients can be informed of both the high-level error class (using the status code) and the finer-grained details of the problem "using this exception class" which will be serialized to any supported format JSON, XML, etc.

**Example:**
```php
throw (new ProblemHttpException(400))
    ->setHeaders([
        'Content-Type' => 'application/problem+json',
        'Content-Language' => 'en',
    ])
    ->setType('https://example.com/problems/validation-error')
    ->setTitle('Your request parameters didn\'t validate.')
    ->setExtensions(['invalid-params' => $invalidParams])
;
```
**Response:**
```
HTTP/1.1 400 Bad Request
Content-Type: application/problem+json
Content-Language: en

{
   "type": "https://example.com/problems/validation-error",
   "title": "Your request parameters didn't validate.",
   "invalid-params": [ 
        {
            "name": "age",
            "reason": "should be a positive integer"
        },
        {
            "name": "firstName",
            "reason": "should not be blank"
        }
    ]
}
```

 * https://tools.ietf.org/html/rfc7807#section-3
 * https://tools.ietf.org/html/rfc7807#section-4.1

<details>
<summary><strong>Full Example</strong></summary>

```php
namespace App\Controller;

// ...

class Endpoint extends AbstractController
{
    /**
     * @Route("person/create", methods={"POST"})
     */
    public function create(Request $request, SerializerInterface $serializer, ValidatorInterface $validator): Response
    {
        $body = $request->getContent();

        if (!$body) {
            throw (new ProblemHttpException(400, 'Missing request content.'))
                ->setHeaders([
                    'Content-Type' => 'application/problem+json',
                    'Content-Language' => 'en',
                ])
                ->setType('https://example.com/problems/validation-error')
            ;
        }

        if ('json' !== $request->getContentType()) {
            throw (new ProblemHttpException(400, 'Invalid Content-Type header.'))
                ->setHeaders([
                    'Content-Type' => 'application/problem+json',
                    'Content-Language' => 'en',
                ])
                ->setType('https://example.com/problems/validation-error')
            ;
        }

        try {
            $person = $serializer->deserialize($body, Person::class, 'json');
        } catch (NotEncodableValueException $e) {
            throw (new ProblemHttpException(400, $e->getMessage(), $e))
                ->setHeaders([
                    'Content-Type' => 'application/problem+json',
                    'Content-Language' => 'en',
                ])
                ->setType('https://example.com/problems/validation-error')
                ->setTitle('Malformed request content')
            ;
        }

        $violations = $validator->validate($person);

        if ($violations->count() > 0) {
            $invalidParams = [];
            foreach ($violations as $violation) {
                $invalidParams[] = [
                    'name' => (string) $violation->getPropertyPath(),
                    'reason' => $violation->getMessage(),
                    'code' => $violation->getCode(),
                ];
            }

            throw (new ProblemHttpException(400))
                ->setHeaders([
                    'Content-Type' => 'application/problem+json',
                    'Content-Language' => 'en',
                ])
                ->setType('https://example.com/problems/validation-error')
                ->setTitle('Your request parameters didn\'t validate.')
                ->setExtensions(['invalid-params' => $invalidParams])
            ;
        }

        // create and save the Person entity

        return $this->json($person);
    }
}
```
</details>

https://tools.ietf.org/html/rfc2616#section-10.4
> **10.4 Client Error 4xx**
>   The 4xx class of status code is intended for cases in which the
   client seems to have erred. **Except when responding to a HEAD request,
   the server SHOULD include an entity containing an explanation of the
   error situation, and whether it is a temporary or permanent
   condition.** These status codes are applicable to any request method.
   User agents SHOULD display any included entity to the user.