### PR TITLE
[Twig/Mime] Added support for locale aware templated emails

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -20,6 +20,7 @@ class TemplatedEmail extends Email
 {
     private $htmlTemplate;
     private $textTemplate;
+    private $locale;
     private $context = [];
 
     /**
@@ -50,6 +51,21 @@ class TemplatedEmail extends Email
     public function getHtmlTemplate(): ?string
     {
         return $this->htmlTemplate;
+    }
+
+    /**
+     * @return $this
+     */
+    public function locale(?string $locale)
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/mailer.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/mailer.xml
@@ -13,6 +13,9 @@
 
         <service id="twig.mime_body_renderer" class="Symfony\Bridge\Twig\Mime\BodyRenderer">
             <argument type="service" id="twig" />
+            <call method="setTranslator">
+                <argument type="service" id="translator" on-invalid="ignore" />
+            </call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

As far as I could see there's no option to set the correct locale for a template to be rendered.
I'm currently using the Mailer component in an API where the default locale is `en` of course. But I want to send e-mails in the language of the respective users so I need to be able to set the locale when rendering the template.

TODOs once the concept is accepted:
* [ ] Changelog entry
* [ ] Docs PR