### PR TITLE
[Console] Allow swapped namespace and command_name for core commands

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -618,8 +618,19 @@ class Application implements ResetInterface
             $commands = preg_grep('{^'.$expr.'}i', $allCommands);
         }
 
+        $nameSwapped = implode(':', array_reverse(explode(':', $name)));
+        $exprSwapped = preg_replace_callback('{([^:]+|)}', function ($matches) { return preg_quote($matches[1]).'[^:]*'; }, $nameSwapped);
+
+        if (empty($commands)) {
+            $commands = preg_grep('{^'.$exprSwapped.'}', $allCommands);
+        }
+
+        if (empty($commands)) {
+            $commands = preg_grep('{^'.$exprSwapped.'}i', $allCommands);
+        }
+
         // if no commands matched or we just matched namespaces
-        if (empty($commands) || \count(preg_grep('{^'.$expr.'$}i', $commands)) < 1) {
+        if (empty($commands) || (\count(preg_grep('{^'.$expr.'$}i', $commands)) < 1 && \count(preg_grep('{^'.$exprSwapped.'$}i', $commands)) < 1)) {
             if (false !== $pos = strrpos($name, ':')) {
                 // check if a namespace exists and contains commands
                 $this->findNamespace(substr($name, 0, $pos));

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -891,7 +891,8 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('foo')->setCode(function () {
-            throw new class('') extends \InvalidArgumentException { };
+            throw new class('') extends \InvalidArgumentException {
+            };
         });
         $tester = new ApplicationTester($application);
 
@@ -901,7 +902,8 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('foo')->setCode(function () {
-            throw new \InvalidArgumentException(sprintf('Dummy type "%s" is invalid.', \get_class(new class() { })));
+            throw new \InvalidArgumentException(sprintf('Dummy type "%s" is invalid.', \get_class(new class() {
+            })));
         });
         $tester = new ApplicationTester($application);
 
@@ -914,7 +916,8 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('foo')->setCode(function () {
-            throw new class('') extends \InvalidArgumentException { };
+            throw new class('') extends \InvalidArgumentException {
+            };
         });
         $tester = new ApplicationTester($application);
 
@@ -924,7 +927,8 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('foo')->setCode(function () {
-            throw new \InvalidArgumentException(sprintf('Dummy type "%s" is invalid.', \get_class(new class() { })));
+            throw new \InvalidArgumentException(sprintf('Dummy type "%s" is invalid.', \get_class(new class() {
+            })));
         });
         $tester = new ApplicationTester($application);
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -357,6 +357,14 @@ class ApplicationTest extends TestCase
         $this->assertInstanceOf('FooCommand', $application->find('a'), '->find() returns a command if the abbreviation exists for an alias');
     }
 
+    public function testFindSwappedNamespaceAndCommandName()
+    {
+        $application = new Application();
+        $application->add(new \FooCommand());
+        $this->assertInstanceOf('FooCommand', $application->find('foo:bar'), '->find() returns a command if its name exists');
+        $this->assertInstanceOf('FooCommand', $application->find('bar:foo'), '->find() returns a command if it exists for the swapped namespace and command name');
+    }
+
     public function testFindCaseSensitiveFirst()
     {
         $application = new Application();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | https://github.com/orgs/symfony/projects/1#card-32042548
| License       | MIT
| Doc PR        | - <!-- required for new features -->

It's now possible to use `bin/console debug:container` and `bin/console container:debug` interchangeable.