### PR TITLE
Fixed missing friendly error on call of getMimeType()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -54,11 +54,10 @@ class File extends \SplFileInfo
      */
     public function guessExtension()
     {
-        if (!class_exists(MimeTypes::class)) {
-            throw new \LogicException('You cannot guess the extension as the Mime component is not installed. Try running "composer require symfony/mime".');
-        }
+        // Do not inline this
+        $mimeType = $this->getMimeType();
 
-        return MimeTypes::getDefault()->getExtensions($this->getMimeType())[0] ?? null;
+        return MimeTypes::getDefault()->getExtensions($mimeType)[0] ?? null;
     }
 
     /**
@@ -74,6 +73,10 @@ class File extends \SplFileInfo
      */
     public function getMimeType()
     {
+        if (!class_exists(MimeTypes::class)) {
+            throw new \LogicException('You cannot guess the mime type as the Mime component is not installed. Try running "composer require symfony/mime".');
+        }
+
         return MimeTypes::getDefault()->guessMimeType($this->getPathname());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I would actually be in favour for reverting this change entirely, as it is breaking. It breaks `laravel/framework`'s 7.x branch which depends on `symfony/http-foundation: ^5.0`. When v5.1.0 comes out, it will be broken. I'd argue Laravel was not using `symfony/mime` implicitly, since it called code in http-foundation. It didn't make use of a non-direct dependency by bypassing http-foundation code. I think Symfony should wait until 6.0 before making this an optional dependency.