### PR TITLE
[Validator] Allow Sequentially constraints on classes + target guards

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Sequentially.php
+++ b/src/Symfony/Component/Validator/Constraints/Sequentially.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Validator\Constraints;
  * Validation for the nested constraints collection will stop at first violation.
  *
  * @Annotation
- * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ * @Target({"CLASS", "PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
@@ -37,5 +37,10 @@ class Sequentially extends Composite
     protected function getCompositeOption()
     {
         return 'constraints';
+    }
+
+    public function getTargets()
+    {
+        return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | todo in https://github.com/symfony/symfony-docs/pull/13206 if not merged yet

There is no reason to limit this constraint to properties, so let's add classes as targets.

Additionally, let's ensure embedded constraints matches allowed targets too.