### PR TITLE
Fix bad merge in README of Nexmo Notifier bridge

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/README.md
@@ -3,19 +3,6 @@ Nexmo Notifier
 
 Provides Nexmo integration for Symfony Notifier.
 
-Getting Started
----------------
-
-```
-$ composer install symfony/debug
-```
-
-```php
-use Symfony\Component\Debug\Debug;
-
-Debug::enable();
-```
-
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.0 
| License       | MIT

[Bad merge](https://github.com/symfony/symfony/commit/85f793bec65c54bce9cb2b8352ebe45b5a2313df#diff-ba05e8af79b613430b91ba4d4ccbea0d) made https://github.com/symfony/symfony/commit/b52b7b9fd643fff1d17c7204fc3ba55bb5ec8f55 end up in Nexmo README :) 