### PR TITLE
[Notifier][Slack] Send messages using Incoming Webhooks App

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -1,12 +1,12 @@
 CHANGELOG
 =========
 
+5.1.0
+-----
+
+ * [BC BREAK] Change API endpoit to use the Slack Incoming Webhooks API
+
 5.0.0
 -----
 
  * Added the bridge
-
-5.1.0
------
-
- * Support sending messages using Incoming Webhooks

--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -5,3 +5,8 @@ CHANGELOG
 -----
 
  * Added the bridge
+
+5.1.0
+-----
+
+ * Support sending messages using Incoming Webhooks

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -50,9 +50,6 @@ final class SlackOptions implements MessageOptionsInterface
     public function toArray(): array
     {
         $options = $this->options;
-        if (isset($options['blocks'])) {
-            $options['blocks'] = json_encode($options['blocks']);
-        }
         unset($options['recipient_id']);
 
         return $options;
@@ -65,11 +62,24 @@ final class SlackOptions implements MessageOptionsInterface
 
     /**
      * @return $this
+     *
+     * @deprecated since Symfony 5.1, use recipient() instead.
      */
     public function channel(string $channel): self
     {
-        $this->options['channel'] = $channel;
-        $this->options['recipient_id'] = $channel;
+        trigger_deprecation('symfony/slack-notifier', '5.1', 'The "%s()" method is deprecated, use "recipient()" instead.', __METHOD__);
+
+        return $this;
+    }
+
+    /**
+     * @param string $id The hook id (anything after https://hooks.slack.com/services/)
+     *
+     * @return $this
+     */
+    public function recipient(string $id): self
+    {
+        $this->options['recipient_id'] = $id;
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
@@ -23,26 +23,28 @@ use Symfony\Component\Notifier\Transport\TransportInterface;
  */
 final class SlackTransportFactory extends AbstractTransportFactory
 {
+    public const SCHEME = 'slack';
+
     /**
      * @return SlackTransport
      */
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
-        $accessToken = $this->getUser($dsn);
-        $channel = $dsn->getOption('channel');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        if ('slack' === $scheme) {
-            return (new SlackTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        if (self::SCHEME === $scheme) {
+            $path = ltrim($dsn->getPath(), '/');
+
+            return (new SlackTransport($path, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
         }
 
-        throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());
+        throw new UnsupportedSchemeException($dsn, self::SCHEME, $this->getSupportedSchemes());
     }
 
     protected function getSupportedSchemes(): array
     {
-        return ['slack'];
+        return [self::SCHEME];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
@@ -23,28 +23,25 @@ use Symfony\Component\Notifier\Transport\TransportInterface;
  */
 final class SlackTransportFactory extends AbstractTransportFactory
 {
-    public const SCHEME = 'slack';
-
     /**
      * @return SlackTransport
      */
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
+        $id = ltrim($dsn->getPath(), '/');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        if (self::SCHEME === $scheme) {
-            $path = ltrim($dsn->getPath(), '/');
-
-            return (new SlackTransport($path, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        if ('slack' === $scheme) {
+            return (new SlackTransport($id, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
         }
 
-        throw new UnsupportedSchemeException($dsn, self::SCHEME, $this->getSupportedSchemes());
+        throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());
     }
 
     protected function getSupportedSchemes(): array
     {
-        return [self::SCHEME];
+        return ['slack'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Notifier\Bridge\Slack\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
@@ -24,26 +23,18 @@ final class SlackTransportFactoryTest extends TestCase
         $factory = new SlackTransportFactory();
 
         $host = 'testHost';
-        $channel = 'testChannel';
-        $transport = $factory->create(Dsn::fromString(sprintf('slack://testUser@%s/?channel=%s', $host, $channel)));
+        $path = 'testPath';
+        $transport = $factory->create(Dsn::fromString(sprintf('slack://%s/%s', $host, $path)));
 
-        $this->assertSame(sprintf('slack://%s?channel=%s', $host, $channel), (string) $transport);
-    }
-
-    public function testCreateWithNoTokenThrowsMalformed(): void
-    {
-        $factory = new SlackTransportFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-        $factory->create(Dsn::fromString(sprintf('slack://%s/?channel=%s', 'testHost', 'testChannel')));
+        $this->assertSame(sprintf('slack://%s/%s', $host, $path), (string) $transport);
     }
 
     public function testSupportsSlackScheme(): void
     {
         $factory = new SlackTransportFactory();
 
-        $this->assertTrue($factory->supports(Dsn::fromString('slack://host/?channel=testChannel')));
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host/?channel=testChannel')));
+        $this->assertTrue($factory->supports(Dsn::fromString('slack://host/path')));
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host/path')));
     }
 
     public function testNonSlackSchemeThrows(): void
@@ -52,6 +43,6 @@ final class SlackTransportFactoryTest extends TestCase
 
         $this->expectException(UnsupportedSchemeException::class);
 
-        $factory->create(Dsn::fromString('somethingElse://user:pwd@host/?channel=testChannel'));
+        $factory->create(Dsn::fromString('somethingElse://host/path'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

> Legacy tokens are a deprecated method of generating tokens for testing and development.

As tokens will became deprecated on May 5th, 2020 we should use Incoming Webhooks app for using this bundle.
**Usage:**
_`slack://hooks.slack.com/services/xxx/xxx/xxx`_
