### PR TITLE
[BrowserKit] Nested file array prevents uploading file

### DIFF
--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -73,18 +73,9 @@ class HttpBrowser extends AbstractBrowser
         }
 
         $fields = $request->getParameters();
-        $hasFile = false;
-        foreach ($request->getFiles() as $name => $file) {
-            if (!isset($file['tmp_name'])) {
-                continue;
-            }
 
-            $hasFile = true;
-            $fields[$name] = DataPart::fromPath($file['tmp_name'], $file['name']);
-        }
-
-        if ($hasFile) {
-            $part = new FormDataPart($fields);
+        if ($uploadedFiles = $this->getUploadedFiles($request->getFiles())) {
+            $part = new FormDataPart($uploadedFiles);
 
             return [$part->bodyToIterable(), $part->getPreparedHeaders()->toArray()];
         }
@@ -118,5 +109,27 @@ class HttpBrowser extends AbstractBrowser
         }
 
         return $headers;
+    }
+
+    /**
+     * Recursively go through the list. If the file has a tmp_name, convert it to a DataPart.
+     * Keep the original hierarchy.
+     */
+    private function getUploadedFiles(array $files): array
+    {
+        $uploadedFiles = [];
+        foreach ($files as $name => $file) {
+            if (!\is_array($file)) {
+                return $uploadedFiles;
+            }
+            if (!isset($file['tmp_name'])) {
+                $uploadedFiles[$name] = $this->getUploadedFiles($file);
+            }
+            if (isset($file['tmp_name'])) {
+                $uploadedFiles[$name] = DataPart::fromPath($file['tmp_name'], $file['name']);
+            }
+        }
+
+        return $uploadedFiles;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

The HttpBrowser doesn't play nicely with Symfony\Component\DomCrawler::getPhpFiles().
The former assumes a flat array structure, while the latter explicitly un-flattens it, causing files to silently get ignored by the DomCrawler's submitForm.
