### PR TITLE
[Security] Use new IS_* attributes in the expression language functions

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php
@@ -25,21 +25,21 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
     {
         return [
             new ExpressionFunction('is_anonymous', function () {
-                return '$trust_resolver->isAnonymous($token)';
+                return '$token && $auth_checker->isGranted("IS_ANONYMOUS")';
             }, function (array $variables) {
-                return $variables['trust_resolver']->isAnonymous($variables['token']);
+                return $variables['token'] && $variables['auth_checker']->isGranted('IS_ANONYMOUS');
             }),
 
             new ExpressionFunction('is_authenticated', function () {
-                return '$token && !$trust_resolver->isAnonymous($token)';
+                return '$token && !$auth_checker->isGranted("IS_ANONYMOUS")';
             }, function (array $variables) {
-                return $variables['token'] && !$variables['trust_resolver']->isAnonymous($variables['token']);
+                return $variables['token'] && !$variables['auth_checker']->isGranted('IS_ANONYMOUS');
             }),
 
             new ExpressionFunction('is_fully_authenticated', function () {
-                return '$trust_resolver->isFullFledged($token)';
+                return '$token && $auth_checker->isGranted("IS_AUTHENTICATED_FULLY")';
             }, function (array $variables) {
-                return $variables['trust_resolver']->isFullFledged($variables['token']);
+                return $variables['token'] && $variables['auth_checker']->isGranted('IS_AUTHENTICATED_FULLY');
             }),
 
             new ExpressionFunction('is_granted', function ($attributes, $object = 'null') {
@@ -49,9 +49,9 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
             }),
 
             new ExpressionFunction('is_remember_me', function () {
-                return '$trust_resolver->isRememberMe($token)';
+                return '$token && $auth_checker->isGranted("IS_REMEMBERED")';
             }, function (array $variables) {
-                return $variables['trust_resolver']->isRememberMe($variables['token']);
+                return $variables['token'] && $variables['auth_checker']->isGranted('IS_REMEMBERED');
             }),
         ];
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\RoleVoter;
 use Symfony\Component\Security\Core\User\User;
 
@@ -35,11 +36,10 @@ class ExpressionLanguageTest extends TestCase
         $trustResolver = new AuthenticationTrustResolver();
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
-        $accessDecisionManager = new AccessDecisionManager([new RoleVoter()]);
+        $accessDecisionManager = new AccessDecisionManager([new RoleVoter(), new AuthenticatedVoter($trustResolver)]);
         $authChecker = new AuthorizationChecker($tokenStorage, $this->getMockBuilder(AuthenticationManagerInterface::class)->getMock(), $accessDecisionManager);
 
         $context = [];
-        $context['trust_resolver'] = $trustResolver;
         $context['auth_checker'] = $authChecker;
         $context['token'] = $token;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

#31189 has been merged which introduces some new attributes (`IS_ANONYMOUS` & friends). We can now modify the code behind the `is_*()` expression language functions to use these new attributes. This avoids any possibility of having them out of sync.

In case you - just like me - are interested why `isGranted("IS_AUTHENTICATED_FULLY")` wasn't used before: These functions were implemented without `auth_checker` being available. The auth checker  variable was introduced in 4.2 by #27305, so now we can use this.