### PR TITLE
[HttpFoundation] Fixed Mime dependency missing error

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -36,6 +36,7 @@ HttpFoundation
  * Deprecate `Response::create()`, `JsonResponse::create()`,
    `RedirectResponse::create()`, and `StreamedResponse::create()` methods (use
    `__construct()` instead)
+ * Made the Mime component an optional dependency
 
 Messenger
 ---------

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -74,6 +74,10 @@ class File extends \SplFileInfo
      */
     public function getMimeType()
     {
+        if (!class_exists(MimeTypes::class)) {
+            throw new \LogicException('You cannot guess the mime type as the Mime component is not installed. Try running "composer require symfony/mime".');
+        }
+
         return MimeTypes::getDefault()->guessMimeType($this->getPathname());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | kinda
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

Follows #35642, by adding a missing exception and a note in the UPGRADE file (CHANGELOG in HttpFoundation was already up to date).
Reported in symfony/symfony-docs#1307