### PR TITLE
[Mailer][DX] Add notice log when email recipients are not defined

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -65,6 +65,8 @@ abstract class AbstractTransport implements TransportInterface
         }
 
         if (!$envelope->getRecipients()) {
+            $this->getLogger()->notice('There are no recipients in the mailer envelope. Nothing was sent.');
+
             return null;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no (can it be considered as yes regarding issues comments?)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/35805 + https://github.com/symfony/symfony/issues/33753
| License       | MIT
| Doc PR        | none

Hi,

Add a log in order to be aware that no email was sent due to bad data
IF the PR is accepted, is the log level `notice` the right one?

thx