### PR TITLE
[Notifier] Dispatch message event in null transport

### DIFF
--- a/src/Symfony/Component/Notifier/Transport/NullTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/NullTransport.php
@@ -11,7 +11,11 @@
 
 namespace Symfony\Component\Notifier\Transport;
 
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
+use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -20,8 +24,18 @@ use Symfony\Component\Notifier\Message\MessageInterface;
  */
 class NullTransport implements TransportInterface
 {
+    private $dispatcher;
+
+    public function __construct(EventDispatcherInterface $dispatcher = null)
+    {
+        $this->dispatcher = class_exists(Event::class) ? LegacyEventDispatcherProxy::decorate($dispatcher) : $dispatcher;
+    }
+
     public function send(MessageInterface $message): void
     {
+        if (null !== $this->dispatcher) {
+            $this->dispatcher->dispatch(new MessageEvent($message));
+        }
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Notifier/Transport/NullTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Transport/NullTransportFactory.php
@@ -26,7 +26,7 @@ final class NullTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         if ('null' === $dsn->getScheme()) {
-            return new NullTransport();
+            return new NullTransport($this->dispatcher);
         }
 
         throw new UnsupportedSchemeException($dsn, 'null', $this->getSupportedSchemes());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

I think we should be able to log notifications via the `NotificationLoggerListener` even if they were sent to a null transport. The mailer component does it the same way. 