### PR TITLE
[Messenger] Add missing return in AmazonSqsReceiver::getMessageCount

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
@@ -93,7 +93,7 @@ class AmazonSqsReceiver implements ReceiverInterface, MessageCountAwareInterface
     public function getMessageCount(): int
     {
         try {
-            $this->connection->getMessageCount();
+            return $this->connection->getMessageCount();
         } catch (HttpExceptionInterface $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
