### PR TITLE
[DomCrawler][Form] Add the Form::getReference() method

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Added an internal cache layer on top of the CssSelectorConverter
 * Added `UriResolver` to resolve an URI according to a base URI
+* Added the `Form::getReference()` method to get a field value by reference
 
 5.0.0
 -----

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -282,6 +282,11 @@ class Form extends Link implements \ArrayAccess
         return $this->fields->get($name);
     }
 
+    public function &getReference(string $name)
+    {
+        return $this->fields->get($name);
+    }
+
     /**
      * Sets a named field.
      */

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DomCrawler\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Field\TextareaFormField;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\FormFieldRegistry;
 
@@ -979,5 +980,31 @@ class FormTest extends TestCase
         $nodes = $dom->getElementsByTagName('form');
         $form = new Form($nodes->item(0), 'http://example.com');
         $this->assertEquals($form->getPhpValues(), ['example' => '']);
+    }
+
+    public function testGetReference()
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML('
+            <html>
+                <form>
+                    <textarea name="foo[collection][0][bar]">item 0</textarea>
+                </form>
+            </html>'
+        );
+
+        $formNode = $dom->getElementsByTagName('form')->item(0);
+        $form = new Form($formNode, 'http://example.com');
+
+        $collection = &$form->getReference('foo[collection]');
+
+        $item1 = new \DOMElement('textarea', 'item 1');
+        $formNode->appendChild($item1);
+
+        $collection[] = [
+            'bar' => new TextareaFormField($item1),
+        ];
+
+        $this->assertSame('item 1', $form->get('foo[collection][1][bar]')->getValue());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

`FormFieldRegistry::get()` already returns by reference but it is lost in `Form::get()`. I don't see how we can change the `Form::get()` method in a backward compatible way and without renaming it so I propose to create a new method 🤷‍♂

The case where it is useful to get a reference is when you test collections. In this case, you currently don't get the array of `FormField`by reference so you can't modify it to add / delete items easily. Getting it by reference solve this case (see test).