### PR TITLE
[ErrorHandler] fix parsing static return type on interface method annotation

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -428,17 +428,17 @@ class DebugClassLoader
                 }
             }
 
-            if ($refl->isInterface() && false !== strpos($doc, 'method') && preg_match_all('#\n \* @method\s+(static\s+)?+(?:[\w\|&\[\]\\\]+\s+)?(\w+(?:\s*\([^\)]*\))?)+(.+?([[:punct:]]\s*)?)?(?=\r?\n \*(?: @|/$|\r?\n))#', $doc, $notice, PREG_SET_ORDER)) {
+            if ($refl->isInterface() && false !== strpos($doc, 'method') && preg_match_all('#\n \* @method\s+(static\s+)?+([\w\|&\[\]\\\]+\s+)?(\w+(?:\s*\([^\)]*\))?)+(.+?([[:punct:]]\s*)?)?(?=\r?\n \*(?: @|/$|\r?\n))#', $doc, $notice, PREG_SET_ORDER)) {
                 foreach ($notice as $method) {
-                    $static = '' !== $method[1];
-                    $name = $method[2];
-                    $description = $method[3] ?? null;
+                    $static = '' !== $method[1] && !empty($method[2]);
+                    $name = $method[3];
+                    $description = $method[4] ?? null;
                     if (false === strpos($name, '(')) {
                         $name .= '()';
                     }
                     if (null !== $description) {
                         $description = trim($description);
-                        if (!isset($method[4])) {
+                        if (!isset($method[5])) {
                             $description .= '.';
                         }
                     }

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -325,6 +325,7 @@ class DebugClassLoaderTest extends TestCase
         restore_error_handler();
 
         $this->assertSame([
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualParent" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticReturningMethod()".',
             'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualParent" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::sameLineInterfaceMethodNoBraces()".',
             'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualParent" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::newLineInterfaceMethod()": Some description!',
             'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualParent" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::newLineInterfaceMethodNoBraces()": Description.',

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/VirtualInterface.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/VirtualInterface.php
@@ -4,6 +4,7 @@ namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
 
 /**
  * @method string interfaceMethod()
+ * @method static staticReturningMethod()
  * @method        sameLineInterfaceMethod($arg)
  * @method sameLineInterfaceMethodNoBraces
  *
@@ -25,7 +26,7 @@ namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
  *
  * Static
  * @method static Foo&Bar staticMethod()
- * @method static staticMethodNoBraces
+ * @method static mixed staticMethodNoBraces
  * @method static \stdClass staticMethodTyped(int $arg) Description
  * @method static \stdClass[] staticMethodTypedNoBraces
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35836 
| License       | MIT

As suggested in the issue, the regex has been adapted to capture the return type, then it will be checked while determining if the method to be implemented should be static or just returns an instance of `static`.
