### PR TITLE
[3.4][DoctrineBridge] Use new Types::* constants and support new json type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -12,7 +12,8 @@
 namespace Symfony\Bridge\Doctrine\Security\RememberMe;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Types\Type as DoctrineType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentTokenInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
@@ -40,9 +41,15 @@ class DoctrineTokenProvider implements TokenProviderInterface
 {
     private $conn;
 
+    private static $useDeprecatedConstants;
+
     public function __construct(Connection $conn)
     {
         $this->conn = $conn;
+
+        if (null === self::$useDeprecatedConstants) {
+            self::$useDeprecatedConstants = !class_exists(Types::class);
+        }
     }
 
     /**
@@ -90,7 +97,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
         ];
         $paramTypes = [
             'value' => \PDO::PARAM_STR,
-            'lastUsed' => DoctrineType::DATETIME,
+            'lastUsed' => self::$useDeprecatedConstants ? Type::DATETIME : Types::DATETIME_MUTABLE,
             'series' => \PDO::PARAM_STR,
         ];
         $updated = $this->conn->executeUpdate($sql, $paramValues, $paramTypes);
@@ -119,7 +126,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
             'username' => \PDO::PARAM_STR,
             'series' => \PDO::PARAM_STR,
             'value' => \PDO::PARAM_STR,
-            'lastUsed' => DoctrineType::DATETIME,
+            'lastUsed' => self::$useDeprecatedConstants ? Type::DATETIME : Types::DATETIME_MUTABLE,
         ];
         $this->conn->executeUpdate($sql, $paramValues, $paramTypes);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -74,7 +74,7 @@ class DoctrineDummy
     /**
      * @Column(type="json_array")
      */
-    private $json;
+    private $jsonArray;
 
     /**
      * @Column(type="simple_array")

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy210.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy210.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+
+/**
+ * @Entity
+ */
+final class DoctrineDummy210 extends DoctrineDummy
+{
+    /**
+     * @Column(type="json", nullable=true)
+     */
+    private $json;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

All `Type::*` constants were moved and deprecated. This PR makes sure we use the good ones when they exist so we are prepared for their removal. It allows to be deprecation free. If deprecated constants could be detected, we would have failing tests 😄

Also, `json_array` was deprecated and renamed to `json`, so I added support for this new type.

Some new components also use these constants on upper branches, so I will submit PRs there.