### PR TITLE
[HttpFoundation] Fixed issue with empty headers

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -125,7 +125,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
                 return $default;
             }
 
-            if (null === $headers[$key][0]) {
+            if (!isset($headers[$key][0])) {
                 return null;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35802
| License       | MIT
| Doc PR        | -

I was made aware of the issue due to:

1. https://stackoverflow.com/questions/60122162/laravel-undefined-offset-0-in-symfony-http-foundation-when-requiring-simplesaml
2. https://github.com/laravel/framework/issues/31544
3. https://github.com/symfony/symfony/issues/35802

---

Looking at the file history leads me to think it was caused by https://github.com/symfony/symfony/pull/33353, however, it would look like the old code had the bug too. It is also odd how it is claimed the bug is not present in 4.3.8, but is in 4.4.0...

**Does this actually fix the real issue, or does it just mask it?**