### PR TITLE
[HttpFoundation] Add pull method to session/sessioninterface

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * made `Request::getSession()` throw if the session has not been set before
  * removed `Response::HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL`
  * passing a null url when instantiating a `RedirectResponse` is not allowed
+ * added a new `pull` method to `SessionInterface` which removes the key after it is read
 
 4.4.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -71,6 +71,17 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     /**
      * {@inheritdoc}
      */
+    public function pull(string $name, $default = null)
+    {
+        $res = $this->get($name, $default);
+        $this->remove($name);
+
+        return $res;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function set(string $name, $value)
     {
         $this->getAttributeBag()->set($name, $value);

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -108,6 +108,15 @@ interface SessionInterface
     public function get(string $name, $default = null);
 
     /**
+     * Returns and then removes an attribute.
+     *
+     * @param mixed $default The default value if not found
+     *
+     * @return mixed
+     */
+    public function pull(string $name, $default = null);
+
+    /**
      * Sets an attribute.
      *
      * @param mixed $value

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -107,6 +107,14 @@ class SessionTest extends TestCase
         $this->assertEquals(1, $this->session->get('foo', 1));
     }
 
+    public function testPull()
+    {
+        $this->session->set('foo', 'bar');
+
+        $this->assertEquals('bar', $this->session->pull('foo'));
+        $this->assertNull($this->session->get('foo')); // Check that the key has been removed from the session
+    }
+
     /**
      * @dataProvider setProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Hi all, this PR adds a new `pull` method to `SessionInterface` and its implementation in `Session`. The new utility method has the same signature like `get` but it will also remove the value from the session and may be handy for times you're storing read-once data in the session. Will send doc PR as well if the PR is deemed as useful.

Some fictional trivial example below:
```php
$token = $session->get('token');
$session->remove('token');

return $this->render('...', ['token' => $token]);
```

can be rewritten as 

```php
return $this->render('...', ['token' => $session->pull('token')]);
```