### PR TITLE
[Notifier] Remove default transport property in Transports class

### DIFF
--- a/src/Symfony/Component/Notifier/Channel/ChatChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/ChatChannel.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Channel;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Notification\ChatNotificationInterface;
 use Symfony\Component\Notifier\Notification\Notification;
@@ -26,10 +25,6 @@ class ChatChannel extends AbstractChannel
 {
     public function notify(Notification $notification, Recipient $recipient, string $transportName = null): void
     {
-        if (null === $transportName) {
-            throw new LogicException('A Chat notification must have a transport defined.');
-        }
-
         $message = null;
         if ($notification instanceof ChatNotificationInterface) {
             $message = $notification->asChatMessage($recipient, $transportName);
@@ -39,7 +34,9 @@ class ChatChannel extends AbstractChannel
             $message = ChatMessage::fromNotification($notification);
         }
 
-        $message->transport($transportName);
+        if (null !== $transportName) {
+            $message->transport($transportName);
+        }
 
         if (null === $this->bus) {
             $this->transport->send($message);

--- a/src/Symfony/Component/Notifier/Tests/Transport/TransportsTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/TransportsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Component\Notifier\Transport\Transports;
+
+class TransportsTest extends TestCase
+{
+    public function testSendToTransportDefinedByMessage(): void
+    {
+        $transports = new Transports([
+            'one' => $one = $this->createMock(TransportInterface::class),
+        ]);
+
+        $message = new ChatMessage('subject');
+
+        $one->method('supports')->with($message)->willReturn(true);
+
+        $one->expects($this->once())->method('send');
+
+        $transports->send($message);
+    }
+
+    public function testSendToFirstSupportedTransportIfMessageDoesNotDefineATransport(): void
+    {
+        $transports = new Transports([
+            'one' => $one = $this->createMock(TransportInterface::class),
+            'two' => $two = $this->createMock(TransportInterface::class),
+        ]);
+
+        $message = new ChatMessage('subject');
+
+        $one->method('supports')->with($message)->willReturn(false);
+        $two->method('supports')->with($message)->willReturn(true);
+
+        $one->expects($this->never())->method('send');
+        $two->expects($this->once())->method('send');
+
+        $transports->send($message);
+    }
+
+    public function testThrowExceptionIfNoSupportedTransportWasFound(): void
+    {
+        $transports = new Transports([
+            'one' => $one = $this->createMock(TransportInterface::class),
+        ]);
+
+        $message = new ChatMessage('subject');
+
+        $one->method('supports')->with($message)->willReturn(false);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('None of the available transports support the given message (available transports: "one"');
+
+        $transports->send($message);
+    }
+
+    public function testThrowExceptionIfTransportDefinedByMessageIsNotSupported(): void
+    {
+        $transports = new Transports([
+            'one' => $one = $this->createMock(TransportInterface::class),
+            'two' => $two = $this->createMock(TransportInterface::class),
+        ]);
+
+        $message = new ChatMessage('subject');
+        $message->transport('one');
+
+        $one->method('supports')->with($message)->willReturn(false);
+        $two->method('supports')->with($message)->willReturn(true);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "one" transport does not support the given message.');
+
+        $transports->send($message);
+    }
+
+    public function testThrowExceptionIfTransportDefinedByMessageDoesNotExist()
+    {
+        $transports = new Transports([
+            'one' => $one = $this->createMock(TransportInterface::class),
+        ]);
+
+        $message = new ChatMessage('subject');
+        $message->transport('two');
+
+        $one->method('supports')->with($message)->willReturn(false);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "two" transport does not exist (available transports: "one").');
+
+        $transports->send($message);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | tbd. <!-- required for new features -->

At the moment the `Transports` class uses the first element of the injected transports array as the default transport: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Notifier/Transport/Transports.php#L35 

If you try to send a message that doesn't define a transport (`!$message->getTransport()`) the default transport is used. I see two main drawbacks with this solution that I try to fix with this PR:

1. There is no check if the given message is supported by the default transport. What means that the transport is going to fail with an Exception, if it's not supporting the given message. E.g. the `SlackTransport` only supports `ChatMessage`s with nullable options or options from type `SlackOptions`. So as a default transport the `SlackTransport` can't handle all types of `ChatMessage`s.  

2. Why should we only send the message using the default transport if there are more possible transports which are probably supported?

I did the following to fix the mentioned drawbacks:

- removed the default transport property
- added a check to make sure the transport defined by the message supports it 
- send the message to **all** supported transports, in case the given message does not define a transport
- added a test
