### PR TITLE
Mention dropping PHP 7.1 support in VarDumper/CHANGELOG

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -6,6 +6,11 @@ CHANGELOG
 
  * added `RdKafka` support
 
+5.0.0
+-----
+
+ * drop support for PHP 7.1
+
 4.4.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This is a pure documentation update.