### PR TITLE
[PhpUnitBridge] Use trait instead of extending deprecated class

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV6.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\Bridge\PhpUnit\Legacy;
 
-use PHPUnit\Framework\BaseTestListener;
 use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
 
 /**
  * CoverageListener adds `@covers <className>` on each test when possible to
@@ -22,8 +23,10 @@ use PHPUnit\Framework\Test;
  *
  * @internal
  */
-class CoverageListenerForV6 extends BaseTestListener
+class CoverageListenerForV6 implements TestListener
 {
+    use TestListenerDefaultImplementation;
+
     private $trait;
 
     public function __construct(callable $sutFqcnResolver = null, $warningOnSutNotFound = false)

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -24,7 +24,7 @@
         "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
     },
     "conflict": {
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0|<6.4,>=6.0"
     },
     "autoload": {
         "files": [ "bootstrap.php" ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #32086
| License       | MIT
| Doc PR        |

Use `TestListenerDefaultImplementation` instead of deprecated `BaseTestListener` for `CoverageListenerForV6`

As this is my very first pull request for this project, I'd be very glad for hints and suggestions in case I missed something.