### PR TITLE
Changes misleading method name ErrorRendererInterface::render()

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -11,6 +11,11 @@ Dotenv
 
  * Deprecated passing `$usePutenv` argument to Dotenv's constructor, use `Dotenv::usePutenv()` instead.
 
+ErrorHandler
+---------------
+
+ * Deprecated `ErrorRendererInterface::render()`. Use `ErrorRendererInterface::flatten()` instead.
+
 EventDispatcher
 ---------------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -11,6 +11,11 @@ Dotenv
 
  * Removed argument `$usePutenv` from Dotenv's constructor, use `Dotenv::usePutenv()` instead.
 
+ErrorHandler
+---------------
+
+ * Deprecated `ErrorRendererInterface::render()`. Use `ErrorRendererInterface::flatten()` instead.
+
 EventDispatcher
 ---------------
 

--- a/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
+++ b/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
@@ -46,7 +46,7 @@ class TwigErrorRenderer implements ErrorRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function render(\Throwable $exception): FlattenException
+    public function flatten(\Throwable $exception): FlattenException
     {
         $exception = $this->fallbackErrorRenderer->render($exception);
         $debug = \is_bool($this->debug) ? $this->debug : ($this->debug)($exception);
@@ -60,6 +60,16 @@ class TwigErrorRenderer implements ErrorRendererInterface
             'status_code' => $exception->getStatusCode(),
             'status_text' => $exception->getStatusText(),
         ]));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(\Throwable $exception): FlattenException
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 5.1, use "%s" instead.', __METHOD__, 'flatten'), E_USER_DEPRECATED);
+
+        return $this->flatten($exception);
     }
 
     public static function isDebug(RequestStack $requestStack, bool $debug): \Closure

