### PR TITLE
[Ldap] force default network timeout

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -107,6 +107,10 @@ class Connection extends AbstractConnection
                 $value['referrals'] = $options['referrals'];
             }
 
+            if (!isset($value['network_timeout'])) {
+                $value['network_timeout'] = ini_get('default_socket_timeout');
+            }
+
             return $value;
         });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The default network timeout is infinite, which makes no sense and can block workers.

Note that LDAP supports also "timelimit" options, but those are max-durations for LDAP queries. We cannot limit them by default.