### PR TITLE
[DoctrineBridge][DoctrineExtractor] Fix indexBy with custom and some core types

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -117,7 +117,9 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                         $typeOfField = $subMetadata->getTypeOfField($indexProperty);
                     }
 
-                    $collectionKeyType = $this->getPhpType($typeOfField);
+                    if (!$collectionKeyType = $this->getPhpType($typeOfField)) {
+                        return null;
+                    }
                 }
             }
 
@@ -137,39 +139,46 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
 
         if ($metadata->hasField($property)) {
             $typeOfField = $metadata->getTypeOfField($property);
+
+            if (!$builtinType = $this->getPhpType($typeOfField)) {
+                return null;
+            }
+
             $nullable = $metadata instanceof ClassMetadataInfo && $metadata->isNullable($property);
 
-            switch ($typeOfField) {
-                case DBALType::DATE:
-                case DBALType::DATETIME:
-                case DBALType::DATETIMETZ:
-                case 'vardatetime':
-                case DBALType::TIME:
-                    return [new Type(Type::BUILTIN_TYPE_OBJECT, $nullable, 'DateTime')];
+            switch ($builtinType) {
+                case Type::BUILTIN_TYPE_OBJECT:
+                    switch ($typeOfField) {
+                        case DBALType::DATE:
+                        case DBALType::DATETIME:
+                        case DBALType::DATETIMETZ:
+                        case 'vardatetime':
+                        case DBALType::TIME:
+                            return [new Type(Type::BUILTIN_TYPE_OBJECT, $nullable, 'DateTime')];
 
-                case 'date_immutable':
-                case 'datetime_immutable':
-                case 'datetimetz_immutable':
-                case 'time_immutable':
-                    return [new Type(Type::BUILTIN_TYPE_OBJECT, $nullable, 'DateTimeImmutable')];
+                        case 'date_immutable':
+                        case 'datetime_immutable':
+                        case 'datetimetz_immutable':
+                        case 'time_immutable':
+                            return [new Type(Type::BUILTIN_TYPE_OBJECT, $nullable, 'DateTimeImmutable')];
 
-                case 'dateinterval':
-                    return [new Type(Type::BUILTIN_TYPE_OBJECT, $nullable, 'DateInterval')];
+                        case 'dateinterval':
+                            return [new Type(Type::BUILTIN_TYPE_OBJECT, $nullable, 'DateInterval')];
+                    }
 
-                case DBALType::TARRAY:
-                    return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true)];
+                    break;
+                case Type::BUILTIN_TYPE_ARRAY:
+                    switch ($typeOfField) {
+                        case DBALType::TARRAY:
+                        case DBALType::JSON_ARRAY:
+                            return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true)];
 
-                case DBALType::SIMPLE_ARRAY:
-                    return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING))];
-
-                case DBALType::JSON_ARRAY:
-                    return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true)];
-
-                default:
-                    $builtinType = $this->getPhpType($typeOfField);
-
-                    return $builtinType ? [new Type($builtinType, $nullable)] : null;
+                        case DBALType::SIMPLE_ARRAY:
+                            return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING))];
+                    }
             }
+
+            return [new Type($builtinType, $nullable)];
         }
 
         return null;
@@ -234,7 +243,22 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                 return Type::BUILTIN_TYPE_RESOURCE;
 
             case DBALType::OBJECT:
+            case DBALType::DATE:
+            case DBALType::DATETIME:
+            case DBALType::DATETIMETZ:
+            case 'vardatetime':
+            case DBALType::TIME:
+            case 'date_immutable':
+            case 'datetime_immutable':
+            case 'datetimetz_immutable':
+            case 'time_immutable':
+            case 'dateinterval':
                 return Type::BUILTIN_TYPE_OBJECT;
+
+            case DBALType::TARRAY:
+            case DBALType::SIMPLE_ARRAY:
+            case DBALType::JSON_ARRAY:
+                return Type::BUILTIN_TYPE_ARRAY;
         }
 
         return null;

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\PropertyInfo;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Setup;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineRelation;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -62,6 +64,8 @@ class DoctrineExtractorTest extends TestCase
                 'bar',
                 'indexedBar',
                 'indexedFoo',
+                'indexedByDt',
+                'indexedByCustomType',
             ],
             $this->extractor->getProperties('Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineDummy')
         );
@@ -153,6 +157,15 @@ class DoctrineExtractorTest extends TestCase
             ['simpleArray', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING))]],
             ['customFoo', null],
             ['notMapped', null],
+            ['indexedByDt', [new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                Collection::class,
+                true,
+                new Type(Type::BUILTIN_TYPE_OBJECT),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
+            )]],
+            ['indexedByCustomType', null],
         ];
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -112,4 +112,14 @@ class DoctrineDummy
     private $bigint;
 
     public $notMapped;
+
+    /**
+     * @OneToMany(targetEntity="DoctrineRelation", mappedBy="dt", indexBy="dt")
+     */
+    protected $indexedByDt;
+
+    /**
+     * @OneToMany(targetEntity="DoctrineRelation", mappedBy="customType", indexBy="customType")
+     */
+    private $indexedByCustomType;
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
@@ -39,4 +39,14 @@ class DoctrineRelation
      * @ManyToOne(targetEntity="DoctrineDummy", inversedBy="indexedFoo")
      */
     protected $foo;
+
+    /**
+     * @Column(type="datetime")
+     */
+    private $dt;
+
+    /**
+     * @Column(type="foo")
+     */
+    private $customType;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/35542 and https://github.com/symfony/symfony/issues/35604
| License       | MIT
| Doc PR        | -

For https://github.com/symfony/symfony/issues/35604:
To guess the collection key type, the `getPhpType()` method is called. But it does not handle most objects and arrays core types. This is why an indexBy datetime does not work.

For https://github.com/symfony/symfony/issues/35542:
When the php type cannot be guessed, null is returned. In this case, we cannot pass a valid builtin type to PropertyInfo Type, so we should return null.