### PR TITLE
[Notifier] Add correct tags for NullTransportFactory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.xml
@@ -27,7 +27,8 @@
         </service>
 
         <service id="notifier.transport_factory.null" class="Symfony\Component\Notifier\Transport\NullTransportFactory" parent="notifier.transport_factory.abstract">
-            <tag name="notifier.transport_factory" />
+            <tag name="chatter.transport_factory" />
+            <tag name="texter.transport_factory" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

I tried to disable the delivery of notifications in `dev` environment with the following configuration:

```
framework:
    notifier:
        chatter_transports:
            slack: 'null://null'
        texter_transports:
            twilio: 'null://null'
        channel_policy:
            urgent: ['chat/slack', 'sms/twilio']
            high: ['email']
            medium: ['email']
            low: ['email']
```

While sending the notification like this:

```
$notification = (new Notification())
            ->subject('Test subject')
            ->importance(Notification::IMPORTANCE_URGENT)
            ->content('Test content')
;

$this->notifier->send($notification);
```

I got an `UnsupportedSchemeException`: The "null" scheme is not supported.

After some digging I figured out that this Exception occurred because the `NullTransportFactory` was not tagged with the `chatter.transport_factory` and `texter.transport_factory` tags. Which is the reason the `NullTransportFactory` was not injected in the `Transport` class and so the `NullTransport` couldn't be used.

This PR should fix this Bug.

