### PR TITLE
[FrameworkBundle][DX] simplified service subscription when extending AbstractController

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -60,6 +60,11 @@ abstract class AbstractController implements ServiceSubscriberInterface
     protected $container;
 
     /**
+     * @var array|null When overridden those services will be merged with the defaults
+     */
+    protected static $subscribedServices;
+
+    /**
      * @internal
      * @required
      */
@@ -86,6 +91,15 @@ abstract class AbstractController implements ServiceSubscriberInterface
     }
 
     public static function getSubscribedServices()
+    {
+        if (static::$subscribedServices) {
+            return array_merge(self::getDefaultsServices(), static::$subscribedServices);
+        }
+
+        return self::getDefaultsServices();
+    }
+
+    private static function getDefaultsServices(): array
     {
         return [
             'router' => '?'.RouterInterface::class,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -65,6 +65,18 @@ class AbstractControllerTest extends TestCase
         $this->assertEquals($expectedServices, $subscribed, 'Subscribed core services in AbstractController have changed');
     }
 
+    public function testSubscribedServicesAreExtended()
+    {
+        $extendedServicesController = new class() extends AbstractController {
+            protected static $subscribedServices = ['test'];
+        };
+        $controller = $this->createController();
+
+        $this->assertSame($controller::getSubscribedServices(), AbstractController::getSubscribedServices());
+        $this->assertNotContains('test', $controller::getSubscribedServices());
+        $this->assertContains('test', $extendedServicesController::getSubscribedServices());
+    }
+
     public function testGetParameter()
     {
         if (!class_exists(ContainerBag::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

Since Symfony 5.0, we can't fetch public services from abstract controller anymore, this has lead to issues like #33755, #32633, #29583 or more recently symfony/symfony-docs#12852, and in the docs too symfony/symfony-docs#12891, symfony/symfony-docs#12978, symfony/symfony-docs#10744.

To be able to do:
```php
<?php

namespace App\Controller;

use App\Domain\PrivateService;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

class HelloController extends AbstractController
{
    public function index()
    {
        $result = $this->get(PrivateService::class)->doSomething();
        // return a response
    }
}
```
Here's a proposal to make it easier to get private explicitly subscribed services:
- Before:
  ```php
  // ...
  class HelloController extends AbstractController
  {
      public static function getSubscribedServices()
      {
          return array_merge(parent::getSubscribedServices(), [
              PrivateService::class,
          ]);
      }
      // ...
  }
  ```
- After:
  ```php
  class HelloController extends AbstractController
  {
      protected static $subscribedServices = [
          PrivateService::class,
      ];
      // ...
  }
  ```