### PR TITLE
Use strict assertSame instead of assertEquals in Asset component tests

### DIFF
--- a/src/Symfony/Component/Asset/Tests/Context/RequestStackContextTest.php
+++ b/src/Symfony/Component/Asset/Tests/Context/RequestStackContextTest.php
@@ -37,7 +37,7 @@ class RequestStackContextTest extends TestCase
 
         $requestStackContext = new RequestStackContext($requestStack);
 
-        $this->assertEquals($testBasePath, $requestStackContext->getBasePath());
+        $this->assertSame($testBasePath, $requestStackContext->getBasePath());
     }
 
     public function testIsSecureFalse()

--- a/src/Symfony/Component/Asset/Tests/PackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackageTest.php
@@ -24,7 +24,7 @@ class PackageTest extends TestCase
     public function testGetUrl($version, $format, $path, $expected)
     {
         $package = new Package($version ? new StaticVersionStrategy($version, $format) : new EmptyVersionStrategy());
-        $this->assertEquals($expected, $package->getUrl($path));
+        $this->assertSame($expected, $package->getUrl($path));
     }
 
     public function getConfigs()
@@ -50,6 +50,6 @@ class PackageTest extends TestCase
     public function testGetVersion()
     {
         $package = new Package(new StaticVersionStrategy('v1'));
-        $this->assertEquals('v1', $package->getVersion('/foo'));
+        $this->assertSame('v1', $package->getVersion('/foo'));
     }
 }

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -24,13 +24,13 @@ class PackagesTest extends TestCase
         $packages->setDefaultPackage($default = $this->getMockBuilder('Symfony\Component\Asset\PackageInterface')->getMock());
         $packages->addPackage('a', $a = $this->getMockBuilder('Symfony\Component\Asset\PackageInterface')->getMock());
 
-        $this->assertEquals($default, $packages->getPackage());
-        $this->assertEquals($a, $packages->getPackage('a'));
+        $this->assertSame($default, $packages->getPackage());
+        $this->assertSame($a, $packages->getPackage('a'));
 
         $packages = new Packages($default, ['a' => $a]);
 
-        $this->assertEquals($default, $packages->getPackage());
-        $this->assertEquals($a, $packages->getPackage('a'));
+        $this->assertSame($default, $packages->getPackage());
+        $this->assertSame($a, $packages->getPackage('a'));
     }
 
     public function testGetVersion()
@@ -40,8 +40,8 @@ class PackagesTest extends TestCase
             ['a' => new Package(new StaticVersionStrategy('a'))]
         );
 
-        $this->assertEquals('default', $packages->getVersion('/foo'));
-        $this->assertEquals('a', $packages->getVersion('/foo', 'a'));
+        $this->assertSame('default', $packages->getVersion('/foo'));
+        $this->assertSame('a', $packages->getVersion('/foo', 'a'));
     }
 
     public function testGetUrl()
@@ -51,8 +51,8 @@ class PackagesTest extends TestCase
             ['a' => new Package(new StaticVersionStrategy('a'))]
         );
 
-        $this->assertEquals('/foo?default', $packages->getUrl('/foo'));
-        $this->assertEquals('/foo?a', $packages->getUrl('/foo', 'a'));
+        $this->assertSame('/foo?default', $packages->getUrl('/foo'));
+        $this->assertSame('/foo?a', $packages->getUrl('/foo', 'a'));
     }
 
     public function testNoDefaultPackage()

--- a/src/Symfony/Component/Asset/Tests/PathPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PathPackageTest.php
@@ -23,7 +23,7 @@ class PathPackageTest extends TestCase
     public function testGetUrl($basePath, $format, $path, $expected)
     {
         $package = new PathPackage($basePath, new StaticVersionStrategy('v1', $format));
-        $this->assertEquals($expected, $package->getUrl($path));
+        $this->assertSame($expected, $package->getUrl($path));
     }
 
     public function getConfigs()
@@ -55,7 +55,7 @@ class PathPackageTest extends TestCase
     {
         $package = new PathPackage($basePath, new StaticVersionStrategy('v1', $format), $this->getContext($basePathRequest));
 
-        $this->assertEquals($expected, $package->getUrl($path));
+        $this->assertSame($expected, $package->getUrl($path));
     }
 
     public function getContextConfigs()
