### PR TITLE
[Validator] Add the divisibleBy option to the Count constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added option `alpha3` to `Country` constraint
  * allow to define a reusable set of constraints by extending the `Compound` constraint
  * added `Sequentially` constraint, to sequentially validate a set of constraints (any violation raised will prevent further validation of the nested constraints)
+ * added the `divisibleBy` option to the `Count` constraint
 
 5.0.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -24,17 +24,21 @@ class Count extends Constraint
 {
     const TOO_FEW_ERROR = 'bef8e338-6ae5-4caf-b8e2-50e7b0579e69';
     const TOO_MANY_ERROR = '756b1212-697c-468d-a9ad-50dd783bb169';
+    const NOT_DIVISIBLE_BY_ERROR = DivisibleBy::NOT_DIVISIBLE_BY;
 
     protected static $errorNames = [
         self::TOO_FEW_ERROR => 'TOO_FEW_ERROR',
         self::TOO_MANY_ERROR => 'TOO_MANY_ERROR',
+        self::NOT_DIVISIBLE_BY_ERROR => 'NOT_DIVISIBLE_BY_ERROR',
     ];
 
     public $minMessage = 'This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.';
     public $maxMessage = 'This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.';
     public $exactMessage = 'This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.';
+    public $divisibleByMessage = 'The number of elements in this collection should be a multiple of {{ compared_value }}.';
     public $min;
     public $max;
+    public $divisibleBy;
 
     public function __construct($options = null)
     {
@@ -50,8 +54,8 @@ class Count extends Constraint
 
         parent::__construct($options);
 
-        if (null === $this->min && null === $this->max) {
-            throw new MissingOptionsException(sprintf('Either option "min" or "max" must be given for constraint %s', __CLASS__), ['min', 'max']);
+        if (null === $this->min && null === $this->max && null === $this->divisibleBy) {
+            throw new MissingOptionsException(sprintf('Either option "min", "max" or "divisibleBy" must be given for constraint %s', __CLASS__), ['min', 'max', 'divisibleBy']);
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -60,6 +60,20 @@ class CountValidator extends ConstraintValidator
                 ->setPlural((int) $constraint->min)
                 ->setCode(Count::TOO_FEW_ERROR)
                 ->addViolation();
+
+            return;
+        }
+
+        if (null !== $constraint->divisibleBy) {
+            $this->context
+                ->getValidator()
+                ->inContext($this->context)
+                ->validate($count, [
+                    new DivisibleBy([
+                        'value' => $constraint->divisibleBy,
+                        'message' => $constraint->divisibleByMessage,
+                    ]),
+                ], $this->context->getGroup());
         }
     }
 }

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -370,6 +370,10 @@
                 <source>This value is not a valid hostname.</source>
                 <target>This value is not a valid hostname.</target>
             </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>The number of elements in this collection should be a multiple of {{ compared_value }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -370,6 +370,10 @@
                 <source>This value is not a valid hostname.</source>
                 <target>Cette valeur n'est pas un nom d'hôte valide.</target>
             </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Le nombre d'éléments de cette collection doit être un multiple de {{ compared_value }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\CountValidator;
+use Symfony\Component\Validator\Constraints\DivisibleBy;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 /**
@@ -201,5 +202,24 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
         $this->assertEquals(5, $constraint->min);
         $this->assertEquals(5, $constraint->max);
         $this->assertEquals('message', $constraint->exactMessage);
+    }
+
+    // Since the contextual validator is mocked, this test only asserts that it
+    // is called with the right DivisibleBy constraint.
+    public function testDivisibleBy()
+    {
+        $constraint = new Count([
+            'divisibleBy' => 123,
+            'divisibleByMessage' => 'foo {{ compared_value }}',
+        ]);
+
+        $this->expectValidateValue(0, 3, [new DivisibleBy([
+            'value' => 123,
+            'message' => 'foo {{ compared_value }}',
+        ])], $this->group);
+
+        $this->validator->validate(['foo', 'bar', 'ccc'], $constraint);
+
+        $this->assertNoViolation();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

From my experience, it is sometimes useful to assert that the number of elements in a collection is a multiple of X.