### PR TITLE
[Routing] Improve localized routes performances

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -61,6 +61,14 @@ class RouteCompiler implements RouteCompilerInterface
             $hostRegex = $result['regex'];
         }
 
+        $locale = $route->getDefault('_locale');
+        if (null !== $locale && null !== $route->getDefault('_canonical_route') && preg_quote($locale, self::REGEX_DELIMITER) === $route->getRequirement('_locale')) {
+            $requirements = $route->getRequirements();
+            unset($requirements['_locale']);
+            $route->setRequirements($requirements);
+            $route->setPath(str_replace('{_locale}', $locale, $route->getPath()));
+        }
+
         $path = $route->getPath();
 
         $result = self::compilePattern($route, $path, false);

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/compiled_url_matcher14.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/compiled_url_matcher14.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file has been auto-generated
+ * by the Symfony Routing Component.
+ */
+
+return [
+    false, // $matchHost
+    [ // $staticRoutes
+        '/fr/accueil' => [[['_route' => 'home', '_locale' => 'fr'], null, null, null, false, false, null]],
+        '/en/home' => [[['_route' => 'home', '_locale' => 'en'], null, null, null, false, false, null]],
+    ],
+    [ // $regexpList
+    ],
+    [ // $dynamicRoutes
+    ],
+    null, // $checkCondition
+];

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\Routing\Tests\Matcher\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\Loader\PhpFileLoader;
 use Symfony\Component\Routing\Matcher\CompiledUrlMatcher;
 use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
 use Symfony\Component\Routing\Matcher\RedirectableUrlMatcherInterface;
@@ -442,21 +445,34 @@ class CompiledUrlMatcherDumperTest extends TestCase
         $hostCollection->add('r1', (new Route('abc{foo}'))->setHost('{foo}.exampple.com'));
         $hostCollection->add('r2', (new Route('abc{foo}'))->setHost('{foo}.exampple.com'));
 
+        /* test case 14 */
+        $fixedLocaleCollection = new RouteCollection();
+        $routes = new RoutingConfigurator($fixedLocaleCollection, new PhpFileLoader(new FileLocator()), __FILE__, __FILE__);
+        $routes
+            ->collection()
+            ->prefix('/{_locale}')
+            ->add('home', [
+                'fr' => 'accueil',
+                'en' => 'home',
+            ])
+        ;
+
         return [
-           [new RouteCollection(), 'compiled_url_matcher0.php'],
-           [$collection, 'compiled_url_matcher1.php'],
-           [$redirectCollection, 'compiled_url_matcher2.php'],
-           [$rootprefixCollection, 'compiled_url_matcher3.php'],
-           [$headMatchCasesCollection, 'compiled_url_matcher4.php'],
-           [$groupOptimisedCollection, 'compiled_url_matcher5.php'],
-           [$trailingSlashCollection, 'compiled_url_matcher6.php'],
-           [$trailingSlashCollection, 'compiled_url_matcher7.php'],
-           [$unicodeCollection, 'compiled_url_matcher8.php'],
-           [$hostTreeCollection, 'compiled_url_matcher9.php'],
-           [$chunkedCollection, 'compiled_url_matcher10.php'],
-           [$demoCollection, 'compiled_url_matcher11.php'],
-           [$suffixCollection, 'compiled_url_matcher12.php'],
-           [$hostCollection, 'compiled_url_matcher13.php'],
+            [new RouteCollection(), 'compiled_url_matcher0.php'],
+            [$collection, 'compiled_url_matcher1.php'],
+            [$redirectCollection, 'compiled_url_matcher2.php'],
+            [$rootprefixCollection, 'compiled_url_matcher3.php'],
+            [$headMatchCasesCollection, 'compiled_url_matcher4.php'],
+            [$groupOptimisedCollection, 'compiled_url_matcher5.php'],
+            [$trailingSlashCollection, 'compiled_url_matcher6.php'],
+            [$trailingSlashCollection, 'compiled_url_matcher7.php'],
+            [$unicodeCollection, 'compiled_url_matcher8.php'],
+            [$hostTreeCollection, 'compiled_url_matcher9.php'],
+            [$chunkedCollection, 'compiled_url_matcher10.php'],
+            [$demoCollection, 'compiled_url_matcher11.php'],
+            [$suffixCollection, 'compiled_url_matcher12.php'],
+            [$hostCollection, 'compiled_url_matcher13.php'],
+            [$fixedLocaleCollection, 'compiled_url_matcher14.php'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| License       | MIT

Implementation of the following idea: https://github.com/symfony/symfony/pull/35735#pullrequestreview-360525593

Improve route matching performances by turning dynamic routes with fixed `_locale` to actual static routes.
