### PR TITLE
Do not rely on the current locale when dumping a Graphviz object

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -32,10 +32,11 @@ class GraphvizDumper extends Dumper
 {
     private $nodes;
     private $edges;
+    // All values should be strings
     private $options = [
             'graph' => ['ratio' => 'compress'],
-            'node' => ['fontsize' => 11, 'fontname' => 'Arial', 'shape' => 'record'],
-            'edge' => ['fontsize' => 9, 'fontname' => 'Arial', 'color' => 'grey', 'arrowhead' => 'open', 'arrowsize' => 0.5],
+            'node' => ['fontsize' => '11', 'fontname' => 'Arial', 'shape' => 'record'],
+            'edge' => ['fontsize' => '9', 'fontname' => 'Arial', 'color' => 'grey', 'arrowhead' => 'open', 'arrowsize' => '0.5'],
             'node.instance' => ['fillcolor' => '#9999ff', 'style' => 'filled'],
             'node.definition' => ['fillcolor' => '#eeeeee'],
             'node.missing' => ['fillcolor' => '#ff9999', 'style' => 'filled'],

--- a/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
@@ -26,10 +26,11 @@ use Symfony\Component\Workflow\Marking;
  */
 class GraphvizDumper implements DumperInterface
 {
+    // All values should be strings
     protected static $defaultOptions = [
         'graph' => ['ratio' => 'compress', 'rankdir' => 'LR'],
-        'node' => ['fontsize' => 9, 'fontname' => 'Arial', 'color' => '#333333', 'fillcolor' => 'lightblue', 'fixedsize' => true, 'width' => 1],
-        'edge' => ['fontsize' => 9, 'fontname' => 'Arial', 'color' => '#333333', 'arrowhead' => 'normal', 'arrowsize' => 0.5],
+        'node' => ['fontsize' => '9', 'fontname' => 'Arial', 'color' => '#333333', 'fillcolor' => 'lightblue', 'fixedsize' => '1', 'width' => '1'],
+        'edge' => ['fontsize' => '9', 'fontname' => 'Arial', 'color' => '#333333', 'arrowhead' => 'normal', 'arrowsize' => '0.5'],
     ];
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

Funny bug !

With `de_DE.UTF-8` as locale:
```
php > echo sprintf('%s', 0.5);
0,5
php > echo sprintf('%d', 0.5);
0
php > echo sprintf('%f', 0.5);
0,500000
php > echo (string) 0.5;
0,5
```

(so external tools like graphviz could not parse `0,5` - and so skipped the arrow)

So now we force `'0.5'`

/cc @OskarStark