### PR TITLE
[Notifier] Remove recipient argument from getChannels

### DIFF
--- a/src/Symfony/Component/Notifier/Notification/Notification.php
+++ b/src/Symfony/Component/Notifier/Notification/Notification.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Notifier\Notification;
 
 use Psr\Log\LogLevel;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
-use Symfony\Component\Notifier\Recipient\Recipient;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -158,7 +157,7 @@ class Notification
         return $this;
     }
 
-    public function getChannels(Recipient $recipient): array
+    public function getChannels(): array
     {
         return $this->channels;
     }

--- a/src/Symfony/Component/Notifier/Notifier.php
+++ b/src/Symfony/Component/Notifier/Notifier.php
@@ -69,7 +69,7 @@ final class Notifier implements NotifierInterface
 
     private function getChannels(Notification $notification, Recipient $recipient): iterable
     {
-        $channels = $notification->getChannels($recipient);
+        $channels = $notification->getChannels();
         if (!$channels) {
             $errorPrefix = sprintf('Unable to determine which channels to use to send the "%s" notification', \get_class($notification));
             $error = 'you should either pass channels in the constructor, override its "getChannels()" method';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

This PR removes the `$recipient` argument from the `Notification::getChannels()` method, because its not used to retrieve the channels.