### PR TITLE
[Notifier] Remove not needed argument $bus in BrowserChannel::notify(...)

### DIFF
--- a/src/Symfony/Component/Notifier/Channel/BrowserChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/BrowserChannel.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Notifier\Channel;
 
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Recipient\Recipient;
 
@@ -30,7 +29,7 @@ final class BrowserChannel implements ChannelInterface
         $this->stack = $stack;
     }
 
-    public function notify(Notification $notification, Recipient $recipient, string $transportName = null, MessageBusInterface $bus = null): void
+    public function notify(Notification $notification, Recipient $recipient, string $transportName = null): void
     {
         if (null === $request = $this->stack->getCurrentRequest()) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

The `BrowserChannel::notify(...)` method defines a fourth nullable argument `$bus` which is not part of the `ChannelInterface` and also not used in the implementation. So I think it was added by mistake and can be removed.