@@ -83,7 +83,7 @@ class PathPackageTest extends TestCase
             ->willReturn('https://cdn.com/bar/main.css');
         $package = new PathPackage('/subdirectory', $versionStrategy, $this->getContext('/bar'));
 
-        $this->assertEquals('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
+        $this->assertSame('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
     }
 
     private function getContext($basePath)

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -24,7 +24,7 @@ class UrlPackageTest extends TestCase
     public function testGetUrl($baseUrls, $format, $path, $expected)
     {
         $package = new UrlPackage($baseUrls, new StaticVersionStrategy('v1', $format));
-        $this->assertEquals($expected, $package->getUrl($path));
+        $this->assertSame($expected, $package->getUrl($path));
     }
 
     public function getConfigs()
@@ -58,7 +58,7 @@ class UrlPackageTest extends TestCase
     {
         $package = new UrlPackage($baseUrls, new StaticVersionStrategy('v1', $format), $this->getContext($secure));
 
-        $this->assertEquals($expected, $package->getUrl($path));
+        $this->assertSame($expected, $package->getUrl($path));
     }
 
     public function getContextConfigs()
@@ -85,7 +85,7 @@ class UrlPackageTest extends TestCase
             ->willReturn('https://cdn.com/bar/main.css');
         $package = new UrlPackage('https://example.com', $versionStrategy);
 
-        $this->assertEquals('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
+        $this->assertSame('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
     }
 
     public function testNoBaseUrls()

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/EmptyVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/EmptyVersionStrategyTest.php
@@ -29,6 +29,6 @@ class EmptyVersionStrategyTest extends TestCase
         $emptyVersionStrategy = new EmptyVersionStrategy();
         $path = 'test-path';
 
-        $this->assertEquals($path, $emptyVersionStrategy->applyVersion($path));
+        $this->assertSame($path, $emptyVersionStrategy->applyVersion($path));
     }
 }

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
@@ -20,21 +20,21 @@ class JsonManifestVersionStrategyTest extends TestCase
     {
         $strategy = $this->createStrategy('manifest-valid.json');
 
-        $this->assertEquals('main.123abc.js', $strategy->getVersion('main.js'));
+        $this->assertSame('main.123abc.js', $strategy->getVersion('main.js'));
     }
 
     public function testApplyVersion()
     {
         $strategy = $this->createStrategy('manifest-valid.json');
 
-        $this->assertEquals('css/styles.555def.css', $strategy->getVersion('css/styles.css'));
+        $this->assertSame('css/styles.555def.css', $strategy->getVersion('css/styles.css'));
     }
 
     public function testApplyVersionWhenKeyDoesNotExistInManifest()
     {
         $strategy = $this->createStrategy('manifest-valid.json');
 
-        $this->assertEquals('css/other.css', $strategy->getVersion('css/other.css'));
+        $this->assertSame('css/other.css', $strategy->getVersion('css/other.css'));
     }
 
     public function testMissingManifestFileThrowsException()

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/StaticVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/StaticVersionStrategyTest.php
@@ -21,7 +21,7 @@ class StaticVersionStrategyTest extends TestCase
         $version = 'v1';
         $path = 'test-path';
         $staticVersionStrategy = new StaticVersionStrategy($version);
-        $this->assertEquals($version, $staticVersionStrategy->getVersion($path));
+        $this->assertSame($version, $staticVersionStrategy->getVersion($path));
     }
 
     /**
@@ -31,7 +31,7 @@ class StaticVersionStrategyTest extends TestCase
     {
         $staticVersionStrategy = new StaticVersionStrategy($version, $format);
         $formatted = sprintf($format ?: '%s?%s', $path, $version);
-        $this->assertEquals($formatted, $staticVersionStrategy->applyVersion($path));
+        $this->assertSame($formatted, $staticVersionStrategy->applyVersion($path));
     }
 
     public function getConfigs()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/35762#discussion_r381400521
| License       | MIT
| Doc PR        | N/A

Using `assertSame` instead of `assertEquals` is recommended when possible (see https://github.com/sebastianbergmann/phpunit-documentation-english/issues/3). It is stricter and must be more efficient ([`===`](https://github.com/sebastianbergmann/phpunit/blob/8.5.2/src/Framework/Constraint/IsIdentical.php#L63) vs a [comparator class](https://github.com/sebastianbergmann/phpunit/blob/8.5.2/src/Framework/Constraint/IsEqual.php#L79)).

~~Also, removing useless string cast.~~