--- a/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
+++ b/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
@@ -49,7 +49,7 @@ class TwigErrorRenderer implements ErrorRendererInterface
     public function flatten(\Throwable $exception): FlattenException
     {
         if (!method_exists($this->fallbackErrorRenderer, 'flatten')) {
-            @trigger_error(sprintf('Not implementing "flatten" is deprecated since Symfony 5.1.'), E_USER_DEPRECATED);
+            trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, get_class($this->fallbackErrorRenderer));
 
             $exception = $this->fallbackErrorRenderer->render($exception);
         } else {
@@ -73,7 +73,7 @@ class TwigErrorRenderer implements ErrorRendererInterface
      */
     public function render(\Throwable $exception): FlattenException
     {
-        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 5.1, use "%s" instead.', __METHOD__, 'flatten'), E_USER_DEPRECATED);
+        trigger_deprecation('symfony/error-handler', '5.1', 'The "%s" method is deprecated, use "%s" instead.', __METHOD__, 'flatten');
 
         return $this->flatten($exception);
     }

--- a/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
+++ b/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
@@ -48,7 +48,7 @@ class TwigErrorRenderer implements ErrorRendererInterface
      */
     public function flatten(\Throwable $exception): FlattenException
     {
-        $exception = $this->fallbackErrorRenderer->render($exception);
+        $exception = $this->fallbackErrorRenderer->flatten($exception);
         $debug = \is_bool($this->debug) ? $this->debug : ($this->debug)($exception);
 
         if ($debug || !$template = $this->findTemplate($exception->getStatusCode())) {

--- a/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
+++ b/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
@@ -48,7 +48,13 @@ class TwigErrorRenderer implements ErrorRendererInterface
      */
     public function flatten(\Throwable $exception): FlattenException
     {
-        $exception = $this->fallbackErrorRenderer->flatten($exception);
+        if (!method_exists($this->fallbackErrorRenderer, 'flatten')) {
+            @trigger_error(sprintf('Not implementing "flatten" is deprecated since Symfony 5.1.'), E_USER_DEPRECATED);
+
+            $exception = $this->fallbackErrorRenderer->render($exception);
+        } else {
+            $exception = $this->fallbackErrorRenderer->flatten($exception);
+        }
         $debug = \is_bool($this->debug) ? $this->debug : ($this->debug)($exception);
 
         if ($debug || !$template = $this->findTemplate($exception->getStatusCode())) {

--- a/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
+++ b/src/Symfony/Bridge/Twig/ErrorRenderer/TwigErrorRenderer.php
@@ -49,7 +49,7 @@ class TwigErrorRenderer implements ErrorRendererInterface
     public function flatten(\Throwable $exception): FlattenException
     {
         if (!method_exists($this->fallbackErrorRenderer, 'flatten')) {
-            trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, get_class($this->fallbackErrorRenderer));
+            trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, \get_class($this->fallbackErrorRenderer));
 
             $exception = $this->fallbackErrorRenderer->render($exception);
         } else {

--- a/src/Symfony/Bridge/Twig/Tests/ErrorRenderer/TwigErrorRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/ErrorRenderer/TwigErrorRendererTest.php
@@ -29,7 +29,7 @@ class TwigErrorRendererTest extends TestCase
         $nativeRenderer = $this->createMock(HtmlErrorRenderer::class);
         $nativeRenderer
             ->expects($this->once())
-            ->method('render')
+            ->method('flatten')
             ->with($exception)
         ;
 
@@ -45,7 +45,7 @@ class TwigErrorRendererTest extends TestCase
         $nativeRenderer = $this->createMock(HtmlErrorRenderer::class);
         $nativeRenderer
             ->expects($this->once())
-            ->method('render')
+            ->method('flatten')
             ->with($exception)
             ->willReturn(FlattenException::createFromThrowable($exception))
         ;

--- a/src/Symfony/Bridge/Twig/Tests/ErrorRenderer/TwigErrorRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/ErrorRenderer/TwigErrorRendererTest.php
@@ -33,7 +33,7 @@ class TwigErrorRendererTest extends TestCase
             ->with($exception)
         ;
 
-        (new TwigErrorRenderer($twig, $nativeRenderer, true))->render(new \Exception());
+        (new TwigErrorRenderer($twig, $nativeRenderer, true))->flatten(new \Exception());
     }
 
     public function testFallbackToNativeRendererIfCustomTemplateNotFound()
@@ -50,7 +50,7 @@ class TwigErrorRendererTest extends TestCase
             ->willReturn(FlattenException::createFromThrowable($exception))
         ;
 
-        (new TwigErrorRenderer($twig, $nativeRenderer, false))->render($exception);
+        (new TwigErrorRenderer($twig, $nativeRenderer, false))->flatten($exception);
     }
 
     public function testRenderCustomErrorTemplate()
@@ -58,7 +58,7 @@ class TwigErrorRendererTest extends TestCase
         $twig = new Environment(new ArrayLoader([
             '@Twig/Exception/error404.html.twig' => '<h1>Page Not Found</h1>',
         ]));
-        $exception = (new TwigErrorRenderer($twig))->render(new NotFoundHttpException());
+        $exception = (new TwigErrorRenderer($twig))->flatten(new NotFoundHttpException());
 
         $this->assertSame('<h1>Page Not Found</h1>', $exception->getAsString());
     }

--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -6,3 +6,9 @@ CHANGELOG
 
  * added the component
  * added `ErrorHandler::call()` method utility to turn any PHP error into `\ErrorException`
+
+
+5.1.0
+-----
+
+ * Deprecated `ErrorRendererInterface::render()`. Use `ErrorRendererInterface::flatten()` instead.

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -706,7 +706,7 @@ class ErrorHandler
     {
         $renderer = \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliErrorRenderer() : new HtmlErrorRenderer($this->debug);
 
-        $exception = $renderer->render($exception);
+        $exception = $renderer->flatten($exception);
 
         if (!headers_sent()) {
             http_response_code($exception->getStatusCode());

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
@@ -23,7 +23,7 @@ class CliErrorRenderer implements ErrorRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function render(\Throwable $exception): FlattenException
+    public function flatten(\Throwable $exception): FlattenException
     {
         $cloner = new VarCloner();
         $dumper = new class() extends CliDumper {
@@ -42,5 +42,15 @@ class CliErrorRenderer implements ErrorRendererInterface
 
         return FlattenException::createFromThrowable($exception)
             ->setAsString($dumper->dump($cloner->cloneVar($exception), true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(\Throwable $exception): FlattenException
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 5.1, use "%s" instead.', __METHOD__, 'flatten'), E_USER_DEPRECATED);
+
+        return $this->flatten($exception);
     }
 }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
@@ -49,7 +49,7 @@ class CliErrorRenderer implements ErrorRendererInterface
      */
     public function render(\Throwable $exception): FlattenException
     {
-        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 5.1, use "%s" instead.', __METHOD__, 'flatten'), E_USER_DEPRECATED);
+        trigger_deprecation('symfony/error-handler', '5.1', 'The "%s" method is deprecated, use "%s" instead.', __METHOD__, 'flatten');
 
         return $this->flatten($exception);
     }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/ErrorRendererInterface.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/ErrorRendererInterface.php
@@ -21,7 +21,14 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
 interface ErrorRendererInterface
 {
     /**
+     * @deprecated since Symfony 5.1, use flatten() instead.
+     *
      * Renders a Throwable as a FlattenException.
      */
     public function render(\Throwable $exception): FlattenException;
+
+    /**
+     * Flattens a Throwable as a FlattenException.
+     */
+    public function flatten(\Throwable $exception): FlattenException;
 }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/ErrorRendererInterface.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/ErrorRendererInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
  * Formats an exception to be used as response content.
  *
  * @author Yonel Ceruto <yonelceruto@gmail.com>
+ *
+ * @method FlattenException flatten(\Throwable $exception) not implementing it is deprecated since Symfony 5.1
  */
 interface ErrorRendererInterface
 {
@@ -26,9 +28,4 @@ interface ErrorRendererInterface
      * Renders a Throwable as a FlattenException.
      */
     public function render(\Throwable $exception): FlattenException;
-
-    /**
-     * Flattens a Throwable as a FlattenException.
-     */
-    public function flatten(\Throwable $exception): FlattenException;
 }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -64,13 +64,23 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function render(\Throwable $exception): FlattenException
+    public function flatten(\Throwable $exception): FlattenException
     {
         $exception = FlattenException::createFromThrowable($exception, null, [
             'Content-Type' => 'text/html; charset='.$this->charset,
         ]);
 
         return $exception->setAsString($this->renderException($exception));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(\Throwable $exception): FlattenException
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 5.1, use "%s" instead.', __METHOD__, 'flatten'), E_USER_DEPRECATED);
+
+        return $this->flatten($exception);
     }
 
     /**

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -78,7 +78,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
      */
     public function render(\Throwable $exception): FlattenException
     {
-        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 5.1, use "%s" instead.', __METHOD__, 'flatten'), E_USER_DEPRECATED);
+        trigger_deprecation('symfony/error-handler', '5.1', 'The "%s" method is deprecated, use "%s" instead.', __METHOD__, 'flatten');
 
         return $this->flatten($exception);
     }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
@@ -64,7 +64,7 @@ class SerializerErrorRenderer implements ErrorRendererInterface
             ]));
         } catch (NotEncodableValueException $e) {
             if (!method_exists($this->fallbackErrorRenderer, 'flatten')) {
-                @trigger_error(sprintf('Not implementing "flatten" is deprecated since Symfony 5.1.'), E_USER_DEPRECATED);
+                trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, get_class($this->fallbackErrorRenderer));
 
                 return $this->fallbackErrorRenderer->render($exception);
             }
@@ -78,7 +78,7 @@ class SerializerErrorRenderer implements ErrorRendererInterface
      */
     public function render(\Throwable $exception): FlattenException
     {
-        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 5.1, use "%s" instead.', __METHOD__, 'flatten'), E_USER_DEPRECATED);
+        trigger_deprecation('symfony/error-handler', '5.1', 'The "%s" method is deprecated, use "%s" instead.', __METHOD__, 'flatten');
 
         return $this->flatten($exception);
     }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
@@ -64,7 +64,7 @@ class SerializerErrorRenderer implements ErrorRendererInterface
             ]));
         } catch (NotEncodableValueException $e) {
             if (!method_exists($this->fallbackErrorRenderer, 'flatten')) {
-                trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, get_class($this->fallbackErrorRenderer));
+                trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, \get_class($this->fallbackErrorRenderer));
 
                 return $this->fallbackErrorRenderer->render($exception);
             }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
