### PR TITLE
[Security] Deprecated AuthenticationTrustResolver

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
@@ -14,19 +14,31 @@ namespace Symfony\Component\Security\Core\Authentication;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 
 /**
  * The default implementation of the authentication trust resolver.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since symfony/security-core 5.1
  */
 class AuthenticationTrustResolver implements AuthenticationTrustResolverInterface
 {
+    public function __construct(bool $triggerDeprecation = true)
+    {
+        if ($triggerDeprecation) {
+            trigger_deprecation('symfony/security-core', '5.1', '%s is deprecated.', __CLASS__);
+        }
+    }
+
     /**
      * {@inheritdoc}
      */
     public function isAnonymous(TokenInterface $token = null)
     {
+        trigger_deprecation('symfony/security-core', '5.1', 'The %s is deprecated, use %s::isGranted("IS_ANONYMOUS") instead.', __CLASS__, AuthorizationChecker::class);
+
         if (null === $token) {
             return false;
         }
@@ -39,6 +51,8 @@ class AuthenticationTrustResolver implements AuthenticationTrustResolverInterfac
      */
     public function isRememberMe(TokenInterface $token = null)
     {
+        trigger_deprecation('symfony/security-core', '5.1', 'The %s is deprecated, use %s::isGranted("IS_REMEMBERED") instead.', __CLASS__, AuthorizationChecker::class);
+
         if (null === $token) {
             return false;
         }
@@ -51,6 +65,8 @@ class AuthenticationTrustResolver implements AuthenticationTrustResolverInterfac
      */
     public function isFullFledged(TokenInterface $token = null)
     {
+        trigger_deprecation('symfony/security-core', '5.1', 'The %s is deprecated, use %s::isGranted("IS_AUTHENTICATED_FULLY") instead.', __CLASS__, AuthorizationChecker::class);
+
         if (null === $token) {
             return false;
         }

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolverInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolverInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * Interface for resolving the authentication status of a given token.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since symfony/security-core 5.1
  */
 interface AuthenticationTrustResolverInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | n/a
| License       | MIT
| Doc PR        | tbd

After https://github.com/symfony/symfony/pull/26981 , the trust resolver only contains 3 methods doing an `instanceof` check. I think it's better to deprecate this class and its usages. A user can use the attributes of https://github.com/symfony/symfony/pull/31189 or check instance of the token instead. Customizing the token FQCN used for RememberMe/Anonymous is very discouraged and if you do, I would highly recommend extending from them.

This does however result in quite some changes in the constructor arguments of some listeners. This poses the question whether or not it's worth it and if we really need to keep BC here (tbh, I think all firewall listeners can be considered internals, but we never marked them as such :cry: ).