@@ -51,7 +51,7 @@ class SerializerErrorRenderer implements ErrorRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function render(\Throwable $exception): FlattenException
+    public function flatten(\Throwable $exception): FlattenException
     {
         $flattenException = FlattenException::createFromThrowable($exception);
 
@@ -65,6 +65,16 @@ class SerializerErrorRenderer implements ErrorRendererInterface
         } catch (NotEncodableValueException $e) {
             return $this->fallbackErrorRenderer->render($exception);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(\Throwable $exception): FlattenException
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 5.1, use "%s" instead.', __METHOD__, 'flatten'), E_USER_DEPRECATED);
+
+        return $this->flatten($exception);
     }
 
     public static function getPreferredFormat(RequestStack $requestStack): \Closure

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
@@ -63,7 +63,7 @@ class SerializerErrorRenderer implements ErrorRendererInterface
                 'debug' => \is_bool($this->debug) ? $this->debug : ($this->debug)($exception),
             ]));
         } catch (NotEncodableValueException $e) {
-            return $this->fallbackErrorRenderer->render($exception);
+            return $this->fallbackErrorRenderer->flatten($exception);
         }
     }
 

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
@@ -63,6 +63,12 @@ class SerializerErrorRenderer implements ErrorRendererInterface
                 'debug' => \is_bool($this->debug) ? $this->debug : ($this->debug)($exception),
             ]));
         } catch (NotEncodableValueException $e) {
+            if (!method_exists($this->fallbackErrorRenderer, 'flatten')) {
+                @trigger_error(sprintf('Not implementing "flatten" is deprecated since Symfony 5.1.'), E_USER_DEPRECATED);
+
+                return $this->fallbackErrorRenderer->render($exception);
+            }
+
             return $this->fallbackErrorRenderer->flatten($exception);
         }
     }

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/HtmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/HtmlErrorRendererTest.php
@@ -17,14 +17,23 @@ use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
 class HtmlErrorRendererTest extends TestCase
 {
     /**
-     * @dataProvider getRenderData
+     * @legacy
+     * @dataProvider getFlattenData
      */
     public function testRender(\Throwable $exception, HtmlErrorRenderer $errorRenderer, string $expected)
     {
-        $this->assertStringMatchesFormat($expected, $errorRenderer->render($exception)->getAsString());
+        $this->assertStringMatchesFormat($expected, $errorRenderer->flatten($exception)->getAsString());
     }
 
-    public function getRenderData(): iterable
+    /**
+     * @dataProvider getFlattenData
+     */
+    public function testFlatten(\Throwable $exception, HtmlErrorRenderer $errorRenderer, string $expected)
+    {
+        $this->assertStringMatchesFormat($expected, $errorRenderer->flatten($exception)->getAsString());
+    }
+
+    public function getFlattenData(): iterable
     {
         $expectedDebug = <<<HTML
 <!-- Foo (500 Internal Server Error) -->

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/SerializerErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/SerializerErrorRendererTest.php
@@ -23,7 +23,7 @@ class SerializerErrorRendererTest extends TestCase
     {
         $errorRenderer = new SerializerErrorRenderer(new Serializer(), 'html');
 
-        self::assertStringContainsString('<h2>The server returned a "500 Internal Server Error".</h2>', $errorRenderer->render(new \RuntimeException())->getAsString());
+        self::assertStringContainsString('<h2>The server returned a "500 Internal Server Error".</h2>', $errorRenderer->flatten(new \RuntimeException())->getAsString());
     }
 
     public function testSerializerContent()
@@ -34,6 +34,6 @@ class SerializerErrorRendererTest extends TestCase
             function () { return 'json'; }
         );
 
-        $this->assertSame('{"type":"https:\/\/tools.ietf.org\/html\/rfc2616#section-10","title":"An error occurred","status":500,"detail":"Internal Server Error"}', $errorRenderer->render($exception)->getAsString());
+        $this->assertSame('{"type":"https:\/\/tools.ietf.org\/html\/rfc2616#section-10","title":"An error occurred","status":500,"detail":"Internal Server Error"}', $errorRenderer->flatten($exception)->getAsString());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
@@ -39,7 +39,7 @@ class ErrorController
     public function __invoke(\Throwable $exception): Response
     {
         if (!method_exists($this->errorRenderer, 'flatten')) {
-            trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, get_class($this->errorRenderer));
+            trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, \get_class($this->errorRenderer));
 
             $exception = $this->errorRenderer->render($exception);
         } else {

--- a/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
@@ -38,7 +38,13 @@ class ErrorController
 
     public function __invoke(\Throwable $exception): Response
     {
-        $exception = $this->errorRenderer->flatten($exception);
+        if (!method_exists($this->errorRenderer, 'flatten')) {
+            @trigger_error(sprintf('Not implementing "flatten" is deprecated since Symfony 5.1.'), E_USER_DEPRECATED);
+
+            $exception = $this->errorRenderer->render($exception);
+        } else {
+            $exception = $this->errorRenderer->flatten($exception);
+        }
 
         return new Response($exception->getAsString(), $exception->getStatusCode(), $exception->getHeaders());
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
@@ -38,7 +38,7 @@ class ErrorController
 
     public function __invoke(\Throwable $exception): Response
     {
-        $exception = $this->errorRenderer->render($exception);
+        $exception = $this->errorRenderer->flatten($exception);
 
         return new Response($exception->getAsString(), $exception->getStatusCode(), $exception->getHeaders());
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ErrorController.php
@@ -39,7 +39,7 @@ class ErrorController
     public function __invoke(\Throwable $exception): Response
     {
         if (!method_exists($this->errorRenderer, 'flatten')) {
-            @trigger_error(sprintf('Not implementing "flatten" is deprecated since Symfony 5.1.'), E_USER_DEPRECATED);
+            trigger_deprecation('symfony/error-handler', '5.1', 'Not implementing the "%s::flatten()" method in "%s" is deprecated.', ErrorRendererInterface::class, get_class($this->errorRenderer));
 
             $exception = $this->errorRenderer->render($exception);
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

The naming for `ErrorRendererInterface::render()` is a bit misleading as it does not render a string, it converts the existing error/exception into a FlattenException. In a sense this makes the error renderable, but does not actually render it unless you call `getAsString()` on the exception. The naming can lead to some confusion as exemplified in symfony/symfony-docs#13214 and assuming a rendered output in a twig template will lead to an error (also shown in the comments of said doc PR).

I propose renaming the method `render()` to `flatten()` to prevent confusion. It might even make sense to rename the interface and classes later on, but I can't think of a good name.